### PR TITLE
[CONSVC-1935] feat: Parse & log user agent

### DIFF
--- a/merino/main.py
+++ b/merino/main.py
@@ -10,7 +10,7 @@ from merino import providers
 from merino.config_logging import configure_logging
 from merino.config_sentry import configure_sentry
 from merino.metrics import configure_metrics, get_metrics_client
-from merino.middleware import featureflags, geolocation, logging, metrics
+from merino.middleware import featureflags, geolocation, logging, metrics, user_agent
 from merino.web import api_v1, dockerflow
 
 app = FastAPI()
@@ -58,6 +58,7 @@ app.add_middleware(metrics.MetricsMiddleware)
 app.add_middleware(CorrelationIdMiddleware)
 app.add_middleware(featureflags.FeatureFlagsMiddleware)
 app.add_middleware(geolocation.GeolocationMiddleware)
+app.add_middleware(user_agent.UserAgentMiddleware)
 app.add_middleware(logging.LoggingMiddleware)
 
 app.include_router(dockerflow.router)

--- a/merino/middleware/logging.py
+++ b/merino/middleware/logging.py
@@ -55,7 +55,7 @@ class LoggingMiddleware(BaseHTTPMiddleware):
             suggest_request_logger.info("", extra=data)
         else:
             data = {
-                "agent": request.headers["User-Agent"],
+                "agent": request.headers.get("User-Agent"),
                 "path": request.url.path,
                 "method": request.method,
                 "lang": request.headers.get("Accept-Language"),

--- a/merino/middleware/logging.py
+++ b/merino/middleware/logging.py
@@ -48,6 +48,9 @@ class LoggingMiddleware(BaseHTTPMiddleware):
                 "requested_providers": request.query_params.get("providers", "").split(
                     ","
                 ),
+                "browser": request.state.user_agent.browser,
+                "os_family": request.state.user_agent.os_family,
+                "form_factor": request.state.user_agent.form_factor,
             }
             suggest_request_logger.info("", extra=data)
         else:

