### PR TITLE
chore: upgrade dynaconf to 3.1.11

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -233,7 +233,7 @@ sanic = ["sanic"]
 
 [[package]]
 name = "dynaconf"
-version = "3.1.9"
+version = "3.1.11"
 description = "The dynamic configurator for your Python Project"
 category = "main"
 optional = false
@@ -1273,8 +1273,8 @@ dockerflow = [
     {file = "dockerflow-2022.8.0.tar.gz", hash = "sha256:fcb95ea8226551e1fd03c3c82f2b11de50434ddfa63cebc164399dabf5c78908"},
 ]
 dynaconf = [
-    {file = "dynaconf-3.1.9-py2.py3-none-any.whl", hash = "sha256:9eaaa6e64a4a64225f80cdad14379a37656b8f2dc607ab0fd949b75d479674cc"},
-    {file = "dynaconf-3.1.9.tar.gz", hash = "sha256:f435c9e5b0b4b1dddf5e17e60a1e4c91ae0e6275aa51522456e671a7be3380eb"},
+    {file = "dynaconf-3.1.11-py2.py3-none-any.whl", hash = "sha256:87e0b3b12b5db9e8fb465e1f8c7fdb926cd2ec5b6d88aa7f821f316df93fb165"},
+    {file = "dynaconf-3.1.11.tar.gz", hash = "sha256:d9cfb50fd4a71a543fd23845d4f585b620b6ff6d9d3cc1825c614f7b2097cb39"},
 ]
 fastapi = [
     {file = "fastapi-0.79.1-py3-none-any.whl", hash = "sha256:3c584179c64e265749e88221c860520fc512ea37e253282dab378cc503dfd7fd"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ fastapi = "^0.79.0"
 uvicorn = {extras = ["standard"], version = "^0.18.2"}
 dockerflow = "^2022.7.0"
 asgi-correlation-id = "^3.0.1"
-dynaconf = "^3.1.9"
+dynaconf = "^3.1.11"
 httpx = "^0.23.0"
 sentry-sdk = {extras = ["fastapi"], version = "^1.9.5"}
 kinto-http = "^11.0.0"


### PR DESCRIPTION
This allows us to override settings by `MERINO_PROVIDERS__ACCUWEATHER__API_KEY=foo` rather than `MERINO_PROVIDERS__accuweather__API_KEY=foo`.