### PR TITLE
chore: pin node to LTS to avoid bustages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,7 +187,7 @@ jobs:
             - doc
   docs-publish-github-pages:
     docker:
-      - image: node
+      - image: cimg/node:16.18.1
     steps:
       - checkout
       - attach_workspace:


### PR DESCRIPTION
Sigh~, this is the actual fix to the `docs-publish-to-prod` bustage. As verified in #119 .