### PR TITLE
Logging Object to use Separate `datetime` and `str` fields for timestamps

### DIFF
--- a/tests/integration/api/v1/suggest/test_suggest.py
+++ b/tests/integration/api/v1/suggest/test_suggest.py
@@ -5,7 +5,6 @@
 """Integration tests for the Merino v1 suggest API endpoint."""
 
 import logging
-from typing import Any
 
 import aiodogstatsd
 import pytest
@@ -163,28 +162,29 @@ def test_suggest_request_log_data(
     assert len(records) == 1
 
     record = records[0]
-    log_data: dict[str, Any] = {
-        "sensitive": record.__dict__["sensitive"],
-        "errno": record.__dict__["errno"],
-        "time": record.__dict__["time"],
-        "path": record.__dict__["path"],
-        "method": record.__dict__["method"],
-        "query": record.__dict__["query"],
-        "code": record.__dict__["code"],
-        "rid": record.__dict__["rid"],
-        "session_id": record.__dict__["session_id"],
-        "sequence_no": record.__dict__["sequence_no"],
-        "client_variants": record.__dict__["client_variants"],
-        "requested_providers": record.__dict__["requested_providers"],
-        "country": record.__dict__["country"],
-        "region": record.__dict__["region"],
-        "city": record.__dict__["city"],
-        "dma": record.__dict__["dma"],
-        "browser": record.__dict__["browser"],
-        "os_family": record.__dict__["os_family"],
-        "form_factor": record.__dict__["form_factor"],
-    }
-    assert log_data == expected_log_data.dict()
+    log_data: SuggestLogDataModel = SuggestLogDataModel(
+        sensitive=record.__dict__["sensitive"],
+        errno=record.__dict__["errno"],
+        time=record.__dict__["time"],
+        path=record.__dict__["path"],
+        method=record.__dict__["method"],
+        query=record.__dict__["query"],
+        code=record.__dict__["code"],
+        rid=record.__dict__["rid"],
+        session_id=record.__dict__["session_id"],
+        sequence_no=record.__dict__["sequence_no"],
+        client_variants=record.__dict__["client_variants"],
+        requested_providers=record.__dict__["requested_providers"],
+        country=record.__dict__["country"],
+        region=record.__dict__["region"],
+        city=record.__dict__["city"],
+        dma=record.__dict__["dma"],
+        browser=record.__dict__["browser"],
+        os_family=record.__dict__["os_family"],
+        form_factor=record.__dict__["form_factor"],
+    )
+
+    assert log_data == expected_log_data
 
 
 def test_suggest_with_invalid_geolocation_ip(

--- a/tests/unit/utils/test_log_data_creator.py
+++ b/tests/unit/utils/test_log_data_creator.py
@@ -172,7 +172,7 @@ def test_create_suggest_log_data(
 
 @pytest.mark.parametrize(
     "time_input",
-    ["invalid", {"invalid_set"}],
+    ["not a datetime string", {"not", "a", "datetime", "object"}],
     ids=["invalid_string", "invalid_object_type"],
 )
 def test_create_log_object_fails_on_invalid_time(time_input: Any):

--- a/tests/unit/utils/test_log_data_creator.py
+++ b/tests/unit/utils/test_log_data_creator.py
@@ -199,7 +199,7 @@ def test_create_log_object_fails_on_invalid_time(time_input: Any):
     ids=["epoch_time", "datetime_obj", "str"],
 )
 def test_create_log_object_can_convert_time_to_isoformat(
-    datetime_rep: Union[str, int, datetime], expected_time: str
+    datetime_rep: str | int | datetime, expected_time: str
 ):
     """Ensure that `time` field correctly validates datetime inputs and outputs as string."""
     log_data = LogDataModel(

--- a/tests/unit/utils/test_log_data_creator.py
+++ b/tests/unit/utils/test_log_data_creator.py
@@ -5,7 +5,7 @@
 """Unit tests for the log_data_creator.py utility module."""
 
 from datetime import datetime, timezone
-from typing import Any, Union
+from typing import Any
 
 import pytest
 from pydantic import ValidationError
@@ -186,15 +186,13 @@ def test_create_log_object_fails_on_invalid_time(time_input: Any):
         )
 
 
+@pytest.mark.parametrize("expected_time", ["2022-12-18T15:58:41+00:00"])
 @pytest.mark.parametrize(
-    ["datetime_rep", "expected_time"],
+    "datetime_rep",
     [
-        (1671379121, "2022-12-18T15:58:41+00:00"),
-        (
-            datetime(2022, 12, 18, hour=15, minute=58, second=41, tzinfo=timezone.utc),
-            "2022-12-18T15:58:41+00:00",
-        ),
-        ("2022-12-18T15:58:41Z", "2022-12-18T15:58:41+00:00"),
+        1671379121,
+        datetime(2022, 12, 18, hour=15, minute=58, second=41, tzinfo=timezone.utc),
+        "2022-12-18T15:58:41Z",
     ],
     ids=["epoch_time", "datetime_obj", "str"],
 )


### PR DESCRIPTION
As discussed over Slack with @hackebrot , I think it's worth being explicit about having separate fields for `datetime` object and `str` representation. This will make it clearer in the `dict()` export that we care about the `str` object, but also preserves the implicit validation of the `datetime` Pydantic object.