### PR TITLE
[DISCO-2147] refactor: use composition for fake providers in int tests

### DIFF
--- a/tests/integration/api/v1/fake_providers.py
+++ b/tests/integration/api/v1/fake_providers.py
@@ -137,7 +137,7 @@ class FakeProvider(BaseProvider):
         return self._enabled_by_default
 
 
-class ProviderFactory:
+class FakeProviderFactory:
     """Class that holds static methods for creating various fake providers."""
 
     @staticmethod

--- a/tests/integration/api/v1/fake_providers.py
+++ b/tests/integration/api/v1/fake_providers.py
@@ -208,7 +208,7 @@ class FakeProviderFactory:
     def timeout_tolerant_sponsored(
         enabled_by_default: bool = True,
     ) -> FakeProvider:
-        """Return a new sponsored fake provider with a higher timeout that sleeps."""
+        """Return a new sponsored fake provider with its own custom query timeout."""
         provider_name = "timedout-tolerant-sponsored"
         return FakeProvider(
             name=provider_name,

--- a/tests/integration/api/v1/providers/test_providers.py
+++ b/tests/integration/api/v1/providers/test_providers.py
@@ -15,7 +15,7 @@ from pytest import LogCaptureFixture
 from merino.providers import BaseProvider
 from merino.utils.log_data_creators import RequestSummaryLogDataModel
 from tests.integration.api.types import RequestSummaryLogDataFixture
-from tests.integration.api.v1.fake_providers import ProviderFactory
+from tests.integration.api.v1.fake_providers import FakeProviderFactory
 from tests.types import FilterCaplogFixture
 
 
@@ -28,7 +28,7 @@ from tests.types import FilterCaplogFixture
                 {"id": "sponsored", "availability": "enabled_by_default"},
             ],
             {
-                "sponsored": ProviderFactory.sponsored(enabled_by_default=True),
+                "sponsored": FakeProviderFactory.sponsored(enabled_by_default=True),
             },
         ),
         (
@@ -36,7 +36,7 @@ from tests.types import FilterCaplogFixture
                 {"id": "sponsored", "availability": "disabled_by_default"},
             ],
             {
-                "sponsored": ProviderFactory.sponsored(enabled_by_default=False),
+                "sponsored": FakeProviderFactory.sponsored(enabled_by_default=False),
             },
         ),
         (
@@ -44,7 +44,7 @@ from tests.types import FilterCaplogFixture
                 {"id": "hidden-provider", "availability": "hidden"},
             ],
             {
-                "hidden-provider": ProviderFactory.hidden(enabled_by_default=True),
+                "hidden-provider": FakeProviderFactory.hidden(enabled_by_default=True),
             },
         ),
         (
@@ -54,9 +54,11 @@ from tests.types import FilterCaplogFixture
                 {"id": "hidden-provider", "availability": "hidden"},
             ],
             {
-                "sponsored": ProviderFactory.sponsored(enabled_by_default=True),
-                "nonsponsored": ProviderFactory.nonsponsored(enabled_by_default=False),
-                "hidden-provider": ProviderFactory.hidden(enabled_by_default=True),
+                "sponsored": FakeProviderFactory.sponsored(enabled_by_default=True),
+                "nonsponsored": FakeProviderFactory.nonsponsored(
+                    enabled_by_default=False
+                ),
+                "hidden-provider": FakeProviderFactory.hidden(enabled_by_default=True),
             },
         ),
     ],

--- a/tests/integration/api/v1/providers/test_providers.py
+++ b/tests/integration/api/v1/providers/test_providers.py
@@ -15,11 +15,7 @@ from pytest import LogCaptureFixture
 from merino.providers import BaseProvider
 from merino.utils.log_data_creators import RequestSummaryLogDataModel
 from tests.integration.api.types import RequestSummaryLogDataFixture
