### PR TITLE
Use Pydantic's `.json()` serialization for `datetime` objects

### DIFF
--- a/merino/middleware/logging.py
+++ b/merino/middleware/logging.py
@@ -1,4 +1,5 @@
 """The middleware that records various access logs for Merino."""
+import json
 import logging
 import re
 import time
@@ -45,12 +46,14 @@ class LoggingMiddleware:
                     suggest_log_data: SuggestLogDataModel = create_suggest_log_data(
                         request, message, dt
                     )
-                    suggest_request_logger.info("", extra=suggest_log_data.dict())
+                    suggest_request_logger.info(
+                        "", extra=json.loads(suggest_log_data.json())
+                    )
                 else:
                     request_log_data: RequestSummaryLogDataModel = (
                         create_request_summary_log_data(request, message, dt)
                     )
-                    logger.info("", extra=request_log_data.dict())
+                    logger.info("", extra=json.loads(request_log_data.json()))
 
             await send(message)
 

--- a/merino/utils/log_data_creators.py
+++ b/merino/utils/log_data_creators.py
@@ -22,13 +22,6 @@ class LogDataModel(BaseModel):
     path: str
     method: str
 
-    def dict(self, **kwargs) -> dict[str, Any]:
-        """Override the dict method to convert the datetime type to iso-formatted string."""
-        d: dict[str, Any] = super().dict(**kwargs)
-        if d.get("time"):
-            d["time"] = d["time"].isoformat()
-        return d
-
 
 class RequestSummaryLogDataModel(LogDataModel):
     """Log metadata specific to Request Summary."""

--- a/tests/integration/api/v1/suggest/test_suggest.py
+++ b/tests/integration/api/v1/suggest/test_suggest.py
@@ -5,7 +5,6 @@
 """Integration tests for the Merino v1 suggest API endpoint."""
 
 import logging
-from typing import Any
 
 import aiodogstatsd
 import pytest
@@ -163,28 +162,29 @@ def test_suggest_request_log_data(
     assert len(records) == 1
 
     record = records[0]
-    log_data: dict[str, Any] = {
-        "sensitive": record.__dict__["sensitive"],
-        "errno": record.__dict__["errno"],
-        "time": record.__dict__["time"],
-        "path": record.__dict__["path"],
-        "method": record.__dict__["method"],
-        "query": record.__dict__["query"],
-        "code": record.__dict__["code"],
-        "rid": record.__dict__["rid"],
-        "session_id": record.__dict__["session_id"],
-        "sequence_no": record.__dict__["sequence_no"],
-        "client_variants": record.__dict__["client_variants"],
-        "requested_providers": record.__dict__["requested_providers"],
-        "country": record.__dict__["country"],
-        "region": record.__dict__["region"],
-        "city": record.__dict__["city"],
-        "dma": record.__dict__["dma"],
-        "browser": record.__dict__["browser"],
-        "os_family": record.__dict__["os_family"],
-        "form_factor": record.__dict__["form_factor"],
-    }
-    assert log_data == expected_log_data.dict()
+    log_data: SuggestLogDataModel = SuggestLogDataModel(
+        sensitive=record.__dict__["sensitive"],
+        errno=record.__dict__["errno"],
+        time=record.__dict__["time"],
+        path=record.__dict__["path"],
+        method=record.__dict__["method"],
+        query=record.__dict__["query"],
+        code=record.__dict__["code"],
+        rid=record.__dict__["rid"],
+        session_id=record.__dict__["session_id"],
+        sequence_no=record.__dict__["sequence_no"],
+        client_variants=record.__dict__["client_variants"],
+        requested_providers=record.__dict__["requested_providers"],
+        country=record.__dict__["country"],
+        region=record.__dict__["region"],
+        city=record.__dict__["city"],
+        dma=record.__dict__["dma"],
+        browser=record.__dict__["browser"],
+        os_family=record.__dict__["os_family"],
+        form_factor=record.__dict__["form_factor"],
+    )
+
+    assert log_data == expected_log_data
 
 
 def test_suggest_with_invalid_geolocation_ip(


### PR DESCRIPTION
Switching to using Pydantics' serialization for `datetime` objects. This came out of the conversation on https://github.com/mozilla-services/merino-py/pull/141#discussion_r1040098271 thread.

Looking at this implementation, I'm beginning to have second thoughts on it. On the plus side, it is more elegant. However, `.json` serializes the `dict` (so it returns `str`). Since the logger requires a `dict` object, I have to load the `str` back into a `dict`. So, basically there's an unnecessary serialization and de-serialization, which might have performance implications.

@hackebrot what do you think?