### PR TITLE
[CONSVC-1932] Refactor provider to depend on RS backend protocol

### DIFF
--- a/merino/providers/__init__.py
+++ b/merino/providers/__init__.py
@@ -23,7 +23,7 @@ async def init_providers() -> None:
     """
     start = timer()
 
-    providers["adm"] = AdmProvider(rs_client=remotesettings.Client())
+    providers["adm"] = AdmProvider(backend=remotesettings.LiveBackend())
 
     if settings.providers.wiki_fruit.enabled:
         providers["wiki_fruit"] = WikiFruitProvider()

--- a/merino/providers/__init__.py
+++ b/merino/providers/__init__.py
@@ -3,6 +3,7 @@ import asyncio
 import logging
 from timeit import default_timer as timer
 
+from merino import remotesettings
 from merino.config import settings
 from merino.providers.adm import Provider as AdmProvider
 from merino.providers.base import BaseProvider
@@ -21,9 +22,12 @@ async def init_providers() -> None:
     This should only be called once at the startup of application.
     """
     start = timer()
-    providers["adm"] = AdmProvider()
+
+    providers["adm"] = AdmProvider(rs_client=remotesettings.Client())
+
     if settings.providers.wiki_fruit.enabled:
         providers["wiki_fruit"] = WikiFruitProvider()
+
     await asyncio.gather(*[p.initialize() for p in providers.values()])
     default_providers.extend([p for p in providers.values() if p.enabled_by_default()])
     logger.info(

--- a/merino/providers/adm.py
+++ b/merino/providers/adm.py
@@ -30,7 +30,7 @@ class RemoteSettingsBackend(Protocol):
         ...
 
     async def fetch_attachment(
-        self, attachement_uri: Any
+        self, attachment_uri: Any
     ) -> httpx.Response:  # pragma: no cover
         """Fetch the attachment for the given URI."""
         ...

--- a/merino/providers/base.py
+++ b/merino/providers/base.py
@@ -7,7 +7,7 @@ class BaseProvider(ABC):
     """Abstract class for suggestion providers."""
 
     @abstractmethod
-    async def initialize(self, **kwargs: Any) -> None:
+    async def initialize(self) -> None:
         """
         Abstract method for defining an initialize method for bootstrapping the Provider.
         This allows us to use Async API's within as well as initialize providers in parallel

--- a/merino/providers/base.py
+++ b/merino/providers/base.py
@@ -7,7 +7,7 @@ class BaseProvider(ABC):
     """Abstract class for suggestion providers."""
 
     @abstractmethod
-    async def initialize(self) -> None:
+    async def initialize(self, **kwargs: Any) -> None:
         """
         Abstract method for defining an initialize method for bootstrapping the Provider.
         This allows us to use Async API's within as well as initialize providers in parallel

--- a/merino/remotesettings.py
+++ b/merino/remotesettings.py
@@ -1,4 +1,5 @@
 """A thin wrapper around the Remote Settings client."""
+from typing import Any
 from urllib.parse import urljoin
 
 import httpx
@@ -7,8 +8,8 @@ import kinto_http
 from merino.config import settings
 
 
-class Client:
-    """A utility class for Remote Settings client."""
+class LiveBackend:
+    """Backend that connects to a live Remote Settings server."""
 
     client: kinto_http.AsyncClient
     attachment_host: str = ""
@@ -22,7 +23,7 @@ class Client:
         server_info = await self.client.server_info()
         return server_info["capabilities"]["attachments"]["base_url"]
 
-    async def get(self, bucket, collection) -> list[dict]:
+    async def get(self, bucket: str, collection: str) -> list[dict[str, Any]]:
         """Get records from Remote Settings server.
 
         Args:

--- a/merino/remotesettings.py
+++ b/merino/remotesettings.py
@@ -32,7 +32,7 @@ class LiveBackend:
         """
         return await self.client.get_records(collection=collection, bucket=bucket)
 
-    async def fetch_attachment(self, attachement_uri) -> httpx.Response:
+    async def fetch_attachment(self, attachment_uri) -> httpx.Response:
         """Fetch an attachment from Remote Settings server for a given URI.
 
         Args:
@@ -40,7 +40,7 @@ class LiveBackend:
         """
         if not self.attachment_host:
             self.attachment_host = await self.fetch_attachment_host()
-        uri = urljoin(self.attachment_host, attachement_uri)
+        uri = urljoin(self.attachment_host, attachment_uri)
         async with httpx.AsyncClient() as client:
             return await client.get(uri)
 

--- a/tests/providers/test_adm.py
+++ b/tests/providers/test_adm.py
@@ -60,7 +60,7 @@ class FakeBackend:
             },
         ]
 
