### PR TITLE
[DISCO-2044] Put the log metadata fields into their own objects

### DIFF
--- a/merino/middleware/logging.py
+++ b/merino/middleware/logging.py
@@ -9,6 +9,8 @@ from starlette.requests import Request
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from merino.utils.log_data_creators import (
+    RequestSummaryLogDataModel,
+    SuggestLogDataModel,
     create_request_summary_log_data,
     create_suggest_log_data,
 )
@@ -40,11 +42,15 @@ class LoggingMiddleware:
                 request = Request(scope=scope)
                 dt: datetime = datetime.fromtimestamp(time.time())
                 if PATTERN.match(request.url.path):
-                    data = create_suggest_log_data(request, message, dt)
-                    suggest_request_logger.info("", extra=data)
+                    suggest_log_data: SuggestLogDataModel = create_suggest_log_data(
+                        request, message, dt
+                    )
+                    suggest_request_logger.info("", extra=suggest_log_data.dict())
                 else:
-                    data = create_request_summary_log_data(request, message, dt)
-                    logger.info("", extra=data)
+                    request_log_data: RequestSummaryLogDataModel = (
+                        create_request_summary_log_data(request, message, dt)
+                    )
+                    logger.info("", extra=request_log_data.dict())
 
             await send(message)
 

--- a/merino/utils/log_data_creators.py
+++ b/merino/utils/log_data_creators.py
@@ -1,7 +1,8 @@
 """A utility module for lag data creation"""
 from datetime import datetime
-from typing import Any
+from typing import Any, Optional
 
+from pydantic import BaseModel
 from starlette.datastructures import Headers
 from starlette.requests import Request
 from starlette.types import Message
@@ -11,63 +12,98 @@ from merino.middleware.geolocation import Location
 from merino.middleware.user_agent import UserAgent
 
 
+class LogDataModel(BaseModel):
+    """Shared generic log data model. These fields are shared between the Request Summary Logs
+    and the Suggest Logs.
+    """
+
+    errno: int
+    time: datetime
+    path: str
+    method: str
+
+    def dict(self, **kwargs) -> dict[str, Any]:
+        """Override the dict method to convert the datetime type to iso-formatted string."""
+        d: dict[str, Any] = super().dict(**kwargs)
+        if d.get("time"):
+            d["time"] = d["time"].isoformat()
+        return d
+
+
+class RequestSummaryLogDataModel(LogDataModel):
+    """Log metadata specific to Request Summary."""
+
+    agent: Optional[str] = None
+    lang: Optional[str] = None
+    querystring: dict[str, Any]
+    code: int
+
+
+class SuggestLogDataModel(LogDataModel):
+    """Log metadata specific to Suggest logs."""
+
+    sensitive: bool
+    query: Optional[str] = None
+    code: int
+    rid: str  # Provided by the asgi-correlation-id middleware.
+    session_id: Optional[str] = None
+    sequence_no: Optional[int] = None
+    client_variants: str
+    requested_providers: str
+    country: Optional[str] = None
+    region: Optional[str] = None
+    city: Optional[str] = None
+    dma: Optional[int] = None
+    browser: str
+    os_family: str
+    form_factor: str
+
+
 def create_request_summary_log_data(
     request: Request, message: Message, dt: datetime
-) -> dict[str, Any]:
+) -> RequestSummaryLogDataModel:
     """Create log data for API endpoints."""
-    general_data = {
-        "errno": 0,
-        "time": dt.isoformat(),
-    }
-
-    request_data = {
-        "agent": request.headers.get("User-Agent"),
-        "path": request.url.path,
-        "method": request.method,
-        "lang": request.headers.get("Accept-Language"),
-        "querystring": dict(request.query_params),
-        "code": message["status"],
-    }
-
-    return {**general_data, **request_data}
+    return RequestSummaryLogDataModel(
+        errno=0,
+        time=dt,
+        agent=request.headers.get("User-Agent"),
+        path=request.url.path,
+        method=request.method,
+        lang=request.headers.get("Accept-Language"),
+        querystring=dict(request.query_params),
+        code=message["status"],
+    )
 
 
 def create_suggest_log_data(
     request: Request, message: Message, dt: datetime
-) -> dict[str, Any]:
+) -> SuggestLogDataModel:
     """Create log data for the suggest API endpoint."""
