### PR TITLE
fix: Metric names did not share a common prefix. Setting it to `merino`

### DIFF
--- a/merino/metrics.py
+++ b/merino/metrics.py
@@ -16,6 +16,7 @@ def get_metrics_client() -> Client:
     return Client(
         host=settings.metrics.host,
         port=settings.metrics.port,
+        namespace="merino",
         constant_tags={"application": "merino-py"},
     )
 

--- a/merino/providers/__init__.py
+++ b/merino/providers/__init__.py
@@ -55,7 +55,7 @@ async def init_providers() -> None:
                 raise InvalidProviderError(f"Unknown provider type: {provider_type}")
 
     # initialize providers and record time
-    init_metric = f"{__name__}.initialize"
+    init_metric = "providers.initialize"
     client = metrics.get_metrics_client()
     with client.timeit(init_metric):
         wrapped_tasks = [

--- a/merino/providers/adm.py
+++ b/merino/providers/adm.py
@@ -93,6 +93,7 @@ class Provider(BaseProvider):
     ) -> None:
         """Store the given Remote Settings backend on the provider."""
         self.backend = backend
+        self._name = "adm"
         self._enabled_by_default = enabled_by_default
         super().__init__(**kwargs)
 

--- a/merino/providers/base.py
+++ b/merino/providers/base.py
@@ -6,6 +6,7 @@ from typing import Any
 class BaseProvider(ABC):
     """Abstract class for suggestion providers."""
 
+    _name: str
     _enabled_by_default: bool
 
     @abstractmethod
@@ -43,3 +44,7 @@ class BaseProvider(ABC):
             return "enabled_by_default"
         else:
             return "disabled_by_default"
+
+    def name(self) -> str:
+        """Return the name of the provider for use in logging and metrics"""
+        return self._name

--- a/merino/providers/wiki_fruit.py
+++ b/merino/providers/wiki_fruit.py
@@ -13,6 +13,7 @@ class WikiFruitProvider(BaseProvider):
     def __init__(self, enabled_by_default: bool):
         """Init for WikiFruitProvider."""
         self._enabled_by_default = enabled_by_default
+        self._name = "wiki_fruit"
 
     async def initialize(self) -> None:
         """Initialize wiki fruit"""

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -65,7 +65,7 @@ async def suggest(
         search_from = default_providers
 
     lookups = [
-        metrics_client.timeit_task(p.query(q), f"{p.__module__}.query")
+        metrics_client.timeit_task(p.query(q), f"providers.{p.name()}.query")
         for p in search_from
     ]
     results = await asyncio.gather(*lookups)

--- a/tests/unit/web/util.py
+++ b/tests/unit/web/util.py
@@ -12,6 +12,7 @@ class SponsoredProvider(BaseProvider):
 
     def __init__(self, enabled_by_default) -> None:
         self._enabled_by_default = enabled_by_default
+        self._name = "sponsored"
 
     async def initialize(self) -> None:
         ...
@@ -47,6 +48,7 @@ class NonsponsoredProvider(BaseProvider):
 
     def __init__(self, enabled_by_default) -> None:
         self._enabled_by_default = enabled_by_default
+        self._name = "non-sponsored"
 
     async def initialize(self) -> None:
         ...
@@ -79,6 +81,7 @@ class CorruptProvider(BaseProvider):
     """
 
     def __init__(self) -> None:
+        self._name = "corrupted"
         ...
 
     async def initialize(self) -> None:


### PR DESCRIPTION
This was more annoying than I expected because in the original implementation I used module name in a few places to get the provider name. To fix that I added another method to the base provider class `BaseProvider:name`