### PR TITLE
[CONSVC-2064] test: add integration tests for the providers endpoint

### DIFF
--- a/tests/integration/api/v1/fake_providers.py
+++ b/tests/integration/api/v1/fake_providers.py
@@ -26,6 +26,21 @@ class CorruptProvider(BaseProvider):
         raise RuntimeError(srequest.query)
 
 
+class HiddenProvider(BaseProvider):
+    def __init__(self, enabled_by_default) -> None:
+        self._enabled_by_default = enabled_by_default
+        self._name = "hidden"
+
+    async def initialize(self) -> None:
+        ...
+
+    def hidden(self) -> bool:
+        return True
+
+    async def query(self, srequest: SuggestionRequest) -> list[BaseSuggestion]:
+        raise RuntimeError(srequest.query)
+
+
 class NonsponsoredSuggestion(BaseSuggestion):
     """Model for nonsponsored suggestions."""
 

--- a/tests/integration/api/v1/providers/test_providers.py
+++ b/tests/integration/api/v1/providers/test_providers.py
@@ -5,28 +5,66 @@
 import pytest
 from fastapi.testclient import TestClient
 
+from merino.providers import BaseProvider
 from tests.integration.api.v1.fake_providers import (
+    HiddenProvider,
     NonsponsoredProvider,
     SponsoredProvider,
 )
-from tests.integration.api.v1.types import Providers
 
 
-@pytest.fixture(name="providers")
-def fixture_providers() -> Providers:
-    """Define providers for this module which are injected automatically."""
-    return {
-        "sponsored-provider": SponsoredProvider(enabled_by_default=True),
-        "nonsponsored-provider": NonsponsoredProvider(enabled_by_default=True),
-    }
-
-
-def test_providers(client: TestClient):
-    expected_providers = {"sponsored-provider", "nonsponsored-provider"}
-
+@pytest.mark.parametrize(
+    "expected_response, providers",
+    [
+        ([], {}),
+        (
+            [
+                {"id": "sponsored-provider", "availability": "enabled_by_default"},
+            ],
+            {
+                "sponsored-provider": SponsoredProvider(enabled_by_default=True),
+            },
+        ),
+        (
+            [
+                {"id": "sponsored-provider", "availability": "disabled_by_default"},
+            ],
+            {
+                "sponsored-provider": SponsoredProvider(enabled_by_default=False),
+            },
+        ),
+        (
+            [
+                {"id": "hidden-provider", "availability": "hidden"},
+            ],
+            {
+                "hidden-provider": HiddenProvider(enabled_by_default=True),
+            },
+        ),
+        (
+            [
+                {"id": "sponsored-provider", "availability": "enabled_by_default"},
+                {"id": "nonsponsored-provider", "availability": "disabled_by_default"},
+                {"id": "hidden-provider", "availability": "hidden"},
+            ],
+            {
+                "sponsored-provider": SponsoredProvider(enabled_by_default=True),
+                "nonsponsored-provider": NonsponsoredProvider(enabled_by_default=False),
+                "hidden-provider": HiddenProvider(enabled_by_default=True),
+            },
+        ),
+    ],
+)
+def test_providers(
+    client: TestClient,
+    expected_response: list[dict[str, str]],
+    providers: dict[str, BaseProvider],
+) -> None:
+    """
+    Tests that the response to the 'providers' endpoint is as expected when 0-to-many
+    providers are registered with different availabilities
+    """
     response = client.get("/api/v1/providers")
 
     assert response.status_code == 200
-    providers = response.json()
-    assert len(providers) == 2
-    assert set([provider["id"] for provider in providers]) == expected_providers
+    assert response.json() == expected_response

--- a/tests/integration/api/v1/providers/test_providers.py
+++ b/tests/integration/api/v1/providers/test_providers.py
@@ -54,6 +54,13 @@ from tests.integration.api.v1.fake_providers import (
             },
         ),
     ],
+    ids=[
+        "no-providers",
+        "one-provider-enabled_by_default",
+        "one-provider-disabled_by_default",
+        "one-provider-hidden",
+        "three-providers-all-availabilities",
+    ],
 )
 def test_providers(
     client: TestClient,


### PR DESCRIPTION
## Description
Add integration test coverage to the `providers` endpoint

## Issue(s)
[CONSVC-2064](https://mozilla-hub.atlassian.net/browse/CONSVC-2064)
