### PR TITLE
refactor: cache score from settings to avoid loading overhead

### DIFF
--- a/docs/ops.md
+++ b/docs/ops.md
@@ -60,6 +60,15 @@ such as `config_sentry.py` or `config_logging.py`.
 - `format` (`MERINO_LOGGING__FORMAT`) - Controls the format of outputted logs in
   either `pretty` or `mozlog` format. See [../config_logging.py][log].
 
+### Caveat
+
+Be extra careful whenever you need to reference those deeply nested settings
+(e.g. `settings.foo.bar.baz`) in the hot paths of the code base, such as middlewares
+or route handlers. Under the hood, Dynaconf will perform a dictionary lookup
+for each level of the configuration hierarchy. While it's harmless to do those
+lookups once or twice, it comes a surprisingly high overhead if accessing them
+repeatedly in the hot paths. You can cache those settings somewhere to mitigate
+this issue.
 
 ### Logging
 

--- a/merino/providers/adm.py
+++ b/merino/providers/adm.py
@@ -78,6 +78,9 @@ class Provider(BaseProvider):
     suggestions: dict[str, int] = {}
     results: list[dict[str, Any]] = []
     icons: dict[int, str] = {}
+    # Store the value to avoid fetching it from settings every time as that'd
+    # require a three-way dict lookup.
+    score: float = settings.providers.adm.score
     last_fetch_at: float
     cron_task: asyncio.Task
     backend: RemoteSettingsBackend
@@ -191,7 +194,7 @@ class Provider(BaseProvider):
                     "advertiser": res.get("advertiser"),
                     "is_sponsored": res.get("iab_category") == IABCategory.SHOPPING,
                     "icon": self.icons.get(int(res.get("icon", MISSING_ICON_ID))),
-                    "score": settings.providers.adm.score,
+                    "score": self.score,
                 }
             ]
         return []


### PR DESCRIPTION
Notice this while profiling merino-py. Turns out that the Dynaconf setting lookups can be expensive if the target setting is deeply nested in the hierarchy. The profiling result suggests that repeatedly referencing those nested settings such as in middlewares or route handlers would incur a significant overhead. To mitigate that, we can cache those settings whenever possible in those scenarios.

I've checked that this is the only case we have had so far. Will add a note to the relevant document for future reference.  