### PR TITLE
Suggest endpoint provider limitation on duplicate query params and client variants DISCO-2152

### DIFF
--- a/docs/ops.md
+++ b/docs/ops.md
@@ -91,11 +91,17 @@ tooling.
 
 ### API Configurations
 
-- `default.web.api.v1` (`MERINO_WEB__API__V1__CLIENT_VARIANT_MAX`)
+- `default.web.api.v1.client_variant_max` (`MERINO_WEB__API__V1__CLIENT_VARIANT_MAX`)
 - A non-negative integer to contol the limit of optional client variants passed 
   to suggest endpoint as part of experiments or rollouts.  Additional validators
   can/will be implemented to ensure a limitation on the number of variants passed
   to the request. See: https://mozilla-services.github.io/merino/api.html#suggest.
+
+- `default.web.api.v1.query_max_length` (`MERINO_WEB__API__V1__QUERY_MAX_LENGTH`)
+- A non-negative integer value that is passed into the `max_length` parameter 
+  of the FastAPI Query object constructor.  This limits the string character length
+  of a given query string.
+  
 
 ### Logging
 

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -97,10 +97,15 @@ tooling.
   can/will be implemented to ensure a limitation on the number of variants passed
   to the request. See: https://mozilla-services.github.io/merino/api.html#suggest.
 
-- `default.web.api.v1.query_max_length` (`MERINO_WEB__API__V1__QUERY_MAX_LENGTH`)
+- `default.web.api.v1.query_character_max` (`MERINO_WEB__API__V1__QUERY_CHARACTER_MAX`)
 - A non-negative integer value that is passed into the `max_length` parameter 
   of the FastAPI Query object constructor.  This limits the string character length
-  of a given query string.
+  of a given query string, in this case the total string length count for the suggestion query.
+
+- `default.web.api.v1.client_variant_character_max` (`MERINO_WEB__API__V1__CLIENT_VARIANT_CHARACTER_MAX`)
+- A non-negative integer value that is passed into the `max_length` parameter 
+  of the FastAPI Query object constructor.  This limits the string character length
+  of a given query string, in this case the total string length count for client variants.
   
 
 ### Logging

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -80,7 +80,7 @@ added as a constant tag `deployment.canary` with type `int` to emitted metrics.
 Note that this setting is supposed to be controlled exclusively by deployment
 tooling.
 
-### Runtime configurations
+### Runtime Configurations
 
 - `runtime.query_timeout_sec` (`MERINO_RUNTIME__QUERY_TIMEOUT_SEC`) - A floating
   point (in seconds) indicating the maximum waiting period for queries issued within
@@ -88,6 +88,14 @@ tooling.
   cancelled once the timeout gets triggered. Note that this timeout can also be
   configured by specific providers. The provider timeout takes precedence over this
   value.
+
+### API Configurations
+
+- `default.web.api.v1` (`MERINO_WEB__API__V1__CLIENT_VARIANT_MAX`)
+- A non-negative integer to contol the limit of optional client variants passed 
+  to suggest endpoint as part of experiments or rollouts.  Additional validators
+  can/will be implemented to ensure a limitation on the number of variants passed
+  to the request. See: https://mozilla-services.github.io/merino/api.html#suggest.
 
 ### Logging
 

--- a/merino/config.py
+++ b/merino/config.py
@@ -33,7 +33,8 @@ _validators = [
     ),
     Validator("web.api.v1.client_variant_max", is_type_of=int, gte=0, lte=50),
     # Max set that is passed into FastAPI Query constuctor param 'max_length'.
