### PR TITLE
fix(ci): specify repo when publishing gh-pages [do not deploy]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,6 +199,10 @@ jobs:
           fingerprints:
             - "af:ac:a0:85:b4:a1:af:4d:e1:08:42:b5:16:e3:67:2d"
       - run:
+          name: Set remote orgin if needed
+          command: |
+            git remote add origin git@github.com:mozilla-services/merino-py.git || true
+      - run:
           name: Deploy docs to gh-pages
           command: |
             npx --yes gh-pages@3.0.0 \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -204,6 +204,7 @@ jobs:
             npx --yes gh-pages@3.0.0 \
               --user "ci-build <ci-build@merino.mozilla.org>" \
               --message "[skip ci] Docs updates" \
+              --repo "git@github.com:mozilla-services/merino-py.git" \
               --dist workspace/doc
 
 commands:


### PR DESCRIPTION
The `docs-publish-github-pages` job is broken on `main`, I guess CircleCI might've changed how the `- checkout` step works and `repo` is now needed for `gh-pages`. 