### PR TITLE
[CONSVC-2139] feat: add support for provider-level timeouts

### DIFF
--- a/merino/config.py
+++ b/merino/config.py
@@ -10,6 +10,7 @@ _validators = [
     Validator("metrics.dev_logger", is_type_of=bool),
     Validator("deployment.canary", is_type_of=bool),
     Validator("providers.accuweather.enabled_by_default", is_type_of=bool),
+    Validator("providers.accuweather.query_timeout_sec", is_type_of=float, gte=0),
     Validator("providers.adm.enabled_by_default", is_type_of=bool),
     Validator("providers.adm.cron_interval_sec", gt=0),
     Validator("providers.adm.resync_interval_sec", gt=0),

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -24,7 +24,10 @@
 debug = false
 
 [default.runtime]
-# A float timeout (in seconds) for all queries issued in "web/api_v1.py"
+# A float timeout (in seconds) for all queries issued in "web/api_v1.py".
+# Each provider can overwrtie this timeout by specifying a provider-level
+# timeout with the same name `query_timeout_sec`. See `accuweather` as an
+# example.
 query_timeout_sec = 0.2
 
 [default.logging]
@@ -67,6 +70,7 @@ traces_sample_rate = 0.1
 [default.providers.accuweather]
 enabled_by_default = false
 score = 0.3
+query_timeout_sec = 1.0
 # Our API key used to access the AccuWeather API.
 api_key = ""
 # The remainder of these variables are related to endpoint URLs.

--- a/merino/providers/accuweather.py
+++ b/merino/providers/accuweather.py
@@ -12,6 +12,7 @@ from merino.providers.base import BaseProvider, BaseSuggestion, SuggestionReques
 API_KEY: str = settings.providers.accuweather.api_key
 CLIENT_IP_OVERRIDE: str = settings.location.client_ip_override
 SCORE: float = settings.providers.accuweather.score
+QUERY_TIMEOUT_SEC: float = settings.providers.accuweather.query_timeout_sec
 
 # Endpoint URL components
 URL_BASE: str = settings.providers.accuweather.url_base
@@ -80,11 +81,13 @@ class Provider(BaseProvider):
         app: Optional[FastAPI] = None,
         name: str = "accuweather",
         enabled_by_default: bool = False,
+        query_timeout_sec: float = QUERY_TIMEOUT_SEC,
         **kwargs: Any,
     ) -> None:
         self._app = app
         self._name = name
         self._enabled_by_default = enabled_by_default
+        self._query_timeout_sec = query_timeout_sec
         super().__init__(**kwargs)
 
     async def initialize(self) -> None:

--- a/merino/providers/base.py
+++ b/merino/providers/base.py
@@ -3,6 +3,7 @@ from abc import ABC, abstractmethod
 
 from pydantic import BaseModel, HttpUrl
 
+from merino.config import settings
 from merino.middleware.geolocation import Location
 
 
@@ -31,6 +32,7 @@ class BaseProvider(ABC):
 
     _name: str
     _enabled_by_default: bool
+    _query_timeout_sec: float = settings.runtime.query_timeout_sec
 
     @abstractmethod
     async def initialize(self) -> None:
@@ -71,3 +73,8 @@ class BaseProvider(ABC):
     def name(self) -> str:
         """Return the name of the provider for use in logging and metrics"""
         return self._name
+
+    @property
+    def query_timeout_sec(self) -> float:
+        """Return the query timeout for this provider."""
+        return self._query_timeout_sec

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -14,7 +14,7 @@ from starlette.requests import Request
 from merino.config import settings
 from merino.metrics import Client
 from merino.middleware import ScopeKey
-from merino.providers import get_providers
+from merino.providers import get_max_timeout, get_providers
 from merino.providers.base import BaseProvider, BaseSuggestion, SuggestionRequest
 from merino.utils import task_runner
 from merino.web.models_v1 import ProviderResponse, SuggestResponse
@@ -89,7 +89,9 @@ async def suggest(
 
     completed_tasks, _ = await task_runner.gather(
         lookups,
-        timeout=QUERY_TIMEOUT_SEC,
+        timeout=get_max_timeout(
+            frozenset(p.name for p in search_from), QUERY_TIMEOUT_SEC
+        ),
         timeout_cb=partial(task_runner.metrics_timeout_handler, metrics_client),
     )
     suggestions = list(


### PR DESCRIPTION
In certain cases, providers might be able to tolerate higher query latency than others, for instance, for zero-prefix weather suggestions, Firefox sends the query request to Merino in the background, hence no timeout is enforced on the client side. This patch allows us to specify provider-level query timeout to overwrite the top-level timeout. When multiple providers are specified in the request, Merino will use the maximum timeout among those providers as the maximum query waiting time for that request. 

Particularly, now the Accuweather provider uses a 1-second timeout rather than the default 200ms.

This closes [CONSVC-2139](https://mozilla-hub.atlassian.net/browse/CONSVC-2139).

cc: @0c0w3 