### PR TITLE
[CONSVC-2016] test: added contract tests for top pick provider [do not deploy]

### DIFF
--- a/dev/top_picks_for_ci.json
+++ b/dev/top_picks_for_ci.json
@@ -1,0 +1,50 @@
+{
+    "domains": [
+        {
+            "rank": 1,
+            "title": "Example",
+            "domain": "example",
+            "url": "https://example.com",
+            "icon": "",
+            "categories": [
+                "web-browser"
+            ],
+            "similars": [
+                "exxample",
+                "exampple",
+                "eexample"
+            ]
+        },
+        {
+            "rank": 2,
+            "title": "Firefox",
+            "domain": "firefox",
+            "url": "https://firefox.com",
+            "icon": "",
+            "categories": [
+                "web-browser"
+            ],
+            "similars": [
+                "firefoxx",
+                "foyerfox",
+                "fiirefox",
+                "firesfox",
+                "firefoxes"
+            ]
+        },
+        {
+            "rank": 3,
+            "title": "Mozilla",
+            "domain": "mozilla",
+            "url": "https://mozilla.org/en-US/",
+            "icon": "",
+            "categories": [
+                "web-browser"
+            ],
+            "similars": [
+                "mozzilla",
+                "mozila"
+            ]
+        }
+    ]
+}

--- a/merino/configs/ci.toml
+++ b/merino/configs/ci.toml
@@ -37,3 +37,4 @@ enabled_by_default = true
 [ci.providers.top_picks]
 # Whether or not this provider is enabled by default.
 enabled_by_default = true
+top_picks_file_path = "dev/top_picks_for_ci.json"

--- a/merino/configs/ci.toml
+++ b/merino/configs/ci.toml
@@ -33,3 +33,7 @@ score = 0.3
 [ci.providers.wiki_fruit]
 # Whether or not this provider is enabled by default.
 enabled_by_default = true
+
+[ci.providers.top_picks]
+# Whether or not this provider is enabled by default.
+enabled_by_default = true

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -83,7 +83,7 @@ score = 0.3
 score_wikipedia = 0.2
 
 [default.providers.top_picks]
-enabled_by_default = true
+enabled_by_default = false
 score = 0.25
 query_char_limit = 4
 top_picks_file_path = "dev/top_picks.json"

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -83,7 +83,7 @@ score = 0.3
 score_wikipedia = 0.2
 
 [default.providers.top_picks]
-enabled_by_default = false
+enabled_by_default = true
 score = 0.25
 query_char_limit = 4
 top_picks_file_path = "dev/top_picks.json"

--- a/tests/contract/client/tests/models.py
+++ b/tests/contract/client/tests/models.py
@@ -51,11 +51,11 @@ class Suggestion(BaseModel, extra=Extra.allow):
     """Class that holds information about a Suggestion returned by Merino."""
 
     block_id: int
-    full_keyword: str
+    full_keyword: Optional[str]
     title: str
     url: str
     provider: str
-    advertiser: str
+    advertiser: Optional[str]
     is_sponsored: bool
     score: float
     icon: Optional[str] = Field(...)
@@ -63,6 +63,8 @@ class Suggestion(BaseModel, extra=Extra.allow):
     # Mozilla-provided Wikipedia suggestions.
     impression_url: Optional[str]
     click_url: Optional[str]
+    # Field for Top Picks Nav Queries that are absent for other providers.
+    is_top_pick: Optional[bool]
 
 
 class ResponseContent(BaseModel):

--- a/tests/contract/volumes/client/scenarios.yml
+++ b/tests/contract/volumes/client/scenarios.yml
@@ -193,6 +193,131 @@ scenarios:
                 icon: null
                 score: 0.3
 
