### PR TITLE
[CONSVC-2047] fix: do not collect location data in the query log

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,9 +28,7 @@ repos:
         #   - https://bandit.readthedocs.io/en/latest/plugins/b104_hardcoded_bind_all_interfaces.html
         args:
           - '--skip'
-          - B101
-          - '--skip'
-          - B104
+          - 'B101,B104'
   - repo: 'https://github.com/pycqa/pydocstyle'
     rev: 6.1.1
     hooks:

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -88,6 +88,11 @@ Settings to control the format and amount of logs generated.
   Each entry can be one of `CRITICAL`, `ERROR`, `WARN`, `INFO`,  or `DEBUG` (in
   increasing verbosity).
 
+- `logging.collect_location` (`MERINO_LOGGING__COLLECT_LOCATION`) - Whether or
+  not to collect location data in the query log. By the data collection policy
+  of Firefox Suggest, we shouldn't collect location data in the stage or production
+  environments.
+
 ### Metrics
 
 Settings for Statsd/Datadog style metrics reporting.

--- a/merino/config.py
+++ b/merino/config.py
@@ -5,6 +5,7 @@ from dynaconf import Dynaconf, Validator
 _validators = [
     Validator("logging.level", is_in=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]),
     Validator("logging.format", is_in=["mozlog", "pretty"]),
+    Validator("logging.collection_location", is_type_of=bool),
     Validator("metrics.host", is_type_of=str),
     Validator("metrics.port", gte=0, is_type_of=int),
     Validator("metrics.dev_logger", is_type_of=bool),

--- a/merino/config_logging.py
+++ b/merino/config_logging.py
@@ -21,6 +21,12 @@ def configure_logging() -> None:
     if settings.current_env.lower() == "production" and handler != ["console-mozlog"]:
         raise ValueError("Log format must be 'mozlog' in production")
 
+    if (
+        settings.current_env.lower() == "production"
+        and settings.logging.collect_location
+    ):
+        raise ValueError("`collect_location` should be `false` in production")
+
     dictConfig(
         {
             "version": 1,

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -28,6 +28,8 @@ debug = false
 level = "INFO"
 # Any of "mozlog" (i.e. JSON) or "pretty"
 format = "mozlog"
+# Whether or not to collect location data in the query log
+collect_location = false
 
 [default.metrics]
 dev_logger = false

--- a/merino/configs/testing.toml
+++ b/merino/configs/testing.toml
@@ -14,6 +14,7 @@ dev_logger = true
 # Any of "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"
 level = "DEBUG"
 format = "pretty"
+collect_location = true
 
 [testing.providers.accuweather]
 # Whether or not this provider is enabled by default.

--- a/tests/unit/test_config_logging.py
+++ b/tests/unit/test_config_logging.py
@@ -27,3 +27,16 @@ def test_mozlog_production():
         assert "Log format must be 'mozlog' in production" in str(excinfo)
 
         settings.logging.format = old_format
+
+
+def test_collect_data_in_production():
+    with settings.using_env("production"):
+        old_value = settings.logging.collect_location
+        settings.logging.collect_location = True
+
+        with pytest.raises(ValueError) as excinfo:
+            configure_logging()
+
+        assert "`collect_location` should be `false` in production" in str(excinfo)
+
+        settings.logging.collect_location = old_value


### PR DESCRIPTION
This allows us to use the full-sized geolocation database rather than the dev one, which is required for features like the weather provider.

This fixes [CONSVC-2047](https://mozilla-hub.atlassian.net/browse/CONSVC-2047).