### PR TITLE
fix: resolve formatting issues in pre-commit config file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,40 +1,48 @@
 default_language_version:
   python: python3.10
 repos:
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.3.0
-  hooks:
-  - id: trailing-whitespace
-  - id: end-of-file-fixer
-  - id: check-added-large-files
-- repo: https://github.com/psf/black
-  rev: 22.6.0
-  hooks:
-  - id: black
-- repo: https://github.com/pycqa/flake8
-  rev: 4.0.1
-  hooks:
-  - id: flake8
-- repo: https://github.com/pycqa/isort
-  rev: 5.10.1
-  hooks:
-  - id: isort
-- repo: https://github.com/pycqa/bandit
-  rev: 1.7.4
-  hooks:
-   - id: bandit
-     # skips asserts https://bandit.readthedocs.io/en/1.7.4/plugins/b101_assert_used.html#
-     args: [--skip, "B101"]
-# - repo: https://github.com/pre-commit/mirrors-mypy
-  # rev: v0.961
-  # hooks:
-  # - id: mypy
-    # exclude: tests/
-    # args: ["--ignore-missing-imports", "--follow-imports=skip", "--no-strict-optional"]
- - repo: https://github.com/pycqa/pydocstyle
-   rev: 6.1.1
-   hooks:
-   - id: pydocstyle
-     exclude: tests/
-     args: [--convention, "pep257", --add-ignore, "D203,D205,D400"]
-
+  - repo: 'https://github.com/pre-commit/pre-commit-hooks'
+    rev: v4.3.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-added-large-files
+  - repo: 'https://github.com/psf/black'
+    rev: 22.6.0
+    hooks:
+      - id: black
+  - repo: 'https://github.com/pycqa/flake8'
+    rev: 4.0.1
+    hooks:
+      - id: flake8
+  - repo: 'https://github.com/pycqa/isort'
+    rev: 5.10.1
+    hooks:
+      - id: isort
+  - repo: 'https://github.com/pycqa/bandit'
+    rev: 1.7.4
+    hooks:
+      - id: bandit
+        # skips asserts https://bandit.readthedocs.io/en/1.7.4/plugins/b101_assert_used.html#
+        args:
+          - '--skip'
+          - B101
+  - repo: 'https://github.com/pycqa/pydocstyle'
+    rev: 6.1.1
+    hooks:
+      - id: pydocstyle
+        exclude: tests/
+        args:
+          - '--convention'
+          - pep257
+          - '--add-ignore'
+          - 'D203,D205,D400'
+  # - repo: 'https://github.com/pre-commit/mirrors-mypy'
+  #   rev: v0.961
+  #   hooks:
+  #     - id: mypy
+  #       exclude: tests/
+  #       args:
+  #         - '--ignore-missing-imports'
+  #         - '--follow-imports=skip'
+  #         - '--no-strict-optional'


### PR DESCRIPTION
I was unable to create new commits after rebasing to the latest `main` branch with pre-commit installed and enabled.

This pull request resolves the indentation issue with the `pydocstyle` object. I also ran the config through a YAML autoformatter for consistent formatting.