+  - name: top_picks__mozilla
+    description: Test that Merino successfully returns suggestion for Top Pick Navigational Query
+    steps:
+      - request:
+          service: merino
+          method: GET
+          path: '/api/v1/suggest?q=mozi'
+          headers:
+            - name: User-Agent
+              value: 'Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0'
+            - name: Accept-Language
+              value: 'en-US'
+        response:
+          status_code: 200
+          content:
+            client_variants: []
+            server_variants: []
+            request_id: null
+            suggestions:
+              - block_id: 0
+                title: 'Mozilla'
+                url: 'https://mozilla.org/en-US/'
+                provider: 'top_picks'
+                is_sponsored: false
+                is_top_pick: true
+                score: 0.25
+                icon: ""
+      - request:
+          service: merino
+          method: GET
+          path: '/api/v1/suggest?q=mozil'
+          headers:
+            - name: User-Agent
+              value: 'Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0'
+            - name: Accept-Language
+              value: 'en-US'
+        response:
+          status_code: 200
+          content:
+            client_variants: []
+            server_variants: []
+            request_id: null
+            suggestions:
+              - block_id: 0
+                title: 'Mozilla'
+                url: 'https://mozilla.org/en-US/'
+                provider: 'top_picks'
+                is_sponsored: false
+                is_top_pick: true
+                score: 0.25
+                icon: ""
+      - request:
+          service: merino
+          method: GET
+          path: '/api/v1/suggest?q=mozill'
+          headers:
+            - name: User-Agent
+              value: 'Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0'
+            - name: Accept-Language
+              value: 'en-US'
+        response:
+          status_code: 200
+          content:
+            client_variants: []
+            server_variants: []
+            request_id: null
+            suggestions:
+              - block_id: 0
+                title: 'Mozilla'
+                url: 'https://mozilla.org/en-US/'
+                provider: 'top_picks'
+                is_sponsored: false
+                is_top_pick: true
+                score: 0.25
+                icon: ""
+      - request:
+          service: merino
+          method: GET
+          path: '/api/v1/suggest?q=mozzil'
+          headers:
+            - name: User-Agent
+              value: 'Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0'
+            - name: Accept-Language
+              value: 'en-US'
+        response:
+          status_code: 200
+          content:
+            client_variants: []
+            server_variants: []
+            request_id: null
+            suggestions:
+              - block_id: 0
+                title: 'Mozilla'
+                url: 'https://mozilla.org/en-US/'
+                provider: 'top_picks'
+                is_sponsored: false
+                is_top_pick: true
+                score: 0.25
+                icon: ""
+      - request:
+          service: merino
+          method: GET
+          path: '/api/v1/suggest?q=exxamp'
+          headers:
+            - name: User-Agent
+              value: 'Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0'
+            - name: Accept-Language
+              value: 'en-US'
+        response:
+          status_code: 200
+          content:
+            client_variants: []
+            server_variants: []
+            request_id: null
+            suggestions:
+              - block_id: 0
+                title: 'Example'
+                url: 'https://example.com'
+                provider: 'top_picks'
+                is_sponsored: false
+                is_top_pick: true
+                score: 0.25
+                icon: ""
+
+                
   - name: remote_settings__offline_expansion_orange
     description: Test that Merino successfully returns a Remote Settings suggestion for Offline Expansion
     steps:

--- a/tests/contract/volumes/client/scenarios.yml
+++ b/tests/contract/volumes/client/scenarios.yml
@@ -324,30 +324,6 @@ scenarios:
                 is_top_pick: true
                 score: 0.25
                 icon: ""
-      - request:
-          service: merino
-          method: GET
-          path: "/api/v1/suggest?q=mozill"
-          headers:
-            - name: User-Agent
-              value: "Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0"
-            - name: Accept-Language
-              value: "en-US"
-        response:
-          status_code: 200
-          content:
-            client_variants: []
-            server_variants: []
-            request_id: null
-            suggestions:
-              - block_id: 0
-                title: "Mozilla"
-                url: "https://mozilla.org/en-US/"
-                provider: "top_picks"
-                is_sponsored: false
-                is_top_pick: true
-                score: 0.25
-                icon: ""
 
   - name: top_picks__secondary_similars_match
     description: >
