### PR TITLE
chore: set accuweather query timeout to 5 seconds

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -70,7 +70,7 @@ traces_sample_rate = 0.1
 [default.providers.accuweather]
 enabled_by_default = false
 score = 0.3
-query_timeout_sec = 1.0
+query_timeout_sec = 5.0
 # Our API key used to access the AccuWeather API.
 api_key = ""
 # The remainder of these variables are related to endpoint URLs.


### PR DESCRIPTION
A followup of [DISCO-2139](https://mozilla-hub.atlassian.net/browse/DISCO-2139?focusedCommentId=627176).