### PR TITLE
chore: Remove extra character in title [do not deploy]

### DIFF
--- a/docs/dev/feature_flags.md
+++ b/docs/dev/feature_flags.md
@@ -1,4 +1,4 @@
-g# Feature Flags
+# Feature Flags
 
 ## Usage
 


### PR DESCRIPTION
Sorry, my fault... I keep adding random `g` everywhere. This should remove it and fix the title on this. [do not deploy]