@@ -373,30 +349,6 @@ scenarios:
               - block_id: 0
                 title: "Mozilla"
                 url: "https://mozilla.org/en-US/"
-                provider: "top_picks"
-                is_sponsored: false
-                is_top_pick: true
-                score: 0.25
-                icon: ""
-      - request:
-          service: merino
-          method: GET
-          path: "/api/v1/suggest?q=exxamp"
-          headers:
-            - name: User-Agent
-              value: "Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0"
-            - name: Accept-Language
-              value: "en-US"
-        response:
-          status_code: 200
-          content:
-            client_variants: []
-            server_variants: []
-            request_id: null
-            suggestions:
-              - block_id: 0
-                title: "Example"
-                url: "https://example.com"
                 provider: "top_picks"
                 is_sponsored: false
                 is_top_pick: true

--- a/tests/contract/volumes/client/scenarios.yml
+++ b/tests/contract/volumes/client/scenarios.yml
@@ -5,12 +5,12 @@ scenarios:
       - request:
           service: merino
           method: GET
-          path: '/api/v1/suggest?q=apple'
+          path: "/api/v1/suggest?q=apple"
           headers:
             - name: User-Agent
-              value: 'Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0'
+              value: "Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0"
             - name: Accept-Language
-              value: 'en-US'
+              value: "en-US"
         response:
           status_code: 200
           content:
@@ -22,15 +22,15 @@ scenarios:
             request_id: null
             suggestions:
               - block_id: 1
-                full_keyword: 'apple'
-                title: 'Wikipedia - Apple'
-                url: 'https://en.wikipedia.org/wiki/Apple'
-                impression_url: 'https://127.0.0.1/'
-                click_url: 'https://127.0.0.1/'
-                provider: 'test_wiki_fruit'
-                advertiser: 'test_advertiser'
+                full_keyword: "apple"
+                title: "Wikipedia - Apple"
+                url: "https://en.wikipedia.org/wiki/Apple"
+                impression_url: "https://127.0.0.1/"
+                click_url: "https://127.0.0.1/"
+                provider: "test_wiki_fruit"
+                advertiser: "test_advertiser"
                 is_sponsored: false
-                icon: 'https://en.wikipedia.org/favicon.ico'
+                icon: "https://en.wikipedia.org/favicon.ico"
                 score: 0.0
 
   - name: wiki_fruit__apple_with_client_variants
@@ -39,31 +39,31 @@ scenarios:
       - request:
           service: merino
           method: GET
-          path: '/api/v1/suggest?q=apple&client_variants=one,two'
+          path: "/api/v1/suggest?q=apple&client_variants=one,two"
           headers:
             - name: User-Agent
-              value: 'Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0'
+              value: "Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0"
             - name: Accept-Language
-              value: 'en-US'
+              value: "en-US"
         response:
           status_code: 200
           content:
             client_variants:
-              - 'one'
-              - 'two'
+              - "one"
+              - "two"
             server_variants: []
             request_id: null
             suggestions:
               - block_id: 1
-                full_keyword: 'apple'
-                title: 'Wikipedia - Apple'
-                url: 'https://en.wikipedia.org/wiki/Apple'
-                impression_url: 'https://127.0.0.1/'
-                click_url: 'https://127.0.0.1/'
-                provider: 'test_wiki_fruit'
-                advertiser: 'test_advertiser'
+                full_keyword: "apple"
+                title: "Wikipedia - Apple"
+                url: "https://en.wikipedia.org/wiki/Apple"
+                impression_url: "https://127.0.0.1/"
+                click_url: "https://127.0.0.1/"
+                provider: "test_wiki_fruit"
+                advertiser: "test_advertiser"
                 is_sponsored: false
-                icon: 'https://en.wikipedia.org/favicon.ico'
+                icon: "https://en.wikipedia.org/favicon.ico"
                 score: 0.0
 
   - name: wiki_fruit__cherry
