### PR TITLE
feat: Metrics - initial implementation

### DIFF
--- a/merino/config.py
+++ b/merino/config.py
@@ -27,7 +27,6 @@ settings = Dynaconf(
     envvar_prefix="MERINO",
     settings_files=[
         "configs/default.toml",
-        "configs/testing.toml",
         "configs/development.toml",
         "configs/production.toml",
         "configs/ci.toml",

--- a/merino/config.py
+++ b/merino/config.py
@@ -5,6 +5,7 @@ from dynaconf import Dynaconf, Validator
 _validators = [
     Validator("logging.level", is_in=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]),
     Validator("logging.format", is_in=["mozlog", "pretty"]),
+    Validator("metrics.port", gte=0),
     Validator("providers.adm.cron_interval_sec", gt=0),
     Validator("providers.adm.resync_interval_sec", gt=0),
     Validator("providers.adm.score", gte=0, lte=1),

--- a/merino/config.py
+++ b/merino/config.py
@@ -27,6 +27,7 @@ settings = Dynaconf(
     envvar_prefix="MERINO",
     settings_files=[
         "configs/default.toml",
+        "configs/testing.toml",
         "configs/development.toml",
         "configs/production.toml",
         "configs/ci.toml",

--- a/merino/config.py
+++ b/merino/config.py
@@ -5,7 +5,9 @@ from dynaconf import Dynaconf, Validator
 _validators = [
     Validator("logging.level", is_in=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]),
     Validator("logging.format", is_in=["mozlog", "pretty"]),
-    Validator("metrics.port", gte=0),
+    Validator("metrics.host", is_type_of=str),
+    Validator("metrics.port", gte=0, is_type_of=int),
+    Validator("metrics.dev_logger", is_type_of=bool),
     Validator("providers.adm.cron_interval_sec", gt=0),
     Validator("providers.adm.resync_interval_sec", gt=0),
     Validator("providers.adm.score", gte=0, lte=1),

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -30,7 +30,7 @@ level = "INFO"
 format = "mozlog"
 
 [default.metrics]
-dev_logger = true
+dev_logger = false
 host = "localhost"
 port = 8092
 

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -29,6 +29,11 @@ level = "INFO"
 # Any of "mozlog" (i.e. JSON) or "pretty"
 format = "mozlog"
 
+[default.metrics]
+dev_logger = true
+host = "localhost"
+port = 8092
+
 [default.location]
 # Path to the MaxMindDB file. This should be overridden in production.
 maxmind_database = "./dev/GeoLite2-City-Test.mmdb"

--- a/merino/configs/development.toml
+++ b/merino/configs/development.toml
@@ -3,19 +3,16 @@
 
 # This would be the default environment for development.
 
-
 [development]
 debug = true
+# For `list` or `table` settings, `dynaconf_merge` allows you to merge settings with the default
+# settings. This enables merge for the entire `development` environment.
+dynaconf_merge = true
 
 [development.metrics]
 dev_logger = true
-dynaconf_merge = true
 
 [development.logging]
 # Any of "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"
 level = "DEBUG"
 format = "pretty"
-# For `list` or `table` settings, `dynaconf_merge` allows you to merge settings with the default
-# settings. For instance, `logging.level` in this case will override its counterpart defined in
-# `default_settings`.
-dynaconf_merge = true

--- a/merino/configs/development.toml
+++ b/merino/configs/development.toml
@@ -7,7 +7,15 @@
 [development]
 debug = true
 
+[development.metrics]
+dev_logger = true
+dynaconf_merge = true
+
 [development.logging]
 # Any of "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"
 level = "DEBUG"
 format = "pretty"
+# For `list` or `table` settings, `dynaconf_merge` allows you to merge settings with the default
+# settings. For instance, `logging.level` in this case will override its counterpart defined in
+# `default_settings`.
+dynaconf_merge = true

--- a/merino/configs/testing.toml
+++ b/merino/configs/testing.toml
@@ -1,6 +1,0 @@
-[testing]
-debug = true
-dynaconf_merge = true
-
-[testing.metrics]
-dev_logger = true

--- a/merino/configs/testing.toml
+++ b/merino/configs/testing.toml
@@ -1,0 +1,6 @@
+[testing]
+debug = true
+dynaconf_merge = true
+
+[testing.metrics]
+dev_logger = true

--- a/merino/main.py
+++ b/merino/main.py
@@ -18,9 +18,7 @@ app = FastAPI()
 
 @app.on_event("startup")
 async def startup_configuration() -> None:
-    """
-    Set up various configurations such as logging.
-    """
+    """Set up various configurations such as logging."""
     configure_logging()
     configure_sentry()
     await configure_metrics()
@@ -34,9 +32,7 @@ async def startup_providers() -> None:
 
 @app.on_event("shutdown")
 async def shutdown() -> None:
-    """
-    Clean up for the application shutdown.
-    """
+    """Clean up for the application shutdown."""
     await get_metrics_client().close()
 
 

--- a/merino/main.py
+++ b/merino/main.py
@@ -58,11 +58,11 @@ app.add_middleware(
     allow_credentials=False,
     allow_methods=["GET", "OPTIONS", "HEAD"],
 )
+app.add_middleware(metrics.MetricsMiddleware)
 app.add_middleware(CorrelationIdMiddleware)
 app.add_middleware(featureflags.FeatureFlagsMiddleware)
 app.add_middleware(geolocation.GeolocationMiddleware)
 app.add_middleware(logging.LoggingMiddleware)
-app.add_middleware(metrics.MetricsMiddleware)
 
 app.include_router(dockerflow.router)
 app.include_router(api_v1.router, prefix="/api/v1")

--- a/merino/main.py
+++ b/merino/main.py
@@ -35,7 +35,7 @@ async def startup_providers() -> None:
 @app.on_event("shutdown")
 async def shutdown() -> None:
     """
-    Set up various configurations such as logging.
+    Clean up for the application shutdown.
     """
     await get_metrics_client().close()
 

--- a/merino/main.py
+++ b/merino/main.py
@@ -7,9 +7,9 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
 from merino import providers
-from merino.metrics import configure_metrics, get_client
 from merino.config_logging import configure_logging
 from merino.config_sentry import configure_sentry
+from merino.metrics import configure_metrics, get_client
 from merino.middleware import featureflags, geolocation, logging, metrics
 from merino.web import api_v1, dockerflow
 

--- a/merino/main.py
+++ b/merino/main.py
@@ -9,7 +9,7 @@ from fastapi.responses import JSONResponse
 from merino import providers
 from merino.config_logging import configure_logging
 from merino.config_sentry import configure_sentry
-from merino.metrics import configure_metrics, get_client
+from merino.metrics import configure_metrics, get_metrics_client
 from merino.middleware import featureflags, geolocation, logging, metrics
 from merino.web import api_v1, dockerflow
 
@@ -37,7 +37,7 @@ async def shutdown() -> None:
     """
     Set up various configurations such as logging.
     """
-    await get_client().close()
+    await get_metrics_client().close()
 
 
 @app.exception_handler(RequestValidationError)

--- a/merino/metrics.py
+++ b/merino/metrics.py
@@ -1,0 +1,38 @@
+import logging
+from functools import cache
+
+from aiodogstatsd import Client
+from aiodogstatsd.client import DatagramProtocol
+
+from merino.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+@cache
+def get_client() -> Client:
+    return Client(
+        host=settings.metrics.host,
+        port=settings.metrics.port,
+        constant_tags={"application": "merino"},
+    )
+
+
+async def configure_metrics() -> Client:
+    client = get_client()
+    try:
+        if settings.metrics.dev_logger:
+            client._protocol = LocalDatagramLogger()
+        await client.connect()
+    except Exception as e:
+        logger.exception(e)
+    finally:
+        return client
+
+
+class LocalDatagramLogger(DatagramProtocol):
+    def send(self, data):
+        logger.debug("sending metrics", extra={"data": data.decode("utf8")})
+
+    def error_received(self, exc):
+        logger.exception(exc)

--- a/merino/metrics.py
+++ b/merino/metrics.py
@@ -10,28 +10,23 @@ logger = logging.getLogger(__name__)
 
 
 @cache
-def get_client() -> Client:
+def get_metrics_client() -> Client:
     return Client(
         host=settings.metrics.host,
         port=settings.metrics.port,
-        constant_tags={"application": "merino"},
+        constant_tags={"application": "merino-py"},
     )
 
 
-async def configure_metrics() -> Client:
-    client = get_client()
-    try:
-        if settings.metrics.dev_logger:
-            client._protocol = LocalDatagramLogger()
-        await client.connect()
-    except Exception as e:
-        logger.exception(e)
-    finally:
-        return client
+async def configure_metrics() -> None:
+    client = get_metrics_client()
+    if settings.metrics.dev_logger:
+        client._protocol = LocalDatagramLogger()
+    await client.connect()
 
 
 class LocalDatagramLogger(DatagramProtocol):
-    def send(self, data):
+    def send(self, data: bytes):
         logger.debug("sending metrics", extra={"data": data.decode("utf8")})
 
     def error_received(self, exc):

--- a/merino/middleware/metrics.py
+++ b/merino/middleware/metrics.py
@@ -1,9 +1,15 @@
 import logging
+from typing import Optional
 
 from fastapi import HTTPException
-from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.middleware.base import (
+    BaseHTTPMiddleware,
+    DispatchFunction,
+    RequestResponseEndpoint,
+)
 from starlette.requests import Request
 from starlette.responses import Response
+from starlette.types import ASGIApp
 
 from merino.metrics import get_client
 
@@ -11,20 +17,32 @@ logger = logging.getLogger(__name__)
 
 
 class MetricsMiddleware(BaseHTTPMiddleware):
+
+    _metric_names: dict[str, str]
+
+    def __init__(
+        self, app: ASGIApp, dispatch: Optional[DispatchFunction] = None
+    ) -> None:
+        super().__init__(app, dispatch)
+        self._metric_names = {
+            route.path: route.path.lstrip("/").replace("/", ".") for route in app.routes
+        }
+
     async def dispatch(
         self, request: Request, call_next: RequestResponseEndpoint
     ) -> Response:
+        client = get_client()
+        metric_name = self._metric_names[request.url.path]
+        status_code = 0
+
         try:
-            async with get_client() as client:
-                metric_name = build_metric_name(request)
-                with client.timeit(f"{metric_name}.timing"):
-                    response = await call_next(request)
-                client.increment(f"{metric_name}.status_codes.{response.status_code}")
-                return response
-        except Exception as e:
-            logger.exception(e)
-            raise HTTPException(status_code=500, detail=e)
-
-
-def build_metric_name(req: Request) -> str:
-    return req.url.path.lstrip("/").replace("/", ".")
+            with client.timeit(f"{metric_name}.timing"):
+                response = await call_next(request)
+            client.increment(f"{metric_name}.status_codes.{response.status_code}")
+            status_code = response.status_code
+        except HTTPException as e:
+            status_code = e.status_code
+            raise e
+        finally:
+            client.increment(f"{metric_name}.status_codes.{status_code}")
+        return response

--- a/merino/middleware/metrics.py
+++ b/merino/middleware/metrics.py
@@ -42,7 +42,7 @@ class MetricsMiddleware(BaseHTTPMiddleware):
         finally:
             duration = (loop.time() - started_at) * 1000
             # don't track NOT_FOUND statuses by path.
-            # Instead we will track those within a general `status_codes` bucket.
+            # Instead we will track those within a general `response.status_codes` metric.
             if status_code != HTTPStatus.NOT_FOUND.value:
                 metric_name = self._build_metric_name(request.method, request.url.path)
                 client.timing(f"{metric_name}.timing", value=duration)

--- a/merino/middleware/metrics.py
+++ b/merino/middleware/metrics.py
@@ -16,7 +16,7 @@ class MetricsMiddleware(BaseHTTPMiddleware):
         self, request: Request, call_next: RequestResponseEndpoint
     ) -> Response:
         client = get_client()
-        metric_name = self._build_metric_name(request.url.path)
+        metric_name = self._build_metric_name(request.method, request.url.path)
         status_code = 0
 
         try:
@@ -31,5 +31,7 @@ class MetricsMiddleware(BaseHTTPMiddleware):
             client.increment(f"{metric_name}.status_codes.{status_code}")
 
     @cache
-    def _build_metric_name(self, path: str) -> str:
-        return path.lower().lstrip("/").replace("/", ".")
+    def _build_metric_name(self, method: str, path: str) -> str:
+        return "{}.{}".format(
+            method, path.lower().lstrip("/").replace("/", ".")
+        ).lower()

--- a/merino/middleware/metrics.py
+++ b/merino/middleware/metrics.py
@@ -25,12 +25,12 @@ class MetricsMiddleware(BaseHTTPMiddleware):
             with client.timeit(f"{metric_name}.timing"):
                 response = await call_next(request)
             status_code = response.status_code
+            return response
         except HTTPException as e:
             status_code = e.status_code
             raise e
         finally:
             client.increment(f"{metric_name}.status_codes.{status_code}")
-        return response
 
     def build_metric_name(self, path: str) -> str:
         if path not in self._metric_names:

--- a/merino/middleware/metrics.py
+++ b/merino/middleware/metrics.py
@@ -1,0 +1,29 @@
+from fastapi import HTTPException
+import logging
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import Response
+
+from merino.metrics import get_client
+
+logger = logging.getLogger(__name__)
+
+
+class MetricsMiddleware(BaseHTTPMiddleware):
+    async def dispatch(
+        self, request: Request, call_next: RequestResponseEndpoint
+    ) -> Response:
+        try:
+            async with get_client() as client:
+                metric_name = build_metric_name(request)
+                with client.timeit(f"{metric_name}.timing"):
+                    response = await call_next(request)
+                client.increment(f"{metric_name}.status_codes.{response.status_code}")
+                return response
+        except Exception as e:
+            logger.exception(e)
+            raise HTTPException(status_code=500, detail=e)
+
+
+def build_metric_name(req: Request) -> str:
+    return req.url.path.lstrip("/").replace("/", ".")

--- a/merino/middleware/metrics.py
+++ b/merino/middleware/metrics.py
@@ -1,5 +1,8 @@
+"""Middleware for request metrics."""
 import logging
+from asyncio import get_event_loop
 from functools import cache
+from http import HTTPStatus
 
 from fastapi import HTTPException
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
@@ -12,23 +15,43 @@ logger = logging.getLogger(__name__)
 
 
 class MetricsMiddleware(BaseHTTPMiddleware):
+    """
+    Middleware for instrumenting request level metrics. We currently collect timing
+    and status codes for all known paths as well as status codes for all paths (known and unknown).
+    """
+
     async def dispatch(
         self, request: Request, call_next: RequestResponseEndpoint
     ) -> Response:
+        """Wrap the request with metrics"""
         client = get_metrics_client()
-        metric_name = self._build_metric_name(request.method, request.url.path)
-        status_code = 0
+
+        loop = get_event_loop()
+        started_at = loop.time()
+
+        # 500 errors raise as non HTTPException so we can avoid a catchall `except`
+        # by defaulting to 500 and overwriting on a successful request or an HTTPException
+        status_code = HTTPStatus.INTERNAL_SERVER_ERROR.value
 
         try:
-            with client.timeit(f"{metric_name}.timing"):
-                response = await call_next(request)
+            response = await call_next(request)
             status_code = response.status_code
-            return response
         except HTTPException as e:
             status_code = e.status_code
             raise e
         finally:
-            client.increment(f"{metric_name}.status_codes.{status_code}")
+            duration = (loop.time() - started_at) * 1000
+            # don't track NOT_FOUND statuses by path.
+            # Instead we will track those within a general `status_codes` bucket.
+            if status_code != HTTPStatus.NOT_FOUND.value:
+                metric_name = self._build_metric_name(request.method, request.url.path)
+                client.timing(f"{metric_name}.timing", value=duration)
+                client.increment(f"{metric_name}.status_codes.{status_code}")
+
+            # track all status codes here.
+            client.increment(f"request.status_codes.{status_code}")
+
+        return response
 
     @cache
     def _build_metric_name(self, method: str, path: str) -> str:

--- a/merino/middleware/metrics.py
+++ b/merino/middleware/metrics.py
@@ -49,8 +49,7 @@ class MetricsMiddleware(BaseHTTPMiddleware):
                 client.increment(f"{metric_name}.status_codes.{status_code}")
 
             # track all status codes here.
-            client.increment(f"request.status_codes.{status_code}")
-
+            client.increment(f"response.status_codes.{status_code}")
         return response
 
     @cache

--- a/merino/middleware/metrics.py
+++ b/merino/middleware/metrics.py
@@ -6,7 +6,7 @@ from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoin
 from starlette.requests import Request
 from starlette.responses import Response
 
-from merino.metrics import get_client
+from merino.metrics import get_metrics_client
 
 logger = logging.getLogger(__name__)
 
@@ -15,7 +15,7 @@ class MetricsMiddleware(BaseHTTPMiddleware):
     async def dispatch(
         self, request: Request, call_next: RequestResponseEndpoint
     ) -> Response:
-        client = get_client()
+        client = get_metrics_client()
         metric_name = self._build_metric_name(request.method, request.url.path)
         status_code = 0
 

--- a/merino/middleware/metrics.py
+++ b/merino/middleware/metrics.py
@@ -1,5 +1,6 @@
-from fastapi import HTTPException
 import logging
+
+from fastapi import HTTPException
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.requests import Request
 from starlette.responses import Response

--- a/merino/middleware/metrics.py
+++ b/merino/middleware/metrics.py
@@ -1,15 +1,9 @@
 import logging
-from typing import Optional
 
 from fastapi import HTTPException
-from starlette.middleware.base import (
-    BaseHTTPMiddleware,
-    DispatchFunction,
-    RequestResponseEndpoint,
-)
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.requests import Request
 from starlette.responses import Response
-from starlette.types import ASGIApp
 
 from merino.metrics import get_client
 
@@ -18,27 +12,18 @@ logger = logging.getLogger(__name__)
 
 class MetricsMiddleware(BaseHTTPMiddleware):
 
-    _metric_names: dict[str, str]
-
-    def __init__(
-        self, app: ASGIApp, dispatch: Optional[DispatchFunction] = None
-    ) -> None:
-        super().__init__(app, dispatch)
-        self._metric_names = {
-            route.path: route.path.lstrip("/").replace("/", ".") for route in app.routes
-        }
+    _metric_names: dict[str, str] = {}
 
     async def dispatch(
         self, request: Request, call_next: RequestResponseEndpoint
     ) -> Response:
         client = get_client()
-        metric_name = self._metric_names[request.url.path]
+        metric_name = self.build_metric_name(request.url.path)
         status_code = 0
 
         try:
             with client.timeit(f"{metric_name}.timing"):
                 response = await call_next(request)
-            client.increment(f"{metric_name}.status_codes.{response.status_code}")
             status_code = response.status_code
         except HTTPException as e:
             status_code = e.status_code
@@ -46,3 +31,8 @@ class MetricsMiddleware(BaseHTTPMiddleware):
         finally:
             client.increment(f"{metric_name}.status_codes.{status_code}")
         return response
+
+    def build_metric_name(self, path: str) -> str:
+        if path not in self._metric_names:
+            self._metric_names[path] = path.lower().lstrip("/").replace("/", ".")
+        return self._metric_names[path]

--- a/merino/providers/__init__.py
+++ b/merino/providers/__init__.py
@@ -32,7 +32,7 @@ async def init_providers() -> None:
 
     # initialize providers and record time
     init_metric = f"{__name__}.initialize"
-    client = metrics.get_client()
+    client = metrics.get_metrics_client()
     with client.timeit(init_metric):
         wrapped_tasks = [
             client.timeit_task(p.initialize(), f"{init_metric}.{provider_name}")

--- a/merino/providers/__init__.py
+++ b/merino/providers/__init__.py
@@ -6,6 +6,7 @@ from timeit import default_timer as timer
 from merino import remotesettings
 from merino.config import settings
 from merino import metrics
+from merino.config import settings
 from merino.providers.adm import Provider as AdmProvider
 from merino.providers.base import BaseProvider
 from merino.providers.wiki_fruit import WikiFruitProvider

--- a/merino/providers/__init__.py
+++ b/merino/providers/__init__.py
@@ -3,9 +3,7 @@ import asyncio
 import logging
 from timeit import default_timer as timer
 
-from merino import remotesettings
-from merino.config import settings
-from merino import metrics
+from merino import metrics, remotesettings
 from merino.config import settings
 from merino.providers.adm import Provider as AdmProvider
 from merino.providers.base import BaseProvider

--- a/merino/providers/__init__.py
+++ b/merino/providers/__init__.py
@@ -5,6 +5,7 @@ from timeit import default_timer as timer
 
 from merino import remotesettings
 from merino.config import settings
+from merino import metrics
 from merino.providers.adm import Provider as AdmProvider
 from merino.providers.base import BaseProvider
 from merino.providers.wiki_fruit import WikiFruitProvider
@@ -23,17 +24,27 @@ async def init_providers() -> None:
     """
     start = timer()
 
+    # register providers
     providers["adm"] = AdmProvider(backend=remotesettings.LiveBackend())
-
     if settings.providers.wiki_fruit.enabled:
         providers["wiki_fruit"] = WikiFruitProvider()
 
-    await asyncio.gather(*[p.initialize() for p in providers.values()])
-    default_providers.extend([p for p in providers.values() if p.enabled_by_default()])
-    logger.info(
-        "Provider initialization complete",
-        extra={"providers": [*providers.keys()], "elapsed": timer() - start},
-    )
+    # initialize providers and record time
+    init_metric = f"{__name__}.initialize"
+    client = metrics.get_client()
+    with client.timeit(init_metric):
+        wrapped_tasks = [
+            client.timeit_task(p.initialize(), f"{init_metric}.{provider_name}")
+            for provider_name, p in providers.items()
+        ]
+        await asyncio.gather(*wrapped_tasks)
+        default_providers.extend(
+            [p for p in providers.values() if p.enabled_by_default()]
+        )
+        logger.info(
+            "Provider initialization complete",
+            extra={"providers": [*providers.keys()], "elapsed": timer() - start},
+        )
 
 
 def get_providers() -> tuple[dict[str, BaseProvider], list[BaseProvider]]:

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -2,11 +2,13 @@
 import asyncio
 from itertools import chain
 
+from aiodogstatsd import Client
 from asgi_correlation_id.context import correlation_id
 from fastapi import APIRouter, Depends
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
 
+from merino.metrics import get_client
 from merino.providers import get_providers
 from merino.providers.base import BaseProvider
 from merino.web.models_v1 import (
@@ -40,6 +42,7 @@ async def suggest(
     sources: tuple[dict[str, BaseProvider], list[BaseProvider]] = Depends(
         get_providers
     ),
+    metrics_client: Client = Depends(get_client),
 ) -> JSONResponse:
     """
     Query Merino for suggestions.
@@ -60,7 +63,12 @@ async def suggest(
         ]
     else:
         search_from = default_providers
-    lookups = [p.query(q) for p in search_from]
+    lookups = [
+        metrics_client.timeit_task(
+            p.query(q), f"{p.__module__}.query"
+        )
+        for p in search_from
+    ]
     results = await asyncio.gather(*lookups)
 
     suggestions = [

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
 
-from merino.metrics import get_client
+from merino.metrics import get_metrics_client
 from merino.providers import get_providers
 from merino.providers.base import BaseProvider
 from merino.web.models_v1 import (
@@ -42,7 +42,7 @@ async def suggest(
     sources: tuple[dict[str, BaseProvider], list[BaseProvider]] = Depends(
         get_providers
     ),
-    metrics_client: Client = Depends(get_client),
+    metrics_client: Client = Depends(get_metrics_client),
 ) -> JSONResponse:
     """
     Query Merino for suggestions.

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -63,6 +63,7 @@ async def suggest(
         ]
     else:
         search_from = default_providers
+
     lookups = [
         metrics_client.timeit_task(p.query(q), f"{p.__module__}.query")
         for p in search_from

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -64,9 +64,7 @@ async def suggest(
     else:
         search_from = default_providers
     lookups = [
-        metrics_client.timeit_task(
-            p.query(q), f"{p.__module__}.query"
-        )
+        metrics_client.timeit_task(p.query(q), f"{p.__module__}.query")
         for p in search_from
     ]
     results = await asyncio.gather(*lookups)

--- a/poetry.lock
+++ b/poetry.lock
@@ -39,14 +39,6 @@ python-versions = ">=3.7,<4.0"
 starlette = ">=0.18,<0.21"
 
 [[package]]
-name = "atomicwrites"
-version = "1.4.1"
-description = "Atomic file writes."
-category = "dev"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-
-[[package]]
 name = "attrs"
 version = "22.1.0"
 description = "Classes Without Boilerplate"
@@ -89,7 +81,7 @@ yaml = ["pyyaml"]
 
 [[package]]
 name = "black"
-version = "22.6.0"
+version = "22.8.0"
 description = "The uncompromising code formatter."
 category = "dev"
 optional = false
@@ -342,7 +334,7 @@ socks = ["socksio (>=1.0.0,<2.0.0)"]
 
 [[package]]
 name = "identify"
-version = "2.5.3"
+version = "2.5.5"
 description = "File identification library for Python"
 category = "dev"
 optional = false
@@ -457,7 +449,7 @@ pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
 
 [[package]]
 name = "pathspec"
-version = "0.10.0"
+version = "0.10.1"
 description = "Utility library for gitignore style pattern matching of file paths."
 category = "dev"
 optional = false
@@ -529,7 +521,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "pydantic"
-version = "1.10.1"
+version = "1.10.2"
 description = "Data validation and settings management using python type hints"
 category = "main"
 optional = false
@@ -588,14 +580,13 @@ diagrams = ["railroad-diagrams", "jinja2"]
 
 [[package]]
 name = "pytest"
-version = "7.1.2"
+version = "7.1.3"
 description = "pytest: simple powerful testing with Python"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 
 [package.dependencies]
-atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
 attrs = ">=19.2.0"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
 iniconfig = "*"
@@ -652,11 +643,11 @@ dev = ["pre-commit", "tox", "pytest-asyncio"]
 
 [[package]]
 name = "python-dotenv"
-version = "0.20.0"
+version = "0.21.0"
 description = "Read key-value pairs from a .env file and set them as environment variables"
 category = "main"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.7"
 
 [package.extras]
 cli = ["click (>=5.0)"]
@@ -718,7 +709,7 @@ jupyter = ["ipywidgets (>=7.5.1,<8.0.0)"]
 
 [[package]]
 name = "sentry-sdk"
-version = "1.9.6"
+version = "1.9.8"
 description = "Python client for Sentry (https://sentry.io)"
 category = "main"
 optional = false
@@ -759,11 +750,11 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "sniffio"
-version = "1.2.0"
+version = "1.3.0"
 description = "Sniff out which async library your code is running under"
 category = "main"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.7"
 
 [[package]]
 name = "snowballstemmer"
@@ -917,7 +908,7 @@ python-versions = ">=3.7"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "01f4d306395cf88ffec636431eda27c474f1c9176355faa0c9c7df1b08c5bdbb"
+content-hash = "72143d5c0db91fae4a5253184ff971cf66372a29495425915cffd48d9d2c7ac6"
 
 [metadata.files]
 aiodogstatsd = [
@@ -932,9 +923,6 @@ asgi-correlation-id = [
     {file = "asgi-correlation-id-3.0.1.tar.gz", hash = "sha256:8e79ce4556f480cfd7be20504665afc3595dddd0c716d631f3c2c1900514a54f"},
     {file = "asgi_correlation_id-3.0.1-py3-none-any.whl", hash = "sha256:f8c64b34bc41d08cd373f80daacf1c6163c69e60e6a653dc10d28c0567f4c2bc"},
 ]
-atomicwrites = [
-    {file = "atomicwrites-1.4.1.tar.gz", hash = "sha256:81b2c9071a49367a7f770170e5eec8cb66567cfbbc8c73d20ce5ca4a8d71cf11"},
-]
 attrs = [
     {file = "attrs-22.1.0-py2.py3-none-any.whl", hash = "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"},
     {file = "attrs-22.1.0.tar.gz", hash = "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6"},
@@ -948,29 +936,29 @@ bandit = [
     {file = "bandit-1.7.4.tar.gz", hash = "sha256:2d63a8c573417bae338962d4b9b06fbc6080f74ecd955a092849e1e65c717bd2"},
 ]
 black = [
-    {file = "black-22.6.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:f586c26118bc6e714ec58c09df0157fe2d9ee195c764f630eb0d8e7ccce72e69"},
-    {file = "black-22.6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b270a168d69edb8b7ed32c193ef10fd27844e5c60852039599f9184460ce0807"},
-    {file = "black-22.6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:6797f58943fceb1c461fb572edbe828d811e719c24e03375fd25170ada53825e"},
-    {file = "black-22.6.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c85928b9d5f83b23cee7d0efcb310172412fbf7cb9d9ce963bd67fd141781def"},
-    {file = "black-22.6.0-cp310-cp310-win_amd64.whl", hash = "sha256:f6fe02afde060bbeef044af7996f335fbe90b039ccf3f5eb8f16df8b20f77666"},
-    {file = "black-22.6.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:cfaf3895a9634e882bf9d2363fed5af8888802d670f58b279b0bece00e9a872d"},
-    {file = "black-22.6.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:94783f636bca89f11eb5d50437e8e17fbc6a929a628d82304c80fa9cd945f256"},
-    {file = "black-22.6.0-cp36-cp36m-win_amd64.whl", hash = "sha256:2ea29072e954a4d55a2ff58971b83365eba5d3d357352a07a7a4df0d95f51c78"},
-    {file = "black-22.6.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:e439798f819d49ba1c0bd9664427a05aab79bfba777a6db94fd4e56fae0cb849"},
-    {file = "black-22.6.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:187d96c5e713f441a5829e77120c269b6514418f4513a390b0499b0987f2ff1c"},
-    {file = "black-22.6.0-cp37-cp37m-win_amd64.whl", hash = "sha256:074458dc2f6e0d3dab7928d4417bb6957bb834434516f21514138437accdbe90"},
-    {file = "black-22.6.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:a218d7e5856f91d20f04e931b6f16d15356db1c846ee55f01bac297a705ca24f"},
-    {file = "black-22.6.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:568ac3c465b1c8b34b61cd7a4e349e93f91abf0f9371eda1cf87194663ab684e"},
-    {file = "black-22.6.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:6c1734ab264b8f7929cef8ae5f900b85d579e6cbfde09d7387da8f04771b51c6"},
-    {file = "black-22.6.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c9a3ac16efe9ec7d7381ddebcc022119794872abce99475345c5a61aa18c45ad"},
-    {file = "black-22.6.0-cp38-cp38-win_amd64.whl", hash = "sha256:b9fd45787ba8aa3f5e0a0a98920c1012c884622c6c920dbe98dbd05bc7c70fbf"},
-    {file = "black-22.6.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:7ba9be198ecca5031cd78745780d65a3f75a34b2ff9be5837045dce55db83d1c"},
-    {file = "black-22.6.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:a3db5b6409b96d9bd543323b23ef32a1a2b06416d525d27e0f67e74f1446c8f2"},
-    {file = "black-22.6.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:560558527e52ce8afba936fcce93a7411ab40c7d5fe8c2463e279e843c0328ee"},
-    {file = "black-22.6.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b154e6bbde1e79ea3260c4b40c0b7b3109ffcdf7bc4ebf8859169a6af72cd70b"},
-    {file = "black-22.6.0-cp39-cp39-win_amd64.whl", hash = "sha256:4af5bc0e1f96be5ae9bd7aaec219c901a94d6caa2484c21983d043371c733fc4"},
-    {file = "black-22.6.0-py3-none-any.whl", hash = "sha256:ac609cf8ef5e7115ddd07d85d988d074ed00e10fbc3445aee393e70164a2219c"},
-    {file = "black-22.6.0.tar.gz", hash = "sha256:6c6d39e28aed379aec40da1c65434c77d75e65bb59a1e1c283de545fb4e7c6c9"},
+    {file = "black-22.8.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ce957f1d6b78a8a231b18e0dd2d94a33d2ba738cd88a7fe64f53f659eea49fdd"},
+    {file = "black-22.8.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5107ea36b2b61917956d018bd25129baf9ad1125e39324a9b18248d362156a27"},
+    {file = "black-22.8.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e8166b7bfe5dcb56d325385bd1d1e0f635f24aae14b3ae437102dedc0c186747"},
+    {file = "black-22.8.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd82842bb272297503cbec1a2600b6bfb338dae017186f8f215c8958f8acf869"},
+    {file = "black-22.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:d839150f61d09e7217f52917259831fe2b689f5c8e5e32611736351b89bb2a90"},
+    {file = "black-22.8.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:a05da0430bd5ced89176db098567973be52ce175a55677436a271102d7eaa3fe"},
+    {file = "black-22.8.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4a098a69a02596e1f2a58a2a1c8d5a05d5a74461af552b371e82f9fa4ada8342"},
+    {file = "black-22.8.0-cp36-cp36m-win_amd64.whl", hash = "sha256:5594efbdc35426e35a7defa1ea1a1cb97c7dbd34c0e49af7fb593a36bd45edab"},
+    {file = "black-22.8.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:a983526af1bea1e4cf6768e649990f28ee4f4137266921c2c3cee8116ae42ec3"},
+    {file = "black-22.8.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b2c25f8dea5e8444bdc6788a2f543e1fb01494e144480bc17f806178378005e"},
+    {file = "black-22.8.0-cp37-cp37m-win_amd64.whl", hash = "sha256:78dd85caaab7c3153054756b9fe8c611efa63d9e7aecfa33e533060cb14b6d16"},
+    {file = "black-22.8.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:cea1b2542d4e2c02c332e83150e41e3ca80dc0fb8de20df3c5e98e242156222c"},
+    {file = "black-22.8.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:5b879eb439094751185d1cfdca43023bc6786bd3c60372462b6f051efa6281a5"},
+    {file = "black-22.8.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:0a12e4e1353819af41df998b02c6742643cfef58282915f781d0e4dd7a200411"},
+    {file = "black-22.8.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c3a73f66b6d5ba7288cd5d6dad9b4c9b43f4e8a4b789a94bf5abfb878c663eb3"},
+    {file = "black-22.8.0-cp38-cp38-win_amd64.whl", hash = "sha256:e981e20ec152dfb3e77418fb616077937378b322d7b26aa1ff87717fb18b4875"},
+    {file = "black-22.8.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:8ce13ffed7e66dda0da3e0b2eb1bdfc83f5812f66e09aca2b0978593ed636b6c"},
+    {file = "black-22.8.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:32a4b17f644fc288c6ee2bafdf5e3b045f4eff84693ac069d87b1a347d861497"},
+    {file = "black-22.8.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:0ad827325a3a634bae88ae7747db1a395d5ee02cf05d9aa7a9bd77dfb10e940c"},
+    {file = "black-22.8.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:53198e28a1fb865e9fe97f88220da2e44df6da82b18833b588b1883b16bb5d41"},
+    {file = "black-22.8.0-cp39-cp39-win_amd64.whl", hash = "sha256:bc4d4123830a2d190e9cc42a2e43570f82ace35c3aeb26a512a2102bce5af7ec"},
+    {file = "black-22.8.0-py3-none-any.whl", hash = "sha256:d2c21d439b2baf7aa80d6dd4e3659259be64c6f49dfd0f32091063db0e006db4"},
+    {file = "black-22.8.0.tar.gz", hash = "sha256:792f7eb540ba9a17e8656538701d3eb1afcb134e3b45b71f20b25c77a8db7e6e"},
 ]
 certifi = [
     {file = "certifi-2022.6.15-py3-none-any.whl", hash = "sha256:fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412"},
@@ -1129,8 +1117,8 @@ httpx = [
     {file = "httpx-0.23.0.tar.gz", hash = "sha256:f28eac771ec9eb4866d3fb4ab65abd42d38c424739e80c08d8d20570de60b0ef"},
 ]
 identify = [
-    {file = "identify-2.5.3-py2.py3-none-any.whl", hash = "sha256:25851c8c1370effb22aaa3c987b30449e9ff0cece408f810ae6ce408fdd20893"},
-    {file = "identify-2.5.3.tar.gz", hash = "sha256:887e7b91a1be152b0d46bbf072130235a8117392b9f1828446079a816a05ef44"},
+    {file = "identify-2.5.5-py2.py3-none-any.whl", hash = "sha256:ef78c0d96098a3b5fe7720be4a97e73f439af7cf088ebf47b620aeaa10fadf97"},
+    {file = "identify-2.5.5.tar.gz", hash = "sha256:322a5699daecf7c6fd60e68852f36f2ecbb6a36ff6e6e973e0d2bb6fca203ee6"},
 ]
 idna = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
@@ -1193,8 +1181,8 @@ packaging = [
     {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
 ]
 pathspec = [
-    {file = "pathspec-0.10.0-py3-none-any.whl", hash = "sha256:aefa80ac32d5bf1f96139dca67cefb69a431beff4e6bf1168468f37d7ab87015"},
-    {file = "pathspec-0.10.0.tar.gz", hash = "sha256:01eecd304ba0e6eeed188ae5fa568e99ef10265af7fd9ab737d6412b4ee0ab85"},
+    {file = "pathspec-0.10.1-py3-none-any.whl", hash = "sha256:46846318467efc4556ccfd27816e004270a9eeeeb4d062ce5e6fc7a87c573f93"},
+    {file = "pathspec-0.10.1.tar.gz", hash = "sha256:7ace6161b621d31e7902eb6b5ae148d12cfd23f4a249b9ffb6b9fee12084323d"},
 ]
 pbr = [
     {file = "pbr-5.10.0-py2.py3-none-any.whl", hash = "sha256:da3e18aac0a3c003e9eea1a81bd23e5a3a75d745670dcf736317b7d966887fdf"},
@@ -1221,42 +1209,42 @@ pycodestyle = [
     {file = "pycodestyle-2.8.0.tar.gz", hash = "sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f"},
 ]
 pydantic = [
-    {file = "pydantic-1.10.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:221166d99726238f71adc4fa9f3e94063a10787574b966f86a774559e709ac5a"},
-    {file = "pydantic-1.10.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a90e85d95fd968cd7cae122e0d3e0e1f6613bc88c1ff3fe838ac9785ea4b1c4c"},
-    {file = "pydantic-1.10.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f2157aaf5718c648eaec9e654a34179ae42ffc363dc3ad058538a4f3ecbd9341"},
-    {file = "pydantic-1.10.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6142246fc9adb51cadaeb84fb52a86f3adad4c6a7b0938a5dd0b1356b0088217"},
-    {file = "pydantic-1.10.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:60dad97a09b6f44690c05467a4f397b62bfc2c839ac39102819d6979abc2be0d"},
-    {file = "pydantic-1.10.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:d6f5bcb59d33ec46621dae76e714c53035087666cac80c81c9047a84f3ff93d0"},
-    {file = "pydantic-1.10.1-cp310-cp310-win_amd64.whl", hash = "sha256:522906820cd60e63c7960ba83078bf2d2ad2dd0870bf68248039bcb1ec3eb0a4"},
-    {file = "pydantic-1.10.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d545c89d88bdd5559db17aeb5a61a26799903e4bd76114779b3bf1456690f6ce"},
-    {file = "pydantic-1.10.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ad2374b5b3b771dcc6e2f6e0d56632ab63b90e9808b7a73ad865397fcdb4b2cd"},
-    {file = "pydantic-1.10.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90e02f61b7354ed330f294a437d0bffac9e21a5d46cb4cc3c89d220e497db7ac"},
-    {file = "pydantic-1.10.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cc5ffe7bd0b4778fa5b7a5f825c52d6cfea3ae2d9b52b05b9b1d97e36dee23a8"},
-    {file = "pydantic-1.10.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:7acb7b66ffd2bc046eaff0063df84c83fc3826722d5272adaeadf6252e17f691"},
-    {file = "pydantic-1.10.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:7e6786ed5faa559dea5a77f6d2de9a08d18130de9344533535d945f34bdcd42e"},
-    {file = "pydantic-1.10.1-cp311-cp311-win_amd64.whl", hash = "sha256:c7bf8ff1d18186eb0cbe42bd9bfb4cbf7fde1fd01b8608925458990c21f202f0"},
-    {file = "pydantic-1.10.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:14a5babda137a294df7ad5f220986d79bbb87fdeb332c6ded61ce19da7f5f3bf"},
-    {file = "pydantic-1.10.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5659cb9c6b3d27fc0067025c4f5a205f5e838232a4a929b412781117c2343d44"},
-    {file = "pydantic-1.10.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c8d70fb91b03c32d2e857b071a22a5225e6b625ca82bd2cc8dd729d88e0bd200"},
-    {file = "pydantic-1.10.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:9a93be313e40f12c6f2cb84533b226bbe23d0774872e38d83415e6890215e3a6"},
-    {file = "pydantic-1.10.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:d55aeb01bb7bd7c7e1bd904668a4a2ffcbb1c248e7ae9eb40a272fd7e67dd98b"},
-    {file = "pydantic-1.10.1-cp37-cp37m-win_amd64.whl", hash = "sha256:43d41b6f13706488e854729955ba8f740e6ec375cd16b72b81dc24b9d84f0d15"},
-    {file = "pydantic-1.10.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:f31ffe0e38805a0e6410330f78147bb89193b136d7a5f79cae60d3e849b520a6"},
-    {file = "pydantic-1.10.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:8eee69eda7674977b079a21e7bf825b59d8bf15145300e8034ed3eb239ac444f"},
-    {file = "pydantic-1.10.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6f927bff6c319fc92e0a2cbeb2609b5c1cd562862f4b54ec905e353282b7c8b1"},
-    {file = "pydantic-1.10.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:eb1bc3f8fef6ba36977108505e90558911e7fbccb4e930805d5dd90891b56ff4"},
-    {file = "pydantic-1.10.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:96ab6ce1346d14c6e581a69c333bdd1b492df9cf85ad31ad77a8aa42180b7e09"},
-    {file = "pydantic-1.10.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:444cf220a12134da1cd42fe4f45edff622139e10177ce3d8ef2b4f41db1291b2"},
-    {file = "pydantic-1.10.1-cp38-cp38-win_amd64.whl", hash = "sha256:dbfbff83565b4514dd8cebc8b8c81a12247e89427ff997ad0a9da7b2b1065c12"},
-    {file = "pydantic-1.10.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:5327406f4bfd5aee784e7ad2a6a5fdd7171c19905bf34cb1994a1ba73a87c468"},
-    {file = "pydantic-1.10.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:1072eae28bf034a311764c130784e8065201a90edbca10f495c906737b3bd642"},
-    {file = "pydantic-1.10.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ce901335667a68dfbc10dd2ee6c0d676b89210d754441c2469fbc37baf7ee2ed"},
-    {file = "pydantic-1.10.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:54d6465cd2112441305faf5143a491b40de07a203116b5755a2108e36b25308d"},
-    {file = "pydantic-1.10.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:2b5e5e7a0ec96704099e271911a1049321ba1afda92920df0769898a7e9a1298"},
-    {file = "pydantic-1.10.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:ae43704358304da45c1c3dd7056f173c618b252f91594bcb6d6f6b4c6c284dee"},
-    {file = "pydantic-1.10.1-cp39-cp39-win_amd64.whl", hash = "sha256:2d7da49229ffb1049779a5a6c1c50a26da164bd053cf8ee9042197dc08a98259"},
-    {file = "pydantic-1.10.1-py3-none-any.whl", hash = "sha256:f8b10e59c035ff3dcc9791619d6e6c5141e0fa5cbe264e19e267b8d523b210bf"},
-    {file = "pydantic-1.10.1.tar.gz", hash = "sha256:d41bb80347a8a2d51fbd6f1748b42aca14541315878447ba159617544712f770"},
+    {file = "pydantic-1.10.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bb6ad4489af1bac6955d38ebcb95079a836af31e4c4f74aba1ca05bb9f6027bd"},
+    {file = "pydantic-1.10.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a1f5a63a6dfe19d719b1b6e6106561869d2efaca6167f84f5ab9347887d78b98"},
+    {file = "pydantic-1.10.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:352aedb1d71b8b0736c6d56ad2bd34c6982720644b0624462059ab29bd6e5912"},
+    {file = "pydantic-1.10.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:19b3b9ccf97af2b7519c42032441a891a5e05c68368f40865a90eb88833c2559"},
+    {file = "pydantic-1.10.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:e9069e1b01525a96e6ff49e25876d90d5a563bc31c658289a8772ae186552236"},
+    {file = "pydantic-1.10.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:355639d9afc76bcb9b0c3000ddcd08472ae75318a6eb67a15866b87e2efa168c"},
+    {file = "pydantic-1.10.2-cp310-cp310-win_amd64.whl", hash = "sha256:ae544c47bec47a86bc7d350f965d8b15540e27e5aa4f55170ac6a75e5f73b644"},
+    {file = "pydantic-1.10.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a4c805731c33a8db4b6ace45ce440c4ef5336e712508b4d9e1aafa617dc9907f"},
+    {file = "pydantic-1.10.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d49f3db871575e0426b12e2f32fdb25e579dea16486a26e5a0474af87cb1ab0a"},
+    {file = "pydantic-1.10.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:37c90345ec7dd2f1bcef82ce49b6235b40f282b94d3eec47e801baf864d15525"},
+    {file = "pydantic-1.10.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7b5ba54d026c2bd2cb769d3468885f23f43710f651688e91f5fb1edcf0ee9283"},
+    {file = "pydantic-1.10.2-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:05e00dbebbe810b33c7a7362f231893183bcc4251f3f2ff991c31d5c08240c42"},
+    {file = "pydantic-1.10.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:2d0567e60eb01bccda3a4df01df677adf6b437958d35c12a3ac3e0f078b0ee52"},
+    {file = "pydantic-1.10.2-cp311-cp311-win_amd64.whl", hash = "sha256:c6f981882aea41e021f72779ce2a4e87267458cc4d39ea990729e21ef18f0f8c"},
+    {file = "pydantic-1.10.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c4aac8e7103bf598373208f6299fa9a5cfd1fc571f2d40bf1dd1955a63d6eeb5"},
+    {file = "pydantic-1.10.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:81a7b66c3f499108b448f3f004801fcd7d7165fb4200acb03f1c2402da73ce4c"},
+    {file = "pydantic-1.10.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bedf309630209e78582ffacda64a21f96f3ed2e51fbf3962d4d488e503420254"},
+    {file = "pydantic-1.10.2-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:9300fcbebf85f6339a02c6994b2eb3ff1b9c8c14f502058b5bf349d42447dcf5"},
+    {file = "pydantic-1.10.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:216f3bcbf19c726b1cc22b099dd409aa371f55c08800bcea4c44c8f74b73478d"},
+    {file = "pydantic-1.10.2-cp37-cp37m-win_amd64.whl", hash = "sha256:dd3f9a40c16daf323cf913593083698caee97df2804aa36c4b3175d5ac1b92a2"},
+    {file = "pydantic-1.10.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b97890e56a694486f772d36efd2ba31612739bc6f3caeee50e9e7e3ebd2fdd13"},
+    {file = "pydantic-1.10.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:9cabf4a7f05a776e7793e72793cd92cc865ea0e83a819f9ae4ecccb1b8aa6116"},
+    {file = "pydantic-1.10.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:06094d18dd5e6f2bbf93efa54991c3240964bb663b87729ac340eb5014310624"},
+    {file = "pydantic-1.10.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cc78cc83110d2f275ec1970e7a831f4e371ee92405332ebfe9860a715f8336e1"},
+    {file = "pydantic-1.10.2-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:1ee433e274268a4b0c8fde7ad9d58ecba12b069a033ecc4645bb6303c062d2e9"},
+    {file = "pydantic-1.10.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:7c2abc4393dea97a4ccbb4ec7d8658d4e22c4765b7b9b9445588f16c71ad9965"},
+    {file = "pydantic-1.10.2-cp38-cp38-win_amd64.whl", hash = "sha256:0b959f4d8211fc964772b595ebb25f7652da3f22322c007b6fed26846a40685e"},
+    {file = "pydantic-1.10.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c33602f93bfb67779f9c507e4d69451664524389546bacfe1bee13cae6dc7488"},
+    {file = "pydantic-1.10.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:5760e164b807a48a8f25f8aa1a6d857e6ce62e7ec83ea5d5c5a802eac81bad41"},
+    {file = "pydantic-1.10.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6eb843dcc411b6a2237a694f5e1d649fc66c6064d02b204a7e9d194dff81eb4b"},
+    {file = "pydantic-1.10.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4b8795290deaae348c4eba0cebb196e1c6b98bdbe7f50b2d0d9a4a99716342fe"},
+    {file = "pydantic-1.10.2-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:e0bedafe4bc165ad0a56ac0bd7695df25c50f76961da29c050712596cf092d6d"},
+    {file = "pydantic-1.10.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:2e05aed07fa02231dbf03d0adb1be1d79cabb09025dd45aa094aa8b4e7b9dcda"},
+    {file = "pydantic-1.10.2-cp39-cp39-win_amd64.whl", hash = "sha256:c1ba1afb396148bbc70e9eaa8c06c1716fdddabaf86e7027c5988bae2a829ab6"},
+    {file = "pydantic-1.10.2-py3-none-any.whl", hash = "sha256:1b6ee725bd6e83ec78b1aa32c5b1fa67a3a65badddde3976bca5fe4568f27709"},
+    {file = "pydantic-1.10.2.tar.gz", hash = "sha256:91b8e218852ef6007c2b98cd861601c6a09f1aa32bbbb74fab5b1c33d4a1e410"},
 ]
 pydocstyle = [
     {file = "pydocstyle-6.1.1-py3-none-any.whl", hash = "sha256:6987826d6775056839940041beef5c08cc7e3d71d63149b48e36727f70144dc4"},
@@ -1275,8 +1263,8 @@ pyparsing = [
     {file = "pyparsing-3.0.9.tar.gz", hash = "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb"},
 ]
 pytest = [
-    {file = "pytest-7.1.2-py3-none-any.whl", hash = "sha256:13d0e3ccfc2b6e26be000cb6568c832ba67ba32e719443bfe725814d3c42433c"},
-    {file = "pytest-7.1.2.tar.gz", hash = "sha256:a06a0425453864a270bc45e71f783330a7428defb4230fb5e6a731fde06ecd45"},
+    {file = "pytest-7.1.3-py3-none-any.whl", hash = "sha256:1377bda3466d70b55e3f5cecfa55bb7cfcf219c7964629b967c37cf0bda818b7"},
+    {file = "pytest-7.1.3.tar.gz", hash = "sha256:4f365fec2dff9c1162f834d9f18af1ba13062db0c708bf7b946f8a5c76180c39"},
 ]
 pytest-asyncio = [
     {file = "pytest-asyncio-0.19.0.tar.gz", hash = "sha256:ac4ebf3b6207259750bc32f4c1d8fcd7e79739edbc67ad0c58dd150b1d072fed"},
@@ -1291,8 +1279,8 @@ pytest-mock = [
     {file = "pytest_mock-3.8.2-py3-none-any.whl", hash = "sha256:8a9e226d6c0ef09fcf20c94eb3405c388af438a90f3e39687f84166da82d5948"},
 ]
 python-dotenv = [
-    {file = "python-dotenv-0.20.0.tar.gz", hash = "sha256:b7e3b04a59693c42c36f9ab1cc2acc46fa5df8c78e178fc33a8d4cd05c8d498f"},
-    {file = "python_dotenv-0.20.0-py3-none-any.whl", hash = "sha256:d92a187be61fe482e4fd675b6d52200e7be63a12b724abbf931a40ce4fa92938"},
+    {file = "python-dotenv-0.21.0.tar.gz", hash = "sha256:b77d08274639e3d34145dfa6c7008e66df0f04b7be7a75fd0d5292c191d79045"},
+    {file = "python_dotenv-0.21.0-py3-none-any.whl", hash = "sha256:1684eb44636dd462b66c3ee016599815514527ad99965de77f43e0944634a7e5"},
 ]
 pyyaml = [
     {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},
@@ -1342,16 +1330,16 @@ rich = [
     {file = "rich-12.5.1.tar.gz", hash = "sha256:63a5c5ce3673d3d5fbbf23cd87e11ab84b6b451436f1b7f19ec54b6bc36ed7ca"},
 ]
 sentry-sdk = [
-    {file = "sentry-sdk-1.9.6.tar.gz", hash = "sha256:f713f33ff7f82658c30e7e8cdec72c432218e6dd41b0f004905733793bd9719b"},
-    {file = "sentry_sdk-1.9.6-py2.py3-none-any.whl", hash = "sha256:630faec958e09b1151d88b8655bb749274c6b1acd19baa6f7a5ec3106276f752"},
+    {file = "sentry-sdk-1.9.8.tar.gz", hash = "sha256:ef4b4d57631662ff81e15c22bf007f7ce07c47321648c8e601fbd22950ed1a79"},
+    {file = "sentry_sdk-1.9.8-py2.py3-none-any.whl", hash = "sha256:7378c08d81da78a4860da7b4900ac51fef38be841d01bc5b7cb249ac51e070c6"},
 ]
 smmap = [
     {file = "smmap-5.0.0-py3-none-any.whl", hash = "sha256:2aba19d6a040e78d8b09de5c57e96207b09ed71d8e55ce0959eeee6c8e190d94"},
     {file = "smmap-5.0.0.tar.gz", hash = "sha256:c840e62059cd3be204b0c9c9f74be2c09d5648eddd4580d9314c3ecde0b30936"},
 ]
 sniffio = [
-    {file = "sniffio-1.2.0-py3-none-any.whl", hash = "sha256:471b71698eac1c2112a40ce2752bb2f4a4814c22a54a3eed3676bc0f5ca9f663"},
-    {file = "sniffio-1.2.0.tar.gz", hash = "sha256:c4666eecec1d3f50960c6bdf61ab7bc350648da6c126e3cf6898d8cd4ddcd3de"},
+    {file = "sniffio-1.3.0-py3-none-any.whl", hash = "sha256:eecefdce1e5bbfb7ad2eeaabf7c1eeb404d7757c379bd1f7e5cce9d8bf425384"},
+    {file = "sniffio-1.3.0.tar.gz", hash = "sha256:e60305c5e5d314f5389259b7f22aaa33d8f7dee49763119234af3755c55b9101"},
 ]
 snowballstemmer = [
     {file = "snowballstemmer-2.2.0-py2.py3-none-any.whl", hash = "sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,4 +1,16 @@
 [[package]]
+name = "aiodogstatsd"
+version = "0.16.0.post0"
+description = "An asyncio-based client for sending metrics to StatsD with support of DogStatsD extension"
+category = "main"
+optional = false
+python-versions = ">=3.7,<4.0"
+
+[package.extras]
+aiohttp = ["aiohttp (>=3.0)"]
+starlette = ["starlette (>=0.13)"]
+
+[[package]]
 name = "anyio"
 version = "3.6.1"
 description = "High level compatibility layer for multiple asynchronous event loop implementations"
@@ -908,6 +920,10 @@ python-versions = "^3.10"
 content-hash = "01f4d306395cf88ffec636431eda27c474f1c9176355faa0c9c7df1b08c5bdbb"
 
 [metadata.files]
+aiodogstatsd = [
+    {file = "aiodogstatsd-0.16.0.post0-py3-none-any.whl", hash = "sha256:82000e6da599aee92e3c129d8cdf05cd102e2ac7a8a7da7ec07a16967031c865"},
+    {file = "aiodogstatsd-0.16.0.post0.tar.gz", hash = "sha256:f783c7d6d74edd160b34141ff5f069c9a935bb32636823e39e36f0d1dbe14931"},
+]
 anyio = [
     {file = "anyio-3.6.1-py3-none-any.whl", hash = "sha256:cb29b9c70620506a9a8f87a309591713446953302d7d995344d0d7c6c0c9a7be"},
     {file = "anyio-3.6.1.tar.gz", hash = "sha256:413adf95f93886e442aea925f3ee43baa5a765a64a0f52c6081894f9992fdd0b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ httpx = "^0.23.0"
 maxminddb = "^2.2.0"
 sentry-sdk = {extras = ["fastapi"], version = "^1.9.5"}
 kinto-http = "^11.0.0"
+aiodogstatsd = "^0.16.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.2"

--- a/tests/test_config_logging.py
+++ b/tests/test_config_logging.py
@@ -17,13 +17,13 @@ def test_invalid_format():
 
 
 def test_mozlog_production():
-    settings.configure(FORCE_ENV_FOR_DYNACONF="production")
-    old_format = settings.logging.format
-    settings.logging.format = "pretty"
+    with settings.using_env("production"):
+        old_format = settings.logging.format
+        settings.logging.format = "pretty"
 
-    with pytest.raises(ValueError) as excinfo:
-        configure_logging()
+        with pytest.raises(ValueError) as excinfo:
+            configure_logging()
 
-    assert "Log format must be 'mozlog' in production" in str(excinfo)
+        assert "Log format must be 'mozlog' in production" in str(excinfo)
 
-    settings.logging.format = old_format
+        settings.logging.format = old_format

--- a/tests/web/test_metrics.py
+++ b/tests/web/test_metrics.py
@@ -6,7 +6,6 @@ from fastapi.testclient import TestClient
 
 from merino.main import app
 from merino.providers import get_providers
-from merino.web import api_v1
 from tests.web.util import CorruptProvider, get_provider_factory
 
 client = TestClient(app)
@@ -14,9 +13,11 @@ client = TestClient(app)
 
 @pytest.fixture()
 def corrupt_provider():
-    app.dependency_overrides[get_providers] = get_provider_factory({
-        "corrupt": CorruptProvider(),
-    })
+    app.dependency_overrides[get_providers] = get_provider_factory(
+        {
+            "corrupt": CorruptProvider(),
+        }
+    )
     yield
     del app.dependency_overrides[get_providers]
 
@@ -50,7 +51,8 @@ def test_metrics(url, metric_keys):
             reporter.assert_any_call(metric, mock.ANY, mock.ANY, mock.ANY, mock.ANY)
 
 
-def test_metrics_500(mocker, corrupt_provider):
+@pytest.mark.usefixtures("corrupt_provider")
+def test_metrics_500(mocker):
     error_msg = "test"
     metric_keys = [
         "get.api.v1.suggest.timing",

--- a/tests/web/test_metrics.py
+++ b/tests/web/test_metrics.py
@@ -1,53 +1,39 @@
-from logging import LogRecord
+import unittest.mock as mock
 
+import aiodogstatsd
 import pytest
 from fastapi.testclient import TestClient
 
 from merino.main import app
-from merino.metrics import configure_metrics, get_client
+from merino.metrics import get_metrics_client
 from merino.providers import get_providers
 from tests.web.util import get_providers as override_dependency
 
 app.dependency_overrides[get_providers] = override_dependency
 client = TestClient(app)
-metrics_client = get_client()
+metrics_client = get_metrics_client()
 
 
 @pytest.mark.parametrize(
-    "url,metric,expected_count",
+    "url,metric_keys",
     [
-        ("/api/v1/suggest?q=none", "get.api.v1.suggest.timing", 1),
-        ("/api/v1/suggest?q=none", "get.api.v1.suggest.status_codes.200", 1),
-        ("/api/v1/no", "get.api.v1.no.timing", 1),
-        ("/api/v1/no", "get.api.v1.no.status_codes.404", 1),
-        ("/api/v1/suggest", "get.api.v1.suggest.timing", 1),
-        ("/api/v1/suggest", "get.api.v1.suggest.status_codes.400", 1),
+        (
+            "/api/v1/suggest?q=none",
+            ["get.api.v1.suggest.timing", "get.api.v1.suggest.status_codes.200"],
+        ),
+        (
+            "/api/v1/nonono",
+            ["get.api.v1.nonono.timing", "get.api.v1.nonono.status_codes.404"],
+        ),
+        (
+            "/api/v1/suggest",
+            ["get.api.v1.suggest.timing", "get.api.v1.suggest.status_codes.400"],
+        ),
     ],
 )
-@pytest.mark.asyncio
-async def test_metrics(caplog, url, metric, expected_count):
-    import logging
+def test_metrics_spy(url, metric_keys):
 
-    caplog.set_level(logging.DEBUG)
-
-    await configure_metrics()
-    client.get(url)
-    await metrics_client.close()
-
-    # assertions
-    metrics = _parse_metrics(caplog.records)
-    assert metric in metrics
-    assert len(metrics[metric]) == expected_count
-
-
-def _parse_metrics(records: list[LogRecord]) -> dict[str, list]:
-    metrics = {}
-    for rec in filter(lambda r: r.name == "merino.metrics", records):
-        parts = rec.__dict__.get("data", "").split("|")
-        key, value = parts[0].split(":")
-        details = {"value": value, "type": parts[1], "tags": parts[2]}
-        if key in metrics:
-            metrics[key].append(details)
-        else:
-            metrics[key] = [details]
-    return metrics
+    with mock.patch.object(aiodogstatsd.Client, "_report") as reporter:
+        client.get(url)
+        for metric in metric_keys:
+            reporter.assert_any_call(metric, mock.ANY, mock.ANY, mock.ANY, mock.ANY)

--- a/tests/web/test_metrics.py
+++ b/tests/web/test_metrics.py
@@ -22,19 +22,13 @@ metrics_client = get_client()
         ("/api/v1/no", "get.api.v1.no.status_codes.404", 1),
         ("/api/v1/suggest", "get.api.v1.suggest.timing", 1),
         ("/api/v1/suggest", "get.api.v1.suggest.status_codes.400", 1),
-        ("/api/v1/providers", "get.api.v1.providers.timing", 1),
-        # ("/api/v1/providers", "get.api.v1.providers.status_codes.500", 1),
     ],
 )
 @pytest.mark.asyncio
-async def test_metrics(mocker, caplog, url, metric, expected_count):
+async def test_metrics(caplog, url, metric, expected_count):
     import logging
 
     caplog.set_level(logging.DEBUG)
-
-    if "providers" in url:
-        mock_endpoint = mocker.patch("merino.web.api_v1.providers")
-        mock_endpoint.side_effect = KeyError("nope")
 
     await configure_metrics()
     client.get(url)

--- a/tests/web/test_metrics.py
+++ b/tests/web/test_metrics.py
@@ -1,0 +1,52 @@
+from logging import LogRecord
+
+import pytest
+from fastapi.testclient import TestClient
+
+from merino.main import app
+from merino.metrics import configure_metrics, get_client
+from merino.providers import get_providers
+from tests.web.util import get_providers as override_dependency
+
+app.dependency_overrides[get_providers] = override_dependency
+client = TestClient(app)
+metrics_client = get_client()
+
+
+# # The first two IP addresses are taken from `GeoLite2-City-Test.mmdb`
+@pytest.mark.parametrize(
+    "url,metric,expected_count",
+    [
+        ("/api/v1/suggest?q=none", "api.v1.suggest.timing", 1),
+        ("/api/v1/suggest?q=none", "api.v1.suggest.status_codes.200", 1),
+        ("/api/v1/no", "api.v1.no.timing", 1),
+        ("/api/v1/no", "api.v1.no.status_codes.404", 1),
+    ],
+)
+@pytest.mark.asyncio
+async def test_metrics(caplog, url, metric, expected_count):
+    import logging
+
+    caplog.set_level(logging.DEBUG)
+
+    await configure_metrics()
+    client.get(url)
+    await metrics_client.close()
+
+    # assertions
+    metrics = _parse_metrics(caplog.records)
+    assert metric in metrics
+    assert len(metrics[metric]) == expected_count
+
+
+def _parse_metrics(records: list[LogRecord]) -> dict[str, list]:
+    metrics = {}
+    for rec in filter(lambda r: r.name == "merino.metrics", records):
+        parts = rec.__dict__.get("data", "").split("|")
+        key, value = parts[0].split(":")
+        details = {"value": value, "type": parts[1], "tags": parts[2]}
+        if key in metrics:
+            metrics[key].append(details)
+        else:
+            metrics[key] = [details]
+    return metrics

--- a/tests/web/test_metrics.py
+++ b/tests/web/test_metrics.py
@@ -7,6 +7,7 @@ from fastapi.testclient import TestClient
 from merino.main import app
 from merino.metrics import get_metrics_client
 from merino.providers import get_providers
+from merino.web import api_v1
 from tests.web.util import get_providers as override_dependency
 
 app.dependency_overrides[get_providers] = override_dependency
@@ -29,6 +30,10 @@ metrics_client = get_metrics_client()
             "/api/v1/suggest",
             ["get.api.v1.suggest.timing", "get.api.v1.suggest.status_codes.400"],
         ),
+        (
+            "/__error__",
+            ["get.__error__.timing", "get.__error__.status_codes.500"],
+        ),
     ],
 )
 def test_metrics_spy(url, metric_keys):
@@ -37,3 +42,24 @@ def test_metrics_spy(url, metric_keys):
         client.get(url)
         for metric in metric_keys:
             reporter.assert_any_call(metric, mock.ANY, mock.ANY, mock.ANY, mock.ANY)
+
+
+def test_metrics_side_effect(mocker):
+    error_msg = "Error creating ProviderResponse model instance"
+    metric_keys = [
+        "get.api.v1.providers.timing",
+        "get.api.v1.providers.status_codes.500",
+    ]
+
+    mocker.patch.object(
+        api_v1, "ProviderResponse", side_effect=RuntimeError(error_msg), autospec=True
+    )
+    reporter = mocker.patch.object(aiodogstatsd.Client, "_report")
+
+    with pytest.raises(RuntimeError) as excinfo:
+        client.get("/api/v1/providers")
+
+    for metric in metric_keys:
+        reporter.assert_any_call(metric, mock.ANY, mock.ANY, mock.ANY, mock.ANY)
+
+    assert str(excinfo.value) == error_msg

--- a/tests/web/test_wiki_fruit.py
+++ b/tests/web/test_wiki_fruit.py
@@ -11,9 +11,11 @@ client = TestClient(app)
 
 @pytest.fixture(scope="module", autouse=True)
 def inject_providers():
-    app.dependency_overrides[get_providers] = get_provider_factory({
-        "wiki_fruit": WikiFruitProvider(),
-    })
+    app.dependency_overrides[get_providers] = get_provider_factory(
+        {
+            "wiki_fruit": WikiFruitProvider(),
+        }
+    )
     yield
     del app.dependency_overrides[get_providers]
 

--- a/tests/web/test_wiki_fruit.py
+++ b/tests/web/test_wiki_fruit.py
@@ -3,14 +3,17 @@ from fastapi.testclient import TestClient
 
 from merino.main import app
 from merino.providers import get_providers
-from tests.web.util import get_wiki_fruit_provider
+from merino.providers.wiki_fruit import WikiFruitProvider
+from tests.web.util import get_provider_factory
 
 client = TestClient(app)
 
 
 @pytest.fixture(scope="module", autouse=True)
 def inject_providers():
-    app.dependency_overrides[get_providers] = get_wiki_fruit_provider
+    app.dependency_overrides[get_providers] = get_provider_factory({
+        "wiki_fruit": WikiFruitProvider(),
+    })
     yield
     del app.dependency_overrides[get_providers]
 

--- a/tests/web/util.py
+++ b/tests/web/util.py
@@ -3,7 +3,6 @@ from collections.abc import Callable, Coroutine
 from typing import Any
 
 from merino.providers.base import BaseProvider
-from merino.providers.wiki_fruit import WikiFruitProvider
 
 
 class SponsoredProvider(BaseProvider):
@@ -107,6 +106,7 @@ def get_provider_factory(
     ..., Coroutine[Any, Any, tuple[dict[str, BaseProvider], list[BaseProvider]]]
 ]:
     """Returns a callable that builds and initializes the given providers."""
+
     async def provider_factory() -> tuple[dict[str, BaseProvider], list[BaseProvider]]:
         await asyncio.gather(*[p.initialize() for p in providers.values()])
         default_providers = [p for p in providers.values() if p.enabled_by_default()]
@@ -119,7 +119,9 @@ async def get_providers() -> tuple[dict[str, BaseProvider], list[BaseProvider]]:
     """
     Return a tuple of all the providers and default providers.
     """
-    return await get_provider_factory({
-        "sponsored-provider": SponsoredProvider(),
-        "nonsponsored-provider": NonsponsoredProvider(),
-    })()
+    return await get_provider_factory(
+        {
+            "sponsored-provider": SponsoredProvider(),
+            "nonsponsored-provider": NonsponsoredProvider(),
+        }
+    )()

--- a/tests/web/util.py
+++ b/tests/web/util.py
@@ -1,4 +1,5 @@
 import asyncio
+from collections.abc import Callable, Coroutine
 from typing import Any
 
 from merino.providers.base import BaseProvider
@@ -79,28 +80,46 @@ class NonsponsoredProvider(BaseProvider):
             return []
 
 
+class CorruptProvider(BaseProvider):
+    """
+    A test nonsponsored provider that only responds to query "nonsponsored".
+    """
+
+    def __init__(self) -> None:
+        ...
+
+    async def initialize(self) -> None:
+        ...
+
+    def enabled_by_default(self) -> bool:
+        return True
+
+    def hidden(self) -> bool:
+        return False
+
+    async def query(self, q: str) -> list[dict[str, Any]]:
+        raise RuntimeError(q)
+
+
+def get_provider_factory(
+    providers: dict[str, BaseProvider]
+) -> Callable[
+    ..., Coroutine[Any, Any, tuple[dict[str, BaseProvider], list[BaseProvider]]]
+]:
+    """Returns a callable that builds and initializes the given providers."""
+    async def provider_factory() -> tuple[dict[str, BaseProvider], list[BaseProvider]]:
+        await asyncio.gather(*[p.initialize() for p in providers.values()])
+        default_providers = [p for p in providers.values() if p.enabled_by_default()]
+        return providers, default_providers
+
+    return provider_factory
+
+
 async def get_providers() -> tuple[dict[str, BaseProvider], list[BaseProvider]]:
     """
     Return a tuple of all the providers and default providers.
     """
-    providers = {
+    return await get_provider_factory({
         "sponsored-provider": SponsoredProvider(),
         "nonsponsored-provider": NonsponsoredProvider(),
-    }
-    await asyncio.gather(*[p.initialize() for p in providers.values()])
-    default_providers = [p for p in providers.values() if p.enabled_by_default()]
-    return providers, default_providers
-
-
-async def get_wiki_fruit_provider() -> tuple[
-    dict[str, BaseProvider], list[BaseProvider]
-]:
-    """
-    A test provider for WikiFruit.
-    """
-    providers = {
-        "wiki_fruit": WikiFruitProvider(),
-    }
-    await asyncio.gather(*[p.initialize() for p in providers.values()])
-    default_providers = [p for p in providers.values() if p.enabled_by_default()]
-    return providers, default_providers
+    })()

--- a/tests/web/util.py
+++ b/tests/web/util.py
@@ -1,6 +1,5 @@
 import asyncio
-from collections.abc import Callable, Coroutine
-from typing import Any
+from typing import Any, Callable, Coroutine
 
 from merino.providers.base import BaseProvider
 
@@ -81,7 +80,7 @@ class NonsponsoredProvider(BaseProvider):
 
 class CorruptProvider(BaseProvider):
     """
-    A test nonsponsored provider that only responds to query "nonsponsored".
+    A test corrupted provider that raises `RuntimeError` for all queries received.
     """
 
     def __init__(self) -> None:


### PR DESCRIPTION
Adding metrics for merino. Currently the following are instrumented:
* Total provider initialization timing
* Individual provider initialization timing
* Total request timing (including middleware)
* Count of request status codes (per url path)
* Total provider query timing 
* Individual provider timing

Novel thing here is monkeypatching a local logger for dev that does not send messages across the upd socket and insteads logs the metrics. I like the visibility in development so if there's a better way please let me know.

