### PR TITLE
[CONSVC-2015] feat: lower down score for adm wikipedia suggestions

### DIFF
--- a/docs/ops.md
+++ b/docs/ops.md
@@ -170,6 +170,9 @@ These are production providers that generate suggestions.
     - Retry if the regular resync fails.
   - `score` (`MERINO_PROVIDERS__ADM__SCORE`) - The ranking score for this provider
     as a floating point number. Defaults to 0.3.
+  - `score_wikipedia` (`MERINO_PROVIDERS__ADM__SCORE_WIKIPEDIA`) - The ranking score
+    of Wikipedia suggestions for this provider as a floating point number.
+    Defaults to 0.2.
 
 #### Wiki Fruit Provider
 - Wiki Fruit - Provides suggestions from a test provider. Should not be used

--- a/merino/config.py
+++ b/merino/config.py
@@ -14,6 +14,7 @@ _validators = [
     Validator("providers.adm.resync_interval_sec", gt=0),
     Validator("providers.adm.score", gte=0, lte=1),
     Validator("providers.adm.backend", is_in=["remote-settings", "test"]),
+    Validator("providers.adm.score_wikipedia", gte=0, lte=1),
     Validator("providers.wikifruit.enabled_by_default", is_type_of=bool),
     Validator("sentry.mode", is_in=["disabled", "release", "debug"]),
     Validator("sentry.env", is_in=["prod", "stage", "dev"]),

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -80,6 +80,7 @@ backend = "remote-settings"
 cron_interval_sec = 60
 resync_interval_sec = 10800
 score = 0.3
+score_wikipedia = 0.2
 
 [default.providers.top_picks]
 enabled_by_default = false

--- a/merino/providers/adm.py
+++ b/merino/providers/adm.py
@@ -106,6 +106,7 @@ class Provider(BaseProvider):
     # Store the value to avoid fetching it from settings every time as that'd
     # require a three-way dict lookup.
     score: float = settings.providers.adm.score
+    score_wikipedia: float = settings.providers.adm.score_wikipedia
     last_fetch_at: float
     cron_task: asyncio.Task
     backend: RemoteSettingsBackend
@@ -212,6 +213,11 @@ class Provider(BaseProvider):
         if (id := self.suggestions.get(q)) is not None:
             res = self.results[id]
             is_sponsored = res.get("iab_category") == IABCategory.SHOPPING
+            score = (
+                self.score_wikipedia
+                if (advertiser := res.get("advertiser")) == "Wikipedia"
+                else self.score
+            )
             suggestion_dict = {
                 "block_id": res.get("id"),
                 "full_keyword": q,
@@ -220,10 +226,10 @@ class Provider(BaseProvider):
                 "impression_url": res.get("impression_url"),
                 "click_url": res.get("click_url"),
                 "provider": self.name,
-                "advertiser": res.get("advertiser"),
+                "advertiser": advertiser,
                 "is_sponsored": is_sponsored,
                 "icon": self.icons.get(int(res.get("icon", MISSING_ICON_ID))),
-                "score": self.score,
+                "score": score,
             }
             return [
                 SponsoredSuggestion(**suggestion_dict)

--- a/tests/unit/providers/test_adm.py
+++ b/tests/unit/providers/test_adm.py
@@ -18,7 +18,7 @@ from tests.unit.web.util import filter_caplog, srequest
 class FakeBackend:
     """Fake Remote Settings backend that returns suggest data for tests."""
 
-    async def get(self, bucket: Any, collection: Any) -> list[dict[Any, Any]]:
+    async def get(self, bucket: str, collection: str) -> list[dict[str, Any]]:
         """Return fake records."""
 
         return [
@@ -64,7 +64,7 @@ class FakeBackend:
             },
         ]
 
-    async def fetch_attachment(self, attachment_uri: Any) -> httpx.Response:
+    async def fetch_attachment(self, attachment_uri: str) -> httpx.Response:
         """Return a fake attachment for the given URI."""
 
         attachments = {

--- a/tests/unit/providers/test_adm_wikipedia.py
+++ b/tests/unit/providers/test_adm_wikipedia.py
@@ -1,0 +1,122 @@
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+
+from merino.config import settings
+from merino.providers.adm import NonsponsoredSuggestion, Provider
+from tests.unit.web.util import srequest
+
+
+class FakeBackend:
+    """Fake Remote Settings backend that returns suggest data for tests."""
+
+    async def get(self, bucket: Any, collection: Any) -> list[dict[Any, Any]]:
+        """Return fake records."""
+
+        return [
+            {
+                "type": "data",
+                "schema": 111,
+                "attachment": {
+                    "hash": "efgh",
+                    "size": 1,
+                    "filename": "data-01.json",
+                    "location": "main-workspace/quicksuggest/attachment-01.json",
+                    "mimetype": "application/octet-stream",
+                },
+                "id": "data-01",
+                "last_modified": 123,
+            },
+            {
+                "type": "icon",
+                "schema": 456,
+                "attachment": {
+                    "hash": "efghabcasd",
+                    "size": 1,
+                    "filename": "icon-01",
+                    "location": "main-workspace/quicksuggest/icon-01",
+                    "mimetype": "application/octet-stream",
+                },
+                "content_type": "image/png",
+                "id": "icon-01",
+                "last_modified": 123,
+            },
+        ]
+
+    async def fetch_attachment(self, attachment_uri: Any) -> httpx.Response:
+        """Return a fake attachment for the given URI."""
+
+        attachments = {
+            "main-workspace/quicksuggest/attachment-01.json": {
+                "id": 1,
+                "url": "https://wikipedia.org/en/Mozilla",
+                "iab_category": "5 - Education",
+                "icon": "01",
+                "advertiser": "Wikipedia",
+                "title": "Mozilla",
+                "keywords": ["mozilla"],
+            },
+        }
+
+        return httpx.Response(200, text=json.dumps([attachments[attachment_uri]]))
+
+    def get_icon_url(self, icon_uri: str) -> str:
+        """Return a fake icon URL for the given URI."""
+
+        return f"attachment-host/{icon_uri}"
+
+
+@pytest.fixture(name="adm")
+def fixture_adm() -> Provider:
+    """Return an adM provider that uses a fake remote settings client."""
+
+    return Provider(backend=FakeBackend())
+
+
+@pytest.mark.asyncio
+async def test_initialize(adm: Provider) -> None:
+    """Test for the initialize() method of the adM provider."""
+
+    await adm.initialize()
+
+    assert adm.suggestions == {"mozilla": 0}
+    assert adm.results == [
+        {
+            "id": 1,
+            "url": "https://wikipedia.org/en/Mozilla",
+            "iab_category": "5 - Education",
+            "icon": "01",
+            "advertiser": "Wikipedia",
+            "title": "Mozilla",
+        },
+    ]
+    assert adm.icons == {1: "attachment-host/main-workspace/quicksuggest/icon-01"}
+
+
+@pytest.mark.asyncio
+async def test_wikipedia_specific_score(adm: Provider) -> None:
+    """Test for the query() method of the adM provider."""
+
+    await adm.initialize()
+
+    res = await adm.query(srequest("mozilla"))
+    assert res == [
+        NonsponsoredSuggestion(
+            block_id=1,
+            full_keyword="mozilla",
+            title="Mozilla",
+            url="https://wikipedia.org/en/Mozilla",
+            impression_url=None,
+            click_url=None,
+            provider="adm",
+            advertiser="Wikipedia",
+            is_sponsored=False,
+            icon="attachment-host/main-workspace/quicksuggest/icon-01",
+            score=settings.providers.adm.score_wikipedia,
+        )
+    ]

--- a/tests/unit/providers/test_adm_wikipedia.py
+++ b/tests/unit/providers/test_adm_wikipedia.py
@@ -15,7 +15,7 @@ from tests.unit.web.util import srequest
 class FakeBackend:
     """Fake Remote Settings backend that returns suggest data for tests."""
 
-    async def get(self, bucket: Any, collection: Any) -> list[dict[Any, Any]]:
+    async def get(self, bucket: str, collection: str) -> list[dict[str, Any]]:
         """Return fake records."""
 
         return [
@@ -48,7 +48,7 @@ class FakeBackend:
             },
         ]
 
-    async def fetch_attachment(self, attachment_uri: Any) -> httpx.Response:
+    async def fetch_attachment(self, attachment_uri: str) -> httpx.Response:
         """Return a fake attachment for the given URI."""
 
         attachments = {


### PR DESCRIPTION
This enforces the ranking criteria of "Sponsored Suggestions (0.3)" > "Top Picks (0.25)" > "Wikipedia (0.2)" >= "Local Remote Settings (0.2)". It's a bit messy to juggle those many scores, but we will clean those up once more sophisticated ranking gets added to Merino.

This fixes [CONSVC-2015](https://mozilla-hub.atlassian.net/browse/CONSVC-2015).