--- a/merino/middleware/user_agent.py
+++ b/merino/middleware/user_agent.py
@@ -1,0 +1,115 @@
+"""The middleware that parses the "User-Agent" from the HTTP request header.
+
+Note that Merino is a service made for Firefox users, this middleware only
+focuses on Firefox related user agents.
+"""
+from typing import Any
+
+from pydantic import BaseModel
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from ua_parser import user_agent_parser
+
+
+class UserAgent(BaseModel):
+    """Data model for user agent information.
+
+    `browser`: The browser and possibly the version if detected. E.g. 'Firefox(104.0.1)'.
+               'Other' is used if the browser cannot be parsed.
+    `os_family`: The OS family, One of "windows", "macos", "linux", "ios", "android",
+                 "chromeos", or "other".
+    `form_factor`: One of "desktop", "phone", "tablet", or "other".
+    """
+
+    browser: str
+    os_family: str
+    form_factor: str
+
+
+class UserAgentMiddleware(BaseHTTPMiddleware):
+    """A middleware to populate user agent information from the HTTP request header.
+
+    The parsed result `UserAgent` is stored in `Request.state.user_agent`.
+    """
+
+    async def dispatch(self, request: Request, call_next):
+        """Provide user agent information before handling request"""
+        browser, os_family, form_factor = UserAgentMiddleware.parse(
+            request.headers["User-Agent"]
+        )
+        request.state.user_agent = UserAgent(
+            browser=browser, os_family=os_family, form_factor=form_factor
+        )
+
+        return await call_next(request)
+
+    @staticmethod
+    def parse(ua_str: str) -> tuple[str, str, str]:
+        """Parse the "User-Agent" string for browser, os family, and form factor."""
+        ua = user_agent_parser.Parse(ua_str)
+        browser = UserAgentMiddleware._parse_browser(ua["user_agent"])
+        os_family = UserAgentMiddleware._parse_os_family(ua["os"])
+        form_factor = UserAgentMiddleware._parse_form_factor(ua["device"], os_family)
+        return browser, os_family, form_factor
+
+    @staticmethod
+    def _parse_browser(user_agent: dict[str, Any]) -> str:
+        """Parse the browser family and version from the user agent dictionary."""
+        match user_agent:
+            case {
+                "family": "Firefox"
+                | "Firefox iOS"
+                | "Firefox Mobile"
+                | "Firefox Alpha",
+                "major": major,
+                "minor": minor,
+                "patch": patch,
+            }:
+                version = f"{major or ''}.{minor or ''}.{patch or ''}"
+                return "Firefox" if major is None else f"Firefox({version.rstrip('.')})"
+            case {"family": browser}:
+                # Do not bother parsing the browser version for non-Firefox user agents.
+                return browser
+            case _:
+                return "Other"
+
+    @staticmethod
+    def _parse_os_family(operating_system: dict[str, Any]) -> str:
+        """Parse the OS family from the os dictionary."""
+        match operating_system:
+            case {"family": "Windows"}:
+                return "windows"
+            case {"family": "iOS"}:
+                return "ios"
+            case {"family": "Mac OS X"}:
+                return "macos"
+            case {"family": "Android"}:
+                return "android"
+            case {"family": "Chrome OS"}:
+                return "chromeos"
+            case {"family": "Ubuntu" | "Fedora" | "Debian" | "Arch Linux" | "Linux"}:
+                # This should cover the most of main-stream Linux distros
+                return "linux"
+            case _:
+                return "other"
+
+    @staticmethod
+    def _parse_form_factor(device: dict[str, Any], os_family: str) -> str:
+        """Parse the form factor from the device dictionary.
+
+        It akes an extra argument `os_family` to facilitate parsing for Windows
+        and Linux form factors, as the underlying parser doesn't support well
+        for those two platforms.
+        """
+        match device:
+            case {"family": "iPhone" | "Generic Smartphone"}:
+                return "phone"
+            case {"family": "iPad" | "Generic Tablet"}:
+                return "tablet"
+            case {"family": "Mac"}:
+                return "desktop"
+            case {"family": "Other"} if os_family in ["linux", "windows"]:
+                # Hardcode to "desktop" if the os_family is Linux or Windows
+                return "desktop"
+            case _:
+                return "other"

