### PR TITLE
feat: enable cors CONSVC-1906

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ of `<type>: <subject>` where `type` must be one of:
 * **chore**: Changes to the build process or auxiliary tools and libraries such as documentation
   generation
 
-Name the branch using this nomenclature with the `<type>` followed by a forward slash, followed by a dash-seperated description of the task. Ex. `feat/add-sentry-sdk-MOZ-1234`. Note, if associated with a Jira ticket, synchronization with Jira and GitHub is possible by appending the suffix of the Jira ticket to the branch name (`-MOZ-1234` in the example above). This can be added anywhere in the branch name, but adding to the end is ideal.
+Name the branch using this nomenclature with the `<type>` followed by a forward slash, followed by a dash-seperated description of the task. Ex. `feat/add-sentry-sdk-MOZ-1234`. Note, if associated with a Jira ticket, synchronization with Jira and GitHub is possible by appending the suffix of the Jira ticket to the branch name (`-MOZ-1234` in the example above). This can be added anywhere in the branch name, but adding to the end is ideal. You can also include the Jira issue at the end of ccommit messages to keep the task up to date. See Jira Docs for referencing issues [here](https://support.atlassian.com/jira-software-cloud/docs/reference-issues-in-your-development-work/)
 
 ### Subject
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,103 @@
+# Contribution Guidelines
+
+Anyone is welcome to contribute to this project. Feel free to get in touch with
+other community members on [Matrix](https://chat.mozilla.org), the mailing list or through issues here on
+GitHub.
+
+## Bug Reports
+
+You can file issues here on GitHub. Please try to include as much information as
+you can and under what conditions you saw the issue.
+
+## Sending Pull Requests
+
+Patches should be submitted as pull requests (PR).
+
+Before submitting a PR:
+- Ensure you are pulling from the most recent `main` branch and install dependencies with Poetry. See 
+  [See the README](/README.md) for more details.
+- Your code must run and pass all the automated tests before you submit your PR
+  for review. [See the README](/README.md) for information on linting, formatting and testing. "Work in progress" or "Draft" pull requests are allowed to be submitted, but
+  should be clearly labeled as such and should not be merged until all tests
+  pass and the code has been reviewed.
+- Ideally, your patch should include new tests that cover your changes. It is your and
+  your reviewer's responsibility to ensure your patch includes adequate tests.
+
+When submitting a PR:
+- You agree to license your code under the project's open source license
+  ([MPL 2.0](/LICENSE)).
+- Base your branch off the current `main`.
+- Add both your code and new tests if relevant.
+- [Sign](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/signing-commits) your git commit.
+- Run tests, linting and formatting checks to make sure your code complies with established standards.
+(e.g. No warnings are returned for python: "`make lint`", "`make test`", "`make format`")
+- Ensure your changes do not reduce code coverage of the test suite.
+- Please do not include merge commits in pull requests; include only commits
+  with the new relevant code.
+
+WIP: See the main
+[documentation](https://github.com/mozilla-services/merino-py)
+for information on prerequisites, installing, running and testing.
+
+## Code Review
+
+This project is production Mozilla code and subject to our [engineering practices and quality standards](https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Committing_Rules_and_Responsibilities). Every patch must be peer reviewed.
+
+## Git Commit Guidelines & Branch Naming
+
+We loosely follow the [Angular commit guidelines](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#type)
+of `<type>: <subject>` where `type` must be one of:
+
+* **feat**: A new feature
+* **fix**: A bug fix
+* **docs**: Documentation only changes
+* **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing
+  semi-colons, etc)
+* **refactor**: A code change that neither fixes a bug or adds a feature
+* **perf**: A code change that improves performance
+* **test**: Adding missing tests
+* **chore**: Changes to the build process or auxiliary tools and libraries such as documentation
+  generation
+
+Name the branch using this nomenclature with the `<type>` followed by a forward slash, followed by a dash-seperated description of the task. Ex. `feat/add-sentry-sdk-MOZ-1234`. Note, if associated with a Jira ticket, synchronization with Jira and GitHub is possible by appending the suffix of the Jira ticket to the branch name (`-MOZ-1234` in the example above). This can be added anywhere in the branch name, but adding to the end is ideal.
+
+### Subject
+
+The subject contains succinct description of the change:
+
+* use the imperative, present tense: "change" not "changed" nor "changes"
+* don't capitalize first letter
+* no dot (.) at the end
+
+### Body
+
+In order to maintain a reference to the context of the commit, add
+`Closes #<issue_number>` if it closes a related issue or `Issue #<issue_number>`
+if it's a partial fix.
+
+You can also write a detailed description of the commit: Just as in the
+**subject**, use the imperative, present tense: "change" not "changed" nor
+"changes" It should include the motivation for the change and contrast this with
+previous behavior.
+
+### Footer
+
+The footer should contain any information about **Breaking Changes** and is also
+the place to reference GitHub issues that this commit **Closes**.
+
+### Example
+
+A properly formatted commit message should look like:
+
+```
+feat: give the developers a delicious cookie
+
+Properly formatted commit messages provide understandable history and
+documentation. This patch will provide a delicious cookie when all tests have
+passed and the commit message is properly formatted.
+
+BREAKING CHANGE: This patch requires developer to lower expectations about
+    what "delicious" and "cookie" may mean. Some sadness may result.
+
+Closes #314, #975
+```

--- a/merino/main.py
+++ b/merino/main.py
@@ -46,17 +46,9 @@ app.add_middleware(logging.LoggingMiddleware)
 app.include_router(dockerflow.router)
 app.include_router(api_v1.router, prefix="/api/v1")
 
-cors_origins = [
-    "http://localhost:8000",
-    "http://127.0.0.1:8000",
-    "http://localhost:80",
-]
-
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=cors_origins,
-    allow_origin_regex=r"http://localhost:^([1-9][0-9]{0,3}|[1-5][0-9]{4}"
-    / r"|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$",
+    allow_origins=["*"],
     allow_credentials=False,
     allow_methods=["GET", "POST", "OPTIONS", "HEAD"],
     allow_headers=["*"],

--- a/merino/main.py
+++ b/merino/main.py
@@ -50,7 +50,6 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
     allow_credentials=False,
-    allow_methods=["GET", "POST", "OPTIONS", "HEAD"],
+    allow_methods=["GET", "OPTIONS", "HEAD"],
     allow_headers=["*"],
-    max_age=3600,
 )

--- a/merino/main.py
+++ b/merino/main.py
@@ -51,5 +51,4 @@ app.add_middleware(
     allow_origins=["*"],
     allow_credentials=False,
     allow_methods=["GET", "OPTIONS", "HEAD"],
-    allow_headers=["*"],
 )

--- a/merino/main.py
+++ b/merino/main.py
@@ -49,6 +49,7 @@ app.include_router(api_v1.router, prefix="/api/v1")
 cors_origins = [
     "http://localhost:8000",
     "http://127.0.0.1:8000",
+    "http://localhost:80",
 ]
 
 app.add_middleware(

--- a/merino/main.py
+++ b/merino/main.py
@@ -2,6 +2,7 @@ from asgi_correlation_id import CorrelationIdMiddleware
 from fastapi import FastAPI, status
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
 from merino import providers
@@ -44,3 +45,19 @@ app.add_middleware(logging.LoggingMiddleware)
 
 app.include_router(dockerflow.router)
 app.include_router(api_v1.router, prefix="/api/v1")
+
+cors_origins = [
+    "http://localhost:8000",
+    "http://127.0.0.1:8000",
+]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=cors_origins,
+    allow_origin_regex=r"http://localhost:^([1-9][0-9]{0,3}|[1-5][0-9]{4}"
+    / r"|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$",
+    allow_credentials=False,
+    allow_methods=["GET", "POST", "OPTIONS", "HEAD"],
+    allow_headers=["*"],
+    max_age=3600,
+)


### PR DESCRIPTION
Added simple CORS configurations to mernio-py as defined in the [FastAPI CORS docs](https://fastapi.tiangolo.com/tutorial/cors).

Looking at our current Merino-rs config, see [here in actix docs](https://docs.rs/actix-cors/latest/actix_cors/struct.Cors.html#method.permissive) and [here in source](https://docs.rs/actix-cors/latest/src/actix_cors/builder.rs.html#81) it was using the `permissive` setting, which for production is of course not desirable. While in the local testing phases, a permissible CORS configuration is desirable, but we will want to adjust it as time goes on. However, I did implement a few restrictions:

- Only permit GET, POST, OPTIONS, and HEAD requests (simple requests, excl OPTIONS)
- Did not permit credentials and cookies to be supported in cross-origin requests. Since the wildcard `"*"` is set for origins, this is not allowed. Not sure if we may want auth cooks enabled that match the API's domain down the road.

In discussing whether we should make any adjustments to the current config, I want to pose the following questions to reviewers:
- In an ideal world, we could consider the specific origins from which we allow requests. Do we have a list or potential collection we could partially validate against? Given my relative newness to quicksuggest and the general architecture, I can't confidently know what this should or shouldn't be. Can we make some assumptions about the origins of some of our requests? This will differ significantly from development to production. Is there a world in which we store and dynamically add origins to our list? If so, I have seen some possible implementations using Starlette's classes.
- We want to consider the returned `Access-Control-Request-Method`  and `Access-Control-Request-Headers`  headers and if we want to set up a whitelist. For request headers, by default  `Accept`, `Accept-Language`, `Content-Language` and `Content-Type` are allowed.
- Consider what response headers we may want to expose to the browser. Default: `expose_headers=[]`. Can I get some input on what responses we may want to expose?
- Is the 3600 age setting good or do we want to increase the TTL for the browser to use to cache the response? Default is 800.

I also added a CONTRIBUTING.md file here. I know it's not part of the task, so I can take it out, but I thought it useful at this initial phase. Based on some of our other Mozilla-services projects with merino-py specific revisions. 