@@ -72,12 +72,12 @@ scenarios:
       - request:
           service: merino
           method: GET
-          path: '/api/v1/suggest?q=cherry'
+          path: "/api/v1/suggest?q=cherry"
           headers:
             - name: User-Agent
-              value: 'Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0'
+              value: "Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0"
             - name: Accept-Language
-              value: 'en-US'
+              value: "en-US"
         response:
           status_code: 200
           content:
@@ -86,15 +86,15 @@ scenarios:
             request_id: null
             suggestions:
               - block_id: 1
-                full_keyword: 'cherry'
-                title: 'Wikipedia - Cherry'
-                url: 'https://en.wikipedia.org/wiki/Cherry'
-                impression_url: 'https://127.0.0.1/'
-                click_url: 'https://127.0.0.1/'
-                provider: 'test_wiki_fruit'
-                advertiser: 'test_advertiser'
+                full_keyword: "cherry"
+                title: "Wikipedia - Cherry"
+                url: "https://en.wikipedia.org/wiki/Cherry"
+                impression_url: "https://127.0.0.1/"
+                click_url: "https://127.0.0.1/"
+                provider: "test_wiki_fruit"
+                advertiser: "test_advertiser"
                 is_sponsored: false
-                icon: 'https://en.wikipedia.org/favicon.ico'
+                icon: "https://en.wikipedia.org/favicon.ico"
                 score: 0.0
 
   - name: remote_settings__coffee
@@ -114,12 +114,12 @@ scenarios:
           delay: 5 # Wait for remote settings data to load into merino
           service: merino
           method: GET
-          path: '/api/v1/suggest?q=coffee'
+          path: "/api/v1/suggest?q=coffee"
           headers:
             - name: User-Agent
-              value: 'Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0'
+              value: "Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0"
             - name: Accept-Language
-              value: 'en-US'
+              value: "en-US"
         response:
           status_code: 200
           content:
@@ -128,13 +128,13 @@ scenarios:
             request_id: null
             suggestions:
               - block_id: 3
-                full_keyword: 'coffee'
-                title: 'Coffee'
-                url: 'https://example.com/target/coffee'
-                impression_url: 'https://example.com/impression/coffee'
-                click_url: 'https://example.com/click/coffee'
-                provider: 'adm'
-                advertiser: 'Example.com'
+                full_keyword: "coffee"
+                title: "Coffee"
+                url: "https://example.com/target/coffee"
+                impression_url: "https://example.com/impression/coffee"
+                click_url: "https://example.com/click/coffee"
+                provider: "adm"
+                advertiser: "Example.com"
                 is_sponsored: true
                 # The client test framework knows how to interpret a value of `null` for this field.
                 icon: null
@@ -154,15 +154,15 @@ scenarios:
           filename: "data-02.json"
           data_type: "data"
       - request:
-          delay: 5  # Wait for remote settings data to load into merino
+          delay: 5 # Wait for remote settings data to load into merino
           service: merino
           method: GET
-          path: '/api/v1/suggest?q=banana'
+          path: "/api/v1/suggest?q=banana"
           headers:
             - name: User-Agent
-              value: 'Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0'
+              value: "Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0"
             - name: Accept-Language
-              value: 'en-US'
+              value: "en-US"
         response:
           status_code: 200
           content:
@@ -171,40 +171,42 @@ scenarios:
             request_id: null
             suggestions:
               - block_id: 1
-                full_keyword: 'banana'
-                title: 'Wikipedia - Banana'
-                url: 'https://en.wikipedia.org/wiki/Banana'
-                impression_url: 'https://127.0.0.1/'
-                click_url: 'https://127.0.0.1/'
-                provider: 'test_wiki_fruit'
-                advertiser: 'test_advertiser'
+                full_keyword: "banana"
+                title: "Wikipedia - Banana"
+                url: "https://en.wikipedia.org/wiki/Banana"
+                impression_url: "https://127.0.0.1/"
+                click_url: "https://127.0.0.1/"
+                provider: "test_wiki_fruit"
+                advertiser: "test_advertiser"
                 is_sponsored: false
                 icon: https://en.wikipedia.org/favicon.ico
                 score: 0.0
               - block_id: 2
