### PR TITLE
[CONSVC-2065] Set minimum coverage for combined unit and integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,8 @@ jobs:
   unit-tests:
     docker:
       - image: cimg/python:3.10
+    environment:
+      TEST_RESULTS_DIR: workspace/test-results
     steps:
       - checkout
       - run:
@@ -99,9 +101,9 @@ jobs:
           command: mkdir -p workspace
       - run:
           name: Unit tests
-          command: make unit-tests
+          command: make unit-tests TEST_RESULTS_DIR=$TEST_RESULTS_DIR
       - store_test_results:
-          path: workspace/test-results
+          path: $TEST_RESULTS_DIR
       - persist_to_workspace:
           root: workspace
           paths:
@@ -109,6 +111,8 @@ jobs:
   integration-tests:
     docker:
       - image: cimg/python:3.10
+    environment:
+      TEST_RESULTS_DIR: workspace/test-results
     steps:
       - checkout
       - run:
@@ -116,9 +120,9 @@ jobs:
           command: mkdir -p workspace
       - run:
           name: Integration tests
-          command: make integration-tests
+          command: make integration-tests TEST_RESULTS_DIR=$TEST_RESULTS_DIR
       - store_test_results:
-          path: workspace/test-results
+          path: $TEST_RESULTS_DIR
       - persist_to_workspace:
           root: workspace
           paths:
@@ -126,13 +130,15 @@ jobs:
   test-coverage-check:
     docker:
       - image: cimg/python:3.10
+    environment:
+      TEST_RESULTS_DIR: workspace/test-results
     steps:
       - checkout
       - attach_workspace:
           at: workspace
       - run:
           name: Evaluate minimum test coverage
-          command: make test-coverage-check
+          command: make test-coverage-check TEST_RESULTS_DIR=$TEST_RESULTS_DIR
   contract-tests:
     machine:
       docker_layer_caching: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,8 +92,6 @@ jobs:
   unit-tests:
     docker:
       - image: cimg/python:3.10
-    environment:
-      TEST_RESULTS_DIR: workspace/test-results
     steps:
       - checkout
       - run:
@@ -101,9 +99,11 @@ jobs:
           command: mkdir -p workspace
       - run:
           name: Unit tests
-          command: make unit-tests TEST_RESULTS_DIR=$TEST_RESULTS_DIR
+          command: make unit-tests
+          environment:
+            TEST_RESULTS_DIR: workspace/test-results
       - store_test_results:
-          path: $TEST_RESULTS_DIR
+          path: workspace/test-results
       - persist_to_workspace:
           root: workspace
           paths:
@@ -111,8 +111,6 @@ jobs:
   integration-tests:
     docker:
       - image: cimg/python:3.10
-    environment:
-      TEST_RESULTS_DIR: workspace/test-results
     steps:
       - checkout
       - run:
@@ -120,9 +118,11 @@ jobs:
           command: mkdir -p workspace
       - run:
           name: Integration tests
-          command: make integration-tests TEST_RESULTS_DIR=$TEST_RESULTS_DIR
+          command: make integration-tests
+          environment:
+            TEST_RESULTS_DIR: workspace/test-results
       - store_test_results:
-          path: $TEST_RESULTS_DIR
+          path: workspace/test-results
       - persist_to_workspace:
           root: workspace
           paths:
@@ -130,15 +130,15 @@ jobs:
   test-coverage-check:
     docker:
       - image: cimg/python:3.10
-    environment:
-      TEST_RESULTS_DIR: workspace/test-results
     steps:
       - checkout
       - attach_workspace:
           at: workspace
       - run:
           name: Evaluate minimum test coverage
-          command: make test-coverage-check TEST_RESULTS_DIR=$TEST_RESULTS_DIR
+          command: make test-coverage-check
+          environment:
+            TEST_RESULTS_DIR: workspace/test-results
   contract-tests:
     machine:
       docker_layer_caching: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,11 @@ workflows:
           <<: *pr-filters
       - integration-tests:
           <<: *pr-filters
+      - test-coverage-check:
+          <<: *pr-filters
+          requires:
+            - unit-tests
+            - integration-tests
       - contract-tests:
           <<: *pr-filters
           requires:
@@ -34,6 +39,11 @@ workflows:
           <<: *main-filters
       - integration-tests:
           <<: *main-filters
+      - test-coverage-check:
+          <<: *main-filters
+          requires:
+            - unit-tests
+            - integration-tests
       - contract-tests:
           <<: *main-filters
           requires:
@@ -50,6 +60,7 @@ workflows:
             - checks
             - unit-tests
             - integration-tests
+            - test-coverage-check
             - contract-tests
       # The following job will require manual approval in the CircleCI web application.
       # Once provided, and when all the requirements are fullfilled (e.g. tests)
