### PR TITLE
Test/add contract tests for setting refresh consvc 1866 [do not deploy]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ of `<type>: <subject>` where `type` must be one of:
   semi-colons, etc)
 * **refactor**: A code change that neither fixes a bug or adds a feature
 * **perf**: A code change that improves performance
-* **test**: Adding missing tests
+* **test**: Adding missing tests, test maintenance, and adding test features
 * **chore**: Changes to the build process or auxiliary tools and libraries such as documentation
   generation
 

--- a/test-engineering/contract-tests/volumes/client/scenarios.yml
+++ b/test-engineering/contract-tests/volumes/client/scenarios.yml
@@ -233,7 +233,7 @@ scenarios:
                 score: 0.3
 
   - name: remote_settings__refresh
-    description: Test that Merino successfully returns a refreshed output for the same suggestion search term.
+    description: Test that Merino successfully returns a refreshed output for the same suggestion search term
     steps:
       - request:
           service: kinto

--- a/test-engineering/contract-tests/volumes/client/scenarios.yml
+++ b/test-engineering/contract-tests/volumes/client/scenarios.yml
@@ -233,7 +233,9 @@ scenarios:
                 score: 0.3
 
   - name: remote_settings__refresh
-    description: Test that Merino successfully returns a refreshed output for the same suggestion search term
+    description: >
+      Test that Merino successfully returns refreshed output in the cases of /
+      suggestion content updates and additions
     steps:
       - request:
           service: kinto
@@ -265,9 +267,24 @@ scenarios:
                 provider: 'adm'
                 advertiser: 'Example.org'
                 is_sponsored: true
-                # The client test framework knows how to interpret a value of `null` for this field.
                 icon: null
                 score: 0.3
+      - request:
+          service: merino
+          method: GET
+          path: '/api/v1/suggest?q=flower'
+          headers:
+            - name: User-Agent
+              value: 'Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0'
+            - name: Accept-Language
+              value: 'en-US'
+        response:
+          status_code: 200
+          content:
+            client_variants: []
+            server_variants: []
+            request_id: null
+            suggestions: []
       - request:
           service: kinto
           filename: "data-04.json"
@@ -289,7 +306,7 @@ scenarios:
             server_variants: []
             request_id: null
             suggestions:
-              - block_id: 7
+              - block_id: 6
                 full_keyword: 'tree'
                 title: 'Tree 2'
                 url: 'https://example.org/target/tree2'
@@ -298,6 +315,32 @@ scenarios:
                 provider: 'adm'
                 advertiser: 'Example.org'
                 is_sponsored: true
-                # The client test framework knows how to interpret a value of `null` for this field.
+                icon: null
+                score: 0.3
+      - request:
+          service: merino
+          method: GET
+          path: '/api/v1/suggest?q=flower'
+          headers:
+            - name: User-Agent
+              value: 'Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0'
+            - name: Accept-Language
+              value: 'en-US'
+        response:
+          status_code: 200
+          content:
+            client_variants: []
+            server_variants: []
+            request_id: null
+            suggestions:
+              - block_id: 7
+                full_keyword: 'flower'
+                title: 'Flower'
+                url: 'https://example.org/target/flower'
+                impression_url: 'https://example.org/impression/flower'
+                click_url: 'https://example.org/click/flower'
+                provider: 'adm'
+                advertiser: 'Example.org'
+                is_sponsored: true
                 icon: null
                 score: 0.3

--- a/test-engineering/contract-tests/volumes/client/scenarios.yml
+++ b/test-engineering/contract-tests/volumes/client/scenarios.yml
@@ -290,7 +290,7 @@ scenarios:
           filename: "data-04.json"
           data_type: "data"
       - request:
-          delay: 6 # Wait for remote settings data to load into merino
+          delay: 7 # Wait for remote settings data to load into merino
           service: merino
           method: GET
           path: '/api/v1/suggest?q=tree'

--- a/test-engineering/contract-tests/volumes/client/scenarios.yml
+++ b/test-engineering/contract-tests/volumes/client/scenarios.yml
@@ -290,7 +290,7 @@ scenarios:
           filename: "data-04.json"
           data_type: "data"
       - request:
-          delay: 7 # Wait for remote settings data to load into merino
+          delay: 8 # Wait for remote settings data to load into merino
           service: merino
           method: GET
           path: '/api/v1/suggest?q=tree'