-                full_keyword: 'banana'
-                title: 'Banana'
-                url: 'https://example.org/target/banana'
-                impression_url: 'https://example.org/impression/banana'
-                click_url: 'https://example.org/click/banana'
-                provider: 'adm'
-                advertiser: 'Example.org'
+                full_keyword: "banana"
+                title: "Banana"
+                url: "https://example.org/target/banana"
+                impression_url: "https://example.org/impression/banana"
+                click_url: "https://example.org/click/banana"
+                provider: "adm"
+                advertiser: "Example.org"
                 is_sponsored: false
                 icon: null
                 score: 0.3
 
-  - name: top_picks__mozilla
-    description: Test that Merino successfully returns suggestion for Top Pick Navigational Query
+  - name: top_picks__keyword_match
+    description: >
+      Test that Merino successfully returns suggestion for Top Pick Navigational Queries / 
+      with exact keyword matches.
     steps:
       - request:
           service: merino
           method: GET
-          path: '/api/v1/suggest?q=mozi'
+          path: "/api/v1/suggest?q=mozilla"
           headers:
             - name: User-Agent
-              value: 'Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0'
+              value: "Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0"
             - name: Accept-Language
-              value: 'en-US'
+              value: "en-US"
         response:
           status_code: 200
           content:
@@ -213,9 +215,9 @@ scenarios:
             request_id: null
             suggestions:
               - block_id: 0
-                title: 'Mozilla'
-                url: 'https://mozilla.org/en-US/'
-                provider: 'top_picks'
+                title: "Mozilla"
+                url: "https://mozilla.org/en-US/"
+                provider: "top_picks"
                 is_sponsored: false
                 is_top_pick: true
                 score: 0.25
@@ -223,12 +225,12 @@ scenarios:
       - request:
           service: merino
           method: GET
-          path: '/api/v1/suggest?q=mozil'
+          path: "/api/v1/suggest?q=firefox"
           headers:
             - name: User-Agent
-              value: 'Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0'
+              value: "Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0"
             - name: Accept-Language
-              value: 'en-US'
+              value: "en-US"
         response:
           status_code: 200
           content:
@@ -237,9 +239,9 @@ scenarios:
             request_id: null
             suggestions:
               - block_id: 0
-                title: 'Mozilla'
-                url: 'https://mozilla.org/en-US/'
-                provider: 'top_picks'
+                title: "Firefox"
+                url: "https://firefox.com"
+                provider: "top_picks"
                 is_sponsored: false
                 is_top_pick: true
                 score: 0.25
@@ -247,12 +249,12 @@ scenarios:
       - request:
           service: merino
           method: GET
-          path: '/api/v1/suggest?q=mozill'
+          path: "/api/v1/suggest?q=example"
           headers:
             - name: User-Agent
-              value: 'Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0'
+              value: "Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0"
             - name: Accept-Language
-              value: 'en-US'
+              value: "en-US"
         response:
           status_code: 200
           content:
@@ -261,63 +263,170 @@ scenarios:
             request_id: null
             suggestions:
               - block_id: 0