@@ -60,6 +71,7 @@ workflows:
             - checks
             - unit-tests
             - integration-tests
+            - test-coverage-check
             - contract-tests
       # On approval of the `unhold-to-deploy-to-prod` job, any successive job that requires it
       # will run. In this case, it's manually triggering deployment to production.
@@ -83,16 +95,40 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Create Workspace
+          command: mkdir -p workspace
+      - run:
           name: Unit tests
           command: make unit-tests
+      - persist_to_workspace:
+          root: workspace
+          paths:
+            - test-results
   integration-tests:
     docker:
       - image: cimg/python:3.10
     steps:
       - checkout
       - run:
+          name: Create Workspace
+          command: mkdir -p workspace
+      - run:
           name: Integration tests
           command: make integration-tests
+      - persist_to_workspace:
+          root: workspace
+          paths:
+            - test-results
+  test-coverage-check:
+    docker:
+      - image: cimg/python:3.10
+    steps:
+      - checkout
+      - attach_workspace:
+          at: workspace
+      - run:
+          name: Evaluate minimum test coverage
+          command: make test-coverage-check
   contract-tests:
     machine:
       docker_layer_caching: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,6 +100,8 @@ jobs:
       - run:
           name: Unit tests
           command: make unit-tests
+      - store_test_results:
+          path: workspace/test-results
       - persist_to_workspace:
           root: workspace
           paths:
@@ -115,6 +117,8 @@ jobs:
       - run:
           name: Integration tests
           command: make integration-tests
+      - store_test_results:
+          path: workspace/test-results
       - persist_to_workspace:
           root: workspace
           paths:

--- a/.dockerignore
+++ b/.dockerignore
@@ -16,3 +16,5 @@ venv
 merino/configs/.secrets.*
 book/
 profile.json
+workspace/
+test-results/

--- a/.dockerignore
+++ b/.dockerignore
@@ -17,4 +17,3 @@ merino/configs/.secrets.*
 book/
 profile.json
 workspace/
-test-results/

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ pip-log.txt
 pip-delete-this-directory.txt
 
 # Unit test / coverage reports
+test-results/
 htmlcov/
 .tox/
 .nox/

--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,6 @@ pip-log.txt
 pip-delete-this-directory.txt
 
 # Unit test / coverage reports
-test-results/
 htmlcov/
 .tox/
 .nox/

--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,6 @@ book/
 
 # Scalene profile artifacts
 profile.json
+
+# CircleCI workspace artifacts
+workspace/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 APP_DIR := merino
 TEST_DIR := tests
-TEST_RESULTS_DIR := "workspace/test-results"
+TEST_RESULTS_DIR ?= "workspace/test-results"
 COV_FAIL_UNDER := 95
 UNIT_TEST_DIR := $(TEST_DIR)/unit
 INTEGRATION_TEST_DIR := $(TEST_DIR)/integration

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,9 @@ test-coverage-check: $(INSTALL_STAMP)  ##  Evaluate combined unit and integratio
 unit-tests: $(INSTALL_STAMP)  ##  Run unit tests
 	COVERAGE_FILE=$(TEST_RESULT_DIR)/.coverage.unit \
 	    MERINO_ENV=testing \
-	    $(POETRY) run pytest $(UNIT_TEST_DIR) --cov $(APP_DIR)
+	    $(POETRY) run pytest $(UNIT_TEST_DIR) \
+	    --cov $(APP_DIR) \
+	    --junit-xml=$(TEST_RESULT_DIR)/unit_results.xml
 
 .PHONY: unit-test-fixtures
 unit-test-fixtures: $(INSTALL_STAMP)  ##  List fixtures in use per unit test
@@ -63,7 +65,9 @@ unit-test-fixtures: $(INSTALL_STAMP)  ##  List fixtures in use per unit test
 integration-tests: $(INSTALL_STAMP)  ##  Run integration tests
 	COVERAGE_FILE=$(TEST_RESULT_DIR)/.coverage.integration \
 	    MERINO_ENV=testing \
-	    $(POETRY) run pytest $(INTEGRATION_TEST_DIR) --cov $(APP_DIR)
+	    $(POETRY) run pytest $(INTEGRATION_TEST_DIR) \
+	    --cov $(APP_DIR) \
+	    --junit-xml=$(TEST_RESULT_DIR)/integration_results.xml
 
 .PHONY: integration-test-fixtures
 integration-test-fixtures: $(INSTALL_STAMP)  ##  List fixtures in use per integration test

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 APP_DIR := merino
 TEST_DIR := tests
-TEST_RESULT_DIR := "workspace/test-results"
+TEST_RESULTS_DIR := "workspace/test-results"
 COV_FAIL_UNDER := 95
 UNIT_TEST_DIR := $(TEST_DIR)/unit
 INTEGRATION_TEST_DIR := $(TEST_DIR)/integration
