### PR TITLE
chore: specify streams for log handlers

### DIFF
--- a/merino/config_logging.py
+++ b/merino/config_logging.py
@@ -1,4 +1,5 @@
 """Logging configuration"""
+import sys
 from logging.config import dictConfig
 
 from merino.config import settings
@@ -37,6 +38,7 @@ def configure_logging() -> None:
                     "level": settings.logging.level,
                     "class": "logging.StreamHandler",
                     "formatter": "json",
+                    "stream": sys.stdout,
                 },
                 "console-pretty": {
                     "level": settings.logging.level,
@@ -47,6 +49,7 @@ def configure_logging() -> None:
                     "level": "ERROR",
                     "class": "logging.StreamHandler",
                     "formatter": "text",
+                    "stream": sys.stderr,
                 },
             },
             "loggers": {


### PR DESCRIPTION
The default stream of log handlers is `stderr` in Python, which confuses Cloud Logging as it treats all log records from stderr as `ERROR`.

Note that `console-pretty` is used in dev environments only, and it has its own stream implicitly set, so we don't need to configure it separately. 