-                title: 'Mozilla'
-                url: 'https://mozilla.org/en-US/'
-                provider: 'top_picks'
-                is_sponsored: false
-                is_top_pick: true
-                score: 0.25
-                icon: ""
-      - request:
-          service: merino
-          method: GET
-          path: '/api/v1/suggest?q=mozzil'
-          headers:
-            - name: User-Agent
-              value: 'Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0'
-            - name: Accept-Language
-              value: 'en-US'
-        response:
-          status_code: 200
-          content:
-            client_variants: []
-            server_variants: []
-            request_id: null
-            suggestions:
-              - block_id: 0
-                title: 'Mozilla'
-                url: 'https://mozilla.org/en-US/'
-                provider: 'top_picks'
-                is_sponsored: false
-                is_top_pick: true
-                score: 0.25
-                icon: ""
-      - request:
-          service: merino
-          method: GET
-          path: '/api/v1/suggest?q=exxamp'
-          headers:
-            - name: User-Agent
-              value: 'Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0'
-            - name: Accept-Language
-              value: 'en-US'
-        response:
-          status_code: 200
-          content:
-            client_variants: []
-            server_variants: []
-            request_id: null
-            suggestions:
-              - block_id: 0
-                title: 'Example'
-                url: 'https://example.com'
-                provider: 'top_picks'
+                title: "Example"
+                url: "https://example.com"
+                provider: "top_picks"
                 is_sponsored: false
                 is_top_pick: true
                 score: 0.25
                 icon: ""
 
-                
+  - name: top_picks__characters
+    description: >
+      Test that Merino successfully returns suggestion for Top Pick Navigational Queries /
+      with partial keyword matches above query character limit.
+    steps:
+      - request:
+          service: merino
+          method: GET
+          path: "/api/v1/suggest?q=mozi"
+          headers:
+            - name: User-Agent
+              value: "Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0"
+            - name: Accept-Language
+              value: "en-US"
+        response:
+          status_code: 200
+          content:
+            client_variants: []
+            server_variants: []
+            request_id: null
+            suggestions:
+              - block_id: 0
+                title: "Mozilla"
+                url: "https://mozilla.org/en-US/"
+                provider: "top_picks"
+                is_sponsored: false
+                is_top_pick: true
+                score: 0.25
+                icon: ""
+      - request:
+          service: merino
+          method: GET
+          path: "/api/v1/suggest?q=mozil"
+          headers:
+            - name: User-Agent
+              value: "Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0"
+            - name: Accept-Language
+              value: "en-US"
+        response:
+          status_code: 200
+          content:
+            client_variants: []
+            server_variants: []
+            request_id: null
+            suggestions:
+              - block_id: 0
+                title: "Mozilla"
+                url: "https://mozilla.org/en-US/"
+                provider: "top_picks"
+                is_sponsored: false
+                is_top_pick: true
+                score: 0.25
+                icon: ""
+      - request:
+          service: merino
+          method: GET
+          path: "/api/v1/suggest?q=mozill"
+          headers:
+            - name: User-Agent
+              value: "Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0"
+            - name: Accept-Language
+              value: "en-US"
+        response:
+          status_code: 200
+          content:
+            client_variants: []
+            server_variants: []
+            request_id: null
+            suggestions:
+              - block_id: 0
+                title: "Mozilla"
+                url: "https://mozilla.org/en-US/"
+                provider: "top_picks"
+                is_sponsored: false
+                is_top_pick: true
+                score: 0.25
+                icon: ""
+
+  - name: top_picks__secondary_similars_match
+    description: >
+      Test that Merino successfully returns suggestion for Top Pick Navigational Queries /
+      with matches for similars collection in secondary index for a given domain.
+    steps:
+      - request:
+          service: merino
+          method: GET
+          path: "/api/v1/suggest?q=mozzil"
+          headers:
+            - name: User-Agent
+              value: "Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0"
+            - name: Accept-Language
+              value: "en-US"
+        response:
+          status_code: 200
+          content:
+            client_variants: []
+            server_variants: []
+            request_id: null
+            suggestions:
+              - block_id: 0
+                title: "Mozilla"
+                url: "https://mozilla.org/en-US/"
+                provider: "top_picks"
+                is_sponsored: false
+                is_top_pick: true
+                score: 0.25
+                icon: ""
+      - request:
+          service: merino
+          method: GET
+          path: "/api/v1/suggest?q=exxamp"
+          headers:
+            - name: User-Agent
+              value: "Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0"
+            - name: Accept-Language
+              value: "en-US"
+        response:
+          status_code: 200
+          content:
+            client_variants: []
+            server_variants: []
+            request_id: null
+            suggestions:
+              - block_id: 0
+                title: "Example"
+                url: "https://example.com"
+                provider: "top_picks"
+                is_sponsored: false
+                is_top_pick: true
+                score: 0.25
+                icon: ""
+      - request:
+          service: merino
+          method: GET
+          path: "/api/v1/suggest?q=fiire"
+          headers:
+            - name: User-Agent
+              value: "Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0"
+            - name: Accept-Language
+              value: "en-US"
+        response:
+          status_code: 200
+          content:
+            client_variants: []
+            server_variants: []
+            request_id: null
+            suggestions:
+              - block_id: 0
+                title: "Firefox"
+                url: "https://firefox.com"
+                provider: "top_picks"
+                is_sponsored: false
+                is_top_pick: true
+                score: 0.25
+                icon: ""
+
   - name: remote_settings__offline_expansion_orange
     description: Test that Merino successfully returns a Remote Settings suggestion for Offline Expansion
     steps:
