### PR TITLE
Add ADR template and metrics in testing ADR.

### DIFF
--- a/docs/adr/0000-local-and-test-metrics.md
+++ b/docs/adr/0000-local-and-test-metrics.md
@@ -1,0 +1,108 @@
+# Reporting metrics in local development and tests
+
+* Status: Proposed
+* Deciders: raphael, lina
+* Date: 2022-12-16
+
+## Context and Problem Statement
+
+merino-py emits counts, histograms, and timing metrics as it runs. In production, these metrics are sent to Datadog, using an extension of the [StatsD](https://github.com/statsd/statsd) protocol called [DogStatsD](https://docs.datadoghq.com/developers/dogstatsd). For local development, merino-py provides the `metrics.dev_logger` config option, which logs outgoing metrics to the console instead of sending them to Datadog. merino-py also has integration tests that cover recording and emitting metrics. How can we avoid having the `metrics.dev_logger` setting and integration tests rely on implementation details of the `aiodogstatsd` client library to suppress reporting to Datadog?
+
+## Decision Drivers
+
+* Maintain test coverage for merino-py's metrics.
+* Make it easy for engineers to see what metrics are emitted while working on the code.
+* Avoid potential future compatibility issues when upgrading `aiodogstatsd`.
+
+## Considered Options
+
+* A. Do nothing.
+* B. Always send metrics to a live DogStatsD agent.
+* C. Change merino-py's `metrics.Client` proxy to not call into `aiodogstatsd`.
+* D. Subclass `aiodogstatsd.Client` to suppress sending metrics to DogStatsD.
+* E. Extend merino-py's `metrics` module with pluggable backends for production and testing.
+* F. Set up a mock DogStatsD endpoint that collects and checks metrics.
+* G. Ask the `aiodogstatsd` authors to expose a reporting hook as part of their public API.
+
+## Decision Outcome
+
+TODO: Fill me in once we decide!
+
+## Pros and Cons of the Options
+
+### A. Do nothing.
+
+This option would keep the code as it's written today:
+
+1. When the `metrics.dev_logger` config option is set, `metrics.configure_metrics()` sets the pseudo-private `aiodogstatsd.Client._protocol` property to an instance of `metrics._LocalDatagramLogger`. `_LocalDatagramLogger` subclasses `aiodogstatsd.client.DatagramProtocol` to log metrics instead of sending them to DogStatsD. ([DISCO-2089](https://mozilla-hub.atlassian.net/browse/DISCO-2089))
+2. merino-py's integration tests patch the pseudo-private `aiodogstatsd.Client._report()` method with a mock implementation. ([DISCO-2090](https://mozilla-hub.atlassian.net/browse/DISCO-2090))
+
+* Good, because this approach currently works!
+* Good, because this option doesn't require any extra work.
+* Good, because `aiodogstatsd` is in maintenance mode, and unlikely to break merino-py's usage in the future.
+* Bad, because relying on non-public APIs could break merino-py if `aiodogstatsd` does change its implementation in the future.
+* Bad, because merino-py's metrics reporting is tightly coupled to `aiodogstatsd`. Sending metrics to a different backend would require substantial changes to the tests.
+
+### B. Send metrics to a live DogStatsD agent.
+
+This option would remove `metrics.dev_logger`. Instead, developers would need to run a DogStatsD agent locally, and configure merino-py to use that agent.
+
+* Good, because there would be a single path for metrics reporting in local development, testing, and production.
+* Good, because this means less code in merino-py for metrics logging.
+* Good, because unofficial local DogStatsD agents exist, written in [Go](https://github.com/jonmorehouse/dogstatsd-local) and [Ruby](https://github.com/drish/dogstatsd-local).
+* Good, because local DogStatsD agents can log metrics in different formats.
+* Bad, because developers would need to configure and run a separate service when working locally.
+* Bad, because this approach requires an unofficial local DogStatsD agent. The [official DogStatsD agent](https://hub.docker.com/r/datadog/dogstatsd) is only offered as a Docker container that reports metrics to Datadog, and doesn't support custom or local-only backends. The plain StatsD agent, which supports [custom backends](https://github.com/statsd/statsd/blob/master/docs/backend.md), doesn't support the DogStatsD extensions (histograms) that merino-py uses.
+* Bad, because this is only suitable for local development. Setting up a live DogStatsD agent would be more cumbersome to do in the integration tests.
+* Bad, because this option assumes that merino-py will only ever report metrics to DogStatsD.
+
+### C. Change merino-py's `metrics.Client` proxy to not call into `aiodogstatsd` in testing.
+
+merino-py's `metrics.Client` class proxies calls to `aiodogstatsd.Client`. The proxy keeps track of all metrics calls for testing, and adds custom tags for feature flags. We can extend the proxy to only log metrics to the console if `metrics.dev_logger` is set, without forwarding them to the underlying `aiodogstatsd.Client`.
+
+* Good, because this needs minimal changes to support metrics logging for gauges, counters, histograms, and one-off timings.
+* Good, because proxying calls avoids relying on implementation details of `aiodogstatsd`.
+* Bad, because this approach doesn't work for `aiodogstatsd.Client.{timeit, timeit_task}()`, which return thunks that call `aiodogstatsd.Client.timing()`. Since the proxy can't intercept these calls, it would need to reimplement these methods.
+* Bad, because this option assumes that merino-py will only ever report metrics to DogStatsD.
+
+### D. Subclass `aiodogstatsd.Client` to suppress sending metrics to StatsD in tests.
+
+This option would change `metrics.Client` to be a subclass of `aiodogstatsd.Client`, instead of proxying calls to it. The subclass would override the `{gauge, increment, decrement, histogram, distribution, timing}()` methods to log metrics if the f
+
+#### Pros
+
+* Good, because this would involve making the same changes as Option C needed to support methods that don't return anything.
+* Good, because this works for `aiodogstatsd.Client.{timeit, timeit_task}()` out of the box, without needing to reimplement them.
+* Bad, because subclassing `aiodogstatsd.Client` relies on implementation details (for example, that `timeit_task()` calling `timing()` when it's done) that could change in a future version of `aiodogstatsd`.
+* Bad, because this option assumes that merino-py will only ever report metrics to DogStatsD.
+
+### E. Extend merino-py's `metrics` module with pluggable backends for production and testing.
+
+This option would turn `metrics.Client` into a generic metrics interface that could send metrics to any supported backend: DogStatsD, the console, or another metrics provider (Graphite, InfluxDB) in the future.
+
+* Good, because this option doesn't rely on implementation details of `aiodogstatsd`.
+* Good, because this option would make it easy to add an integration test backend to verify recorded metrics.
+* Good, because this option can support any number of backends, without requiring substantial changes to merino-py or the metrics interface.
+* Bad, because it incurs the most engineering work out of all our options.
+* Bad, because it introduces another layer of abstraction that might not be useful beyond tests or local development.
+* Bad, because the new interface would need to reimplement convenience methods like `timeit_task()` from `aiodogstatsd`.
+
+### F. Set up a mock DogStatsD endpoint that collects and checks metrics in tests.
+
+This option would have the integration tests set up a UDP socket that collects, parses, and checks the recorded metrics, following [the same approach](https://github.com/Gr1N/aiodogstatsd/blob/4c363d795df04d1cc4c137307b7f91592224ed32/tests/conftest.py#L11-L13) in the `aiodogstatsd` tests. merino-py's `metrics.Client` would be configured to send metrics to this endpoint in tests.
+
+* Good, because integration tests wouldn't need to patch `aiodogstatsd.Client._report()`.
+* Bad, because the mock socket would need to parse the DogStatsD ping, which could introduce additional bugs.
+* Bad, because this replaces integration test usage only. This option doesn't address the `metrics.dev_logger` use case, and setting up a mock socket for local development would be more cumbersome.
+* Bad, because this option assumes that merino-py will only ever report metrics to DogStatsD.
+
+### G. Ask the `aiodogstatsd` authors to expose a reporting hook as part of their public API.
+
+This option would involve changing `aiodogstatsd` to expose a public API for intercepting metrics before they're sent. This could involve exposing `_protocol` and `_report()`, or adding a new API surface.
+
+* Good, because this option wouldn't require substantial engineering work from us.
+* Good, because it would provide a supported way to log and check metrics without relying on implementation details.
+* Bad, because we'd need to wait for the authors to consider, approve, implement, and publish a new version with our proposal. This could take an unknown amount of time.
+* Bad, because `aiodogstatsd` is stable (the last commit was December 2021), and the authors could reject making such a substantial changes to the interface.
+* Bad, because this commits the `aiodogstatsd` authors to maintaining a new API, of which we would be the only consumer.
+* Bad, because this option assumes that merino-py will only ever report metrics to DogStatsD.

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,72 @@
+# [short title of solved problem and solution]
+
+* Status: [proposed | rejected | accepted | deprecated | … | superseded by [ADR-0005](0005-example.md)] <!-- optional -->
+* Deciders: [list everyone involved in the decision] <!-- optional -->
+* Date: [YYYY-MM-DD when the decision was last updated] <!-- optional -->
+
+Technical Story: [description | ticket/issue URL] <!-- optional -->
+
+## Context and Problem Statement
+
+[Describe the context and problem statement, e.g., in free form using two to three sentences. You may want to articulate the problem in form of a question.]
+
+## Decision Drivers <!-- optional -->
+
+* [driver 1, e.g., a force, facing concern, …]
+* [driver 2, e.g., a force, facing concern, …]
+* … <!-- numbers of drivers can vary -->
+
+## Considered Options
+
+* [option 1]
+* [option 2]
+* [option 3]
+* … <!-- numbers of options can vary -->
+
+## Decision Outcome
+
+Chosen option: "[option 1]", because [justification. e.g., only option, which meets k.o. criterion decision driver | which resolves force force | … | comes out best (see below)].
+
+### Positive Consequences <!-- optional -->
+
+* [e.g., improvement of quality attribute satisfaction, follow-up decisions required, …]
+* …
+
+### Negative Consequences <!-- optional -->
+
+* [e.g., compromising quality attribute, follow-up decisions required, …]
+* …
+
+## Pros and Cons of the Options <!-- optional -->
+
+### [option 1]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+* Good, because [argument a]
+* Good, because [argument b]
+* Bad, because [argument c]
+* … <!-- numbers of pros and cons can vary -->
+
+### [option 2]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+* Good, because [argument a]
+* Good, because [argument b]
+* Bad, because [argument c]
+* … <!-- numbers of pros and cons can vary -->
+
+### [option 3]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+* Good, because [argument a]
+* Good, because [argument b]
+* Bad, because [argument c]
+* … <!-- numbers of pros and cons can vary -->
+
+## Links <!-- optional -->
+
+* [Link type] [Link to ADR] <!-- example: Refined by [ADR-0005](0005-example.md) -->
+* … <!-- numbers of links can vary -->


### PR DESCRIPTION
This PR:

1. Adds a template for our Architecture Decision Records, using the same format as Firefox Accounts. It's more structured than Nygard's [status-context-decision-consequences template](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions), but explicitly enumerates the alternatives considered and the pros and cons of each, which has been helpful in other projects (FxA, Application Services, UniFFI) that use this format. How do we feel about trying out this format?
2. Adds our first ADR for [DISCO-2089](https://mozilla-hub.atlassian.net/browse/DISCO-2089) and [DISCO-2090](https://mozilla-hub.atlassian.net/browse/DISCO-2090)!