-    async def fetch_attachment(self, attachement_uri: Any) -> httpx.Response:
+    async def fetch_attachment(self, attachment_uri: Any) -> httpx.Response:
         """Return a fake attachment for the given URI."""
 
         attachments = {
@@ -87,7 +87,7 @@ class FakeBackend:
             },
         }
 
-        return httpx.Response(200, text=json.dumps([attachments[attachement_uri]]))
+        return httpx.Response(200, text=json.dumps([attachments[attachment_uri]]))
 
     def get_icon_url(self, icon_uri: str) -> str:
         """Return a fake icon URL for the given URI."""

--- a/tests/providers/test_adm.py
+++ b/tests/providers/test_adm.py
@@ -1,0 +1,135 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+
+from merino.providers.adm import Provider
+
+
+class FakeRSClient:
+    """Fake Remote Settings client that returns suggest data for tests."""
+
+    async def get(self, bucket: Any, collection: Any) -> list[dict[Any, Any]]:
+        """Return fake records.."""
+
+        return [
+            {
+                "type": "data",
+                "schema": 123,
+                "attachment": {
+                    "hash": "abcd",
+                    "size": 1,
+                    "filename": "data-01.json",
+                    "location": "main-workspace/quicksuggest/attachmment-01.json",
+                    "mimetype": "application/octet-stream",
+                },
+                "id": "data-01",
+                "last_modified": 123,
+            },
+            {
+                "type": "offline-expansion-data",
+                "schema": 111,
+                "attachment": {
+                    "hash": "efgh",
+                    "size": 1,
+                    "filename": "offline-expansion-data-01.json",
+                    "location": "main-workspace/quicksuggest/attachment-02.json",
+                    "mimetype": "application/octet-stream",
+                },
+                "id": "offline-expansion-data-01",
+                "last_modified": 123,
+            },
+            {
+                "type": "icon",
+                "schema": 456,
+                "attachment": {
+                    "hash": "efghabcasd",
+                    "size": 1,
+                    "filename": "icon-01",
+                    "location": "main-workspace/quicksuggest/icon-01",
+                    "mimetype": "application/octet-stream",
+                },
+                "content_type": "image/png",
+                "id": "icon-01",
+                "last_modified": 123,
+            },
+        ]
+
+    async def fetch_attachment(self, attachement_uri: Any) -> httpx.Response:
+        """Return a fake attachment for the given URI."""
+
+        attachments = {
+            "main-workspace/quicksuggest/attachmment-01.json": {
+                "id": 1,
+                "url": "https://example.com/target/helloworld",
+                "click_url": "https://example.com/click/helloworld",
+                "impression_url": "https://example.com/impression/helloworld",
+                "iab_category": "22 - Shopping",
+                "icon": "01",
+                "advertiser": "Example.com",
+                "title": "Hello World",
+                "keywords": ["hello", "world", "hello world"],
+            },
+            "main-workspace/quicksuggest/attachment-02.json": {
+                "id": 2,
+                "url": "https://example.org/target/banana",
+                "click_url": "https://example.org/click/banana",
+                "iab_category": "5 - Education",
+                "icon": "01",
+                "advertiser": "Example.org",
+                "title": "Hello Banana",
+                "keywords": ["hello", "banana", "hello banana"],
+            },
+        }
+
+        return httpx.Response(200, text=json.dumps([attachments[attachement_uri]]))
+
+    def get_icon_url(self, icon_uri: str) -> str:
+        """Return a fake icon URL for the given URI."""
+
+        return f"attachment-host/{icon_uri}"
+
+
+@pytest.fixture(name="adm")
+def fixture_adm() -> Provider:
+    """Return an adM provider that uses a fake remote settings client."""
+
+    return Provider(rs_client=FakeRSClient())
+
+
+def test_enabled_by_default(adm: Provider) -> None:
+    """Test for the enabled_by_default method."""
+
+    assert adm.enabled_by_default() is True
+
+
+def test_hidden(adm: Provider) -> None:
+    """Test for the hidden method."""
+
+    assert adm.hidden() is False
+
+
+@pytest.mark.asyncio
+async def test_initialize(adm: Provider) -> None:
+    """Test for the the initialize() method of the adM provider."""
+
+    await adm.initialize()
+
+    assert adm.suggestions == {"banana": 0, "hello": 0, "hello banana": 0}
+    assert adm.results == [
+        {
+            "id": 2,
+            "url": "https://example.org/target/banana",
+            "click_url": "https://example.org/click/banana",
+            "iab_category": "5 - Education",
+            "icon": "01",
+            "advertiser": "Example.org",
+            "title": "Hello Banana",
+        }
+    ]
+    assert adm.icons == {1: "attachment-host/main-workspace/quicksuggest/icon-01"}