@@ -340,12 +449,12 @@ scenarios:
           delay: 5 # Wait for remote settings data to load into merino
           service: merino
           method: GET
-          path: '/api/v1/suggest?q=orange'
+          path: "/api/v1/suggest?q=orange"
           headers:
             - name: User-Agent
-              value: 'Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0'
+              value: "Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0"
             - name: Accept-Language
-              value: 'en-US'
+              value: "en-US"
         response:
           status_code: 200
           content:
@@ -354,11 +463,11 @@ scenarios:
             request_id: null
             suggestions:
               - block_id: 10
-                full_keyword: 'orange'
-                title: 'Orange - Offline Expansion'
-                url: 'https://example.org/target/orange-offline-expansion'
-                provider: 'adm'
-                advertiser: 'Example.org'
+                full_keyword: "orange"
+                title: "Orange - Offline Expansion"
+                url: "https://example.org/target/orange-offline-expansion"
+                provider: "adm"
+                advertiser: "Example.org"
                 is_sponsored: false
                 # The client test framework knows how to interpret a value of `null` for this field.
                 icon: null
@@ -378,12 +487,12 @@ scenarios:
           delay: 5 # Wait for remote settings data to load into merino
           service: merino
           method: GET
-          path: '/api/v1/suggest?q=tree'
+          path: "/api/v1/suggest?q=tree"
           headers:
             - name: User-Agent
-              value: 'Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0'
+              value: "Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0"
             - name: Accept-Language
-              value: 'en-US'
+              value: "en-US"
         response:
           status_code: 200
           content:
@@ -392,25 +501,25 @@ scenarios:
             request_id: null
             suggestions:
               - block_id: 6
-                full_keyword: 'tree'
-                title: 'Tree'
-                url: 'https://example.org/target/tree'
-                impression_url: 'https://example.org/impression/tree'
-                click_url: 'https://example.org/click/tree'
-                provider: 'adm'
-                advertiser: 'Example.org'
+                full_keyword: "tree"
+                title: "Tree"
+                url: "https://example.org/target/tree"
+                impression_url: "https://example.org/impression/tree"
+                click_url: "https://example.org/click/tree"
+                provider: "adm"
+                advertiser: "Example.org"
                 is_sponsored: true
                 icon: null
                 score: 0.3
       - request:
           service: merino
           method: GET
-          path: '/api/v1/suggest?q=flower'
+          path: "/api/v1/suggest?q=flower"
           headers:
             - name: User-Agent
-              value: 'Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0'
+              value: "Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0"
             - name: Accept-Language
-              value: 'en-US'
+              value: "en-US"
         response:
           status_code: 200
           content:
@@ -427,12 +536,12 @@ scenarios:
           delay: 5 # Wait for remote settings data to load into merino
           service: merino
           method: GET
-          path: '/api/v1/suggest?q=tree'
+          path: "/api/v1/suggest?q=tree"
           headers:
             - name: User-Agent
