### PR TITLE
[DISCO-2141] Build merinopy in separate CI step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,7 +156,7 @@ jobs:
             docker_layer_caching: true
       - run:
             name: Build image
-            command: docker build -t app:build .
+            command: make docker-build
       - run:
           name: Save image into workspace
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,10 +22,13 @@ workflows:
           requires:
             - unit-tests
             - integration-tests
+      - docker-image-build:
+          <<: *pr-filters
       - contract-tests:
           <<: *pr-filters
           requires:
             - checks
+            - docker-image-build
       - docs-build:
           <<: *pr-filters
 
@@ -44,10 +47,13 @@ workflows:
           requires:
             - unit-tests
             - integration-tests
+      - docker-image-build:
+          <<: *main-filters
       - contract-tests:
           <<: *main-filters
           requires:
             - checks
+            - docker-image-build
       - docs-build:
           <<: *main-filters
       - docs-publish-github-pages:
@@ -62,6 +68,7 @@ workflows:
             - integration-tests
             - test-coverage-check
             - contract-tests
+            - docker-image-build
       # The following job will require manual approval in the CircleCI web application.
       # Once provided, and when all the requirements are fullfilled (e.g. tests)
       - unhold-to-deploy-to-prod:
@@ -73,6 +80,7 @@ workflows:
             - integration-tests
             - test-coverage-check
             - contract-tests
+            - docker-image-build
       # On approval of the `unhold-to-deploy-to-prod` job, any successive job that requires it
       # will run. In this case, it's manually triggering deployment to production.
       - docker-image-publish-prod:
@@ -139,6 +147,26 @@ jobs:
           command: make test-coverage-check
           environment:
             TEST_RESULTS_DIR: workspace/test-results
+  docker-image-build:
+    docker:
+      - image: cimg/base:2022.08
+    steps:
+      - checkout
+      - setup_remote_docker:
+            docker_layer_caching: true
+      - run:
+            name: Build image
+            command: docker build -t app:build .
+      - run:
+          name: Save image into workspace
+          command: |
+            mkdir -p /tmp/workspace
+            docker save -o /tmp/workspace/merinopy.tar app:build
+            gzip /tmp/workspace/merinopy.tar
+      - persist_to_workspace:
+          root: /tmp/workspace
+          paths:
+            - merinopy.tar.gz
   contract-tests:
     machine:
       docker_layer_caching: true
@@ -146,6 +174,11 @@ jobs:
     working_directory: ~/merino
     steps:
       - checkout
+      - attach_workspace:
+            at: /tmp/workspace
+      - run:
+            name: Load Docker image from workspace
+            command: docker load -i /tmp/workspace/merinopy.tar.gz
       - run:
           name: Contract tests
           command: |
@@ -157,14 +190,15 @@ jobs:
     steps:
       - checkout
       - skip-if-do-not-deploy
-      - setup_remote_docker:
-          docker_layer_caching: true
+      - attach_workspace:
+            at: /tmp/workspace
+      - setup_remote_docker
       - write-version
       - store_artifacts:
           path: version.json
       - run:
-          name: Build image
-          command: docker build -t app:build .
+          name: Load Docker image from workspace
+          command: docker load -i /tmp/workspace/merino.tar.gz
       - dockerhub-login
       - run:
           name: Push to Docker Hub
@@ -187,14 +221,15 @@ jobs:
     steps:
       - checkout
       - skip-if-do-not-deploy
-      - setup_remote_docker:
-          docker_layer_caching: true
+      - attach_workspace:
+            at: /tmp/workspace
+      - setup_remote_docker
       - write-version
       - store_artifacts:
           path: version.json
       - run:
-          name: Build image
-          command: docker build -t app:build .
+            name: Load Docker image from workspace
+            command: docker load -i /tmp/workspace/merino.tar.gz
       - dockerhub-login
       - run:
           name: Push to Docker Hub (prod)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,7 +183,7 @@ jobs:
           name: Contract tests
           command: |
             sudo chown 1000:1000 tests/contract/kinto-attachments
-            make contract-tests
+            make run-contract-tests
   docker-image-publish-stage:
     docker:
       - image: cimg/base:2022.08

--- a/Makefile
+++ b/Makefile
@@ -75,12 +75,19 @@ integration-tests: $(INSTALL_STAMP)  ##  Run integration tests
 integration-test-fixtures: $(INSTALL_STAMP)  ##  List fixtures in use per integration test
 	MERINO_ENV=testing $(POETRY) run pytest $(INTEGRATION_TEST_DIR) --fixtures-per-test
 