--- a/test-engineering/contract-tests/volumes/client/scenarios.yml
+++ b/test-engineering/contract-tests/volumes/client/scenarios.yml
@@ -290,7 +290,7 @@ scenarios:
           filename: "data-04.json"
           data_type: "data"
       - request:
-          delay: 5 # Wait for remote settings data to load into merino
+          delay: 6 # Wait for remote settings data to load into merino
           service: merino
           method: GET
           path: '/api/v1/suggest?q=tree'

--- a/test-engineering/contract-tests/volumes/client/scenarios.yml
+++ b/test-engineering/contract-tests/volumes/client/scenarios.yml
@@ -290,7 +290,7 @@ scenarios:
           filename: "data-04.json"
           data_type: "data"
       - request:
-          delay: 8 # Wait for remote settings data to load into merino
+          delay: 10 # Wait for remote settings data to load into merino
           service: merino
           method: GET
           path: '/api/v1/suggest?q=tree'

--- a/test-engineering/contract-tests/volumes/client/scenarios.yml
+++ b/test-engineering/contract-tests/volumes/client/scenarios.yml
@@ -260,9 +260,11 @@ scenarios:
                 full_keyword: 'tree'
                 title: 'Tree'
                 url: 'https://example.org/target/tree'
+                impression_url: 'https://example.org/impression/tree'
+                click_url: 'https://example.org/click/tree'
                 provider: 'adm'
                 advertiser: 'Example.org'
-                is_sponsored: false
+                is_sponsored: true
                 # The client test framework knows how to interpret a value of `null` for this field.
                 icon: null
                 score: 0.3
@@ -289,11 +291,13 @@ scenarios:
             suggestions:
               - block_id: 7
                 full_keyword: 'tree'
-                title: 'Tree2'
+                title: 'Tree 2'
                 url: 'https://example.org/target/tree2'
+                impression_url: 'https://example.org/impression/tree2'
+                click_url: 'https://example.org/click/tree2'
                 provider: 'adm'
                 advertiser: 'Example.org'
-                is_sponsored: false
+                is_sponsored: true
                 # The client test framework knows how to interpret a value of `null` for this field.
                 icon: null
                 score: 0.3

--- a/test-engineering/contract-tests/volumes/client/scenarios.yml
+++ b/test-engineering/contract-tests/volumes/client/scenarios.yml
@@ -231,3 +231,69 @@ scenarios:
                 # The client test framework knows how to interpret a value of `null` for this field.
                 icon: null
                 score: 0.3
+
+  - name: remote_settings__refresh
+    description: Test that Merino successfully returns a refreshed output for the same suggestion search term.
+    steps:
+      - request:
+          service: kinto
+          filename: "data-03.json"
+          data_type: "data"
+      - request:
+          delay: 5 # Wait for remote settings data to load into merino
+          service: merino
+          method: GET
+          path: '/api/v1/suggest?q=tree'
+          headers:
+            - name: User-Agent
+              value: 'Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0'
+            - name: Accept-Language
+              value: 'en-US'
+        response:
+          status_code: 200
+          content:
+            client_variants: []
+            server_variants: []
+            request_id: null
+            suggestions:
+              - block_id: 6
+                full_keyword: 'tree'
+                title: 'Tree'
+                url: 'https://example.org/target/tree'
+                provider: 'adm'
+                advertiser: 'Example.org'
+                is_sponsored: false
+                # The client test framework knows how to interpret a value of `null` for this field.
+                icon: null
+                score: 0.3
+      - request:
+          service: kinto
+          filename: "data-04.json"
+          data_type: "data"
+      - request:
+          delay: 5 # Wait for remote settings data to load into merino
+          service: merino
+          method: GET
+          path: '/api/v1/suggest?q=tree'
+          headers:
+            - name: User-Agent
+              value: 'Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0'
+            - name: Accept-Language
+              value: 'en-US'
+        response:
+          status_code: 200
+          content:
+            client_variants: []
+            server_variants: []
+            request_id: null
+            suggestions:
+              - block_id: 7
+                full_keyword: 'tree'
+                title: 'Tree2'
+                url: 'https://example.org/target/tree2'
+                provider: 'adm'
+                advertiser: 'Example.org'
+                is_sponsored: false
+                # The client test framework knows how to interpret a value of `null` for this field.
+                icon: null
+                score: 0.3