-    general_data = {
-        "sensitive": True,
-        "errno": 0,
-        "time": dt.isoformat(),
-    }
-
-    request_data = {
-        "path": request.url.path,
-        "method": request.method,
-        "query": request.query_params.get("q"),
-        "code": message["status"],
-        # Provided by the asgi-correlation-id middleware.
-        "rid": Headers(scope=message)["X-Request-ID"],
-        "session_id": request.query_params.get("sid"),
-        "sequence_no": int(seq) if (seq := request.query_params.get("seq")) else None,
-        "client_variants": request.query_params.get("client_variants", ""),
-        "requested_providers": request.query_params.get("providers", ""),
-    }
-
     location: Location = request.scope[ScopeKey.GEOLOCATION]
-    location_data = {
-        "country": location.country,
-        "region": location.region,
-        "city": location.city,
-        "dma": location.dma,
-    }
-
     user_agent: UserAgent = request.scope[ScopeKey.USER_AGENT]
-    user_agent_data = {
-        "browser": user_agent.browser,
-        "os_family": user_agent.os_family,
-        "form_factor": user_agent.form_factor,
-    }
 
-    return {**general_data, **request_data, **location_data, **user_agent_data}
+    return SuggestLogDataModel(
+        # General Data
+        sensitive=True,
+        errno=0,
+        time=dt,
+        # Request Data
+        path=request.url.path,
+        method=request.method,
+        query=request.query_params.get("q"),
+        code=message["status"],
+        rid=Headers(scope=message)["X-Request-ID"],
+        session_id=request.query_params.get("sid"),
+        sequence_no=int(seq) if (seq := request.query_params.get("seq")) else None,
+        client_variants=request.query_params.get("client_variants", ""),
+        requested_providers=request.query_params.get("providers", ""),
+        # Location Data
+        country=location.country,
+        region=location.region,
+        city=location.city,
+        dma=location.dma,
+        # User Agent Data
+        browser=user_agent.browser,
+        os_family=user_agent.os_family,
+        form_factor=user_agent.form_factor,
+    )

--- a/tests/integration/api/conftest.py
+++ b/tests/integration/api/conftest.py
@@ -5,12 +5,13 @@
 """Module for test configurations for the integration test directory."""
 
 from logging import LogRecord
-from typing import Any, Iterator
+from typing import Iterator
 
 import pytest
 from starlette.testclient import TestClient
 
 from merino.main import app
+from merino.utils.log_data_creators import RequestSummaryLogDataModel
 from tests.integration.api.types import RequestSummaryLogDataFixture
 
 
@@ -41,17 +42,18 @@ def fixture_extract_request_summary_log_data() -> RequestSummaryLogDataFixture:
     "request.summary" log record
     """
 
-    def extract_request_summary_log_data(record: LogRecord) -> dict[str, Any]:
-        return {
-            "name": record.name,
-            "errno": record.__dict__["errno"],
-            "time": record.__dict__["time"],
-            "agent": record.__dict__["agent"],
-            "path": record.__dict__["path"],
-            "method": record.__dict__["method"],
-            "lang": record.__dict__["lang"],
-            "querystring": record.__dict__["querystring"],
-            "code": record.__dict__["code"],
-        }
+    def extract_request_summary_log_data(
+        record: LogRecord,
+    ) -> RequestSummaryLogDataModel:
+        return RequestSummaryLogDataModel(
+            errno=record.__dict__["errno"],
+            time=record.__dict__["time"],
+            agent=record.__dict__["agent"],
+            path=record.__dict__["path"],
+            method=record.__dict__["method"],
+            lang=record.__dict__["lang"],
+            querystring=record.__dict__["querystring"],
+            code=record.__dict__["code"],
+        )
 
     return extract_request_summary_log_data

--- a/tests/integration/api/test_error.py
+++ b/tests/integration/api/test_error.py
@@ -6,7 +6,6 @@
 
 import logging
 from logging import LogRecord
-from typing import Any
 
 import aiodogstatsd
 from fastapi.testclient import TestClient
@@ -14,6 +13,7 @@ from freezegun import freeze_time
 from pytest import LogCaptureFixture
 from pytest_mock import MockerFixture
 
+from merino.utils.log_data_creators import RequestSummaryLogDataModel
 from tests.integration.api.types import RequestSummaryLogDataFixture
 from tests.types import FilterCaplogFixture
 
@@ -44,20 +44,19 @@ def test_error_request_log_data(
     """
     caplog.set_level(logging.INFO)
 