+.PHONY: docker-build
+docker-build:
+	docker build -t app:build .
+
 .PHONY: contract-tests
 contract-tests:  ##  Run contract tests using docker compose
 	docker-compose \
       -f $(CONTRACT_TEST_DIR)/docker-compose.yml \
       -p merino-py-contract-tests \
-      up --abort-on-container-exit 
+      up --abort-on-container-exit
+
+.PHONY: local-contract-tests
+local-contract-tests: docker-build contract-tests
 
 .PHONY: contract-tests-clean
 contract-tests-clean:  ##  Stop and remove containers and networks for contract tests

--- a/Makefile
+++ b/Makefile
@@ -79,15 +79,15 @@ integration-test-fixtures: $(INSTALL_STAMP)  ##  List fixtures in use per integr
 docker-build:  ## Build the docker image for Merino named "app:build"
 	docker build -t app:build .
 
-.PHONY: contract-tests
-contract-tests:  ##  Run contract tests using docker compose
+.PHONY: run-contract-tests
+run-contract-tests:  ##  Run contract tests using docker compose
 	docker-compose \
       -f $(CONTRACT_TEST_DIR)/docker-compose.yml \
       -p merino-py-contract-tests \
       up --abort-on-container-exit
 
-.PHONY: local-contract-tests
-local-contract-tests: docker-build contract-tests
+.PHONY: contract-tests
+contract-tests: docker-build run-contract-tests  ## Run contract tests, with build step
 
 .PHONY: contract-tests-clean
 contract-tests-clean:  ##  Stop and remove containers and networks for contract tests

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ contract-tests:  ##  Run contract tests using docker compose
 	docker-compose \
       -f $(CONTRACT_TEST_DIR)/docker-compose.yml \
       -p merino-py-contract-tests \
-      up --abort-on-container-exit --build
+      up --abort-on-container-exit 
 
 .PHONY: contract-tests-clean
 contract-tests-clean:  ##  Stop and remove containers and networks for contract tests

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ integration-test-fixtures: $(INSTALL_STAMP)  ##  List fixtures in use per integr
 	MERINO_ENV=testing $(POETRY) run pytest $(INTEGRATION_TEST_DIR) --fixtures-per-test
 
 .PHONY: docker-build
-docker-build:
+docker-build:  ## Build the docker image for Merino named "app:build"
 	docker build -t app:build .
 
 .PHONY: contract-tests

--- a/docs/dev/index.md
+++ b/docs/dev/index.md
@@ -62,8 +62,14 @@ $ make integration-tests
 # List fixtures in use per integration test
 $ make integration-test-fixtures
 
-# Run contract tests
+# Build the merino-py docker image
+$ make docker-build
+
+# Run contract tests only
 $ make contract-tests
+
+# Run contract tests locally, ensuring merino builds
+$ make local-contract-tests
 
 # Run contract tests cleanup
 $ make contract-tests-clean

--- a/docs/dev/index.md
+++ b/docs/dev/index.md
@@ -62,14 +62,14 @@ $ make integration-tests
 # List fixtures in use per integration test
 $ make integration-test-fixtures
 
-# Build the merino-py docker image
+# Build the docker image for Merino named "app:build"
 $ make docker-build
 
-# Run contract tests only
-$ make contract-tests
+# Run contract tests on existing merino-py docker image
+$ make run-contract-tests
 
-# Run contract tests locally, ensuring merino builds
-$ make local-contract-tests
+# Run contract tests, with build step
+$ make contract-tests
 
 # Run contract tests cleanup
 $ make contract-tests-clean

--- a/tests/contract/README.md
+++ b/tests/contract/README.md
@@ -53,7 +53,7 @@ For more details see the Remote Settings [documentation][kinto_docs]
 To run the contract tests locally, execute the following from the repository root:
 
 ```shell
-make local-contract-tests
+make contract-tests
 ```
 
 To remove contract test containers and network artifacts, execute the following from

--- a/tests/contract/README.md
+++ b/tests/contract/README.md
@@ -53,7 +53,7 @@ For more details see the Remote Settings [documentation][kinto_docs]
 To run the contract tests locally, execute the following from the repository root:
 
 ```shell
-make contract-tests
+make local-contract-tests
 ```
 
 To remove contract test containers and network artifacts, execute the following from

--- a/tests/contract/docker-compose.yml
+++ b/tests/contract/docker-compose.yml
@@ -2,8 +2,7 @@ version: "3"
 services:
   merino:
     # See `docker-image-build` job in `.circleci/config.yml`
-    image: app:runtime
-    build: ../..
+    image: app:build
     container_name: merino
     environment:
       # The configuration preset to use


### PR DESCRIPTION
This allows the built artifact to be reused in various downstream steps.