### PR TITLE
[CONSVC-2124] fix: handle empty city names for geolocation parsing

### DIFF
--- a/merino/middleware/geolocation.py
+++ b/merino/middleware/geolocation.py
@@ -64,7 +64,7 @@ class GeolocationMiddleware:
             Location(
                 country=record.country.iso_code,
                 region=record.subdivisions[0].iso_code if record.subdivisions else None,
-                city=record.city.names["en"],
+                city=record.city.names.get("en"),
                 dma=record.location.metro_code,
                 postal_code=record.postal.code if record.postal else None,
             )


### PR DESCRIPTION
This fixes [CONSVC-2124](https://mozilla-hub.atlassian.net/browse/CONSVC-2124).