### PR TITLE
[CONSVC-1603] chore: remove example feature flag decision

### DIFF
--- a/docs/dev/feature_flags.md
+++ b/docs/dev/feature_flags.md
@@ -80,3 +80,13 @@ feature_flag.<feature_flag_name>
 
 For more information about this see the `ClientMeta` meta class and the
 `add_feature_flags` decorator in `merino/metrics.py`.
+
+## Monitoring in Grafana
+
+Because feature flag decisions are automatically added as tags to emitted
+metrics, you can use them in your queries in Grafana. 📈
+
+For example, if you want to group by decisions for a feature flag with name
+`hello_world`, you can use `tag(feature_flag.hello_world)` in `GROUP BY` in
+Grafana. You can also use `[[tag_feature_flag.hello_world]]` in the `ALIAS` for
+panel legends.

--- a/merino/configs/flags/default.toml
+++ b/merino/configs/flags/default.toml
@@ -14,10 +14,3 @@
 #   the flag is 'off' (meaning that a check for the flag will return False 100%
 #   of the time) and a value of 1 indicates that the flag is 'on' for all.
 # enabled=0.5
-
-# We define the following feature flag in the default config, so we can learn
-# about using StatsD tags as query filters in our Grafana dashboard, while we
-# don't use any actual feature flags in the suggest API.
-[default.flags.test_flight_01]
-scheme = 'random'
-enabled = 0.5

--- a/merino/configs/flags/testing.toml
+++ b/merino/configs/flags/testing.toml
@@ -1,10 +1,6 @@
 [testing]
 dynaconf_merge = true
 
-[testing.flags.test_flight_01]
-scheme = 'random'
-enabled = 0.5
-
 [testing.flags.test-enabled]
 enabled = 1
 scheme = 'random'

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -11,7 +11,6 @@ from fastapi.responses import JSONResponse
 from starlette.requests import Request
 
 from merino.config import settings
-from merino.featureflags import FeatureFlags
 from merino.metrics import Client
 from merino.middleware import ScopeKey
 from merino.providers import get_providers
@@ -59,13 +58,10 @@ async def suggest(
     Returns:
     A list of suggestions or an empty list if nothing was found.
     """
-    feature_flags: FeatureFlags = request.scope[ScopeKey.FEATURE_FLAGS]
-
-    if decision := feature_flags.is_enabled("test_flight_01"):
-        logger.debug(
-            "feature flag test_flight_01 is enabled for this request",
-            extra={"test_flight_01": decision},
-        )
+    # Do you plan to release code behind a feature flag? Uncomment the following
+    # line to get access to feature flags and then check if your feature flag is
+    # enabled for this request by calling feature_flags.is_enabled("example").
+    # feature_flags: FeatureFlags = request.scope[ScopeKey.FEATURE_FLAGS]
 
     metrics_client: Client = request.scope[ScopeKey.METRICS_CLIENT]
 

--- a/tests/integration/api/v1/suggest/test_suggest.py
+++ b/tests/integration/api/v1/suggest/test_suggest.py
@@ -283,9 +283,7 @@ def test_suggest_metrics_500(mocker: MockerFixture, client: TestClient) -> None:
                 "get.api.v1.suggest.status_codes.200",
                 "response.status_codes.200",
             ],
-            [
-                "feature_flag.test_flight_01",
-            ],
+            [],
         ),
         (
             "/api/v1/suggest",


### PR DESCRIPTION
# Description

Our experiment was successful and showed that tags for feature flag decisions are indeed available in InfluxDB/Grafana. This means we can remove the `test_flight_01` feature flag, which I added in #123.

This pull request also adds a brief explanation on how to use feature flag tags in Grafana to our developer documentation. 

# Issue(s)
[CONSVC-1603](https://mozilla-hub.atlassian.net/browse/CONSVC-1603)

