### PR TITLE
`CONSVC-2086` test: include tests in pydocstyle linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,12 +33,11 @@ repos:
     rev: 6.1.1
     hooks:
       - id: pydocstyle
-        exclude: tests/
         args:
           - '--convention'
           - pep257
           - '--add-ignore'
-          - 'D203,D205,D400'
+          - 'D105,D107,D203,D205,D400'
   - repo: 'https://github.com/pre-commit/mirrors-mypy'
     rev: v0.971
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,8 @@ repos:
         args:
           - '--convention'
           - pep257
+          - '--add-select'
+          - 'D212'
           - '--add-ignore'
           - 'D105,D107,D203,D205,D400'
   - repo: 'https://github.com/pre-commit/mirrors-mypy'

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ lint: $(INSTALL_STAMP)  ##  Run various linters
 	$(POETRY) run black --quiet --diff --check merino $(APP_AND_TEST_DIRS)
 	$(POETRY) run flake8 $(APP_AND_TEST_DIRS)
 	$(POETRY) run bandit --quiet -r $(APP_AND_TEST_DIRS) -c "pyproject.toml"
-	$(POETRY) run pydocstyle $(APP_DIR) --config="pyproject.toml"
+	$(POETRY) run pydocstyle $(APP_AND_TEST_DIRS) --config="pyproject.toml"
 	$(POETRY) run mypy $(APP_DIR) $(INTEGRATION_TEST_DIR) $(CONTRACT_TEST_DIR) --config-file="pyproject.toml"
 
 .PHONY: format

--- a/merino/metrics.py
+++ b/merino/metrics.py
@@ -163,8 +163,7 @@ async def configure_metrics() -> None:
 
 
 class _LocalDatagramLogger(aiodogstatsd.client.DatagramProtocol):
-    """
-    This class can be used to override the default DatagramProtocol.
+    """This class can be used to override the default DatagramProtocol.
     Instead of writing bytes to a socket, it logs them.
     The purpose is to make it easy to see the metrics in development environments.
     """

--- a/merino/providers/__init__.py
+++ b/merino/providers/__init__.py
@@ -32,8 +32,7 @@ class ProviderType(str, Enum):
 
 
 async def init_providers() -> None:
-    """
-    Initialize all suggestion providers.
+    """Initialize all suggestion providers.
 
     This should only be called once at the startup of application.
     """

--- a/merino/providers/base.py
+++ b/merino/providers/base.py
@@ -34,8 +34,7 @@ class BaseProvider(ABC):
 
     @abstractmethod
     async def initialize(self) -> None:
-        """
-        Abstract method for defining an initialize method for bootstrapping the Provider.
+        """Abstract method for defining an initialize method for bootstrapping the Provider.
         This allows us to use Async API's within as well as initialize providers in parallel
 
         """

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -45,8 +45,7 @@ async def suggest(
         get_providers
     ),
 ) -> JSONResponse:
-    """
-    Query Merino for suggestions.
+    """Query Merino for suggestions.
 
     Args:
     - `q`: The query string
@@ -123,8 +122,7 @@ async def providers(
         get_providers
     ),
 ) -> JSONResponse:
-    """
-    Query Merino for suggestion providers.
+    """Query Merino for suggestion providers.
 
     Returns:
     A list of search providers.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,8 @@ warn_unreachable = true
 match = ".*\\.py"
 convention = "pep257"
 # Error Code Ref: https://www.pydocstyle.org/en/stable/error_codes.html
+# D212 Multi-line docstring summary should start at the first line
+add-select = ["D212"]
 # D105 Docstrings for magic methods
 # D107 Docstrings for __init__
 # D203 as it conflicts with D211 https://github.com/PyCQA/pydocstyle/issues/141

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ warn_unused_ignores = true
 warn_unreachable = true
 
 [tool.pydocstyle]
-match = "(?!test_).*\\.py"
+match = ".*\\.py"
 convention = "pep257"
 # Error Code Ref: https://www.pydocstyle.org/en/stable/error_codes.html
 # D105 Docstrings for magic methods

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,5 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Modules dedicated to testing the merino service."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,9 +13,8 @@ from tests.types import FilterCaplogFixture
 
 @pytest.fixture(scope="session", name="filter_caplog")
 def fixture_filter_caplog() -> FilterCaplogFixture:
-    """
-    Return a function that will filter pytest captured log records for a given logger
-    name
+    """Return a function that will filter pytest captured log records for a given logger
+    name.
     """
 
     def filter_caplog(records: list[LogRecord], logger_name: str) -> list[LogRecord]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+"""Module for test configurations for the tests directory."""
+
 from logging import LogRecord
 
 import pytest

--- a/tests/contract/client/tests/conftest.py
+++ b/tests/contract/client/tests/conftest.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+"""Contract tests client test configurations."""
+
 import json
 import os
 import pathlib
