### PR TITLE
feat(provider): Periodically resync data from Remote Setting

### DIFF
--- a/merino/config.py
+++ b/merino/config.py
@@ -5,6 +5,8 @@ _validators = [
     Validator("logging.level", is_in=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]),
     Validator("logging.format", is_in=["json"]),
     Validator("remote_settings.record_type", is_in=["data", "offline-expansion-data"]),
+    Validator("providers.adm.cron_interval_sec", gt=0),
+    Validator("providers.adm.resync_interval_sec", gt=0),
 ]
 
 # `root_path` = The root path for Dynaconf, DO NOT CHANGE.

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -34,3 +34,9 @@ bucket = "main"
 collection = "quicksuggest"
 # Can be "data" or "offline-expansion-data"
 record_type = "data"
+
+[default.providers.adm]
+# The cron job should tick more frequently than `resync_interval_sec` so that
+# the resync failure can be retried soon.
+cron_interval_sec = 60
+resync_interval_sec = 10800


### PR DESCRIPTION
This adds a background job to resync data from Remote Settings for the adm provider. The implementation is identical to the Rust version. Also, we should add some test coverage to this module as it gets more stuff in there. 

This fixes [CONSVC-1902](https://mozilla-hub.atlassian.net/browse/CONSVC-1902).