### PR TITLE
[CONSVC-1955][Part 1] fix: enable mypy checks on merino directory

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
     rev: v0.971
     hooks:
       - id: mypy
-        files: tests/contract
+        files: '^merino|^tests/contract'
         args: [
           --python-version=3.10,
           --disallow-untyped-calls,

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ lint: $(INSTALL_STAMP)  ##  Run various linters
 	$(POETRY) run flake8 $(APP_AND_TEST_DIRS)
 	$(POETRY) run bandit --quiet -r $(APP_AND_TEST_DIRS) -c "pyproject.toml"
 	$(POETRY) run pydocstyle $(APP_DIR) --config="pyproject.toml"
-	$(POETRY) run mypy $(CONTRACT_TEST_DIR) --config-file="pyproject.toml"
+	$(POETRY) run mypy $(APP_DIR) $(CONTRACT_TEST_DIR) --config-file="pyproject.toml"
 
 .PHONY: format
 format: $(INSTALL_STAMP)  ##  Sort imports and reformat code

--- a/merino/config_sentry.py
+++ b/merino/config_sentry.py
@@ -6,7 +6,7 @@ from sentry_sdk.integrations.starlette import StarletteIntegration
 from merino.config import settings
 
 
-def configure_sentry():  # pragma: no cover
+def configure_sentry() -> None:  # pragma: no cover
     """Configure and initialize Sentry integration."""
     if settings.sentry.mode == "disabled":
         return

--- a/merino/featureflags.py
+++ b/merino/featureflags.py
@@ -1,21 +1,23 @@
 """Implementation of Feature Flags (feature toggles) for Merino"""
 import hashlib
 import logging
-from collections.abc import Iterable
 from contextvars import ContextVar
 from enum import Enum
 from random import randbytes
-from typing import Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from dynaconf import Dynaconf
 from pydantic import BaseModel, ConstrainedFloat
 from pydantic.types import OptionalIntFloat
 
+if TYPE_CHECKING:
+    from pydantic.typing import TupleGenerator
+
 logger = logging.getLogger(__name__)
 
 
 # Configuration and schema
-def _dynaconf_loader():
+def _dynaconf_loader() -> Any:
     return Dynaconf(
         root_path="merino",
         envvar_prefix="MERINO",
@@ -54,9 +56,9 @@ class FeatureFlagConfigs(BaseModel):
 
     flags: dict[str, Optional[FeatureFlag]]
 
-    def __iter__(self) -> Iterable[str]:
+    def __iter__(self) -> "TupleGenerator":
         """TODO"""
-        return iter(self.flags)
+        yield from self.flags.items()
 
     def __getitem__(self, flag_name) -> FeatureFlag | None:
         """TODO"""

--- a/merino/providers/__init__.py
+++ b/merino/providers/__init__.py
@@ -41,7 +41,7 @@ async def init_providers() -> None:
             case ProviderType.ADM:
                 providers["adm"] = AdmProvider(
                     backend=(
-                        LiveBackend()
+                        LiveBackend()  # type: ignore
                         if setting.backend == "remote-settings"
                         else TestBackend()
                     ),

--- a/merino/providers/adm.py
+++ b/merino/providers/adm.py
@@ -30,7 +30,7 @@ class RemoteSettingsBackend(Protocol):
         ...
 
     async def fetch_attachment(
-        self, attachment_uri: Any
+        self, attachment_uri: str
     ) -> httpx.Response:  # pragma: no cover
         """Fetch the attachment for the given URI."""
         ...
@@ -43,11 +43,11 @@ class RemoteSettingsBackend(Protocol):
 class TestBackend:
     """A test backend that always returns empty results for tests."""
 
-    async def get(self, bucket: Any, collection: Any) -> list[dict[Any, Any]]:
+    async def get(self, bucket: str, collection: str) -> list[dict[str, Any]]:
         """Return fake records."""
         return []
 
-    async def fetch_attachment(self, attachment_uri: Any) -> httpx.Response:
+    async def fetch_attachment(self, attachment_uri: str) -> httpx.Response:
         """Return a fake attachment for the given URI."""
         return httpx.Response(200, text="")
 
@@ -120,7 +120,7 @@ class Provider(BaseProvider):
 
     def _should_fetch(self) -> bool:
         """Check if it should fetch data from Remote Settings."""
-        return (
+        return (  # type: ignore
             time.time() - self.last_fetch_at
             >= settings.providers.adm.resync_interval_sec
         )

--- a/merino/remotesettings.py
+++ b/merino/remotesettings.py
@@ -1,5 +1,5 @@
 """A thin wrapper around the Remote Settings client."""
-from typing import Any
+from typing import Any, cast
 from urllib.parse import urljoin
 
 import httpx
@@ -21,7 +21,7 @@ class LiveBackend:
     async def fetch_attachment_host(self) -> str:
         """Fetch the attachment host from the Remote Settings server."""
         server_info = await self.client.server_info()
-        return server_info["capabilities"]["attachments"]["base_url"]
+        return cast(str, server_info["capabilities"]["attachments"]["base_url"])
 
     async def get(self, bucket: str, collection: str) -> list[dict[str, Any]]:
         """Get records from Remote Settings server.
@@ -30,9 +30,12 @@ class LiveBackend:
           - `collection`: the collection name
           -  `bucket`: the bucket name
         """
-        return await self.client.get_records(collection=collection, bucket=bucket)
+        return cast(
+            list[dict[str, Any]],
+            await self.client.get_records(collection=collection, bucket=bucket),
+        )
 
-    async def fetch_attachment(self, attachment_uri) -> httpx.Response:
+    async def fetch_attachment(self, attachment_uri: str) -> httpx.Response:
         """Fetch an attachment from Remote Settings server for a given URI.
 
         Args:

--- a/merino/util/user_agent_parsing.py
+++ b/merino/util/user_agent_parsing.py
@@ -1,5 +1,5 @@
 """A utility module for user agent parsing."""
-from typing import Any
+from typing import Any, cast
 
 from ua_parser import user_agent_parser
 
@@ -29,7 +29,7 @@ def _parse_browser(user_agent: dict[str, Any]) -> str:
             return "Firefox" if major is None else f"Firefox({version.rstrip('.')})"
         case {"family": browser}:
             # Do not bother parsing the browser version for non-Firefox user agents.
-            return browser
+            return cast(str, browser)
         case _:  # pragma: no cover
             return "Other"
 
@@ -54,7 +54,7 @@ def _parse_os_family(operating_system: dict[str, Any]) -> str:
             return "other"
 
 
-def _parse_form_factor(device: dict[str, Any], os_family: str) -> str:
+def _parse_form_factor(device: dict[str, Any], os_family: str) -> str:  # type: ignore
     """Parse the form factor from the device dictionary.
 
     It takes an extra argument `os_family` to facilitate parsing for Windows


### PR DESCRIPTION
Took a first stab at appeasing `mypy` against everything in the `merino` directory. Partially enabled mypy in linting (`make lint`) and pre-commit checking.

@taddes Apologize in advance if this conflicts with anything in your working branch. `mypy` is indeed not 100% accurate, had to manually ignore several cases as I believed those are definitely false alarms.  