-from tests.integration.api.v1.fake_providers import (
-    HiddenProvider,
-    NonsponsoredProvider,
-    SponsoredProvider,
-)
+from tests.integration.api.v1.fake_providers import ProviderFactory
 from tests.types import FilterCaplogFixture
 
 
@@ -32,7 +28,7 @@ from tests.types import FilterCaplogFixture
                 {"id": "sponsored", "availability": "enabled_by_default"},
             ],
             {
-                "sponsored": SponsoredProvider(enabled_by_default=True),
+                "sponsored": ProviderFactory.sponsored(enabled_by_default=True),
             },
         ),
         (
@@ -40,7 +36,7 @@ from tests.types import FilterCaplogFixture
                 {"id": "sponsored", "availability": "disabled_by_default"},
             ],
             {
-                "sponsored": SponsoredProvider(enabled_by_default=False),
+                "sponsored": ProviderFactory.sponsored(enabled_by_default=False),
             },
         ),
         (
@@ -48,7 +44,7 @@ from tests.types import FilterCaplogFixture
                 {"id": "hidden-provider", "availability": "hidden"},
             ],
             {
-                "hidden-provider": HiddenProvider(enabled_by_default=True),
+                "hidden-provider": ProviderFactory.hidden(enabled_by_default=True),
             },
         ),
         (
@@ -58,9 +54,9 @@ from tests.types import FilterCaplogFixture
                 {"id": "hidden-provider", "availability": "hidden"},
             ],
             {
-                "sponsored": SponsoredProvider(enabled_by_default=True),
-                "nonsponsored": NonsponsoredProvider(enabled_by_default=False),
-                "hidden-provider": HiddenProvider(enabled_by_default=True),
+                "sponsored": ProviderFactory.sponsored(enabled_by_default=True),
+                "nonsponsored": ProviderFactory.nonsponsored(enabled_by_default=False),
+                "hidden-provider": ProviderFactory.hidden(enabled_by_default=True),
             },
         ),
     ],

--- a/tests/integration/api/v1/suggest/test_suggest.py
+++ b/tests/integration/api/v1/suggest/test_suggest.py
@@ -15,7 +15,7 @@ from pytest import LogCaptureFixture
 from pytest_mock import MockerFixture
 
 from merino.utils.log_data_creators import SuggestLogDataModel
-from tests.integration.api.v1.fake_providers import ProviderFactory
+from tests.integration.api.v1.fake_providers import FakeProviderFactory
 from tests.integration.api.v1.types import Providers
 from tests.types import FilterCaplogFixture
 
@@ -28,8 +28,8 @@ def fixture_providers() -> Providers:
           'pytest.mark.parametrize' decorator with a 'providers' definition.
     """
     return {
-        "sponsored": ProviderFactory.sponsored(enabled_by_default=True),
-        "non-sponsored": ProviderFactory.nonsponsored(enabled_by_default=True),
+        "sponsored": FakeProviderFactory.sponsored(enabled_by_default=True),
+        "non-sponsored": FakeProviderFactory.nonsponsored(enabled_by_default=True),
     }
 
 
@@ -246,7 +246,7 @@ def test_suggest_metrics(
     assert metric_keys == expected_metric_keys
 
 
-@pytest.mark.parametrize("providers", [{"corrupt": ProviderFactory.corrupt()}])
+@pytest.mark.parametrize("providers", [{"corrupt": FakeProviderFactory.corrupt()}])
 def test_suggest_metrics_500(mocker: MockerFixture, client: TestClient) -> None:
     """Test that 500 status codes are recorded as metrics."""
     error_msg = "test"

--- a/tests/integration/api/v1/suggest/test_suggest.py
+++ b/tests/integration/api/v1/suggest/test_suggest.py
@@ -15,11 +15,7 @@ from pytest import LogCaptureFixture
 from pytest_mock import MockerFixture
 
 from merino.utils.log_data_creators import SuggestLogDataModel
-from tests.integration.api.v1.fake_providers import (
-    CorruptProvider,
-    NonsponsoredProvider,
-    SponsoredProvider,
-)
+from tests.integration.api.v1.fake_providers import ProviderFactory
 from tests.integration.api.v1.types import Providers
 from tests.types import FilterCaplogFixture
 
@@ -32,8 +28,8 @@ def fixture_providers() -> Providers:
           'pytest.mark.parametrize' decorator with a 'providers' definition.
     """
     return {
-        "sponsored": SponsoredProvider(enabled_by_default=True),
-        "non-sponsored": NonsponsoredProvider(enabled_by_default=True),
+        "sponsored": ProviderFactory.sponsored(enabled_by_default=True),
+        "non-sponsored": ProviderFactory.nonsponsored(enabled_by_default=True),
     }
 
 