-    expected_log_data: dict[str, Any] = {
-        "name": "request.summary",
-        "agent": (
+    expected_log_data: RequestSummaryLogDataModel = RequestSummaryLogDataModel(
+        agent=(
             "Mozilla/5.0 (Macintosh; Intel Mac OS X 11.2; rv:85.0)"
             " Gecko/20100101 Firefox/103.0"
         ),
-        "path": "/__error__",
-        "method": "GET",
-        "lang": "en-US",
-        "querystring": {},
-        "errno": 0,
-        "code": 500,
-        "time": "1998-03-31T00:00:00",
-    }
+        path="/__error__",
+        method="GET",
+        lang="en-US",
+        querystring={},
+        errno=0,
+        code=500,
+        time="1998-03-31T00:00:00",
+    )
 
     client.get(
         "/__error__",
@@ -74,7 +73,7 @@ def test_error_request_log_data(
     assert len(records) == 1
 
     record: LogRecord = records[0]
-    log_data: dict[str, Any] = extract_request_summary_log_data(record)
+    log_data: RequestSummaryLogDataModel = extract_request_summary_log_data(record)
     assert log_data == expected_log_data
 
 

--- a/tests/integration/api/test_heartbeat.py
+++ b/tests/integration/api/test_heartbeat.py
@@ -6,13 +6,13 @@
 
 import logging
 from logging import LogRecord
-from typing import Any
 
 import pytest
 from _pytest.logging import LogCaptureFixture
 from fastapi.testclient import TestClient
 from freezegun import freeze_time
 
+from merino.utils.log_data_creators import RequestSummaryLogDataModel
 from tests.integration.api.types import RequestSummaryLogDataFixture
 from tests.types import FilterCaplogFixture
 
@@ -39,20 +39,19 @@ def test_heartbeat_request_log_data(
     """
     caplog.set_level(logging.INFO)
 
-    expected_log_data: dict[str, Any] = {
-        "name": "request.summary",
-        "agent": (
+    expected_log_data: RequestSummaryLogDataModel = RequestSummaryLogDataModel(
+        agent=(
             "Mozilla/5.0 (Macintosh; Intel Mac OS X 11.2; rv:85.0)"
             " Gecko/20100101 Firefox/103.0"
         ),
-        "path": f"/{endpoint}",
-        "method": "GET",
-        "lang": "en-US",
-        "querystring": {},
-        "errno": 0,
-        "code": 200,
-        "time": "1998-03-31T00:00:00",
-    }
+        path=f"/{endpoint}",
+        method="GET",
+        lang="en-US",
+        querystring={},
+        errno=0,
+        code=200,
+        time="1998-03-31T00:00:00",
+    )
 
     client.get(
         f"/{endpoint}",
@@ -69,5 +68,5 @@ def test_heartbeat_request_log_data(
     assert len(records) == 1
 
     record: LogRecord = records[0]
-    log_data: dict[str, Any] = extract_request_summary_log_data(record)
+    log_data: RequestSummaryLogDataModel = extract_request_summary_log_data(record)
     assert log_data == expected_log_data

--- a/tests/integration/api/test_version.py
+++ b/tests/integration/api/test_version.py
@@ -6,13 +6,13 @@
 
 import logging
 from logging import LogRecord
-from typing import Any
 
 from fastapi.testclient import TestClient
 from freezegun import freeze_time
 from pytest import LogCaptureFixture
 from pytest_mock import MockerFixture
 
+from merino.utils.log_data_creators import RequestSummaryLogDataModel
 from tests.integration.api.types import RequestSummaryLogDataFixture
 from tests.types import FilterCaplogFixture
 
@@ -52,20 +52,19 @@ def test_version_request_log_data(
     """
     caplog.set_level(logging.INFO)
 
-    expected_log_data: dict[str, Any] = {
-        "name": "request.summary",
-        "agent": (
+    expected_log_data: RequestSummaryLogDataModel = RequestSummaryLogDataModel(
+        agent=(
             "Mozilla/5.0 (Macintosh; Intel Mac OS X 11.2; rv:85.0)"
             " Gecko/20100101 Firefox/103.0"
         ),
-        "path": "/__version__",
-        "method": "GET",
-        "lang": "en-US",
-        "querystring": {},
-        "errno": 0,
-        "code": 200,
-        "time": "1998-03-31T00:00:00",
-    }
+        path="/__version__",
+        method="GET",
+        lang="en-US",
+        querystring={},
+        errno=0,
+        code=200,
+        time="1998-03-31T00:00:00",
+    )
 
     client.get(
         "/__version__",
@@ -82,5 +81,5 @@ def test_version_request_log_data(
     assert len(records) == 1
 
     record: LogRecord = records[0]
-    log_data: dict[str, Any] = extract_request_summary_log_data(record)
+    log_data: RequestSummaryLogDataModel = extract_request_summary_log_data(record)
     assert log_data == expected_log_data

--- a/tests/integration/api/types.py
+++ b/tests/integration/api/types.py
@@ -5,6 +5,8 @@
 """Type definitions for the integration test modules."""
 
 from logging import LogRecord
-from typing import Any, Callable
+from typing import Callable
 
-RequestSummaryLogDataFixture = Callable[[LogRecord], dict[str, Any]]
+from merino.utils.log_data_creators import RequestSummaryLogDataModel
+
+RequestSummaryLogDataFixture = Callable[[LogRecord], RequestSummaryLogDataModel]

--- a/tests/integration/api/v1/providers/test_providers.py
+++ b/tests/integration/api/v1/providers/test_providers.py
@@ -6,7 +6,6 @@
 
 import logging
 from logging import LogRecord
-from typing import Any
 
 import pytest
 from fastapi.testclient import TestClient
@@ -14,6 +13,7 @@ from freezegun import freeze_time
 from pytest import LogCaptureFixture
 
 from merino.providers import BaseProvider
+from merino.utils.log_data_creators import RequestSummaryLogDataModel
 from tests.integration.api.types import RequestSummaryLogDataFixture
 from tests.integration.api.v1.fake_providers import (
     HiddenProvider,
@@ -99,20 +99,19 @@ def test_providers_request_log_data(
     """
     caplog.set_level(logging.INFO)
 
-    expected_log_data: dict[str, Any] = {
-        "name": "request.summary",
-        "agent": (
+    expected_log_data: RequestSummaryLogDataModel = RequestSummaryLogDataModel(
+        agent=(
             "Mozilla/5.0 (Macintosh; Intel Mac OS X 11.2; rv:85.0)"
             " Gecko/20100101 Firefox/103.0"
         ),
-        "path": "/api/v1/providers",
-        "method": "GET",
-        "lang": "en-US",
-        "querystring": {},
-        "errno": 0,
-        "code": 200,
-        "time": "1998-03-31T00:00:00",
-    }
+        path="/api/v1/providers",
+        method="GET",
+        lang="en-US",
+        querystring={},
+        errno=0,
+        code=200,
+        time="1998-03-31T00:00:00",
+    )
 
     client.get(
         "/api/v1/providers",
@@ -129,5 +128,5 @@ def test_providers_request_log_data(
     assert len(records) == 1
 
     record: LogRecord = records[0]
-    log_data: dict[str, Any] = extract_request_summary_log_data(record)
+    log_data: RequestSummaryLogDataModel = extract_request_summary_log_data(record)
     assert log_data == expected_log_data

--- a/tests/integration/api/v1/suggest/test_suggest.py
+++ b/tests/integration/api/v1/suggest/test_suggest.py
@@ -14,6 +14,7 @@ from freezegun import freeze_time
 from pytest import LogCaptureFixture
 from pytest_mock import MockerFixture
 
+from merino.utils.log_data_creators import SuggestLogDataModel
 from tests.integration.api.v1.fake_providers import (
     CorruptProvider,
     NonsponsoredProvider,
@@ -118,37 +119,36 @@ def test_suggest_request_log_data(
     mock_client = mocker.patch("fastapi.Request.client")
     mock_client.host = "216.160.83.56"
 
-    expected_log_data: dict[str, Any] = {
-        "name": "web.suggest.request",
-        "sensitive": True,
-        "errno": 0,
-        "time": "1998-03-31T00:00:00",
-        "path": "/api/v1/suggest",
-        "method": "GET",
-        "query": "nope",
-        "code": 200,
-        "rid": "1b11844c52b34c33a6ad54b7bc2eb7c7",
-        "session_id": "deadbeef-0000-1111-2222-333344445555",
-        "sequence_no": 0,
-        "client_variants": "foo,bar",
-        "requested_providers": "pro,vider",
-        "country": "US",
-        "region": "WA",
-        "city": "Milton",
-        "dma": 819,
-        "browser": "Firefox(103.0)",
-        "os_family": "macos",
-        "form_factor": "desktop",
-    }
+    expected_log_data: SuggestLogDataModel = SuggestLogDataModel(
+        sensitive=True,
+        errno=0,
+        time="1998-03-31T00:00:00",
+        path="/api/v1/suggest",
+        method="GET",
+        query="nope",
+        code=200,
+        rid="1b11844c52b34c33a6ad54b7bc2eb7c7",
+        session_id="deadbeef-0000-1111-2222-333344445555",
+        sequence_no=0,
+        client_variants="foo,bar",
+        requested_providers="pro,vider",
+        country="US",
+        region="WA",
+        city="Milton",
+        dma=819,
+        browser="Firefox(103.0)",
+        os_family="macos",
+        form_factor="desktop",
+    )
 
     client.get(
-        url=expected_log_data["path"],
+        url=expected_log_data.path,
         params={
-            "q": expected_log_data["query"],
-            "sid": expected_log_data["session_id"],
-            "seq": expected_log_data["sequence_no"],
-            "client_variants": expected_log_data["client_variants"],
-            "providers": expected_log_data["requested_providers"],
+            "q": expected_log_data.query,
+            "sid": expected_log_data.session_id,
+            "seq": expected_log_data.sequence_no,
+            "client_variants": expected_log_data.client_variants,
+            "providers": expected_log_data.requested_providers,
         },
         headers={
             "User-Agent": (
@@ -164,7 +164,6 @@ def test_suggest_request_log_data(
 
     record = records[0]
     log_data: dict[str, Any] = {
-        "name": record.name,
         "sensitive": record.__dict__["sensitive"],
         "errno": record.__dict__["errno"],
         "time": record.__dict__["time"],
@@ -185,7 +184,7 @@ def test_suggest_request_log_data(
         "os_family": record.__dict__["os_family"],
         "form_factor": record.__dict__["form_factor"],
     }
-    assert log_data == expected_log_data
+    assert log_data == expected_log_data.dict()
 
 
 def test_suggest_with_invalid_geolocation_ip(

--- a/tests/integration/api/v1/test_unsupported.py
+++ b/tests/integration/api/v1/test_unsupported.py
@@ -6,7 +6,6 @@
 
 import logging
 from logging import LogRecord
-from typing import Any
 
 import aiodogstatsd
 import pytest
@@ -15,6 +14,7 @@ from freezegun import freeze_time
 from pytest import LogCaptureFixture
 from pytest_mock import MockerFixture
 
+from merino.utils.log_data_creators import RequestSummaryLogDataModel
 from tests.integration.api.types import RequestSummaryLogDataFixture
 from tests.types import FilterCaplogFixture
 
@@ -32,20 +32,19 @@ def test_unsupported_endpoint_request_log_data(
     """
     caplog.set_level(logging.INFO)
 
-    expected_log_data: dict[str, Any] = {
-        "name": "request.summary",
-        "agent": (
+    expected_log_data: RequestSummaryLogDataModel = RequestSummaryLogDataModel(
+        agent=(
             "Mozilla/5.0 (Macintosh; Intel Mac OS X 11.2; rv:85.0)"
             " Gecko/20100101 Firefox/103.0"
         ),
-        "path": "/api/v1/unsupported",
-        "method": "GET",
-        "lang": "en-US",
-        "querystring": {},
-        "errno": 0,
-        "code": 404,
-        "time": "1998-03-31T00:00:00",
-    }
+        path="/api/v1/unsupported",
+        method="GET",
+        lang="en-US",
+        querystring={},
+        errno=0,
+        code=404,
+        time="1998-03-31T00:00:00",
+    )
 
     client.get(
         "/api/v1/unsupported",
@@ -62,7 +61,7 @@ def test_unsupported_endpoint_request_log_data(
     assert len(records) == 1
 
     record: LogRecord = records[0]
-    log_data: dict[str, Any] = extract_request_summary_log_data(record)
+    log_data: RequestSummaryLogDataModel = extract_request_summary_log_data(record)
     assert log_data == expected_log_data
 
 

--- a/tests/unit/utils/test_log_data_creator.py
+++ b/tests/unit/utils/test_log_data_creator.py
@@ -5,7 +5,6 @@
 """Unit tests for the log_data_creator.py utility module."""
 
 from datetime import datetime
-from typing import Any
 
 import pytest
 from starlette.requests import Request
@@ -63,7 +62,9 @@ def test_create_request_summary_log_data(
     )
     message: Message = {"type": "http.response.start", "status": "200"}
 
-    log_data: dict[str, Any] = create_request_summary_log_data(request, message, dt)
+    log_data: RequestSummaryLogDataModel = create_request_summary_log_data(
+        request, message, dt
+    )
 
     assert log_data == expected_log_data
 
@@ -161,6 +162,6 @@ def test_create_suggest_log_data(
     }
     dt: datetime = datetime(1998, 3, 31)
 
-    log_data: dict[str, Any] = create_suggest_log_data(request, message, dt)
+    log_data: SuggestLogDataModel = create_suggest_log_data(request, message, dt)
 
     assert log_data == expected_log_data

--- a/tests/unit/utils/test_log_data_creator.py
+++ b/tests/unit/utils/test_log_data_creator.py
@@ -65,7 +65,7 @@ def test_create_request_summary_log_data(
 
     log_data: dict[str, Any] = create_request_summary_log_data(request, message, dt)
 
-    assert log_data == expected_log_data.dict()
+    assert log_data == expected_log_data
 
 
 @pytest.mark.parametrize(
@@ -163,4 +163,4 @@ def test_create_suggest_log_data(
 
     log_data: dict[str, Any] = create_suggest_log_data(request, message, dt)
 
-    assert log_data == expected_log_data.dict()
+    assert log_data == expected_log_data

--- a/tests/unit/utils/test_log_data_creator.py
+++ b/tests/unit/utils/test_log_data_creator.py
@@ -15,6 +15,8 @@ from merino.middleware import ScopeKey
 from merino.middleware.geolocation import Location
 from merino.middleware.user_agent import UserAgent
 from merino.utils.log_data_creators import (
+    RequestSummaryLogDataModel,
+    SuggestLogDataModel,
     create_request_summary_log_data,
     create_suggest_log_data,
 )
@@ -37,16 +39,19 @@ def test_create_request_summary_log_data(
     """Test that the create_request_summary_log_data method properly constructs log
     data given different headers.
     """
-    expected_log_data: dict[str, Any] = {
-        "errno": 0,
-        "time": "1998-03-31T00:00:00",
-        "agent": expected_agent,
-        "path": "/__heartbeat__",
-        "method": "GET",
-        "lang": expected_lang,
-        "querystring": {},
-        "code": "200",
-    }
+    dt: datetime = datetime(1998, 3, 31)
+
+    expected_log_data: RequestSummaryLogDataModel = RequestSummaryLogDataModel(
+        errno=0,
+        time=dt,
+        agent=expected_agent,
+        path="/__heartbeat__",
+        method="GET",
+        lang=expected_lang,
+        querystring={},
+        code=200,
+    )
+
     request: Request = Request(
         scope={
             "type": "http",
@@ -57,11 +62,10 @@ def test_create_request_summary_log_data(
         }
     )
     message: Message = {"type": "http.response.start", "status": "200"}
-    dt: datetime = datetime(1998, 3, 31)
 
     log_data: dict[str, Any] = create_request_summary_log_data(request, message, dt)
 
-    assert log_data == expected_log_data
+    assert log_data == expected_log_data.dict()
 
 
 @pytest.mark.parametrize(
@@ -112,27 +116,28 @@ def test_create_suggest_log_data(
     user_agent: UserAgent = UserAgent(
         browser="Firefox(103.0)", os_family="macos", form_factor="desktop"
     )
-    expected_log_data: dict[str, Any] = {
-        "sensitive": True,
-        "errno": 0,
-        "time": "1998-03-31T00:00:00",
-        "path": "/api/v1/suggest",
-        "method": "GET",
-        "query": expected_query,
-        "code": "200",
-        "rid": "1b11844c52b34c33a6ad54b7bc2eb7c7",
-        "session_id": expected_sid,
-        "sequence_no": expected_seq,
-        "client_variants": expected_client_variants,
-        "requested_providers": expected_providers,
-        "country": location.country,
-        "region": location.region,
-        "city": location.city,
-        "dma": location.dma,
-        "browser": user_agent.browser,
-        "os_family": user_agent.os_family,
-        "form_factor": user_agent.form_factor,
-    }
+    expected_log_data: SuggestLogDataModel = SuggestLogDataModel(
+        sensitive=True,
+        errno=0,
+        time="1998-03-31T00:00:00",
+        path="/api/v1/suggest",
+        method="GET",
+        query=expected_query,
+        code=200,
+        rid="1b11844c52b34c33a6ad54b7bc2eb7c7",
+        session_id=expected_sid,
+        sequence_no=expected_seq,
+        client_variants=expected_client_variants,
+        requested_providers=expected_providers,
+        country=location.country,
+        region=location.region,
+        city=location.city,
+        dma=location.dma,
+        browser=user_agent.browser,
+        os_family=user_agent.os_family,
+        form_factor=user_agent.form_factor,
+    )
+
     request: Request = Request(
         scope={
             "type": "http",
@@ -146,7 +151,7 @@ def test_create_suggest_log_data(
     )
     message: Message = {
         "type": "http.response.start",
-        "status": "200",
+        "status": 200,
         "headers": [
             (b"content-length", b"119"),
             (b"content-type", b"application/json"),
@@ -158,4 +163,4 @@ def test_create_suggest_log_data(
 
     log_data: dict[str, Any] = create_suggest_log_data(request, message, dt)
 
-    assert log_data == expected_log_data
+    assert log_data == expected_log_data.dict()


### PR DESCRIPTION
This will make it easier to do data validation on fields we send to logger and also encapsulates the logging metadata into extendable objects.

Fixes DISCO-2044