--- a/tests/providers/test_adm.py
+++ b/tests/providers/test_adm.py
@@ -11,8 +11,8 @@ import pytest
 from merino.providers.adm import Provider
 
 
-class FakeRSClient:
-    """Fake Remote Settings client that returns suggest data for tests."""
+class FakeBackend:
+    """Fake Remote Settings backend that returns suggest data for tests."""
 
     async def get(self, bucket: Any, collection: Any) -> list[dict[Any, Any]]:
         """Return fake records."""
@@ -99,7 +99,7 @@ class FakeRSClient:
 def fixture_adm() -> Provider:
     """Return an adM provider that uses a fake remote settings client."""
 
-    return Provider(rs_client=FakeRSClient())
+    return Provider(backend=FakeBackend())
 
 
 def test_enabled_by_default(adm: Provider) -> None:

--- a/tests/providers/test_adm.py
+++ b/tests/providers/test_adm.py
@@ -15,7 +15,7 @@ class FakeRSClient:
     """Fake Remote Settings client that returns suggest data for tests."""
 
     async def get(self, bucket: Any, collection: Any) -> list[dict[Any, Any]]:
-        """Return fake records.."""
+        """Return fake records."""
 
         return [
             {
@@ -116,7 +116,7 @@ def test_hidden(adm: Provider) -> None:
 
 @pytest.mark.asyncio
 async def test_initialize(adm: Provider) -> None:
-    """Test for the the initialize() method of the adM provider."""
+    """Test for the initialize() method of the adM provider."""
 
     await adm.initialize()
 


### PR DESCRIPTION
## Description

Following the theme of #33, this pull request refactors the adm provider to improve testability.

It updates the provider to explicitly define the interfaces/protocols it depends on. This allows us to set up a fake remote settings client that implements that interface and use that in automated tests. It returns fake data that we can use to verify the provider implementation.

Outside of tests, we pass the live remote settings client to the provider (see `merino/providers/__init__.py`).

This pull request increases the test coverage for `merino/providers/adm.py` from 37% to 91%. I recommend adding unit tests for the `query()` method in a separate pull request. 🤖 

## Issue(s)

[CONSVC-1932](https://mozilla-hub.atlassian.net/browse/CONSVC-1932)
