### PR TITLE
chore: switch deprecated circleci img

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   checks:
     docker:
-      - image: circleci/python:3.10
+      - image: cimg/python:3.10
     steps:
       - checkout
       - run:
@@ -11,7 +11,7 @@ jobs:
           command: make lint
   run-tests:
     docker:
-      - image: circleci/python:3.10
+      - image: cimg/python:3.10
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Just some low hanging fruit. I noticed:
<img width="953" alt="Screen Shot 2022-08-07 at 10 58 55 AM" src="https://user-images.githubusercontent.com/25379936/183501335-96be42e6-d4d0-404e-92fb-5dae8220b161.png">

which lead me [here](https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034)