-    Validator("web.api.v1.query_max_length", is_type_of=int, gt=5, lte=100),
+    Validator("web.api.v1.query_character_max", is_type_of=int, gt=5, lte=500),
+    Validator("web.api.v1.client_variant_character_max", is_type_of=int, gt=0, lte=100),
     # Allow a longer timeout for testing & development
     Validator(
         "runtime.query_timeout_sec",

--- a/merino/config.py
+++ b/merino/config.py
@@ -31,6 +31,7 @@ _validators = [
         lte=0.2,
         env=["production", "ci"],
     ),
+    Validator("web.api.v1.client_variant_max", is_type_of=int),
     # Allow a longer timeout for testing & development
     Validator(
         "runtime.query_timeout_sec",

--- a/merino/config.py
+++ b/merino/config.py
@@ -31,7 +31,9 @@ _validators = [
         lte=0.2,
         env=["production", "ci"],
     ),
-    Validator("web.api.v1.client_variant_max", is_type_of=int),
+    Validator("web.api.v1.client_variant_max", is_type_of=int, gte=0, lte=50),
+    # Max set that is passed into FastAPI Query constuctor param 'max_length'.
+    Validator("web.api.v1.query_max_length", is_type_of=int, gt=5, lte=100),
     # Allow a longer timeout for testing & development
     Validator(
         "runtime.query_timeout_sec",

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -40,6 +40,9 @@ format = "mozlog"
 # Setting to contol the limit of optional client variants passed
 # to suggest endpoint as part of experiments or rollouts.
 client_variant_max = 25
+# Value passed into Query object for FastAPI query parameter validator.
+# Sets limitation on the maximum string length of a query.
+query_max_length = 100
 
 [default.metrics]
 dev_logger = false

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -29,6 +29,9 @@ debug = false
 # timeout with the same name `query_timeout_sec`. See `accuweather` as an
 # example.
 query_timeout_sec = 0.2
+# Setting to contol the limit on optional client variants passed
+# to suggest endpoint as part of experiments or rollouts.
+client_variant_max = 25
 
 [default.logging]
 # Any of "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -40,9 +40,10 @@ format = "mozlog"
 # Setting to contol the limit of optional client variants passed
 # to suggest endpoint as part of experiments or rollouts.
 client_variant_max = 25
-# Value passed into Query object for FastAPI query parameter validator.
+# Values passed into Query object for FastAPI query parameter validator.
 # Sets limitation on the maximum string length of a query.
-query_max_length = 100
+client_variant_character_max = 100
+query_character_max = 500
 
 [default.metrics]
 dev_logger = false

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -39,7 +39,7 @@ format = "mozlog"
 [default.web.api.v1]
 # Setting to contol the limit of optional client variants passed
 # to suggest endpoint as part of experiments or rollouts.
-client_variant_max = 25
+client_variant_max = 10
 # Values passed into Query object for FastAPI query parameter validator.
 # Sets limitation on the maximum string length of a query.
 client_variant_character_max = 100

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -29,15 +29,17 @@ debug = false
 # timeout with the same name `query_timeout_sec`. See `accuweather` as an
 # example.
 query_timeout_sec = 0.2
-# Setting to contol the limit on optional client variants passed
-# to suggest endpoint as part of experiments or rollouts.
-client_variant_max = 25
 
 [default.logging]
 # Any of "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"
 level = "INFO"
 # Any of "mozlog" (i.e. JSON) or "pretty"
 format = "mozlog"
+
+[default.web.api.v1]
+# Setting to contol the limit of optional client variants passed
+# to suggest endpoint as part of experiments or rollouts.
+client_variant_max = 25
 
 [default.metrics]
 dev_logger = false

--- a/merino/configs/testing.toml
+++ b/merino/configs/testing.toml
@@ -10,6 +10,8 @@ dynaconf_merge = true
 [testing.runtime]
 # Use a larger timeout for testing
 query_timeout_sec = 0.5
+# Smaller max for testing
+client_variant_max = 5
 
 [testing.metrics]
 dev_logger = true

--- a/merino/configs/testing.toml
+++ b/merino/configs/testing.toml
@@ -10,8 +10,7 @@ dynaconf_merge = true
 [testing.runtime]
 # Use a larger timeout for testing
 query_timeout_sec = 0.5
-# Smaller max for testing
-client_variant_max = 5
+
 
 [testing.metrics]
 dev_logger = true
@@ -20,6 +19,12 @@ dev_logger = true
 # Any of "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"
 level = "DEBUG"
 format = "pretty"
+
+[testing.web.api.v1]
+# Setting to contol the limit on optional client variants passed
+# to suggest endpoint as part of experiments or rollouts.
+# Smaller max for testing
+client_variant_max = 5
 
 [testing.providers.accuweather]
 # Whether or not this provider is enabled by default.

--- a/merino/configs/testing.toml
+++ b/merino/configs/testing.toml
@@ -25,9 +25,10 @@ format = "pretty"
 # to suggest endpoint as part of experiments or rollouts.
 # Smaller max for testing
 client_variant_max = 5
-# Value passed into Query object for FastAPI query parameter validator.
+# Values passed into Query object for FastAPI query parameter validator.
 # Sets limitation on the maximum string length of a query.
-query_max_length = 100
+client_variant_character_max = 100
+query_character_max = 500
 
 [testing.providers.accuweather]
 # Whether or not this provider is enabled by default.

--- a/merino/configs/testing.toml
+++ b/merino/configs/testing.toml
@@ -25,6 +25,9 @@ format = "pretty"
 # to suggest endpoint as part of experiments or rollouts.
 # Smaller max for testing
 client_variant_max = 5
+# Value passed into Query object for FastAPI query parameter validator.
+# Sets limitation on the maximum string length of a query.
+query_max_length = 100
 
 [testing.providers.accuweather]
 # Whether or not this provider is enabled by default.

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -32,6 +32,11 @@ SUGGEST_RESPONSE = {
 # Timeout for query tasks.
 QUERY_TIMEOUT_SEC = settings.runtime.query_timeout_sec
 
+# Client Variant Maximum - used to limit the number of
+# possible client variants for experiments.
+# See https://mozilla-services.github.io/merino/api.html#suggest
+CLIENT_VARIANT_MAX = settings.runtime.client_variant_max
+
 
 @router.get(
     "/suggest",
@@ -114,9 +119,9 @@ async def suggest(
     response = SuggestResponse(
         suggestions=suggestions,
         request_id=correlation_id.get(),
-        # client_variant restriction: set to remove duplicates, [0:10] to
+        # client_variant restriction: set to remove duplicates, [0:CLIENT_VARIANT_MAX] to
         # limit potential reflection back to client.
-        client_variants=list(set(client_variants.split(",")))[:5]
+        client_variants=list(set(client_variants.split(",")))[:CLIENT_VARIANT_MAX]
         if client_variants
         else [],
     )

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -35,7 +35,7 @@ QUERY_TIMEOUT_SEC = settings.runtime.query_timeout_sec
 # Client Variant Maximum - used to limit the number of
 # possible client variants for experiments.
 # See https://mozilla-services.github.io/merino/api.html#suggest
-CLIENT_VARIANT_MAX = settings.runtime.client_variant_max
+CLIENT_VARIANT_MAX = settings.web.api.v1.client_variant_max
 
 
 @router.get(

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -69,7 +69,10 @@ async def suggest(
     active_providers, default_providers = sources
     if providers is not None:
         search_from = [
-            active_providers[p] for p in providers.split(",") if p in active_providers
+            active_providers[p]
+            # Set used to filter out possible duplicate provider names.
+            for p in set(providers.split(","))
+            if p in active_providers
         ]
     else:
         search_from = default_providers

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -70,7 +70,7 @@ async def suggest(
     if providers is not None:
         search_from = [
             active_providers[p]
-            # Set used to filter out possible duplicate provider names.
+            # Set used to filter out possible duplicate providers passed in.
             for p in set(providers.split(","))
             if p in active_providers
         ]
@@ -114,7 +114,11 @@ async def suggest(
     response = SuggestResponse(
         suggestions=suggestions,
         request_id=correlation_id.get(),
-        client_variants=client_variants.split(",") if client_variants else [],
+        # client_variant restriction: set to remove duplicates, [0:10] to
+        # limit potential reflection back to client.
+        client_variants=list(set(client_variants.split(",")))[:5]
+        if client_variants
+        else [],
     )
     return JSONResponse(content=jsonable_encoder(response))
 

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -122,9 +122,7 @@ async def suggest(
     response = SuggestResponse(
         suggestions=suggestions,
         request_id=correlation_id.get(),
-        # client_variant restriction: set to remove duplicates, [0:CLIENT_VARIANT_MAX] to
-        # limit potential reflection back to client.
-        # [:CLIENT_VARIANT_MAX] filter at end to drop any trailing string.
+        # [:CLIENT_VARIANT_MAX] filter at end to drop any trailing string beyond max_split.
         client_variants=client_variants.split(",", maxsplit=CLIENT_VARIANT_MAX)[
             :CLIENT_VARIANT_MAX
         ]

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -36,7 +36,8 @@ QUERY_TIMEOUT_SEC = settings.runtime.query_timeout_sec
 # possible client variants for experiments.
 # See https://mozilla-services.github.io/merino/api.html#suggest
 CLIENT_VARIANT_MAX = settings.web.api.v1.client_variant_max
-QUERY_MAX_LENGTH = settings.web.api.v1.query_max_length
+QUERY_CHARACTER_MAX = settings.web.api.v1.query_character_max
+CLIENT_VARIANT_CHARACTER_MAX = settings.web.api.v1.client_variant_character_max
 
 
 @router.get(
@@ -47,9 +48,10 @@ QUERY_MAX_LENGTH = settings.web.api.v1.query_max_length
 )
 async def suggest(
     request: Request,
-    q: str = Query(max_length=QUERY_MAX_LENGTH),
+    q: str = Query(max_length=QUERY_CHARACTER_MAX),
     providers: str | None = None,
-    client_variants: str | None = None,
+    client_variants: str
+    | None = Query(default=None, max_length=CLIENT_VARIANT_CHARACTER_MAX),
     sources: tuple[dict[str, BaseProvider], list[BaseProvider]] = Depends(
         get_providers
     ),

--- a/tests/contract/client/tests/test_merino.py
+++ b/tests/contract/client/tests/test_merino.py
@@ -158,9 +158,16 @@ def assert_200_response(
     fetch_kinto_icon_url: Callable[[str], str],
 ) -> None:
     """Check that the content for a 200 OK response is what we expect."""
+    # Because the order of client_variants and server_variants are not
+    # guaranteed, they are sorted before comparison.
     expected_content_dict = step_content.dict(exclude=CONTENT_EXCLUDE)
     merino_content_dict = merino_content.dict(exclude=CONTENT_EXCLUDE)
-    assert expected_content_dict == merino_content_dict
+
+    sorted_expected_content_dict = {
+        k: sorted(v) for k, v in expected_content_dict.items()
+    }
+    sorted_merino_content_dict = {k: sorted(v) for k, v in merino_content_dict.items()}
+    assert sorted_expected_content_dict == sorted_merino_content_dict
 
     # The order of suggestions in Merino's response is not guaranteed.
     # Sort them by ('provider', 'block_id') before validating them.

--- a/tests/contract/client/tests/test_merino.py
+++ b/tests/contract/client/tests/test_merino.py
@@ -158,11 +158,12 @@ def assert_200_response(
     fetch_kinto_icon_url: Callable[[str], str],
 ) -> None:
     """Check that the content for a 200 OK response is what we expect."""
-    # Because the order of client_variants and server_variants are not
-    # guaranteed, they are sorted before comparison.
+
     expected_content_dict = step_content.dict(exclude=CONTENT_EXCLUDE)
     merino_content_dict = merino_content.dict(exclude=CONTENT_EXCLUDE)
 
+    # Because the order of client_variants and server_variants are not
+    # guaranteed, they are sorted before comparison.
     sorted_expected_content_dict = {
         k: sorted(v) for k, v in expected_content_dict.items()
     }

--- a/tests/contract/client/tests/test_merino.py
+++ b/tests/contract/client/tests/test_merino.py
@@ -158,7 +158,6 @@ def assert_200_response(
     fetch_kinto_icon_url: Callable[[str], str],
 ) -> None:
     """Check that the content for a 200 OK response is what we expect."""
-
     expected_content_dict = step_content.dict(exclude=CONTENT_EXCLUDE)
     merino_content_dict = merino_content.dict(exclude=CONTENT_EXCLUDE)
 

--- a/tests/contract/client/tests/test_merino.py
+++ b/tests/contract/client/tests/test_merino.py
@@ -160,14 +160,7 @@ def assert_200_response(
     """Check that the content for a 200 OK response is what we expect."""
     expected_content_dict = step_content.dict(exclude=CONTENT_EXCLUDE)
     merino_content_dict = merino_content.dict(exclude=CONTENT_EXCLUDE)
-
-    # Because the order of client_variants and server_variants are not
-    # guaranteed, they are sorted before comparison.
-    sorted_expected_content_dict = {
-        k: sorted(v) for k, v in expected_content_dict.items()
-    }
-    sorted_merino_content_dict = {k: sorted(v) for k, v in merino_content_dict.items()}
-    assert sorted_expected_content_dict == sorted_merino_content_dict
+    assert expected_content_dict == merino_content_dict
 
     # The order of suggestions in Merino's response is not guaranteed.
     # Sort them by ('provider', 'block_id') before validating them.

--- a/tests/integration/api/v1/suggest/test_suggest.py
+++ b/tests/integration/api/v1/suggest/test_suggest.py
@@ -5,7 +5,6 @@
 """Integration tests for the Merino v1 suggest API endpoint."""
 
 import logging
-import random
 
 import aiodogstatsd
 import pytest
@@ -26,6 +25,7 @@ from tests.types import FilterCaplogFixture
 
 # Defined in testing.toml under [testing.web.api.v1]
 CLIENT_VARIANT_MAX = settings.web.api.v1.client_variant_max
+QUERY_MAX_LENGTH = settings.web.api.v1.query_max_length
 
 
 @pytest.fixture(name="providers")
@@ -77,6 +77,27 @@ def test_no_suggestion(client: TestClient) -> None:
     assert len(response.json()["suggestions"]) == 0
 
 
+def test_query_max_length(client: TestClient) -> None:
+    """Test that the suggest endpoint query is limited by the defined query_max_length.
+    While no result will return, this tests a matching string length up to max.
+    Constant in configuration under [default | testing].web.api.v1.query_max_length.
+    """
+    query_string = "a" * QUERY_MAX_LENGTH
+    response = client.get(f"/api/v1/suggest?q={query_string}")
+    assert response.status_code == 200
+    assert len(response.json()["suggestions"]) == 0
+
+
+def test_query_failure_exceeds_max_length(client: TestClient) -> None:
+    """Test that the suggest endpoint query is limited by the defined query_max_length.
+    This ensures a 400 code returns and the request fails.
+    Constant in configuration under [default | testing].web.api.v1.query_max_length.
+    """
+    query_string = "a" * (QUERY_MAX_LENGTH * 2)
+    response = client.get(f"/api/v1/suggest?q={query_string}")
+    assert response.status_code == 400
+
+
 def test_suggest_duplicate_providers(client: TestClient) -> None:
     """Test to ensure that duplicated providers passed into the suggest endpoint do not
     result in a flood of responses that could result in Denial of Service. A duplicated
@@ -115,13 +136,12 @@ def test_client_variants(client: TestClient) -> None:
 
     result = response.json()
     assert len(result["suggestions"]) == 1
-    # Both the client_variants and test data are converted to sets to check membership,
-    # irrespective of the order because set() is used to remove duplicates.
-    assert set(result["client_variants"]) == set(["foo", "bar"])
+    assert result["client_variants"] == ["foo", "bar"]
 
 
 def test_client_variants_duplicated_variant(client: TestClient) -> None:
-    """Test that the suggest endpoint response only returns a single client_variant,
+    """Test that the suggest endpoint response only returns a single value for client_variant,
+    limited by the CLIENT_VARIANT_MAX as the total possible recurrences of the value,
     even if the request is bombarded with an identical client_variant of the same name.
     """
     duplicated_client_variant = ("foo," * 10000).rstrip(",")
@@ -132,17 +152,18 @@ def test_client_variants_duplicated_variant(client: TestClient) -> None:
 
     result = response.json()
     assert len(result["suggestions"]) == 1
-    assert result["client_variants"] == ["foo"]
+    assert "foo" in result["client_variants"]
+    assert ["foo"] == list(set(result["client_variants"]))
+    assert len(result["client_variants"]) == CLIENT_VARIANT_MAX
 
 
 def test_client_variants_several_duplicated_variants(client: TestClient) -> None:
-    """Test that the suggest endpoint response only returns unique client_variants,
-    even if the request is bombarded with identical client_variants of different names.
+    """Test that the suggest endpoint response only returns client_variants not exceeding
+    the defined client_variant_max, not any trailing string values, even if the request
+    is bombarded with identical client_variants of different names.
     """
     variants = ["foo", "bar", "baz", "fizz", "buzz"]
-    duplicated_client_variants = ",".join(
-        [random.choice(variants) for _ in range(10000)]  # nosec
-    ).rstrip(",")
+    duplicated_client_variants = ",".join([*variants * 50]).rstrip(",")
     response = client.get(
         f"/api/v1/suggest?q=sponsored&client_variants={duplicated_client_variants}"
     )
@@ -150,14 +171,15 @@ def test_client_variants_several_duplicated_variants(client: TestClient) -> None
 
     result = response.json()
     assert len(result["suggestions"]) == 1
-    # Both the client_variants and test data are converted to sets to check membership,
-    # irrespective of the order because set() is used to remove duplicates.
-    assert set(result["client_variants"]) == set(["foo", "bar", "baz", "fizz", "buzz"])
+    # Both the client_variants and test data are converted to sets to check membership.
+    assert [*variants] == result["client_variants"]
+    assert len(result["client_variants"]) == CLIENT_VARIANT_MAX
 
 
 def test_client_variants_return_minimum_variants(client: TestClient) -> None:
-    """Test that the suggest endpoint restriction of 5 client variants for a suggestion.
-    Ensure that the response does not reflect back excessive client variants.
+    """Test that the suggest endpoint restriction of CLIENT_VARIANT_MAX is met.
+    Ensure that the response does not reflect back excessive client variants, nor trailing
+    string values.
     """
     client_variants = ["foo", "bar", "baz", "fizz", "buzz", "foobar"]
 
@@ -169,10 +191,8 @@ def test_client_variants_return_minimum_variants(client: TestClient) -> None:
     result = response.json()
     assert len(result["suggestions"]) == 1
     # NOTE: Shorter value of 5 for client_variant_max used for testing.
-    # See testing.runtime.client_variant_max. Prod value in default.runtime.client_variant_max.
-
-    # Number of possible client variants counted here opposed to the exact matches, given
-    # set() operations do not guarantee order or precedence.
+    # See testing..web.api.v1.client_variant_max.
+    # Prod value in default..web.api.v1.client_variant_max.
     assert len(result["client_variants"]) == CLIENT_VARIANT_MAX
 
 

--- a/tests/integration/api/v1/suggest/test_suggest.py
+++ b/tests/integration/api/v1/suggest/test_suggest.py
@@ -6,7 +6,6 @@
 
 import logging
 import random
-from typing import Any
 
 import aiodogstatsd
 import pytest
@@ -218,28 +217,29 @@ def test_suggest_request_log_data(
     assert len(records) == 1
 
     record = records[0]
-    log_data: dict[str, Any] = {
-        "sensitive": record.__dict__["sensitive"],
-        "errno": record.__dict__["errno"],
-        "time": record.__dict__["time"],
-        "path": record.__dict__["path"],
-        "method": record.__dict__["method"],
-        "query": record.__dict__["query"],
-        "code": record.__dict__["code"],
-        "rid": record.__dict__["rid"],
-        "session_id": record.__dict__["session_id"],
-        "sequence_no": record.__dict__["sequence_no"],
-        "client_variants": record.__dict__["client_variants"],
-        "requested_providers": record.__dict__["requested_providers"],
-        "country": record.__dict__["country"],
-        "region": record.__dict__["region"],
-        "city": record.__dict__["city"],
-        "dma": record.__dict__["dma"],
-        "browser": record.__dict__["browser"],
-        "os_family": record.__dict__["os_family"],
-        "form_factor": record.__dict__["form_factor"],
-    }
-    assert log_data == expected_log_data.dict()
+    log_data: SuggestLogDataModel = SuggestLogDataModel(
+        sensitive=record.__dict__["sensitive"],
+        errno=record.__dict__["errno"],
+        time=record.__dict__["time"],
+        path=record.__dict__["path"],
+        method=record.__dict__["method"],
+        query=record.__dict__["query"],
+        code=record.__dict__["code"],
+        rid=record.__dict__["rid"],
+        session_id=record.__dict__["session_id"],
+        sequence_no=record.__dict__["sequence_no"],
+        client_variants=record.__dict__["client_variants"],
+        requested_providers=record.__dict__["requested_providers"],
+        country=record.__dict__["country"],
+        region=record.__dict__["region"],
+        city=record.__dict__["city"],
+        dma=record.__dict__["dma"],
+        browser=record.__dict__["browser"],
+        os_family=record.__dict__["os_family"],
+        form_factor=record.__dict__["form_factor"],
+    )
+
+    assert log_data == expected_log_data
 
 
 def test_suggest_with_invalid_geolocation_ip(

--- a/tests/integration/api/v1/suggest/test_suggest.py
+++ b/tests/integration/api/v1/suggest/test_suggest.py
@@ -24,8 +24,8 @@ from tests.integration.api.v1.fake_providers import (
 from tests.integration.api.v1.types import Providers
 from tests.types import FilterCaplogFixture
 
-# Defined in testing.toml under [testing.runtime]
-CLIENT_VARIANT_MAX = settings.runtime.client_variant_max
+# Defined in testing.toml under [testing.web.api.v1]
+CLIENT_VARIANT_MAX = settings.web.api.v1.client_variant_max
 
 
 @pytest.fixture(name="providers")


### PR DESCRIPTION
Simple change to avoid potential DDoS where multiple instances of same provider are passed into the `providers` query param.  Wrapped in a set to eliminate duplicates. Didn't need additional filtering due to `if` check, which ensures the passed in `provider` is among those defined. Closes out one low severity finding in recent pen test. 

UPDATED: Added integration testing of api and also expanded functionality to limit number of `client_variants` that can be passed in to 5 to prevent low-risk reflection of client_variants. From the security assessment, it was found that because a list of `client_variants` would be constructed by splitting the `client_variant` query parameter, it was possible to pass in thousands of junk values or duplicates. This has now been limited to 5 and also filtered out.  If this is not desirable, we can modify the value, or have it set as a config value, as opposed to a hard coded limit. Is there a world in which we'd see more than 5 `client_variants`? Either way, I added testing to ensure only unique values return given duplicate `client_variants` and also that only a limit of values return.