### PR TITLE
[CONSVC-2076] fix: bandit pre-commit hook to exclude B101

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,9 +28,7 @@ repos:
         #   - https://bandit.readthedocs.io/en/latest/plugins/b104_hardcoded_bind_all_interfaces.html
         args:
           - '--skip'
-          - B101
-          - '--skip'
-          - B104
+          - B101,B104
   - repo: 'https://github.com/pycqa/pydocstyle'
     rev: 6.1.1
     hooks:


### PR DESCRIPTION
## Description
* fix to exclude B101 bandit check in git pre-commit

## Issue(s)
[CONSVC-2076](https://mozilla-hub.atlassian.net/browse/CONSVC-2076)