--- a/test-engineering/contract-tests/volumes/kinto/data-03.json
+++ b/test-engineering/contract-tests/volumes/kinto/data-03.json
@@ -5,7 +5,7 @@
         "click_url": "https://example.org/click/tree",
         "impression_url": "https://example.org/impression/tree",
         "iab_category": "22 - Shopping",
-        "icon": "2",
+        "icon": "1",
         "advertiser": "Example.org",
         "title": "Tree",
         "keywords": [

--- a/test-engineering/contract-tests/volumes/kinto/data-03.json
+++ b/test-engineering/contract-tests/volumes/kinto/data-03.json
@@ -1,0 +1,17 @@
+[
+    {
+        "id": 6,
+        "url": "https://example.org/target/tree",
+        "click_url": "https://example.org/click/tree",
+        "impression_url": "https://example.org/impression/tree",
+        "iab_category": "5 - Education",
+        "icon": "2",
+        "advertiser": "Example.org",
+        "title": "Tree",
+        "keywords": [
+            "tree",
+            "birch tree",
+            "maple tree"
+        ]
+    }
+]

--- a/test-engineering/contract-tests/volumes/kinto/data-03.json
+++ b/test-engineering/contract-tests/volumes/kinto/data-03.json
@@ -4,7 +4,7 @@
         "url": "https://example.org/target/tree",
         "click_url": "https://example.org/click/tree",
         "impression_url": "https://example.org/impression/tree",
-        "iab_category": "5 - Education",
+        "iab_category": "22 - Shopping",
         "icon": "2",
         "advertiser": "Example.org",
         "title": "Tree",

--- a/test-engineering/contract-tests/volumes/kinto/data-04.json
+++ b/test-engineering/contract-tests/volumes/kinto/data-04.json
@@ -1,17 +1,32 @@
 [
     {
-        "id": 7,
+        "id": 6,
         "url": "https://example.org/target/tree2",
         "click_url": "https://example.org/click/tree2",
         "impression_url": "https://example.org/impression/tree2",
         "iab_category": "22 - Shopping",
-        "icon": "2",
+        "icon": "1",
         "advertiser": "Example.org",
         "title": "Tree 2",
         "keywords": [
             "tree",
             "birch tree",
             "maple tree"
+        ]
+    },
+    {
+        "id": 7,
+        "url": "https://example.org/target/flower",
+        "click_url": "https://example.org/click/flower",
+        "impression_url": "https://example.org/impression/flower",
+        "iab_category": "22 - Shopping",
+        "icon": "2",
+        "advertiser": "Example.org",
+        "title": "Flower",
+        "keywords": [
+            "flower",
+            "rose",
+            "daisy"
         ]
     }
 ]

--- a/test-engineering/contract-tests/volumes/kinto/data-04.json
+++ b/test-engineering/contract-tests/volumes/kinto/data-04.json
@@ -1,0 +1,17 @@
+[
+    {
+        "id": 7,
+        "url": "https://example.org/target/tree2",
+        "click_url": "https://example.org/click/tree2",
+        "impression_url": "https://example.org/impression/tree2",
+        "iab_category": "5 - Education",
+        "icon": "2",
+        "advertiser": "Example.org",
+        "title": "Tree 2",
+        "keywords": [
+            "tree",
+            "birch tree",
+            "maple tree"
+        ]
+    }
+]

--- a/test-engineering/contract-tests/volumes/kinto/data-04.json
+++ b/test-engineering/contract-tests/volumes/kinto/data-04.json
@@ -4,7 +4,7 @@
         "url": "https://example.org/target/tree2",
         "click_url": "https://example.org/click/tree2",
         "impression_url": "https://example.org/impression/tree2",
-        "iab_category": "5 - Education",
+        "iab_category": "22 - Shopping",
         "icon": "2",
         "advertiser": "Example.org",
         "title": "Tree 2",


### PR DESCRIPTION
## Description
* Suggestions from Remote Settings are made available in testing though a call to Kinto to upload new suggestions. 
* Added new data json files to test and verify different impression and click url for same search term.
* Made additions to scenarios file to check same search term and verify result differs between both results.
* Matching search term is verified by a call to merino.
* Local suggestions removed if their counterpart is removed or updated in Remote Settings.

## Issue(s)
[CONSVC-1866](https://mozilla-hub.atlassian.net/browse/CONSVC-1866)