@@ -250,7 +246,7 @@ def test_suggest_metrics(
     assert metric_keys == expected_metric_keys
 
 
-@pytest.mark.parametrize("providers", [{"corrupt": CorruptProvider()}])
+@pytest.mark.parametrize("providers", [{"corrupt": ProviderFactory.corrupt()}])
 def test_suggest_metrics_500(mocker: MockerFixture, client: TestClient) -> None:
     """Test that 500 status codes are recorded as metrics."""
     error_msg = "test"

--- a/tests/integration/api/v1/suggest/test_timeout_handling.py
+++ b/tests/integration/api/v1/suggest/test_timeout_handling.py
@@ -13,7 +13,7 @@ from fastapi.testclient import TestClient
 from pytest import LogCaptureFixture
 from pytest_mock import MockerFixture
 
-from tests.integration.api.v1.fake_providers import ProviderFactory
+from tests.integration.api.v1.fake_providers import FakeProviderFactory
 from tests.types import FilterCaplogFixture
 
 Scenario = namedtuple(
@@ -35,7 +35,7 @@ SCENARIOS: dict[str, Scenario] = {
     #     - Timeout metrics recorded in the task runner
     "Case-I: A-timed-out-provider": Scenario(
         providers={
-            "timedout-sponsored": ProviderFactory.timeout_sponsored(
+            "timedout-sponsored": FakeProviderFactory.timeout_sponsored(
                 enabled_by_default=True
             ),
         },
@@ -62,8 +62,8 @@ SCENARIOS: dict[str, Scenario] = {
     #     - Timeout metrics recorded in the task runner
     "Case-II: A-non-timed-out-and-a-timed-out-providers": Scenario(
         providers={
-            "sponsored": ProviderFactory.sponsored(enabled_by_default=True),
-            "timedout-sponsored": ProviderFactory.timeout_sponsored(
+            "sponsored": FakeProviderFactory.sponsored(enabled_by_default=True),
+            "timedout-sponsored": FakeProviderFactory.timeout_sponsored(
                 enabled_by_default=True
             ),
         },
@@ -93,7 +93,7 @@ SCENARIOS: dict[str, Scenario] = {
     #     - Timeout metrics should not be recorded in the task runner
     "Case-III: A-timed-out-tolerant-provider": Scenario(
         providers={
-            "timedout-tolerant-sponsored": ProviderFactory.timeout_tolerant_sponsored(
+            "timedout-tolerant-sponsored": FakeProviderFactory.timeout_tolerant_sponsored(
                 enabled_by_default=True
             ),
         },
@@ -118,11 +118,11 @@ SCENARIOS: dict[str, Scenario] = {
     #     - Timeout metrics should not be recorded in the task runner
     "Case-IV: A-non-timed-out-and-a-timed-out-tolerant-and-a-timed-out-providers": Scenario(
         providers={
-            "sponsored": ProviderFactory.sponsored(enabled_by_default=True),
-            "timedout-sponsored": ProviderFactory.timeout_sponsored(
+            "sponsored": FakeProviderFactory.sponsored(enabled_by_default=True),
+            "timedout-sponsored": FakeProviderFactory.timeout_sponsored(
                 enabled_by_default=True
             ),
-            "timedout-tolerant-sponsored": ProviderFactory.timeout_tolerant_sponsored(
+            "timedout-tolerant-sponsored": FakeProviderFactory.timeout_tolerant_sponsored(
                 enabled_by_default=True
             ),
         },

--- a/tests/integration/api/v1/suggest/test_timeout_handling.py
+++ b/tests/integration/api/v1/suggest/test_timeout_handling.py
@@ -13,11 +13,7 @@ from fastapi.testclient import TestClient
 from pytest import LogCaptureFixture
 from pytest_mock import MockerFixture
 
-from tests.integration.api.v1.fake_providers import (
-    SponsoredProvider,
-    TimeoutSponsoredProvider,
-    TimeoutTolerantSponsoredProvider,
-)
+from tests.integration.api.v1.fake_providers import ProviderFactory
 from tests.types import FilterCaplogFixture
 
 Scenario = namedtuple(
@@ -39,7 +35,9 @@ SCENARIOS: dict[str, Scenario] = {
     #     - Timeout metrics recorded in the task runner
     "Case-I: A-timed-out-provider": Scenario(
         providers={
-            "timedout-sponsored": TimeoutSponsoredProvider(enabled_by_default=True),
+            "timedout-sponsored": ProviderFactory.timeout_sponsored(
+                enabled_by_default=True
+            ),
         },
         expected_suggestion_count=0,
         expected_logs_on_task_runner={
@@ -64,8 +62,10 @@ SCENARIOS: dict[str, Scenario] = {
     #     - Timeout metrics recorded in the task runner
     "Case-II: A-non-timed-out-and-a-timed-out-providers": Scenario(
         providers={
-            "sponsored": SponsoredProvider(enabled_by_default=True),
-            "timedout-sponsored": TimeoutSponsoredProvider(enabled_by_default=True),
+            "sponsored": ProviderFactory.sponsored(enabled_by_default=True),
+            "timedout-sponsored": ProviderFactory.timeout_sponsored(
+                enabled_by_default=True
+            ),
         },
         expected_suggestion_count=1,
         expected_logs_on_task_runner={
@@ -93,7 +93,7 @@ SCENARIOS: dict[str, Scenario] = {
     #     - Timeout metrics should not be recorded in the task runner
     "Case-III: A-timed-out-tolerant-provider": Scenario(
         providers={
-            "timedout-tolerant-sponsored": TimeoutTolerantSponsoredProvider(
+            "timedout-tolerant-sponsored": ProviderFactory.timeout_tolerant_sponsored(
                 enabled_by_default=True
             ),
         },
@@ -118,9 +118,11 @@ SCENARIOS: dict[str, Scenario] = {
     #     - Timeout metrics should not be recorded in the task runner
     "Case-IV: A-non-timed-out-and-a-timed-out-tolerant-and-a-timed-out-providers": Scenario(
         providers={
-            "sponsored": SponsoredProvider(enabled_by_default=True),
-            "timedout-sponsored": TimeoutSponsoredProvider(enabled_by_default=True),
-            "timedout-tolerant-sponsored": TimeoutTolerantSponsoredProvider(
+            "sponsored": ProviderFactory.sponsored(enabled_by_default=True),
+            "timedout-sponsored": ProviderFactory.timeout_sponsored(
+                enabled_by_default=True
+            ),
+            "timedout-tolerant-sponsored": ProviderFactory.timeout_tolerant_sponsored(
                 enabled_by_default=True
             ),
         },


### PR DESCRIPTION
# Description

This pull request refactors the fake providers we use in integration tests to use composition instead of inheritance. This architecture is optimized for comprehensibility and long-term maintainability.

For additional context, please see https://github.com/mozilla-services/merino-py/pull/140#discussion_r1046977863.

# Issue(s)
[DISCO-2147](https://mozilla-hub.atlassian.net/browse/DISCO-2147)
