### PR TITLE
chore: Do not export dev dependencies to docker iamge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN pip install --no-cache-dir --quiet poetry
 COPY ./pyproject.toml ./poetry.lock /tmp/
 
 # Just need the requirements.txt from Poetry
-RUN poetry export --no-interaction --dev --output requirements.txt --without-hashes
+RUN poetry export --no-interaction --output requirements.txt --without-hashes
 
 FROM python:${PYTHON_VERSION}-slim
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ kinto-http = "^11.0.0"
 aiodogstatsd = "^0.16.0"
 ua-parser = "^0.16.1"
 geoip2 = "^4.6.0"
+rich = "^12.5.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.2"
@@ -67,7 +68,6 @@ pytest-cov = "^3.0.0"
 pre-commit = "^2.20.0"
 pytest-mock = "^3.8.2"
 bandit = "^1.7.4"
-rich = "^12.5.1"
 pytest-asyncio = "^0.19.0"
 
 [build-system]


### PR DESCRIPTION
Came across this while reviewing another PR. I must've added the `--dev` flag by accident 😅.

We don't need those dev dependencies to run Merino, also they'd bloat the docker image over time.