--- a/merino/middleware/user_agent.py
+++ b/merino/middleware/user_agent.py
@@ -3,12 +3,11 @@
 Note that Merino is a service made for Firefox users, this middleware only
 focuses on Firefox related user agents.
 """
-from typing import Any
-
 from pydantic import BaseModel
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
-from ua_parser import user_agent_parser
+
+from merino.util.user_agent_parsing import parse
 
 
 class UserAgent(BaseModel):
@@ -34,82 +33,8 @@ class UserAgentMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request: Request, call_next):
         """Provide user agent information before handling request"""
-        browser, os_family, form_factor = UserAgentMiddleware.parse(
-            request.headers["User-Agent"]
-        )
-        request.state.user_agent = UserAgent(
-            browser=browser, os_family=os_family, form_factor=form_factor
-        )
+        ua = parse(request.headers.get("User-Agent", ""))
+
+        request.state.user_agent = UserAgent(**ua)
 
         return await call_next(request)
-
-    @staticmethod
-    def parse(ua_str: str) -> tuple[str, str, str]:
-        """Parse the "User-Agent" string for browser, os family, and form factor."""
-        ua = user_agent_parser.Parse(ua_str)
-        browser = UserAgentMiddleware._parse_browser(ua["user_agent"])
-        os_family = UserAgentMiddleware._parse_os_family(ua["os"])
-        form_factor = UserAgentMiddleware._parse_form_factor(ua["device"], os_family)
-        return browser, os_family, form_factor
-
-    @staticmethod
-    def _parse_browser(user_agent: dict[str, Any]) -> str:
-        """Parse the browser family and version from the user agent dictionary."""
-        match user_agent:
-            case {
-                "family": "Firefox"
-                | "Firefox iOS"
-                | "Firefox Mobile"
-                | "Firefox Alpha",
-                "major": major,
-                "minor": minor,
-                "patch": patch,
-            }:
-                version = f"{major or ''}.{minor or ''}.{patch or ''}"
-                return "Firefox" if major is None else f"Firefox({version.rstrip('.')})"
-            case {"family": browser}:
-                # Do not bother parsing the browser version for non-Firefox user agents.
-                return browser
-            case _:  # pragma: no cover
-                return "Other"
-
-    @staticmethod
-    def _parse_os_family(operating_system: dict[str, Any]) -> str:
-        """Parse the OS family from the os dictionary."""
-        match operating_system:
-            case {"family": "Windows"}:
-                return "windows"
-            case {"family": "iOS"}:
-                return "ios"
-            case {"family": "Mac OS X"}:
-                return "macos"
-            case {"family": "Android"}:
-                return "android"
-            case {"family": "Chrome OS"}:
-                return "chromeos"
-            case {"family": "Ubuntu" | "Fedora" | "Debian" | "Arch Linux" | "Linux"}:
-                # This should cover the most of main-stream Linux distros
-                return "linux"
-            case _:
-                return "other"
-
-    @staticmethod
-    def _parse_form_factor(device: dict[str, Any], os_family: str) -> str:
-        """Parse the form factor from the device dictionary.
-
-        It akes an extra argument `os_family` to facilitate parsing for Windows
-        and Linux form factors, as the underlying parser doesn't support well
-        for those two platforms.
-        """
-        match device:
-            case {"family": "iPhone" | "Generic Smartphone"}:
-                return "phone"
-            case {"family": "iPad" | "Generic Tablet"}:
-                return "tablet"
-            case {"family": "Mac"}:
-                return "desktop"
-            case {"family": "Other"} if os_family in ["linux", "windows"]:
-                # Hardcode to "desktop" if the os_family is Linux or Windows
-                return "desktop"
-            case _:
-                return "other"

--- a/merino/middleware/user_agent.py
+++ b/merino/middleware/user_agent.py
@@ -70,7 +70,7 @@ class UserAgentMiddleware(BaseHTTPMiddleware):
             case {"family": browser}:
                 # Do not bother parsing the browser version for non-Firefox user agents.
                 return browser
-            case _:
+            case _:  # pragma: no cover
                 return "Other"
 
     @staticmethod

--- a/merino/util/__init__.py
+++ b/merino/util/__init__.py
@@ -1,0 +1,1 @@
+"""The home for Merino utility modules"""

--- a/merino/util/user_agent_parsing.py
+++ b/merino/util/user_agent_parsing.py
@@ -1,0 +1,75 @@
+"""A utility module for user agent parsing."""
+from typing import Any
+
+from ua_parser import user_agent_parser
+
+
+def parse(ua_str: str) -> dict[str, str]:
+    """Parse the "User-Agent" string for browser, os family, and form factor.
+
+    It returns a dict with `browser`, `family`, and `form_factor` keys.
+    """
+    ua: dict[str, Any] = user_agent_parser.Parse(ua_str)
+    browser = _parse_browser(ua["user_agent"])
+    os_family = _parse_os_family(ua["os"])
+    form_factor = _parse_form_factor(ua["device"], os_family)
+    return {"browser": browser, "os_family": os_family, "form_factor": form_factor}
+
+
+def _parse_browser(user_agent: dict[str, Any]) -> str:
+    """Parse the browser family and version from the user agent dictionary."""
+    match user_agent:
+        case {
+            "family": "Firefox" | "Firefox iOS" | "Firefox Mobile" | "Firefox Alpha",
+            "major": major,
+            "minor": minor,
+            "patch": patch,
+        }:
+            version = f"{major or ''}.{minor or ''}.{patch or ''}"
+            return "Firefox" if major is None else f"Firefox({version.rstrip('.')})"
+        case {"family": browser}:
+            # Do not bother parsing the browser version for non-Firefox user agents.
+            return browser
+        case _:  # pragma: no cover
+            return "Other"
+
+
+def _parse_os_family(operating_system: dict[str, Any]) -> str:
+    """Parse the OS family from the os dictionary."""
+    match operating_system:
+        case {"family": "Windows"}:
+            return "windows"
+        case {"family": "iOS"}:
+            return "ios"
+        case {"family": "Mac OS X"}:
+            return "macos"
+        case {"family": "Android"}:
+            return "android"
+        case {"family": "Chrome OS"}:
+            return "chromeos"
+        case {"family": "Ubuntu" | "Fedora" | "Debian" | "Arch Linux" | "Linux"}:
+            # This should cover most of main-stream Linux distros
+            return "linux"
+        case _:
+            return "other"
+
+
+def _parse_form_factor(device: dict[str, Any], os_family: str) -> str:
+    """Parse the form factor from the device dictionary.
+
+    It takes an extra argument `os_family` to facilitate parsing for Windows
+    and Linux form factors, as the underlying parser doesn't support well
+    for those two platforms.
+    """
+    match device:
+        case {"family": "iPhone" | "Generic Smartphone"}:
+            return "phone"
+        case {"family": "iPad" | "Generic Tablet"}:
+            return "tablet"
+        case {"family": "Mac"}:
+            return "desktop"
+        case {"family": "Other"} if os_family in ["linux", "windows"]:
+            # Hardcode to "desktop" if the os_family is Linux or Windows
+            return "desktop"
+        case _:
+            return "other"

--- a/poetry.lock
+++ b/poetry.lock
@@ -814,6 +814,14 @@ optional = false
 python-versions = ">=3.7"
 
 [[package]]
+name = "ua-parser"
+version = "0.16.1"
+description = "Python port of Browserscope's user agent parser"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "unidecode"
 version = "1.3.4"
 description = "ASCII transliterations of Unicode text"
@@ -1364,6 +1372,10 @@ tomli = [
 typing-extensions = [
     {file = "typing_extensions-4.3.0-py3-none-any.whl", hash = "sha256:25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02"},
     {file = "typing_extensions-4.3.0.tar.gz", hash = "sha256:e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6"},
+]
+ua-parser = [
+    {file = "ua-parser-0.16.1.tar.gz", hash = "sha256:ed3efc695f475ffe56248c9789b3016247e9c20e3556cfa4d5aadc78ab4b26c6"},
+    {file = "ua_parser-0.16.1-py2.py3-none-any.whl", hash = "sha256:f97126300df8ac0f8f2c9d8559669532d626a1af529265fd253cba56e73ab36e"},
 ]
 unidecode = [
     {file = "Unidecode-1.3.4-py3-none-any.whl", hash = "sha256:afa04efcdd818a93237574791be9b2817d7077c25a068b00f8cff7baa4e59257"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ maxminddb = "^2.2.0"
 sentry-sdk = {extras = ["fastapi"], version = "^1.9.5"}
 kinto-http = "^11.0.0"
 aiodogstatsd = "^0.16.0"
+ua-parser = "^0.16.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.2"

--- a/tests/middleware/test_user_agent.py
+++ b/tests/middleware/test_user_agent.py
@@ -1,0 +1,85 @@
+import pytest
+
+from merino.middleware.user_agent import UserAgentMiddleware
+
+FIXTURE = [
+    (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 11.2; rv:85.0) Gecko/20100101 Firefox/103.0",
+        "Firefox(103.0)",
+        "macos",
+        "desktop",
+    ),
+    (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:104.0) Gecko/20100101 Firefox/104.0.1",
+        "Firefox(104.0.1)",
+        "windows",
+        "desktop",
+    ),
+    (
+        "Mozilla/5.0 (X11; Fedora; Linux x86_64; rv:82.0.1) Gecko/20100101 Firefox/106.0a1",
+        "Firefox(106.0.a1)",
+        "linux",
+        "desktop",
+    ),
+    (
+        "Mozilla/5.0 (Android 11; Mobile; rv:68.0) Gecko/68.0 Firefox/105.0",
+        "Firefox(105.0)",
+        "android",
+        "phone",
+    ),
+    (
+        "Mozilla/5.0 (Android 11; Tablet; rv:68.0) Gecko/41.0 Firefox/105.0",
+        "Firefox(105.0)",
+        "android",
+        "tablet",
+    ),
+    (
+        """
+            Mozilla/5.0 (iPhone; CPU iPhone OS 12_5_1 like Mac OS X) AppleWebKit/605.1.15
+             (KHTML, like Gecko) FxiOS/104.0 Mobile/15E148 Safari/605.1.15
+        """,
+        "Firefox(104.0)",
+        "ios",
+        "phone",
+    ),
+    (
+        """
+            Mozilla/5.0 (iPad; CPU OS 12_5_1 like Mac OS X) AppleWebKit/605.1.15
+             (KHTML, like Gecko) FxiOS/104.0 Mobile/15E148 Safari/605.1.15
+        """,
+        "Firefox(104.0)",
+        "ios",
+        "tablet",
+    ),
+    (
+        """
+            Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/605.1.15
+             (KHTML, like Gecko) Version/13.1 Safari/605.1.15
+        """,
+        "Safari",
+        "macos",
+        "desktop",
+    ),
+    (
+        """
+            Mozilla/5.0 (X11; CrOS x86_64 13816.64.0) AppleWebKit/537.36
+             (KHTML, like Gecko) Chrome/90.0.4430.100 Safari/537.36
+        """,
+        "Chrome",
+        "chromeos",
+        "other",
+    ),
+    ("curl/7.84.0", "curl", "other", "other"),
+]
+
+
+@pytest.mark.parametrize(
+    "ua,expected_browser,expected_os_family,expected_form_factor",
+    FIXTURE,
+)
+def test_ua_parsing(ua, expected_browser, expected_os_family, expected_form_factor):
+    browser, os_family, form_factor = UserAgentMiddleware.parse(ua)
+
+    assert browser == expected_browser
+    assert os_family == expected_os_family
+    assert form_factor == expected_form_factor

--- a/tests/middleware/test_user_agent.py
+++ b/tests/middleware/test_user_agent.py
@@ -34,42 +34,43 @@ FIXTURE = [
         "tablet",
     ),
     (
-        """
-            Mozilla/5.0 (iPhone; CPU iPhone OS 12_5_1 like Mac OS X) AppleWebKit/605.1.15
-             (KHTML, like Gecko) FxiOS/104.0 Mobile/15E148 Safari/605.1.15
-        """,
+        (
+            "Mozilla/5.0 (iPhone; CPU iPhone OS 12_5_1 like Mac OS X) AppleWebKit/605.1.15"
+            " (KHTML, like Gecko) FxiOS/104.0 Mobile/15E148 Safari/605.1.15"
+        ),
         "Firefox(104.0)",
         "ios",
         "phone",
     ),
     (
-        """
-            Mozilla/5.0 (iPad; CPU OS 12_5_1 like Mac OS X) AppleWebKit/605.1.15
-             (KHTML, like Gecko) FxiOS/104.0 Mobile/15E148 Safari/605.1.15
-        """,
+        (
+            "Mozilla/5.0 (iPad; CPU OS 12_5_1 like Mac OS X) AppleWebKit/605.1.15"
+            " (KHTML, like Gecko) FxiOS/104.0 Mobile/15E148 Safari/605.1.15"
+        ),
         "Firefox(104.0)",
         "ios",
         "tablet",
     ),
     (
-        """
-            Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/605.1.15
-             (KHTML, like Gecko) Version/13.1 Safari/605.1.15
-        """,
+        (
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/605.1.15"
+            " (KHTML, like Gecko) Version/13.1 Safari/605.1.15"
+        ),
         "Safari",
         "macos",
         "desktop",
     ),
     (
-        """
-            Mozilla/5.0 (X11; CrOS x86_64 13816.64.0) AppleWebKit/537.36
-             (KHTML, like Gecko) Chrome/90.0.4430.100 Safari/537.36
-        """,
+        (
+            "Mozilla/5.0 (X11; CrOS x86_64 13816.64.0) AppleWebKit/537.36"
+            " (KHTML, like Gecko) Chrome/90.0.4430.100 Safari/537.36"
+        ),
         "Chrome",
         "chromeos",
         "other",
     ),
     ("curl/7.84.0", "curl", "other", "other"),
+    ("", "Other", "other", "other"),
 ]
 
 

--- a/tests/test_user_agent.py
+++ b/tests/test_user_agent.py
@@ -1,8 +1,10 @@
 import pytest
 
-from merino.middleware.user_agent import UserAgentMiddleware
+from merino.util.user_agent_parsing import parse
 
-FIXTURE = [
+Scenario = tuple[str, str, str, str]
+
+SCENARIOS: list[Scenario] = [
     (
         "Mozilla/5.0 (Macintosh; Intel Mac OS X 11.2; rv:85.0) Gecko/20100101 Firefox/103.0",
         "Firefox(103.0)",
@@ -76,11 +78,11 @@ FIXTURE = [
 
 @pytest.mark.parametrize(
     "ua,expected_browser,expected_os_family,expected_form_factor",
-    FIXTURE,
+    SCENARIOS,
 )
 def test_ua_parsing(ua, expected_browser, expected_os_family, expected_form_factor):
-    browser, os_family, form_factor = UserAgentMiddleware.parse(ua)
+    result = parse(ua)
 
-    assert browser == expected_browser
-    assert os_family == expected_os_family
-    assert form_factor == expected_form_factor
+    assert result["browser"] == expected_browser
+    assert result["os_family"] == expected_os_family
+    assert result["form_factor"] == expected_form_factor

--- a/tests/web/test_api_v1.py
+++ b/tests/web/test_api_v1.py
@@ -3,6 +3,7 @@ from fastapi.testclient import TestClient
 
 from merino.main import app
 from merino.providers import get_providers
+from tests.web.util import filter_caplog
 from tests.web.util import get_providers as override_dependency
 
 client = TestClient(app)
@@ -96,9 +97,11 @@ def test_suggest_request_logs_contain_required_info(mocker, caplog):
         f"{root_path}?q={query}&sid={sid}&seq={seq}&client_variants={client_variants}"
     )
 
-    assert len(caplog.records) == 1
+    records = filter_caplog(caplog.records, "web.suggest.request")
 
-    record = caplog.records[0]
+    assert len(records) == 1
+
+    record = records[0]
 
     assert record.name == "web.suggest.request"
     assert record.sensitive is True
@@ -123,9 +126,11 @@ def test_non_suggest_request_logs_contain_required_info(mocker, caplog):
 
     client.get("/__heartbeat__")
 
-    assert len(caplog.records) == 1
+    records = filter_caplog(caplog.records, "request.summary")
 
-    record = caplog.records[0]
+    assert len(records) == 1
+
+    record = records[0]
 
     assert record.name == "request.summary"
     assert "country" not in record.args

--- a/tests/web/test_api_v1.py
+++ b/tests/web/test_api_v1.py
@@ -107,6 +107,9 @@ def test_suggest_request_logs_contain_required_info(mocker, caplog):
     assert record.sequence_no == seq
     assert record.query == query
     assert record.client_variants == ["foo", "bar"]
+    assert record.browser == "Other"
+    assert record.os_family == "other"
+    assert record.form_factor == "other"
 
 
 def test_non_suggest_request_logs_contain_required_info(mocker, caplog):

--- a/tests/web/test_dockerflow.py
+++ b/tests/web/test_dockerflow.py
@@ -2,6 +2,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from merino.main import app
+from tests.web.util import filter_caplog
 
 client = TestClient(app)
 
@@ -29,7 +30,7 @@ def test_heartbeats(endpoint):
     assert response.status_code == 200
 
 
-def test_error(mocker, caplog):
+def test_error(caplog):
     import logging
 
     caplog.set_level(logging.ERROR)
@@ -37,5 +38,7 @@ def test_error(mocker, caplog):
     response = client.get("/__error__")
     assert response.status_code == 500
 
-    assert len(caplog.records) == 1
-    assert caplog.messages[0] == "The __error__ endpoint was called"
+    records = filter_caplog(caplog.records, "merino.web.dockerflow")
+
+    assert len(records) == 1
+    assert records[0].message == "The __error__ endpoint was called"

--- a/tests/web/test_user_agent.py
+++ b/tests/web/test_user_agent.py
@@ -2,6 +2,7 @@ from fastapi.testclient import TestClient
 
 from merino.main import app
 from merino.providers import get_providers
+from tests.web.util import filter_caplog
 from tests.web.util import get_providers as override_dependency
 
 client = TestClient(app)
@@ -24,10 +25,32 @@ def test_user_agent_middleware(mocker, caplog):
     }
     client.get("/api/v1/suggest?q=nope", headers=headers)
 
-    assert len(caplog.records) == 1
+    records = filter_caplog(caplog.records, "web.suggest.request")
 
-    record = caplog.records[0]
+    assert len(records) == 1
 
+    record = records[0]
     assert record.browser == "Firefox(103.0)"
     assert record.os_family == "macos"
     assert record.form_factor == "desktop"
+
+
+def test_user_agent_middleware_with_missing_ua_str(mocker, caplog):
+    import logging
+
+    caplog.set_level(logging.INFO)
+
+    mock_client = mocker.patch("fastapi.Request.client")
+    mock_client.host = "127.0.0.1"
+
+    headers = {}
+    client.get("/api/v1/suggest?q=nope", headers=headers)
+
+    records = filter_caplog(caplog.records, "web.suggest.request")
+
+    assert len(records) == 1
+
+    record = records[0]
+    assert record.browser == "Other"
+    assert record.os_family == "other"
+    assert record.form_factor == "other"

--- a/tests/web/test_user_agent.py
+++ b/tests/web/test_user_agent.py
@@ -1,0 +1,33 @@
+from fastapi.testclient import TestClient
+
+from merino.main import app
+from merino.providers import get_providers
+from tests.web.util import get_providers as override_dependency
+
+client = TestClient(app)
+app.dependency_overrides[get_providers] = override_dependency
+
+
+def test_user_agent_middleware(mocker, caplog):
+    import logging
+
+    caplog.set_level(logging.INFO)
+
+    mock_client = mocker.patch("fastapi.Request.client")
+    mock_client.host = "127.0.0.1"
+
+    headers = {
+        "User-Agent": (
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 11.2;"
+            " rv:85.0) Gecko/20100101 Firefox/103.0"
+        )
+    }
+    client.get("/api/v1/suggest?q=nope", headers=headers)
+
+    assert len(caplog.records) == 1
+
+    record = caplog.records[0]
+
+    assert record.browser == "Firefox(103.0)"
+    assert record.os_family == "macos"
+    assert record.form_factor == "desktop"

--- a/tests/web/util.py
+++ b/tests/web/util.py
@@ -1,4 +1,5 @@
 import asyncio
+from logging import LogRecord
 from typing import Any, Callable, Coroutine
 
 from merino.providers.base import BaseProvider
@@ -124,3 +125,8 @@ async def get_providers() -> tuple[dict[str, BaseProvider], list[BaseProvider]]:
             "nonsponsored-provider": NonsponsoredProvider(),
         }
     )()
+
+
+def filter_caplog(records: list[LogRecord], logger_name: str) -> list[LogRecord]:
+    """Filter pytest captured log records for a given logger name."""
+    return [record for record in records if record.name == logger_name]


### PR DESCRIPTION
This adds the user agent parsing & logging feature to merino-py.

Have tried a couple of UA parsing libs: [python-user-agents](https://github.com/selwin/python-user-agents), [woothee-python](https://github.com/woothee/woothee-python), and [uap-python](https://github.com/ua-parser/uap-python). Picking uap-python as it's the fastest one (10x faster than the other two) and it's actively developed & maintained compared to others.
 
This fixes [CONSVC-1935](https://mozilla-hub.atlassian.net/browse/CONSVC-1935).