-              value: 'Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0'
+              value: "Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0"
             - name: Accept-Language
-              value: 'en-US'
+              value: "en-US"
         response:
           status_code: 200
           content:
@@ -441,25 +550,25 @@ scenarios:
             request_id: null
             suggestions:
               - block_id: 6
-                full_keyword: 'tree'
-                title: 'Tree 2'
-                url: 'https://example.org/target/tree2'
-                impression_url: 'https://example.org/impression/tree2'
-                click_url: 'https://example.org/click/tree2'
-                provider: 'adm'
-                advertiser: 'Example.org'
+                full_keyword: "tree"
+                title: "Tree 2"
+                url: "https://example.org/target/tree2"
+                impression_url: "https://example.org/impression/tree2"
+                click_url: "https://example.org/click/tree2"
+                provider: "adm"
+                advertiser: "Example.org"
                 is_sponsored: true
                 icon: null
                 score: 0.3
       - request:
           service: merino
           method: GET
-          path: '/api/v1/suggest?q=flower'
+          path: "/api/v1/suggest?q=flower"
           headers:
             - name: User-Agent
-              value: 'Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0'
+              value: "Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0"
             - name: Accept-Language
-              value: 'en-US'
+              value: "en-US"
         response:
           status_code: 200
           content:
@@ -468,13 +577,13 @@ scenarios:
             request_id: null
             suggestions:
               - block_id: 7
-                full_keyword: 'flower'
-                title: 'Flower'
-                url: 'https://example.org/target/flower'
-                impression_url: 'https://example.org/impression/flower'
-                click_url: 'https://example.org/click/flower'
-                provider: 'adm'
-                advertiser: 'Example.org'
+                full_keyword: "flower"
+                title: "Flower"
+                url: "https://example.org/target/flower"
+                impression_url: "https://example.org/impression/flower"
+                click_url: "https://example.org/click/flower"
+                provider: "adm"
+                advertiser: "Example.org"
                 is_sponsored: true
                 icon: null
                 score: 0.3

--- a/tests/contract/volumes/client/scenarios.yml
+++ b/tests/contract/volumes/client/scenarios.yml
@@ -222,54 +222,6 @@ scenarios:
                 is_top_pick: true
                 score: 0.25
                 icon: ""
-      - request:
-          service: merino
-          method: GET
-          path: "/api/v1/suggest?q=firefox"
-          headers:
-            - name: User-Agent
-              value: "Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0"
-            - name: Accept-Language
-              value: "en-US"
-        response:
-          status_code: 200
-          content:
-            client_variants: []
-            server_variants: []
-            request_id: null
-            suggestions:
-              - block_id: 0
-                title: "Firefox"
-                url: "https://firefox.com"
-                provider: "top_picks"
-                is_sponsored: false
-                is_top_pick: true
-                score: 0.25
-                icon: ""
-      - request:
-          service: merino
-          method: GET
-          path: "/api/v1/suggest?q=example"
-          headers:
-            - name: User-Agent
-              value: "Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0"
-            - name: Accept-Language
-              value: "en-US"
-        response:
-          status_code: 200
-          content:
-            client_variants: []
-            server_variants: []
-            request_id: null
-            suggestions:
-              - block_id: 0
-                title: "Example"
-                url: "https://example.com"
-                provider: "top_picks"
-                is_sponsored: false
-                is_top_pick: true
-                score: 0.25
-                icon: ""
 
   - name: top_picks__characters
     description: >


### PR DESCRIPTION
Added scenarios for top pick provider to test exact match, varied character length, and secondary index 'similar' if mis-spelled.

Enabled top pick as default provider in `ci.toml` with a specific `top_picks_for_ci.json` file to allow contract test Docker to pick up provider and build suggestions.  Otherwise, Top Picks were not showing, since the provider won't be enabled in prod until we have our full domain list to index.  

Added `is_top_pick` to model and made keyword and advertiser optional fields to pass validation for Top Pick result.

Closes #101 