### PR TITLE
Fix some typos in documentation [do not deploy]

### DIFF
--- a/docs/dev/index.md
+++ b/docs/dev/index.md
@@ -118,7 +118,7 @@ It is not advisable to put secrets in `configs/secrets.toml`.
 
 Dynaconf will use the specified values and environment variables in the
 `merino/configs/default.toml` file. You can change the environment you
-want to use as mentioned abouve, but for local changes to adapt to your
+want to use as mentioned above, but for local changes to adapt to your
 machine or tastes, you can put the configuration in `merino/configs/development.local.toml`.
 This file doesn't exist by default, so you will have to create it.
 Then simply copy from the other config files and make the adjustments

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -27,7 +27,7 @@ such as `config_sentry.py` or `config_logging.py`.
 - Local configuration files are not checked into the repository, but if created should be named
   `configs/development.local.toml`, following the format of `<environment>.local.toml`.
   This file is listed in the `.gitignore` file and is safe to use for local configuration.
-  One may secrets here if desired, though it is advised to exercise great caution.
+  One may add secrets here if desired, though it is advised to exercise great caution.
 
 ### General
 

--- a/tests/contract/client/README.md
+++ b/tests/contract/client/README.md
@@ -128,7 +128,7 @@ tests within a Python virtual environment to prevent dependency cross contaminat
 
     The following environment variables are set in `docker-compose.yml`, but will
     require local setup via command line, pytest.ini file or IDE configuration:
-    * `MERION_URL`: The URL of the Merino service
+    * `MERINO_URL`: The URL of the Merino service
       * Example: `MERINO_URL=http://localhost:8000`
     * `KINTO_URL`: The URL of the Kinto service
       * Example: `KINTO_URL=http://localhost:8888`


### PR DESCRIPTION
There were some typos that I noticed while going through the documentation. 

Again, [do not deploy] this change, as it's only documentation changes.