### PR TITLE
ensure both C and F are included in weather suggestions

### DIFF
--- a/merino/providers/accuweather.py
+++ b/merino/providers/accuweather.py
@@ -34,6 +34,13 @@ class Temperature(BaseModel):
     c: Optional[float] = None
     f: Optional[float] = None
 
+    def __init__(self, c: Optional[float] = None, f: Optional[float] = None):
+        super().__init__(c=c, f=f)
+        if c is None and f is not None:
+            self.c = round((f - 32) * 5 / 9, 1)
+        if f is None and c is not None:
+            self.f = round(c * 9 / 5 + 32)
+
 
 class CurrentConditions(BaseModel):
     """Model for AccuWeather current conditions."""

--- a/tests/unit/providers/test_accuweather.py
+++ b/tests/unit/providers/test_accuweather.py
@@ -258,10 +258,7 @@ async def test_forecast_returned(accuweather: Provider, geolocation: Location) -
                 ),
                 summary="Mostly cloudy",
                 icon_id=6,
-                temperature=Temperature(
-                    c=15.5,
-                    f=60.0,
-                ),
+                temperature=Temperature(c=15.5, f=60.0),
             ),
             forecast=Forecast(
                 url=(
@@ -269,8 +266,8 @@ async def test_forecast_returned(accuweather: Provider, geolocation: Location) -
                     "94103/daily-weather-forecast/39376_pc?lang=en-us"
                 ),
                 summary="Pleasant Saturday",
-                high=Temperature(f=70.0),
-                low=Temperature(f=57.0),
+                high=Temperature(c=21.1, f=70.0),
+                low=Temperature(c=13.9, f=57.0),
             ),
         )
     ]


### PR DESCRIPTION
The AccuWeather forecast response contains temperatures only in Fahrenheit, at least in my testing in the U.S. Although we're initially rolling out weather suggestions only in the U.S., not every U.S. user will be using an `en-US` locale. We should support other `en-*` locales by making sure Celsius is included in the suggestions so that Firefox can show the appropriate unit based on the user's locale.