### PR TITLE
[DISCO-2138] fix: guard against malformed seq no

### DIFF
--- a/merino/utils/log_data_creators.py
+++ b/merino/utils/log_data_creators.py
@@ -81,6 +81,7 @@ def create_suggest_log_data(
     """Create log data for the suggest API endpoint."""
     location: Location = request.scope[ScopeKey.GEOLOCATION]
     user_agent: UserAgent = request.scope[ScopeKey.USER_AGENT]
+    seq: str = request.query_params.get("seq", "")
 
     return SuggestLogDataModel(
         # General Data
@@ -94,7 +95,7 @@ def create_suggest_log_data(
         code=message["status"],
         rid=Headers(scope=message)["X-Request-ID"],
         session_id=request.query_params.get("sid"),
-        sequence_no=int(seq) if (seq := request.query_params.get("seq")) else None,
+        sequence_no=int(seq) if (seq.isnumeric() and float(seq).is_integer()) else None,
         client_variants=request.query_params.get("client_variants", ""),
         requested_providers=request.query_params.get("providers", ""),
         # Location Data

--- a/merino/utils/log_data_creators.py
+++ b/merino/utils/log_data_creators.py
@@ -81,7 +81,6 @@ def create_suggest_log_data(
     """Create log data for the suggest API endpoint."""
     location: Location = request.scope[ScopeKey.GEOLOCATION]
     user_agent: UserAgent = request.scope[ScopeKey.USER_AGENT]
-    seq: str = request.query_params.get("seq", "")
 
     return SuggestLogDataModel(
         # General Data
@@ -95,7 +94,9 @@ def create_suggest_log_data(
         code=message["status"],
         rid=Headers(scope=message)["X-Request-ID"],
         session_id=request.query_params.get("sid"),
-        sequence_no=int(seq) if (seq.isnumeric() and float(seq).is_integer()) else None,
+        sequence_no=int(seq)
+        if (seq := request.query_params.get("seq", "")) and seq.isdecimal()
+        else None,
         client_variants=request.query_params.get("client_variants", ""),
         requested_providers=request.query_params.get("providers", ""),
         # Location Data

--- a/tests/unit/utils/test_log_data_creator.py
+++ b/tests/unit/utils/test_log_data_creator.py
@@ -91,6 +91,7 @@ def test_create_request_summary_log_data(
         (b"q=nope&client_variants=foo,bar", "nope", None, "foo,bar", "", None),
         (b"q=nope&providers=testprovider", "nope", None, "", "testprovider", None),
         (b"q=nope&seq=0", "nope", None, "", "", 0),
+        (b"q=nope&seq=hello", "nope", None, "", "", None),
     ],
     ids=[
         "no_query",
@@ -98,6 +99,7 @@ def test_create_request_summary_log_data(
         "query_with_client_variants",
         "query_with_providers",
         "query_with_seq",
+        "query_with_no_numeric_seq",
     ],
 )
 def test_create_suggest_log_data(


### PR DESCRIPTION
We could have requests where `seq` is not a valid integer string. These requests will most likely be sent from non-Firefox user agents but we should still handle the conversion exceptions in Merino to avoid errors.