### PR TITLE
[CONSVC-1603] feat: add example feature flag decision

### DIFF
--- a/merino/configs/flags/default.toml
+++ b/merino/configs/flags/default.toml
@@ -1,16 +1,23 @@
 # Example feature flag configuration block. Replace `example` with the name of your feature.
 # i.e. for a feature called `geo_location` the toml header will be `[default.flags.geo_location]`
 # and it will be checked in code with the name `geo_location` (e.g. `flags.is_enabled("geo_location")`)
-# 
+#
 # [default.flags.example]
 # `scheme` - Bucketing scheme for the flag. Allowed values are 'random' and 'session',
 #   defaults to `session`. Random generates a random bucketing id for every flag check.
 #   Session bucketing uses the session id of the request as the bucketing key so that feature
 #   checks within a given search session would be consistent.
 # scheme="session"
-# 
+#
 # `enabled` - Required. This represents the % enabled for the
 #   flag and must be a float between 0 and 1. A value of 0 indicates that
-#   the flag is 'off' (meaning that a check for the flag will return False 100% 
+#   the flag is 'off' (meaning that a check for the flag will return False 100%
 #   of the time) and a value of 1 indicates that the flag is 'on' for all.
 # enabled=0.5
+
+# We define the following feature flag in the default config, so we can learn
+# about using StatsD tags as query filters in our Grafana dashboard, while we
+# don't use any actual feature flags in the suggest API.
+[default.flags.hello_world]
+scheme = 'random'
+enabled = 0.5

--- a/merino/configs/flags/default.toml
+++ b/merino/configs/flags/default.toml
@@ -18,6 +18,6 @@
 # We define the following feature flag in the default config, so we can learn
 # about using StatsD tags as query filters in our Grafana dashboard, while we
 # don't use any actual feature flags in the suggest API.
-[default.flags.hello_world]
+[default.flags.test_flight_01]
 scheme = 'random'
 enabled = 0.5

--- a/merino/configs/flags/testing.toml
+++ b/merino/configs/flags/testing.toml
@@ -1,3 +1,5 @@
+[testing]
+dynaconf_merge = true
 
 [testing.flags.test-enabled]
 enabled = 1

--- a/merino/configs/flags/testing.toml
+++ b/merino/configs/flags/testing.toml
@@ -1,6 +1,10 @@
 [testing]
 dynaconf_merge = true
 
+[testing.flags.test_flight_01]
+scheme = 'random'
+enabled = 0.5
+
 [testing.flags.test-enabled]
 enabled = 1
 scheme = 'random'

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -1,4 +1,5 @@
 """Merino V1 API"""
+import logging
 from asyncio import Task
 from functools import partial
 from itertools import chain
@@ -10,6 +11,7 @@ from fastapi.responses import JSONResponse
 from starlette.requests import Request
 
 from merino.config import settings
+from merino.featureflags import FeatureFlags
 from merino.metrics import Client
 from merino.middleware import ScopeKey
 from merino.providers import get_providers
@@ -17,6 +19,7 @@ from merino.providers.base import BaseProvider, SuggestionRequest
 from merino.utils import task_runner
 from merino.web.models_v1 import ProviderResponse, SuggestResponse
 
+logger = logging.getLogger(__name__)
 router = APIRouter()
 
 SUGGEST_RESPONSE = {
@@ -57,13 +60,13 @@ async def suggest(
     Returns:
     A list of suggestions or an empty list if nothing was found.
     """
-    # Do you plan to release code behind a feature flag? Uncomment the following
-    # line to get access to feature flags and then check if your feature flag is
-    # enabled for this request by calling feature_flags.is_enabled("example").
-    # feature_flags: FeatureFlags = request.scope[ScopeKey.FEATURE_FLAGS]
+    feature_flags: FeatureFlags = request.scope[ScopeKey.FEATURE_FLAGS]
 
-    # Then remove the `pytest.mark.skip` decorator from the test
-    # `test_feature_flags` and update it with your feature flag.
+    if decision := feature_flags.is_enabled("hello_world"):
+        logger.debug(
+            "feature flag hello_world is enabled for this request",
+            extra={"hello_word": decision},
+        )
 
     metrics_client: Client = request.scope[ScopeKey.METRICS_CLIENT]
 

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -62,10 +62,10 @@ async def suggest(
     """
     feature_flags: FeatureFlags = request.scope[ScopeKey.FEATURE_FLAGS]
 
-    if decision := feature_flags.is_enabled("hello_world"):
+    if decision := feature_flags.is_enabled("test_flight_01"):
         logger.debug(
-            "feature flag hello_world is enabled for this request",
-            extra={"hello_word": decision},
+            "feature flag test_flight_01 is enabled for this request",
+            extra={"test_flight_01": decision},
         )
 
     metrics_client: Client = request.scope[ScopeKey.METRICS_CLIENT]

--- a/tests/integration/api/v1/suggest/test_suggest.py
+++ b/tests/integration/api/v1/suggest/test_suggest.py
@@ -259,23 +259,20 @@ def test_suggest_metrics_500(mocker: MockerFixture, client: TestClient) -> None:
     assert str(excinfo.value) == error_msg
 
 
-@pytest.mark.skip(reason="currently no feature flags in use")
 @pytest.mark.parametrize(
     ["url", "expected_metric_keys", "expected_tags"],
     [
         (
             "/api/v1/suggest?q=none",
             [
+                "providers.sponsored.query",
+                "providers.non-sponsored.query",
                 "get.api.v1.suggest.timing",
                 "get.api.v1.suggest.status_codes.200",
-                "providers.adm.query",
-                "providers.wiki_fruit.query",
-                "providers.top_picks.query",
                 "response.status_codes.200",
             ],
             [
-                "feature_flag.test-perc-enabled",
-                "feature_flag.test-perc-enabled-session",
+                "feature_flag.hello_world",
             ],
         ),
         (
@@ -290,7 +287,7 @@ def test_suggest_metrics_500(mocker: MockerFixture, client: TestClient) -> None:
     ],
     ids=["200_with_feature_flags_tags", "400_no_tags"],
 )
-def test_suggest_feature_flags(
+def test_suggest_feature_flags_tags_in_metrics(
     mocker: MockerFixture,
     client: TestClient,
     url: str,

--- a/tests/integration/api/v1/suggest/test_suggest.py
+++ b/tests/integration/api/v1/suggest/test_suggest.py
@@ -272,7 +272,7 @@ def test_suggest_metrics_500(mocker: MockerFixture, client: TestClient) -> None:
                 "response.status_codes.200",
             ],
             [
-                "feature_flag.hello_world",
+                "feature_flag.test_flight_01",
             ],
         ),
         (


### PR DESCRIPTION
# Description

This is adding a feature flag decision to the API, so we can learn about using StatsD tags as query filters in our Grafana dashboard, while we don't use any actual feature flags in the suggest API.

Note: I enabled `dynaconf_merge` for feature flags the dynaconf `testing` environment, so that we can use the feature flag both in a deployed environment and in tests.

# Issue(s)
[CONSVC-1603](https://mozilla-hub.atlassian.net/browse/CONSVC-1603)