@@ -33,7 +35,6 @@ REQUIRED_OPTIONS = (
 @pytest.fixture(scope="session", name="kinto_environment")
 def fixture_kinto_environment(request: Any) -> KintoEnvironment:
     """Return Kinto environment data."""
-
     return KintoEnvironment(
         server=request.config.option.kinto_url,
         bucket=request.config.option.kinto_bucket,
@@ -44,7 +45,6 @@ def fixture_kinto_environment(request: Any) -> KintoEnvironment:
 @pytest.fixture(scope="session", name="kinto_attachments")
 def fixture_kinto_attachments(request: Any) -> dict[str, KintoRequestAttachment]:
     """Return a map from data file name to suggestion data."""
-
     # Load Kinto data from the given Kinto data directory
     kinto_data_dir: str = request.config.option.kinto_data_dir
     kinto_attachments: dict[str, KintoRequestAttachment] = {}
@@ -74,12 +74,10 @@ def fixture_fetch_kinto_icon_url(
     kinto_attachments: dict[str, KintoRequestAttachment],
 ) -> Callable[[str], str]:
     """Return a function that will query for an icon URL from a suggestion title"""
-
     attachments_url: str = request.config.option.kinto_attachments_url
 
     def fetch_icon_url(suggestion_title: str) -> str:
         """Fetch the icon URL for the given Kinto record ID from Kinto."""
-
         record_id: str = next(
             f"icon-{suggestion.icon}"
             for attachment in kinto_attachments.values()
@@ -94,7 +92,6 @@ def fixture_fetch_kinto_icon_url(
 
 def pytest_configure(config: Any) -> None:
     """Load data for tests and store it on config."""
-
     for option_name in REQUIRED_OPTIONS:
         if getattr(config.option, option_name) is None:
             raise pytest.UsageError(f"Required option '{option_name}' is not set.")
@@ -109,7 +106,6 @@ def pytest_configure(config: Any) -> None:
 
 def pytest_generate_tests(metafunc: Any) -> None:
     """Generate tests from the loaded test scenarios."""
-
     if "steps" not in metafunc.fixturenames:
         return
 

--- a/tests/contract/client/tests/exceptions.py
+++ b/tests/contract/client/tests/exceptions.py
@@ -2,13 +2,15 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+"""Contract tests client exceptions."""
+
 
 class KintoError(Exception):
     """Error specific to Kinto service interactions."""
 
 
 class MissingKintoDataFilesError(KintoError):
-    """Error finding Kinto data files"""
+    """Error finding Kinto data files."""
 
     def __init__(self, kinto_data_dir: str):
         error_message: str = f"Cannot find Kinto data files in {kinto_data_dir}"

--- a/tests/contract/client/tests/kinto.py
+++ b/tests/contract/client/tests/kinto.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+"""Module for communication with Kinto (Remote Settings)."""
+
 from typing import Optional
 
 import requests
@@ -68,7 +70,6 @@ class KintoResponse(BaseModel):
 
 def delete_records(environment: KintoEnvironment) -> None:
     """Clear all record information from Kinto."""
-
     url: str = (
         f"{environment.server}/v1/"
         f"buckets/{environment.bucket}/"
@@ -81,7 +82,6 @@ def delete_records(environment: KintoEnvironment) -> None:
 
 def get_record(environment: KintoEnvironment, record_id: str) -> KintoResponseRecord:
     """Get attachment information from Kinto for the given record ID."""
-
     url: str = (
         f"{environment.server}/v1/"
         f"buckets/{environment.bucket}/"
@@ -102,7 +102,6 @@ def upload_attachment(
     data_type: str,
 ) -> None:
     """Upload attachment to Kinto for the given record."""
-
     url: str = (
         f"{environment.server}/v1/"
         f"buckets/{environment.bucket}/"
@@ -126,7 +125,6 @@ def upload_attachment(
 
 def upload_icons(environment: KintoEnvironment, icon_ids: set[str]) -> None:
     """Upload icon attachments to Kinto for the given icon IDs."""
-
     for icon_id in icon_ids:
         url: str = (
             f"{environment.server}/v1/"

--- a/tests/contract/client/tests/models.py
+++ b/tests/contract/client/tests/models.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+"""Contract tests client models."""
+
 from enum import Enum
 from typing import Any, Literal, Optional
 from uuid import UUID

--- a/tests/contract/client/tests/test_merino.py
+++ b/tests/contract/client/tests/test_merino.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+"""Contract tests client."""
+
 import time
 from typing import Any, Callable
 
@@ -42,7 +44,6 @@ StepFunction = Callable[[Step], None]
 @pytest.fixture(scope="session", name="merino_url")
 def fixture_merino_url(request: Any) -> str:
     """Read the merino URL from the pytest config."""
-
     merino_url: str = request.config.option.merino_url
     return merino_url
 
@@ -139,7 +140,6 @@ def fixture_step_functions(
     kinto_step: StepFunction, merino_step: StepFunction
 ) -> dict[Service, StepFunction]:
     """Return a dict mapping from a service name to request function."""
-
     return {
         Service.KINTO: kinto_step,
         Service.MERINO: merino_step,
@@ -158,7 +158,6 @@ def assert_200_response(
     fetch_kinto_icon_url: Callable[[str], str],
 ) -> None:
     """Check that the content for a 200 OK response is what we expect."""
-
     expected_content_dict = step_content.dict(exclude=CONTENT_EXCLUDE)
     merino_content_dict = merino_content.dict(exclude=CONTENT_EXCLUDE)
     assert expected_content_dict == merino_content_dict
@@ -198,7 +197,6 @@ def assert_200_response(
 @pytest.fixture(scope="function", autouse=True)
 def fixture_function_teardown(kinto_environment: KintoEnvironment):
     """Execute instructions after each test."""
-
     yield  # Allow test to execute
 
     delete_records(kinto_environment)
@@ -206,7 +204,6 @@ def fixture_function_teardown(kinto_environment: KintoEnvironment):
 
 def test_merino(steps: list[Step], step_functions: dict[Service, StepFunction]) -> None:
     """Test for requesting suggestions from Merino."""
-
     for step in steps:
         # Process delay if defined in request model
         if (delay := step.request.delay) is not None:

--- a/tests/contract/kinto-setup/kinto_requests.py
+++ b/tests/contract/kinto-setup/kinto_requests.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+"""Module for communication with Kinto (Remote Settings)."""
+
 import requests
 import typer
 

--- a/tests/contract/kinto-setup/main.py
+++ b/tests/contract/kinto-setup/main.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+"""kinto-setup app startup point."""
+
 from time import sleep
 
 import requests

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,5 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Modules dedicated to integration testing the merino service"""

--- a/tests/integration/api/__init__.py
+++ b/tests/integration/api/__init__.py
@@ -2,4 +2,4 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-"""Modules dedicated to integration testing the merino API"""
+"""Modules dedicated to integration testing the merino API."""

--- a/tests/integration/api/__init__.py
+++ b/tests/integration/api/__init__.py
@@ -1,0 +1,5 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Modules dedicated to integration testing the merino API"""

--- a/tests/integration/api/conftest.py
+++ b/tests/integration/api/conftest.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-"""Module for test fixtures for the integration test directory."""
+"""Module for test configurations for the integration test directory."""
 
 from logging import LogRecord
 from typing import Any, Iterator

--- a/tests/integration/api/conftest.py
+++ b/tests/integration/api/conftest.py
@@ -37,8 +37,7 @@ def fixture_test_client_with_events() -> Iterator[TestClient]:
 
 @pytest.fixture(name="extract_request_summary_log_data")
 def fixture_extract_request_summary_log_data() -> RequestSummaryLogDataFixture:
-    """
-    Return a function that will extract the extra log data from a captured
+    """Return a function that will extract the extra log data from a captured
     "request.summary" log record
     """
 

--- a/tests/integration/api/test_error.py
+++ b/tests/integration/api/test_error.py
@@ -21,7 +21,7 @@ from tests.types import FilterCaplogFixture
 def test_error(
     client: TestClient, caplog: LogCaptureFixture, filter_caplog: FilterCaplogFixture
 ) -> None:
-    """Test that the error endpoint is supported to conform to dockerflow"""
+    """Test that the error endpoint conforms to dockerflow specifications."""
     caplog.set_level(logging.ERROR)
 
     response = client.get("/__error__")
@@ -41,7 +41,7 @@ def test_error_request_log_data(
 ) -> None:
     """
     Test that the request log for the '__error__' endpoint contains the required
-    extra data
+    extra data.
     """
     caplog.set_level(logging.INFO)
 
@@ -80,7 +80,7 @@ def test_error_request_log_data(
 
 
 def test_error_metrics(mocker: MockerFixture, client: TestClient) -> None:
-    """Test that metrics are recorded for the '__error__' endpoint (status code 500)"""
+    """Test that metrics are recorded for the '__error__' endpoint (status code 500)."""
     expected_metric_keys: list[str] = [
         "get.__error__.timing",
         "get.__error__.status_codes.500",
@@ -98,7 +98,8 @@ def test_error_metrics(mocker: MockerFixture, client: TestClient) -> None:
 
 def test_error_feature_flags(mocker: MockerFixture, client: TestClient) -> None:
     """
-    Test that feature flags are not added for the '__error__' endpoint (status code 500)
+    Test that feature flags are not added for the '__error__' endpoint
+    (status code 500).
     """
     expected_tags_per_metric: dict[str, list[str]] = {
         "get.__error__.timing": [],

--- a/tests/integration/api/test_error.py
+++ b/tests/integration/api/test_error.py
@@ -39,8 +39,7 @@ def test_error_request_log_data(
     extract_request_summary_log_data: RequestSummaryLogDataFixture,
     client: TestClient,
 ) -> None:
-    """
-    Test that the request log for the '__error__' endpoint contains the required
+    """Test that the request log for the '__error__' endpoint contains the required
     extra data.
     """
     caplog.set_level(logging.INFO)
@@ -97,8 +96,7 @@ def test_error_metrics(mocker: MockerFixture, client: TestClient) -> None:
 
 
 def test_error_feature_flags(mocker: MockerFixture, client: TestClient) -> None:
-    """
-    Test that feature flags are not added for the '__error__' endpoint
+    """Test that feature flags are not added for the '__error__' endpoint
     (status code 500).
     """
     expected_tags_per_metric: dict[str, list[str]] = {

--- a/tests/integration/api/test_heartbeat.py
+++ b/tests/integration/api/test_heartbeat.py
@@ -34,9 +34,8 @@ def test_heartbeat_request_log_data(
     client: TestClient,
     endpoint: str,
 ) -> None:
-    """
-    Test that the request log for the '__heartbeat__' and '__lbheartbeat__' endpoints
-    contain the required extra data
+    """Test that the request log for the '__heartbeat__' and '__lbheartbeat__'
+    endpoints contain the required extra data
     """
     caplog.set_level(logging.INFO)
 

--- a/tests/integration/api/test_version.py
+++ b/tests/integration/api/test_version.py
@@ -30,8 +30,7 @@ def test_version(client: TestClient) -> None:
 
 
 def test_version_error(mocker: MockerFixture, client: TestClient) -> None:
-    """
-    Test that the version endpoint returns a 500 status if an error occurs while
+    """Test that the version endpoint returns a 500 status if an error occurs while
     evaluating the response.
     """
     mocker.patch("os.path.exists", return_value=False)
@@ -48,8 +47,7 @@ def test_version_request_log_data(
     extract_request_summary_log_data: RequestSummaryLogDataFixture,
     client: TestClient,
 ) -> None:
-    """
-    Test that the request log for the '__version__' endpoint contains the required
+    """Test that the request log for the '__version__' endpoint contains the required
     extra data.
     """
     caplog.set_level(logging.INFO)

--- a/tests/integration/api/test_version.py
+++ b/tests/integration/api/test_version.py
@@ -18,7 +18,7 @@ from tests.types import FilterCaplogFixture
 
 
 def test_version(client: TestClient) -> None:
-    """Test that the version endpoint is supported to conform to dockerflow"""
+    """Test that the version endpoint conforms to dockerflow specifications."""
     response = client.get("/__version__")
 
     assert response.status_code == 200
@@ -30,6 +30,10 @@ def test_version(client: TestClient) -> None:
 
 
 def test_version_error(mocker: MockerFixture, client: TestClient) -> None:
+    """
+    Test that the version endpoint returns a 500 status if an error occurs while
+    evaluating the response.
+    """
     mocker.patch("os.path.exists", return_value=False)
 
     response = client.get("/__version__")
@@ -46,7 +50,7 @@ def test_version_request_log_data(
 ) -> None:
     """
     Test that the request log for the '__version__' endpoint contains the required
-    extra data
+    extra data.
     """
     caplog.set_level(logging.INFO)
 

--- a/tests/integration/api/types.py
+++ b/tests/integration/api/types.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-"""Module for type declarations for the integration test directory."""
+"""Type definitions for the integration test modules."""
 
 from logging import LogRecord
 from typing import Any, Callable

--- a/tests/integration/api/v1/__init__.py
+++ b/tests/integration/api/v1/__init__.py
@@ -1,0 +1,5 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Modules dedicated to integration testing the merino v1 API endpoints."""

--- a/tests/integration/api/v1/conftest.py
+++ b/tests/integration/api/v1/conftest.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+"""Module for test configurations for the v1 integration test directory."""
+
 import asyncio
 from typing import Any, Callable, Coroutine
 

--- a/tests/integration/api/v1/fake_providers.py
+++ b/tests/integration/api/v1/fake_providers.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+"""Provider fakes for the v1 integration test modules."""
+
 import asyncio
 
 from merino.config import settings
@@ -16,31 +18,40 @@ class CorruptProvider(BaseProvider):
         self._name = "corrupted"
 
     async def initialize(self) -> None:
+        """Initialize method for the CorruptProvider."""
         ...
 
     @property
     def enabled_by_default(self) -> bool:
+        """Return boolean indicating whether the provider is enabled."""
         return True
 
     def hidden(self) -> bool:
+        """Return boolean indicating whether the provider is hidden."""
         return False
 
     async def query(self, srequest: SuggestionRequest) -> list[BaseSuggestion]:
+        """Query against the CorruptProvider."""
         raise RuntimeError(srequest.query)
 
 
 class HiddenProvider(BaseProvider):
+    """A provider fake intended for test with a 'hidden' property set to return True."""
+
     def __init__(self, enabled_by_default) -> None:
         self._enabled_by_default = enabled_by_default
         self._name = "hidden"
 
     async def initialize(self) -> None:
+        """Initialize method for the HiddenProvider."""
         ...
 
     def hidden(self) -> bool:
+        """Return boolean indicating whether the provider is hidden."""
         return True
 
     async def query(self, srequest: SuggestionRequest) -> list[BaseSuggestion]:
+        """Query against the HiddenProvider."""
         raise RuntimeError(srequest.query)
 
 
@@ -60,12 +71,15 @@ class NonsponsoredProvider(BaseProvider):
         self._name = "non-sponsored"
 
     async def initialize(self) -> None:
+        """Initialize method for the NonsponsoredProvider."""
         ...
 
     def hidden(self) -> bool:
+        """Return boolean indicating whether the provider is hidden."""
         return False
 
     async def query(self, srequest: SuggestionRequest) -> list[BaseSuggestion]:
+        """Query against the NonsponsoredProvider."""
         if srequest.query.lower() == "nonsponsored":
             return [
                 NonsponsoredSuggestion(
@@ -102,12 +116,15 @@ class SponsoredProvider(BaseProvider):
         self._name = "sponsored"
 
     async def initialize(self) -> None:
+        """Initialize method for the SponsoredProvider."""
         ...
 
     def hidden(self) -> bool:
+        """Return boolean indicating whether the provider is hidden."""
         return False
 
     async def query(self, srequest: SuggestionRequest) -> list[BaseSuggestion]:
+        """Query against the SponsoredProvider."""
         if srequest.query.lower() == "sponsored":
             return [
                 SponsoredSuggestion(
@@ -138,5 +155,6 @@ class TimeoutSponsoredProvider(SponsoredProvider):
         self._name = "timedout-sponsored"
 
     async def query(self, srequest: SuggestionRequest) -> list[BaseSuggestion]:
+        """Query against the TimeoutSponsoredProvider."""
         await asyncio.sleep(settings.runtime.query_timeout_sec * 2)
         return await super().query(srequest)

--- a/tests/integration/api/v1/providers/__init__.py
+++ b/tests/integration/api/v1/providers/__init__.py
@@ -1,0 +1,5 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Modules dedicated to integration testing the merino v1.providers API endpoint."""

--- a/tests/integration/api/v1/providers/test_providers.py
+++ b/tests/integration/api/v1/providers/test_providers.py
@@ -77,8 +77,7 @@ def test_providers(
     expected_response: list[dict[str, str]],
     providers: dict[str, BaseProvider],
 ) -> None:
-    """
-    Test that the response to the 'providers' endpoint is as expected when 0-to-many
+    """Test that the response to the 'providers' endpoint is as expected when 0-to-many
     providers are registered with different availabilities
     """
     response = client.get("/api/v1/providers")
@@ -95,8 +94,7 @@ def test_providers_request_log_data(
     extract_request_summary_log_data: RequestSummaryLogDataFixture,
     client: TestClient,
 ) -> None:
-    """
-    Test that the request log for the 'providers' endpoint contains the required
+    """Test that the request log for the 'providers' endpoint contains the required
     extra data
     """
     caplog.set_level(logging.INFO)

--- a/tests/integration/api/v1/suggest/__init__.py
+++ b/tests/integration/api/v1/suggest/__init__.py
@@ -1,0 +1,5 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Modules dedicated to integration testing the merino v1.suggest API endpoint."""

--- a/tests/integration/api/v1/suggest/test_suggest.py
+++ b/tests/integration/api/v1/suggest/test_suggest.py
@@ -29,7 +29,7 @@ def fixture_providers() -> Providers:
     Define providers for this module which are injected automatically.
 
     Note: This fixture will be overridden if a test method has a
-          'pytest.mark.parametrize' decorator with a 'providers' definition
+          'pytest.mark.parametrize' decorator with a 'providers' definition.
     """
     return {
         "sponsored-provider": SponsoredProvider(enabled_by_default=True),
@@ -38,6 +38,10 @@ def fixture_providers() -> Providers:
 
 
 def test_suggest_sponsored(client: TestClient) -> None:
+    """
+    Test that the suggest endpoint response is as expected using a sponsored
+    provider.
+    """
     response = client.get("/api/v1/suggest?q=sponsored")
     assert response.status_code == 200
 
@@ -48,6 +52,10 @@ def test_suggest_sponsored(client: TestClient) -> None:
 
 
 def test_suggest_nonsponsored(client: TestClient) -> None:
+    """
+    Test that the suggest endpoint response is as expected using a non-sponsored
+    provider.
+    """
     response = client.get("/api/v1/suggest?q=nonsponsored")
 
     assert response.status_code == 200
@@ -59,6 +67,10 @@ def test_suggest_nonsponsored(client: TestClient) -> None:
 
 
 def test_no_suggestion(client: TestClient) -> None:
+    """
+    Test that the suggest endpoint response is as expected when no suggestions are
+    returned from providers.
+    """
     response = client.get("/api/v1/suggest?q=nope")
     assert response.status_code == 200
     assert len(response.json()["suggestions"]) == 0
@@ -76,11 +88,19 @@ def test_suggest_from_missing_providers(client: TestClient, query: str) -> None:
 
 
 def test_no_query_string(client: TestClient) -> None:
+    """
+    Test that a status code of 400 is returned for suggest endpoint calls without
+    a query string.
+    """
     response = client.get("/api/v1/suggest")
     assert response.status_code == 400
 
 
 def test_client_variants(client: TestClient) -> None:
+    """
+    Test that the suggest endpoint response is as expected when called with the
+    client_variants parameter.
+    """
     response = client.get("/api/v1/suggest?q=sponsored&client_variants=foo,bar")
     assert response.status_code == 200
 
@@ -98,7 +118,7 @@ def test_suggest_request_log_data(
 ) -> None:
     """
     Tests that the request logs for the 'suggest' endpoint contain the required
-    extra data
+    extra data.
     """
     caplog.set_level(logging.INFO)
 
@@ -182,7 +202,7 @@ def test_suggest_with_invalid_geolocation_ip(
     filter_caplog: FilterCaplogFixture,
     client: TestClient,
 ) -> None:
-    """Test that a warning message is logged if geolocation data is invalid"""
+    """Test that a warning message is logged if geolocation data is invalid."""
     mock_client = mocker.patch("fastapi.Request.client")
     mock_client.host = "invalid-ip"
 
@@ -225,7 +245,8 @@ def test_suggest_metrics(
     expected_metric_keys: list[str],
 ) -> None:
     """
-    Test that metrics are recorded for the 'suggest' endpoint (status codes: 200 & 400)
+    Test that metrics are recorded for the 'suggest' endpoint
+    (status codes: 200 & 400).
     """
     report = mocker.patch.object(aiodogstatsd.Client, "_report")
 
@@ -238,7 +259,7 @@ def test_suggest_metrics(
 
 @pytest.mark.parametrize("providers", [{"corrupt": CorruptProvider()}])
 def test_suggest_metrics_500(mocker: MockerFixture, client: TestClient) -> None:
-    """Test that 500 status codes are recorded as metrics"""
+    """Test that 500 status codes are recorded as metrics."""
     error_msg = "test"
     expected_metric_keys = [
         "providers.corrupted.query",
@@ -299,7 +320,7 @@ def test_suggest_feature_flags(
 ):
     """
     Test that feature flags are added for the 'suggest' endpoint
-    (status codes: 200 & 400)
+    (status codes: 200 & 400).
     """
     expected_tags_per_metric = {
         metric_key: expected_tags for metric_key in expected_metric_keys

--- a/tests/integration/api/v1/suggest/test_suggest.py
+++ b/tests/integration/api/v1/suggest/test_suggest.py
@@ -25,8 +25,7 @@ from tests.types import FilterCaplogFixture
 
 @pytest.fixture(name="providers")
 def fixture_providers() -> Providers:
-    """
-    Define providers for this module which are injected automatically.
+    """Define providers for this module which are injected automatically.
 
     Note: This fixture will be overridden if a test method has a
           'pytest.mark.parametrize' decorator with a 'providers' definition.
@@ -38,8 +37,7 @@ def fixture_providers() -> Providers:
 
 
 def test_suggest_sponsored(client: TestClient) -> None:
-    """
-    Test that the suggest endpoint response is as expected using a sponsored
+    """Test that the suggest endpoint response is as expected using a sponsored
     provider.
     """
     response = client.get("/api/v1/suggest?q=sponsored")
@@ -52,8 +50,7 @@ def test_suggest_sponsored(client: TestClient) -> None:
 
 
 def test_suggest_nonsponsored(client: TestClient) -> None:
-    """
-    Test that the suggest endpoint response is as expected using a non-sponsored
+    """Test that the suggest endpoint response is as expected using a non-sponsored
     provider.
     """
     response = client.get("/api/v1/suggest?q=nonsponsored")
@@ -67,8 +64,7 @@ def test_suggest_nonsponsored(client: TestClient) -> None:
 
 
 def test_no_suggestion(client: TestClient) -> None:
-    """
-    Test that the suggest endpoint response is as expected when no suggestions are
+    """Test that the suggest endpoint response is as expected when no suggestions are
     returned from providers.
     """
     response = client.get("/api/v1/suggest?q=nope")
@@ -78,9 +74,8 @@ def test_no_suggestion(client: TestClient) -> None:
 
 @pytest.mark.parametrize("query", ["sponsored", "nonsponsored"])
 def test_suggest_from_missing_providers(client: TestClient, query: str) -> None:
-    """
-    Despite the keyword being available for other providers, it should not return any
-    suggestions if the requested provider does not exist.
+    """Despite the keyword being available for other providers, it should not return
+    any suggestions if the requested provider does not exist.
     """
     response = client.get(f"/api/v1/suggest?q={query}&providers=nonexist")
     assert response.status_code == 200
@@ -88,8 +83,7 @@ def test_suggest_from_missing_providers(client: TestClient, query: str) -> None:
 
 
 def test_no_query_string(client: TestClient) -> None:
-    """
-    Test that a status code of 400 is returned for suggest endpoint calls without
+    """Test that a status code of 400 is returned for suggest endpoint calls without
     a query string.
     """
     response = client.get("/api/v1/suggest")
@@ -97,8 +91,7 @@ def test_no_query_string(client: TestClient) -> None:
 
 
 def test_client_variants(client: TestClient) -> None:
-    """
-    Test that the suggest endpoint response is as expected when called with the
+    """Test that the suggest endpoint response is as expected when called with the
     client_variants parameter.
     """
     response = client.get("/api/v1/suggest?q=sponsored&client_variants=foo,bar")
@@ -116,8 +109,7 @@ def test_suggest_request_log_data(
     filter_caplog: FilterCaplogFixture,
     client: TestClient,
 ) -> None:
-    """
-    Tests that the request logs for the 'suggest' endpoint contain the required
+    """Tests that the request logs for the 'suggest' endpoint contain the required
     extra data.
     """
     caplog.set_level(logging.INFO)
@@ -244,8 +236,7 @@ def test_suggest_metrics(
     url: str,
     expected_metric_keys: list[str],
 ) -> None:
-    """
-    Test that metrics are recorded for the 'suggest' endpoint
+    """Test that metrics are recorded for the 'suggest' endpoint
     (status codes: 200 & 400).
     """
     report = mocker.patch.object(aiodogstatsd.Client, "_report")
@@ -318,8 +309,7 @@ def test_suggest_feature_flags(
     expected_metric_keys: list,
     expected_tags: list,
 ):
-    """
-    Test that feature flags are added for the 'suggest' endpoint
+    """Test that feature flags are added for the 'suggest' endpoint
     (status codes: 200 & 400).
     """
     expected_tags_per_metric = {

--- a/tests/integration/api/v1/suggest/test_suggest_top_picks.py
+++ b/tests/integration/api/v1/suggest/test_suggest_top_picks.py
@@ -2,8 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-"""
-Integration tests for the Merino v1 suggest API endpoint configured with the
+"""Integration tests for the Merino v1 suggest API endpoint configured with the
 Top Picks provider.
 """
 

--- a/tests/integration/api/v1/suggest/test_suggest_top_picks.py
+++ b/tests/integration/api/v1/suggest/test_suggest_top_picks.py
@@ -2,6 +2,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+"""
+Integration tests for the Merino v1 suggest API endpoint configured with the
+Top Picks provider.
+"""
+
 import pytest
 from fastapi.testclient import TestClient
 

--- a/tests/integration/api/v1/suggest/test_suggest_wiki_fruit.py
+++ b/tests/integration/api/v1/suggest/test_suggest_wiki_fruit.py
@@ -2,6 +2,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+"""
+Integration tests for the Merino v1 suggest API endpoint configured with the
+Wiki Fruit provider.
+"""
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -19,6 +24,10 @@ def fixture_providers() -> Providers:
 
 @pytest.mark.parametrize("query", ["apple", "banana", "cherry"])
 def test_suggest_hit(client: TestClient, query: str) -> None:
+    """
+    Test that the suggest endpoint response is as expected when a suggestion is
+    supplied from the wiki fruit provider.
+    """
     response = client.get(f"/api/v1/suggest?q={query}")
     assert response.status_code == 200
 
@@ -29,6 +38,10 @@ def test_suggest_hit(client: TestClient, query: str) -> None:
 
 
 def test_suggest_miss(client: TestClient) -> None:
+    """
+    Test that the suggest endpoint response is as expected when a suggestion is not
+    supplied from the wiki fruit provider.
+    """
     response = client.get("/api/v1/suggest?q=nope")
     assert response.status_code == 200
 

--- a/tests/integration/api/v1/suggest/test_suggest_wiki_fruit.py
+++ b/tests/integration/api/v1/suggest/test_suggest_wiki_fruit.py
@@ -2,8 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-"""
-Integration tests for the Merino v1 suggest API endpoint configured with the
+"""Integration tests for the Merino v1 suggest API endpoint configured with the
 Wiki Fruit provider.
 """
 
@@ -24,8 +23,7 @@ def fixture_providers() -> Providers:
 
 @pytest.mark.parametrize("query", ["apple", "banana", "cherry"])
 def test_suggest_hit(client: TestClient, query: str) -> None:
-    """
-    Test that the suggest endpoint response is as expected when a suggestion is
+    """Test that the suggest endpoint response is as expected when a suggestion is
     supplied from the wiki fruit provider.
     """
     response = client.get(f"/api/v1/suggest?q={query}")
@@ -38,8 +36,7 @@ def test_suggest_hit(client: TestClient, query: str) -> None:
 
 
 def test_suggest_miss(client: TestClient) -> None:
-    """
-    Test that the suggest endpoint response is as expected when a suggestion is not
+    """Test that the suggest endpoint response is as expected when a suggestion is not
     supplied from the wiki fruit provider.
     """
     response = client.get("/api/v1/suggest?q=nope")

--- a/tests/integration/api/v1/suggest/test_timeout_handling.py
+++ b/tests/integration/api/v1/suggest/test_timeout_handling.py
@@ -2,8 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-"""
-Integration tests for the Merino v1 suggest API endpoint focusing on time out
+"""Integration tests for the Merino v1 suggest API endpoint focusing on time out
 behavior.
 """
 
@@ -36,9 +35,8 @@ def test_with_timedout_provider(
     caplog: LogCaptureFixture,
     filter_caplog: FilterCaplogFixture,
 ) -> None:
-    """
-    Test that the suggest endpoint response is as expected when providers don't supply
-    suggestions within a configured time limit.
+    """Test that the suggest endpoint response is as expected when providers don't
+    supply suggestions within a configured time limit.
     """
     report = mocker.patch.object(aiodogstatsd.Client, "_report")
 

--- a/tests/integration/api/v1/suggest/test_timeout_handling.py
+++ b/tests/integration/api/v1/suggest/test_timeout_handling.py
@@ -1,3 +1,12 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""
+Integration tests for the Merino v1 suggest API endpoint focusing on time out
+behavior.
+"""
+
 import aiodogstatsd
 import pytest
 from fastapi.testclient import TestClient
@@ -27,6 +36,10 @@ def test_with_timedout_provider(
     caplog: LogCaptureFixture,
     filter_caplog: FilterCaplogFixture,
 ) -> None:
+    """
+    Test that the suggest endpoint response is as expected when providers don't supply
+    suggestions within a configured time limit.
+    """
     report = mocker.patch.object(aiodogstatsd.Client, "_report")
 
     response = client.get("/api/v1/suggest?q=sponsored")

--- a/tests/integration/api/v1/test_unsupported.py
+++ b/tests/integration/api/v1/test_unsupported.py
@@ -28,7 +28,8 @@ def test_unsupported_endpoint_request_log_data(
     client: TestClient,
 ) -> None:
     """
-    Test that the request log for unsupported endpoints contains the required extra data
+    Test that the request log for unsupported endpoints contains the required extra
+    data.
     """
     caplog.set_level(logging.INFO)
 
@@ -70,7 +71,7 @@ def test_unsupported_endpoint_request_log_data(
 def test_unsupported_endpoint_metrics(
     mocker: MockerFixture, client: TestClient
 ) -> None:
-    """Test that metrics are recorded for unsupported endpoints (status code 404)"""
+    """Test that metrics are recorded for unsupported endpoints (status code 404)."""
     expected_metric_keys: list[str] = ["response.status_codes.404"]
 
     report = mocker.patch.object(aiodogstatsd.Client, "_report")
@@ -85,7 +86,8 @@ def test_unsupported_endpoint_metrics(
 @pytest.mark.parametrize("providers", [{}])
 def test_unsupported_endpoint_flags(mocker: MockerFixture, client: TestClient) -> None:
     """
-    Test that feature flags are not added for unsupported endpoints (status code 404)
+    Test that feature flags are not added for unsupported endpoints
+    (status code 404).
     """
     expected_tags_per_metric: dict[str, list[str]] = {"response.status_codes.404": []}
 

--- a/tests/integration/api/v1/test_unsupported.py
+++ b/tests/integration/api/v1/test_unsupported.py
@@ -27,8 +27,7 @@ def test_unsupported_endpoint_request_log_data(
     extract_request_summary_log_data: RequestSummaryLogDataFixture,
     client: TestClient,
 ) -> None:
-    """
-    Test that the request log for unsupported endpoints contains the required extra
+    """Test that the request log for unsupported endpoints contains the required extra
     data.
     """
     caplog.set_level(logging.INFO)
@@ -85,8 +84,7 @@ def test_unsupported_endpoint_metrics(
 
 @pytest.mark.parametrize("providers", [{}])
 def test_unsupported_endpoint_flags(mocker: MockerFixture, client: TestClient) -> None:
-    """
-    Test that feature flags are not added for unsupported endpoints
+    """Test that feature flags are not added for unsupported endpoints
     (status code 404).
     """
     expected_tags_per_metric: dict[str, list[str]] = {"response.status_codes.404": []}

--- a/tests/integration/api/v1/types.py
+++ b/tests/integration/api/v1/types.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+"""Type definitions for the v1 integration test modules."""
+
 from typing import Callable
 
 from merino.providers import BaseProvider

--- a/tests/integration/test_setup.py
+++ b/tests/integration/test_setup.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+"""Integration tests for Merino application startup."""
+
 import pytest
 from pytest_mock import MockerFixture
 from starlette.testclient import TestClient
@@ -13,7 +15,6 @@ from merino.main import app
 
 def test_unknown_providers_should_shutdown_app(mocker: MockerFixture) -> None:
     """Test Merino should shut down upon an unknown provider."""
-
     mocker.patch.dict(settings.providers, values={"unknown-provider": {}})
 
     with pytest.raises(InvalidProviderError) as excinfo:

--- a/tests/load/tests/__init__.py
+++ b/tests/load/tests/__init__.py
@@ -1,3 +1,5 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Modules dedicated to load testing the merino service."""

--- a/tests/load/tests/client_info.py
+++ b/tests/load/tests/client_info.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+"""Load test header definitions."""
+
 # See https://mozilla-services.github.io/merino/api.html#headers
 
 from typing import List

--- a/tests/load/tests/kinto.py
+++ b/tests/load/tests/kinto.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+"""Module for communication with Kinto (Remote Settings)."""
+
 import logging
 from typing import Dict, List
 
@@ -22,7 +24,6 @@ class KintoSuggestion(BaseModel, extra=Extra.ignore):
 
 def download_suggestions(client: kinto_http.Client) -> Dict[int, KintoSuggestion]:
     """Get records, download attachments and return the suggestions."""
-
     # Retrieve the base_url for attachments
     server_info = client.server_info()
     attachments_base_url = server_info["capabilities"]["attachments"]["base_url"]

--- a/tests/load/tests/locustfile.py
+++ b/tests/load/tests/locustfile.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+"""Load test."""
+
 import logging
 import os
 from random import choice, randint
@@ -47,7 +49,6 @@ RS_SUGGESTIONS: List[Dict] = []
 @events.test_start.add_listener
 def on_locust_test_start(environment, **kwargs):
     """Download suggestions from Kinto and store suggestions on workers."""
-
     if not isinstance(environment.runner, MasterRunner):
         return
 
@@ -86,7 +87,6 @@ def on_locust_init(environment, **kwargs):
 
 def request_suggestions(client: HttpSession, query: str) -> None:
     """Request suggestions from Merino for the given query string."""
-
     params: Dict[str, Any] = {"q": query}
 
     if CLIENT_VARIANTS:
@@ -120,6 +120,7 @@ class MerinoUser(HttpUser):
     """User that sends requests to the Merino API."""
 
     def on_start(self):
+        """Instructions to execute for each simulated user when they start."""
         # Create a Faker instance for generating random suggest queries
         self.faker = faker.Faker(locale="en-US", providers=["faker.providers.lorem"])
 
@@ -134,7 +135,6 @@ class MerinoUser(HttpUser):
     @task(weight=10)
     def rs_suggestions(self) -> None:
         """Send multiple requests for Remote Settings queries."""
-
         suggestion = choice(RS_SUGGESTIONS)  # nosec
 
         for query in suggestion["keywords"]:
@@ -143,7 +143,6 @@ class MerinoUser(HttpUser):
     @task(weight=90)
     def faker_suggestions(self) -> None:
         """Send multiple requests for random queries."""
-
         # This produces a query between 2 and 4 random words
         full_query = " ".join(self.faker.words(nb=randint(2, 4)))  # nosec
 
@@ -157,7 +156,6 @@ class MerinoUser(HttpUser):
     @task(weight=1)
     def wikifruit_suggestions(self) -> None:
         """Send multiple requests for random WikiFruit queries."""
-
         # These queries are supported by the WikiFruit provider
         for fruit in ("apple", "banana", "cherry"):
             request_suggestions(self.client, fruit)

--- a/tests/load/tests/models.py
+++ b/tests/load/tests/models.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+"""Load test models."""
+
 from typing import List, Optional
 from uuid import UUID
 

--- a/tests/types.py
+++ b/tests/types.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+"""Type definitions for all test modules."""
+
 from logging import LogRecord
 from typing import Callable
 

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,5 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Modules dedicated to unit testing the merino service."""

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+"""Module for test configurations for the unit test directory."""
+
 import pytest
 
 from merino.middleware.geolocation import Location

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -13,8 +13,7 @@ from tests.unit.types import SuggestionRequestFixture
 
 @pytest.fixture(scope="session", name="srequest")
 def fixture_srequest() -> SuggestionRequestFixture:
-    """
-    Return a function that will create a SuggestionRequest object with a given
+    """Return a function that will create a SuggestionRequest object with a given
     `query`
     """
 

--- a/tests/unit/middleware/__init__.py
+++ b/tests/unit/middleware/__init__.py
@@ -1,0 +1,5 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Modules dedicated to unit testing the middleware in the merino service."""

--- a/tests/unit/middleware/conftest.py
+++ b/tests/unit/middleware/conftest.py
@@ -13,18 +13,18 @@ from starlette.types import Receive, Scope, Send
 
 @pytest.fixture(name="scope")
 def fixture_scope() -> Scope:
-    """Create a Scope object for test"""
+    """Create a Scope object for test."""
     scope: Scope = {"type": "http"}
     return scope
 
 
 @pytest.fixture(name="receive_mock")
 def fixture_receive_mock(mocker: MockerFixture) -> Any:
-    """Create a Receive mock object for test"""
+    """Create a Receive mock object for test."""
     return mocker.AsyncMock(spec=Receive)
 
 
 @pytest.fixture(name="send_mock")
 def fixture_send_mock(mocker: MockerFixture) -> Any:
-    """Create a Send mock object for test"""
+    """Create a Send mock object for test."""
     return mocker.AsyncMock(spec=Send)

--- a/tests/unit/middleware/conftest.py
+++ b/tests/unit/middleware/conftest.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-"""Module for test fixtures for the middleware unit test directory."""
+"""Module for test configurations for the middleware unit test directory."""
 
 from typing import Any
 

--- a/tests/unit/middleware/test_featureflags.py
+++ b/tests/unit/middleware/test_featureflags.py
@@ -14,7 +14,7 @@ from merino.middleware.featureflags import FeatureFlagsMiddleware
 
 @pytest.fixture(name="featureflags_middleware")
 def fixture_featureflags_middleware(mocker: MockerFixture) -> FeatureFlagsMiddleware:
-    """Creates a FeatureFlagsMiddleware object for test"""
+    """Create a FeatureFlagsMiddleware object for test"""
     asgiapp_mock = mocker.AsyncMock(spec=ASGIApp)
     return FeatureFlagsMiddleware(asgiapp_mock)
 
@@ -26,6 +26,7 @@ async def test_featureflags_sid_found(
     receive_mock: Receive,
     send_mock: Send,
 ) -> None:
+    """Test that SID is assigned given an `sid` query parameter."""
     expected_sid: str = "9aadf682-2f7a-4ad1-9976-dc30b60451d8"
     scope["query_string"] = f"q=nope&sid={expected_sid}"
 
@@ -41,7 +42,7 @@ async def test_featureflags_sid_not_found(
     receive_mock: Receive,
     send_mock: Send,
 ) -> None:
-    """Test that SID is assigned `None` is `sid` query parameter is not available."""
+    """Test that SID is assigned `None` if `sid` query parameter is not available."""
     scope["query_string"] = "q=nope"
 
     await featureflags_middleware(scope, receive_mock, send_mock)

--- a/tests/unit/middleware/test_featureflags.py
+++ b/tests/unit/middleware/test_featureflags.py
@@ -14,7 +14,7 @@ from merino.middleware.featureflags import FeatureFlagsMiddleware
 
 @pytest.fixture(name="featureflags_middleware")
 def fixture_featureflags_middleware(mocker: MockerFixture) -> FeatureFlagsMiddleware:
-    """Create a FeatureFlagsMiddleware object for test"""
+    """Create a FeatureFlagsMiddleware object for test."""
     asgiapp_mock = mocker.AsyncMock(spec=ASGIApp)
     return FeatureFlagsMiddleware(asgiapp_mock)
 

--- a/tests/unit/middleware/test_geolocation.py
+++ b/tests/unit/middleware/test_geolocation.py
@@ -67,9 +67,8 @@ async def test_geolocation_address_not_found(
     receive_mock: Receive,
     send_mock: Send,
 ) -> None:
-    """
-    Test that no assignment of Location properties takes place, given a request with an
-    unrecognised IP address.
+    """Test that no assignment of Location properties takes place, given a request
+    with an unrecognised IP address.
     """
     expected_location: Location = Location()
     scope["client"] = ["255.255.255.255", 50000]  # IP and port
@@ -89,8 +88,7 @@ async def test_geolocation_client_ip_override(
     receive_mock: Receive,
     send_mock: Send,
 ) -> None:
-    """
-    Test that the CLIENT_IP_OVERRIDE environment variable will take precedence over
+    """Test that the CLIENT_IP_OVERRIDE environment variable will take precedence over
     request IP assignment.
     """
     expected_location: Location = Location(
@@ -117,9 +115,8 @@ async def test_geolocation_invalid_address(
     send_mock: Send,
     client_ip_and_port: list,
 ) -> None:
-    """
-    Test that a warning is logged and no assignment of Location properties takes place,
-    given a request with an unexpected IP addresses.
+    """Test that a warning is logged and no assignment of Location properties takes
+    place, given a request with an unexpected IP addresses.
     """
     expected_location: Location = Location()
     scope["client"] = client_ip_and_port
@@ -138,9 +135,8 @@ async def test_geolocation_invalid_scope_type(
     receive_mock: Receive,
     send_mock: Send,
 ) -> None:
-    """
-    Test that no action, Location assignment or logging, takes place for an unexpected
-    Scope type.
+    """Test that no action, Location assignment or logging, takes place for an
+    unexpected Scope type.
     """
     scope: Scope = {"type": "not-http"}
 

--- a/tests/unit/middleware/test_geolocation.py
+++ b/tests/unit/middleware/test_geolocation.py
@@ -15,7 +15,7 @@ from merino.middleware.geolocation import GeolocationMiddleware, Location
 
 @pytest.fixture(name="geolocation_middleware")
 def fixture_geolocation_middleware(mocker: MockerFixture) -> GeolocationMiddleware:
-    """Create a GeolocationMiddleware object for test"""
+    """Create a GeolocationMiddleware object for test."""
     asgiapp_mock = mocker.AsyncMock(spec=ASGIApp)
     return GeolocationMiddleware(asgiapp_mock)
 

--- a/tests/unit/middleware/test_geolocation.py
+++ b/tests/unit/middleware/test_geolocation.py
@@ -15,7 +15,7 @@ from merino.middleware.geolocation import GeolocationMiddleware, Location
 
 @pytest.fixture(name="geolocation_middleware")
 def fixture_geolocation_middleware(mocker: MockerFixture) -> GeolocationMiddleware:
-    """Creates a GeolocationMiddleware object for test"""
+    """Create a GeolocationMiddleware object for test"""
     asgiapp_mock = mocker.AsyncMock(spec=ASGIApp)
     return GeolocationMiddleware(asgiapp_mock)
 

--- a/tests/unit/middleware/test_user_agent.py
+++ b/tests/unit/middleware/test_user_agent.py
@@ -14,7 +14,7 @@ from merino.middleware.user_agent import UserAgent, UserAgentMiddleware
 
 @pytest.fixture(name="user_agent_middleware")
 def fixture_user_agent_middleware(mocker: MockerFixture) -> UserAgentMiddleware:
-    """Creates a UserAgentMiddleware object for test"""
+    """Create a UserAgentMiddleware object for test"""
     asgiapp_mock = mocker.AsyncMock(spec=ASGIApp)
     return UserAgentMiddleware(asgiapp_mock)
 

--- a/tests/unit/middleware/test_user_agent.py
+++ b/tests/unit/middleware/test_user_agent.py
@@ -14,7 +14,7 @@ from merino.middleware.user_agent import UserAgent, UserAgentMiddleware
 
 @pytest.fixture(name="user_agent_middleware")
 def fixture_user_agent_middleware(mocker: MockerFixture) -> UserAgentMiddleware:
-    """Create a UserAgentMiddleware object for test"""
+    """Create a UserAgentMiddleware object for test."""
     asgiapp_mock = mocker.AsyncMock(spec=ASGIApp)
     return UserAgentMiddleware(asgiapp_mock)
 

--- a/tests/unit/providers/__init__.py
+++ b/tests/unit/providers/__init__.py
@@ -1,0 +1,5 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Modules dedicated to unit testing the providers in the merino service."""

--- a/tests/unit/providers/test_accuweather.py
+++ b/tests/unit/providers/test_accuweather.py
@@ -357,7 +357,7 @@ async def test_invalid_location_key_forecast(
 async def test_no_client_country_or_postal_code(
     caplog: LogCaptureFixture, accuweather: Provider, geolocation: Location
 ):
-    """Test that if a client has an unknown country or postal code, that a warning is
+    """Test that if a client has an unknown country or postal code, a warning is
     logged and no suggestions are returned.
     """
     set_response_bodies()

--- a/tests/unit/providers/test_accuweather.py
+++ b/tests/unit/providers/test_accuweather.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+"""Unit tests for the accuweather provider module."""
+
 import pytest
 from fastapi import APIRouter, FastAPI
 from pytest import LogCaptureFixture
@@ -176,6 +178,7 @@ def set_response_bodies(
     current_conditions: dict = default_current_conditions_body,
     forecast: dict = default_forecast_body,
 ):
+    """Set the response body values for fake Accuweather API endpoints."""
     global location_body
     global current_conditions_body
     global forecast_body
@@ -186,16 +189,19 @@ def set_response_bodies(
 
 @router.get("/locations/v1/postalcodes/US/search.json")
 async def router_locations_postalcodes_search():
+    """Return fake postal code data."""
     return location_body
 
 
 @router.get("/currentconditions/v1/39376_PC.json")
 async def router_current_conditions():
+    """Return fake current conditions data."""
     return current_conditions_body
 
 
 @router.get("/forecasts/v1/daily/1day/39376_PC.json")
 async def router_forecasts_daily_1day():
+    """Return fake forcast data."""
     return forecast_body
 
 
@@ -222,20 +228,17 @@ def fixture_accuweather() -> Provider:
 
 def test_enabled_by_default(accuweather: Provider) -> None:
     """Test for the enabled_by_default method."""
-
     assert accuweather.enabled_by_default is False
 
 
 def test_hidden(accuweather: Provider) -> None:
     """Test for the hidden method."""
-
     assert accuweather.hidden() is False
 
 
 @pytest.mark.asyncio
 async def test_forecast_returned(accuweather: Provider, geolocation: Location) -> None:
     """Test for a successful query."""
-
     set_response_bodies()
 
     res = await accuweather.query(SuggestionRequest(query="", geolocation=geolocation))
@@ -278,7 +281,6 @@ async def test_no_location_returned(
     accuweather: Provider, geolocation: Location
 ) -> None:
     """Test for a query that doesn't return a location."""
-
     set_response_bodies(location=[])
 
     res = await accuweather.query(SuggestionRequest(query="", geolocation=geolocation))
@@ -289,9 +291,7 @@ async def test_no_location_returned(
 async def test_no_current_conditions_returned(
     accuweather: Provider, geolocation: Location
 ) -> None:
-    """Test for a query that doesn't return current conditions for a valid
-    location."""
-
+    """Test for a query that doesn't return current conditions for a valid location."""
     set_response_bodies(current_conditions=[])
 
     res = await accuweather.query(SuggestionRequest(query="", geolocation=geolocation))
@@ -303,7 +303,6 @@ async def test_no_forecast_returned(
     accuweather: Provider, geolocation: Location
 ) -> None:
     """Test for a query that doesn't return a forecast for a valid location."""
-
     set_response_bodies(forecast={})
 
     res = await accuweather.query(SuggestionRequest(query="", geolocation=geolocation))
@@ -314,9 +313,10 @@ async def test_no_forecast_returned(
 async def test_invalid_location_key_current_conditions(
     accuweather: Provider, geolocation: Location
 ) -> None:
-    """Test for a query that doesn't return current conditions due to an invalid
-    location key."""
-
+    """
+    Test for a query that doesn't return current conditions due to an invalid location
+    key.
+    """
     set_response_bodies(
         current_conditions={
             "Code": "400",
@@ -333,9 +333,7 @@ async def test_invalid_location_key_current_conditions(
 async def test_invalid_location_key_forecast(
     accuweather: Provider, geolocation: Location
 ) -> None:
-    """Test for a query that doesn't return a forecast due to an invalid
-    location key."""
-
+    """Test a query that doesn't return a forecast due to an invalid location key."""
     set_response_bodies(
         forecast={
             "Code": "400",
@@ -360,8 +358,10 @@ async def test_invalid_location_key_forecast(
 async def test_no_client_country_or_postal_code(
     caplog: LogCaptureFixture, accuweather: Provider, geolocation: Location
 ):
-    """Test that if a client has an unknown country or postal code, that a
-    warning is logged and no suggestions are returned."""
+    """
+    Test that if a client has an unknown country or postal code, that a warning is
+    logged and no suggestions are returned.
+    """
     set_response_bodies()
 
     res = await accuweather.query(SuggestionRequest(query="", geolocation=geolocation))

--- a/tests/unit/providers/test_accuweather.py
+++ b/tests/unit/providers/test_accuweather.py
@@ -313,9 +313,8 @@ async def test_no_forecast_returned(
 async def test_invalid_location_key_current_conditions(
     accuweather: Provider, geolocation: Location
 ) -> None:
-    """
-    Test for a query that doesn't return current conditions due to an invalid location
-    key.
+    """Test for a query that doesn't return current conditions due to an invalid
+    location key.
     """
     set_response_bodies(
         current_conditions={
@@ -358,8 +357,7 @@ async def test_invalid_location_key_forecast(
 async def test_no_client_country_or_postal_code(
     caplog: LogCaptureFixture, accuweather: Provider, geolocation: Location
 ):
-    """
-    Test that if a client has an unknown country or postal code, that a warning is
+    """Test that if a client has an unknown country or postal code, that a warning is
     logged and no suggestions are returned.
     """
     set_response_bodies()

--- a/tests/unit/providers/test_adm.py
+++ b/tests/unit/providers/test_adm.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+"""Unit tests for the adm provider module."""
+
 import json
 from typing import Any
 from unittest.mock import AsyncMock
@@ -21,7 +23,6 @@ class FakeBackend:
 
     async def get(self, bucket: str, collection: str) -> list[dict[str, Any]]:
         """Return fake records."""
-
         return [
             {
                 "type": "data",
@@ -67,7 +68,6 @@ class FakeBackend:
 
     async def fetch_attachment(self, attachment_uri: str) -> httpx.Response:
         """Return a fake attachment for the given URI."""
-
         attachments = {
             "main-workspace/quicksuggest/attachmment-01.json": {
                 "id": 1,
@@ -109,33 +109,28 @@ class FakeBackend:
 
     def get_icon_url(self, icon_uri: str) -> str:
         """Return a fake icon URL for the given URI."""
-
         return f"attachment-host/{icon_uri}"
 
 
 @pytest.fixture(name="adm")
 def fixture_adm() -> Provider:
     """Return an adM provider that uses a fake remote settings client."""
-
     return Provider(backend=FakeBackend())
 
 
 def test_enabled_by_default(adm: Provider) -> None:
     """Test for the enabled_by_default method."""
-
     assert adm.enabled_by_default is True
 
 
 def test_hidden(adm: Provider) -> None:
     """Test for the hidden method."""
-
     assert adm.hidden() is False
 
 
 @pytest.mark.asyncio
 async def test_initialize(adm: Provider) -> None:
     """Test for the initialize() method of the adM provider."""
-
     await adm.initialize()
 
     assert adm.suggestions == {
@@ -166,7 +161,6 @@ async def test_initialize_remote_settings_failure(
     caplog: LogCaptureFixture, filter_caplog: FilterCaplogFixture
 ) -> None:
     """Test exception handling for the initialize() method."""
-
     error_message: str = "The remote server was unreachable"
     backend_mock = AsyncMock(spec=RemoteSettingsBackend)
     backend_mock.get.side_effect = Exception(error_message)
@@ -188,7 +182,6 @@ async def test_initialize_remote_settings_failure(
 @pytest.mark.asyncio
 async def test_query_success(srequest: SuggestionRequestFixture, adm: Provider) -> None:
     """Test for the query() method of the adM provider."""
-
     await adm.initialize()
 
     res = await adm.query(srequest("firefox"))
@@ -214,7 +207,6 @@ async def test_query_with_missing_key(
     srequest: SuggestionRequestFixture, adm: Provider
 ) -> None:
     """Test for the query() method of the adM provider with a missing key."""
-
     await adm.initialize()
 
     assert await adm.query(srequest("nope")) == []

--- a/tests/unit/providers/test_adm_wikipedia.py
+++ b/tests/unit/providers/test_adm_wikipedia.py
@@ -1,5 +1,8 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Unit tests for the adm-wikipedia provider module."""
 
 import json
 from typing import Any
@@ -17,7 +20,6 @@ class FakeBackend:
 
     async def get(self, bucket: str, collection: str) -> list[dict[str, Any]]:
         """Return fake records."""
-
         return [
             {
                 "type": "data",
@@ -50,7 +52,6 @@ class FakeBackend:
 
     async def fetch_attachment(self, attachment_uri: str) -> httpx.Response:
         """Return a fake attachment for the given URI."""
-
         attachments = {
             "main-workspace/quicksuggest/attachment-01.json": {
                 "id": 1,
@@ -68,21 +69,18 @@ class FakeBackend:
 
     def get_icon_url(self, icon_uri: str) -> str:
         """Return a fake icon URL for the given URI."""
-
         return f"attachment-host/{icon_uri}"
 
 
 @pytest.fixture(name="adm")
 def fixture_adm() -> Provider:
     """Return an adM provider that uses a fake remote settings client."""
-
     return Provider(backend=FakeBackend())
 
 
 @pytest.mark.asyncio
 async def test_initialize(adm: Provider) -> None:
     """Test for the initialize() method of the adM provider."""
-
     await adm.initialize()
 
     assert adm.suggestions == {"mozilla": (0, 0)}
@@ -104,7 +102,6 @@ async def test_wikipedia_specific_score(
     srequest: SuggestionRequestFixture, adm: Provider
 ) -> None:
     """Test for the query() method of the adM provider."""
-
     await adm.initialize()
 
     res = await adm.query(srequest("mozilla"))

--- a/tests/unit/providers/test_init_providers.py
+++ b/tests/unit/providers/test_init_providers.py
@@ -1,3 +1,9 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Unit tests for the __init__ provider module."""
+
 import pytest
 from pytest_mock import MockerFixture
 
@@ -9,7 +15,6 @@ from merino.providers import ProviderType, get_providers, init_providers
 @pytest.mark.asyncio
 async def test_init_providers() -> None:
     """Test for the `init_providers` method of the Merino providers module."""
-
     await init_providers()
 
     providers, default_providers = get_providers()
@@ -25,7 +30,6 @@ async def test_init_providers() -> None:
 @pytest.mark.asyncio
 async def test_init_providers_unknown_provider_type(mocker: MockerFixture) -> None:
     """Test for the `init_providers` with an unknown provider."""
-
     mocker.patch.dict(settings.providers, values={"unknown-provider": {}})
 
     with pytest.raises(InvalidProviderError) as excinfo:

--- a/tests/unit/providers/test_top_picks.py
+++ b/tests/unit/providers/test_top_picks.py
@@ -170,8 +170,7 @@ async def test_query(srequest: SuggestionRequestFixture, top_picks: Provider) ->
 async def test_short_domain_query(
     query, title, url, srequest: SuggestionRequestFixture, top_picks: Provider
 ) -> None:
-    """
-    Test the Top Pick Provider returns results for short domain queries.
+    """Test the Top Pick Provider returns results for short domain queries.
     Ensure that matching suggestion and similar variants with low char
     threshold return suggestions.
     """
@@ -221,9 +220,8 @@ async def test_short_domain_query_fails(
 async def test_short_domain_query_similars_longer_than_domain(
     query, title, url, srequest: SuggestionRequestFixture, top_picks: Provider
 ) -> None:
-    """
-    Test suggestion results for similar inputs that are indexed for short domains. These
-    similar suggestion results may be longer than the input, so if the domain is
+    """Test suggestion results for similar inputs that are indexed for short domains.
+    These similar suggestion results may be longer than the input, so if the domain is
     categorized as short and the similar is longer than it, the result should
     still return a valid suggestion as its characters will be a subset of the similar.
     """

--- a/tests/unit/providers/test_top_picks.py
+++ b/tests/unit/providers/test_top_picks.py
@@ -1,6 +1,9 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Unit tests for the top picks provider module."""
+
 import os
 
 import pytest
@@ -121,7 +124,6 @@ async def test_initialize_exception(top_picks: Provider, mocker) -> None:
 @pytest.mark.asyncio
 async def test_query(srequest: SuggestionRequestFixture, top_picks: Provider) -> None:
     """Test for the query method of the Top Pick provider."""
-
     await top_picks.initialize()
     assert await top_picks.query(srequest("am")) == []
     assert await top_picks.query(srequest("https://")) == []
@@ -168,9 +170,11 @@ async def test_query(srequest: SuggestionRequestFixture, top_picks: Provider) ->
 async def test_short_domain_query(
     query, title, url, srequest: SuggestionRequestFixture, top_picks: Provider
 ) -> None:
-    """Test the Top Pick Provider returns results for short domain queries.
+    """
+    Test the Top Pick Provider returns results for short domain queries.
     Ensure that matching suggestion and similar variants with low char
-    threshold return suggestions."""
+    threshold return suggestions.
+    """
     expected_suggestion: list[Suggestion] = [
         Suggestion(
             block_id=0,
@@ -217,10 +221,12 @@ async def test_short_domain_query_fails(
 async def test_short_domain_query_similars_longer_than_domain(
     query, title, url, srequest: SuggestionRequestFixture, top_picks: Provider
 ) -> None:
-    """Test suggestion results for similar inputs that are indexed for short domains. These
+    """
+    Test suggestion results for similar inputs that are indexed for short domains. These
     similar suggestion results may be longer than the input, so if the domain is
     categorized as short and the similar is longer than it, the result should
-    still return a valid suggestion as its characters will be a subset of the similar."""
+    still return a valid suggestion as its characters will be a subset of the similar.
+    """
     expected_suggestion: list[Suggestion] = [
         Suggestion(
             block_id=0,

--- a/tests/unit/test_config_logging.py
+++ b/tests/unit/test_config_logging.py
@@ -1,10 +1,20 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Unit tests for the config_logging.py module."""
+
 import pytest
 
 from merino.config import settings
 from merino.config_logging import configure_logging
 
 
-def test_invalid_format():
+def test_configure_logging_invalid_format():
+    """
+    Test that configure_logging will raise a ValueError when encountering unknown log
+    formats.
+    """
     old_format = settings.logging.format
     settings.logging.format = "invalid"
 
@@ -16,7 +26,11 @@ def test_invalid_format():
     settings.logging.format = old_format
 
 
-def test_mozlog_production():
+def test_configure_logging_mozlog_production():
+    """
+    Test that configure_logging will raise a ValueError when using a format other than
+    'mozlog' in production.
+    """
     with settings.using_env("production"):
         old_format = settings.logging.format
         settings.logging.format = "pretty"

--- a/tests/unit/test_config_logging.py
+++ b/tests/unit/test_config_logging.py
@@ -11,8 +11,7 @@ from merino.config_logging import configure_logging
 
 
 def test_configure_logging_invalid_format():
-    """
-    Test that configure_logging will raise a ValueError when encountering unknown log
+    """Test that configure_logging will raise a ValueError when encountering unknown log
     formats.
     """
     old_format = settings.logging.format
@@ -27,9 +26,8 @@ def test_configure_logging_invalid_format():
 
 
 def test_configure_logging_mozlog_production():
-    """
-    Test that configure_logging will raise a ValueError when using a format other than
-    'mozlog' in production.
+    """Test that configure_logging will raise a ValueError when using a format other
+    than 'mozlog' in production.
     """
     with settings.using_env("production"):
         old_format = settings.logging.format

--- a/tests/unit/test_cron.py
+++ b/tests/unit/test_cron.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+"""Unit tests for the cron.py module."""
+
 import asyncio
 import logging
 from typing import Any
@@ -22,7 +24,7 @@ def fixture_condition(numbers: list[int]) -> cron.Condition:
     """Return a condition for a cron job."""
 
     def should_run() -> bool:
-        """Returns True if there are no more than 2 items in numbers."""
+        """Return True if there are no more than 2 items in numbers."""
         return len(numbers) <= 2
 
     return should_run
@@ -33,7 +35,7 @@ def fixture_task(numbers: list[int]) -> cron.Task:
     """Return a task for a cron job."""
 
     async def add_number() -> None:
-        """Adds a new number to the list."""
+        """Add a new number to the list."""
         new_number = numbers[-1] + 1
 
         if new_number == 2:
@@ -48,14 +50,12 @@ def fixture_task(numbers: list[int]) -> cron.Task:
 @pytest.fixture(name="cron_job")
 def fixture_cron_job(condition: cron.Condition, task: cron.Task) -> cron.Job:
     """Return a cron job."""
-
     return cron.Job(name="create_numbers", interval=0.1, condition=condition, task=task)
 
 
 @pytest.mark.asyncio
 async def test_cron(caplog: Any, cron_job: cron.Job, numbers: list[int]) -> None:
     """Test for the CronJob implementation."""
-
     caplog.set_level(logging.INFO)
 
     # Schedule the task like adm.Provider does it

--- a/tests/unit/test_featureflags.py
+++ b/tests/unit/test_featureflags.py
@@ -4,7 +4,7 @@
 
 """Unit tests for the featureflags.py module.
 
-This module depends on testing.toml
+This module depends on testing.toml.
 """
 
 import pytest

--- a/tests/unit/test_featureflags.py
+++ b/tests/unit/test_featureflags.py
@@ -2,8 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-"""
-Unit tests for the featureflags.py module.
+"""Unit tests for the featureflags.py module.
 
 This module depends on testing.toml
 """
@@ -33,9 +32,8 @@ def test_not_enabled():
 
 
 def test_no_scheme_no_session_id(caplog):
-    """
-    Test that if a flag is defined without a 'scheme' then is_enabled will return False
-    and an error message will be logged.
+    """Test that if a flag is defined without a 'scheme' then is_enabled will return
+    False and an error message will be logged.
     """
     import logging
 
@@ -56,9 +54,8 @@ def test_no_scheme_no_session_id(caplog):
     ids=["session_id_on", "session_id_off"],
 )
 def test_no_scheme_default_session_id(bucket_id: str, want: bool):
-    """
-    Test that is_enabled returns as expected given a flag with no 'scheme' definition
-    and a given session_id_context.
+    """Test that is_enabled returns as expected given a flag with no 'scheme'
+    definition and a given session_id_context.
     """
     session_id_context.set(bucket_id)
     flags = FeatureFlags()

--- a/tests/unit/test_featureflags.py
+++ b/tests/unit/test_featureflags.py
@@ -1,25 +1,42 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""
+Unit tests for the featureflags.py module.
+
+This module depends on testing.toml
+"""
+
 import pytest
 from pydantic import ValidationError
 
 from merino.featureflags import FeatureFlags, session_id_context
 
 
-def test_missing():
+def test__missing():
+    """Test that is_enabled will return False if a flag is undefined."""
     flags = FeatureFlags()
     assert not flags.is_enabled("test-missing")
 
 
 def test_enabled():
+    """Test that is_enabled will return True if a flag is defined as enabled."""
     flags = FeatureFlags()
     assert flags.is_enabled("test-enabled")
 
 
 def test_not_enabled():
+    """Test that is_enabled will return False if a flag is defined as disabled."""
     flags = FeatureFlags()
     assert not flags.is_enabled("test-not-enabled")
 
 
 def test_no_scheme_no_session_id(caplog):
+    """
+    Test that if a flag is defined without a 'scheme' then is_enabled will return False
+    and an error message will be logged.
+    """
     import logging
 
     caplog.set_level(logging.ERROR)
@@ -39,6 +56,10 @@ def test_no_scheme_no_session_id(caplog):
     ids=["session_id_on", "session_id_off"],
 )
 def test_no_scheme_default_session_id(bucket_id: str, want: bool):
+    """
+    Test that is_enabled returns as expected given a flag with no 'scheme' definition
+    and a given session_id_context.
+    """
     session_id_context.set(bucket_id)
     flags = FeatureFlags()
     assert flags.is_enabled("test-no-scheme") is want
@@ -82,5 +103,6 @@ def test_enabled_perc_session(bucket_id: str, want: bool):
     ids=["invalid-scheme", "enabled-range"],
 )
 def test_raises_malformed_config(config: dict):
+    """Test that a ValidationError is raised given a malformed flag configuration."""
     with pytest.raises(ValidationError):
         FeatureFlags(flags=config)

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -1,4 +1,8 @@
-"""Unit tests for the metrics client."""
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Unit tests for the metrics.py module."""
 
 import aiodogstatsd
 import pytest
@@ -25,7 +29,6 @@ def fixture_metrics_client(statsd_mock):
 
 def test_unsupported_method(metrics_client: Client, statsd_mock):
     """Test that the metrics client raises an error for unsupported methods."""
-
     want = "attribute 'hello_world' is not supported by metrics.Client class"
 
     with pytest.raises(AttributeError) as exc_info:

--- a/tests/unit/types.py
+++ b/tests/unit/types.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+"""Type definitions for unit test modules."""
+
 from typing import Callable
 
 from merino.providers.base import SuggestionRequest

--- a/tests/unit/utils/__init__.py
+++ b/tests/unit/utils/__init__.py
@@ -1,0 +1,5 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Modules dedicated to unit testing the utils in the merino service."""

--- a/tests/unit/utils/test_log_data_creator.py
+++ b/tests/unit/utils/test_log_data_creator.py
@@ -34,9 +34,8 @@ def test_create_request_summary_log_data(
     expected_agent: str | None,
     expected_lang: str | None,
 ) -> None:
-    """
-    Test that the create_request_summary_log_data method properly constructs log data
-    given different headers.
+    """Test that the create_request_summary_log_data method properly constructs log
+    data given different headers.
     """
     expected_log_data: dict[str, Any] = {
         "errno": 0,
@@ -104,8 +103,7 @@ def test_create_suggest_log_data(
     expected_providers: str,
     expected_seq: int | None,
 ) -> None:
-    """
-    Test that the create_suggest_log_data method properly constructs log data given
+    """Test that the create_suggest_log_data method properly constructs log data given
     different query parameters.
     """
     location: Location = Location(

--- a/tests/unit/utils/test_log_data_creator.py
+++ b/tests/unit/utils/test_log_data_creator.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-"""Unit tests for the log data creator utility module."""
+"""Unit tests for the log_data_creator.py utility module."""
 
 from datetime import datetime
 from typing import Any
@@ -34,6 +34,10 @@ def test_create_request_summary_log_data(
     expected_agent: str | None,
     expected_lang: str | None,
 ) -> None:
+    """
+    Test that the create_request_summary_log_data method properly constructs log data
+    given different headers.
+    """
     expected_log_data: dict[str, Any] = {
         "errno": 0,
         "time": "1998-03-31T00:00:00",
@@ -100,6 +104,10 @@ def test_create_suggest_log_data(
     expected_providers: str,
     expected_seq: int | None,
 ) -> None:
+    """
+    Test that the create_suggest_log_data method properly constructs log data given
+    different query parameters.
+    """
     location: Location = Location(
         country="US", region="WA", city="Milton", dma=819, postal_code="98354"
     )

--- a/tests/unit/utils/test_task_runner.py
+++ b/tests/unit/utils/test_task_runner.py
@@ -1,3 +1,9 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Unit tests for the task_runner.py utility module."""
+
 import asyncio
 
 import pytest
@@ -14,6 +20,8 @@ SLOW_COROUTINE_DURATION = 0.5
 
 @pytest_asyncio.fixture(name="normal_task")
 async def fixture_normal_task() -> asyncio.Task:
+    """Return a function that will return True."""
+
     async def normal_op() -> bool:
         return True
 
@@ -22,6 +30,8 @@ async def fixture_normal_task() -> asyncio.Task:
 
 @pytest_asyncio.fixture(name="timedout_task")
 async def fixture_timedout_task() -> asyncio.Task:
+    """Return a function that will return True after a given SLOW_COROUTINE_DURATION."""
+
     async def some_slow_op() -> bool:
         await asyncio.sleep(SLOW_COROUTINE_DURATION)
         return True
@@ -31,6 +41,8 @@ async def fixture_timedout_task() -> asyncio.Task:
 
 @pytest_asyncio.fixture(name="raised_task")
 async def fixture_raised_task() -> asyncio.Task:
+    """Return a function that will raise a RuntimeError."""
+
     async def will_raise() -> None:
         raise RuntimeError("error")
 

--- a/tests/unit/utils/test_user_agent_parsing.py
+++ b/tests/unit/utils/test_user_agent_parsing.py
@@ -1,3 +1,9 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Unit tests for the user_agent_parsing.py utility module."""
+
 import pytest
 
 from merino.utils.user_agent_parsing import parse
@@ -81,6 +87,10 @@ SCENARIOS: list[Scenario] = [
     SCENARIOS,
 )
 def test_ua_parsing(ua, expected_browser, expected_os_family, expected_form_factor):
+    """
+    Test that the parse method assigns the 'browser', 'os_family' and 'form_factor'
+    values as expected from a User-Agent heading.
+    """
     result = parse(ua)
 
     assert result["browser"] == expected_browser

--- a/tests/unit/utils/test_user_agent_parsing.py
+++ b/tests/unit/utils/test_user_agent_parsing.py
@@ -87,8 +87,7 @@ SCENARIOS: list[Scenario] = [
     SCENARIOS,
 )
 def test_ua_parsing(ua, expected_browser, expected_os_family, expected_form_factor):
-    """
-    Test that the parse method assigns the 'browser', 'os_family' and 'form_factor'
+    """Test that the parse method assigns the 'browser', 'os_family' and 'form_factor'
     values as expected from a User-Agent heading.
     """
     result = parse(ua)


### PR DESCRIPTION
# Description
- Update the `Makefile` to include the `tests` directory in pydocstyle linting
- Update the `.pre-commit-config.yaml` file to including the tests directory in pydocstyle linting
- Update the `pyproject.toml` file to include test modules
- Remediate errors in `tests` directory

# Issue(s)
#124 | [CONSVC-2086](https://mozilla-hub.atlassian.net/browse/CONSVC-2086)