@@ -46,16 +46,18 @@ test: unit-tests integration-tests test-coverage-check  ##  Run unit and integra
 
 .PHONY: test-coverage-check
 test-coverage-check: $(INSTALL_STAMP)  ##  Evaluate combined unit and integration test coverage
-	$(POETRY) run coverage combine
-	$(POETRY) run coverage report --fail-under=$(COV_FAIL_UNDER)
+	$(POETRY) run coverage combine --data-file=$(TEST_RESULTS_DIR)/.coverage
+	$(POETRY) run coverage report \
+	    --data-file=$(TEST_RESULTS_DIR)/.coverage \
+	    --fail-under=$(COV_FAIL_UNDER)
 
 .PHONY: unit-tests
 unit-tests: $(INSTALL_STAMP)  ##  Run unit tests
-	COVERAGE_FILE=$(TEST_RESULT_DIR)/.coverage.unit \
+	COVERAGE_FILE=$(TEST_RESULTS_DIR)/.coverage.unit \
 	    MERINO_ENV=testing \
 	    $(POETRY) run pytest $(UNIT_TEST_DIR) \
 	    --cov $(APP_DIR) \
-	    --junit-xml=$(TEST_RESULT_DIR)/unit_results.xml
+	    --junit-xml=$(TEST_RESULTS_DIR)/unit_results.xml
 
 .PHONY: unit-test-fixtures
 unit-test-fixtures: $(INSTALL_STAMP)  ##  List fixtures in use per unit test
@@ -63,11 +65,11 @@ unit-test-fixtures: $(INSTALL_STAMP)  ##  List fixtures in use per unit test
 
 .PHONY: integration-tests
 integration-tests: $(INSTALL_STAMP)  ##  Run integration tests
-	COVERAGE_FILE=$(TEST_RESULT_DIR)/.coverage.integration \
+	COVERAGE_FILE=$(TEST_RESULTS_DIR)/.coverage.integration \
 	    MERINO_ENV=testing \
 	    $(POETRY) run pytest $(INTEGRATION_TEST_DIR) \
 	    --cov $(APP_DIR) \
-	    --junit-xml=$(TEST_RESULT_DIR)/integration_results.xml
+	    --junit-xml=$(TEST_RESULTS_DIR)/integration_results.xml
 
 .PHONY: integration-test-fixtures
 integration-test-fixtures: $(INSTALL_STAMP)  ##  List fixtures in use per integration test

--- a/docs/dev/index.md
+++ b/docs/dev/index.md
@@ -26,6 +26,9 @@ $ make run
 
 ### General commands
 ```shell
+# List all available make commands with descriptions
+$ make help
+
 # Just like `poetry install`
 $ make install
 
@@ -41,11 +44,23 @@ $ make dev
 # Run merino-py without the auto code reloading
 $ make run
 
+# Run unit and integration tests and evaluate combined coverage
+$ make test
+
+# Evaluate combined unit and integration test coverage
+$ make test-coverage-check
+
 # Run unit tests
 $ make unit-tests
 
+# List fixtures in use per unit test
+$ make unit-test-fixtures
+
 # Run integration tests
 $ make integration-tests
+
+# List fixtures in use per integration test
+$ make integration-test-fixtures
 
 # Run contract tests
 $ make contract-tests
@@ -58,6 +73,9 @@ $ make doc
 
 # Preview the generated documents
 $ make doc-preview
+
+# Profile Merino with Scalene
+$ make profile
 ```
 
 ## Documentation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,6 @@
 source = ["src"]
 branch = true
 relative_files = true
-data_file = "workspace/test-results/.coverage"
 
 [tool.coverage.report]
 show_missing = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 source = ["src"]
 branch = true
 relative_files = true
+data_file = "workspace/test-results/.coverage"
 
 [tool.coverage.report]
 show_missing = true


### PR DESCRIPTION
# Description
- Add a minimum combined unit and integration test coverage check for 95%
    - In the case of failure, Circle CI reports as follows:
    <img width="488" alt="image" src="https://user-images.githubusercontent.com/3422688/203152818-d56af71d-3832-486e-8ee2-4558e0fbfaeb.png">
    <img width="427" alt="image" src="https://user-images.githubusercontent.com/3422688/203152742-76e377fa-ecc1-416f-aa4e-91640d081928.png">
- Output test results to file format compatible with CircleCI in order to take advantage of test insights
    - ref: [Collecting test data](https://circleci.com/docs/collect-test-data/)
- Add `test-results` directory to `.gitignore`
- Update documentation
# Issue(s)
#87 | [CONSVC-2065](https://mozilla-hub.atlassian.net/browse/CONSVC-2065)