### PR TITLE
Write the version.json file before building image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,6 +155,8 @@ jobs:
       - setup_remote_docker:
             docker_layer_caching: true
       - write-version
+      - store_artifacts:
+            path: version.json
       - run:
             name: Build image
             command: make docker-build
@@ -194,9 +196,6 @@ jobs:
       - attach_workspace:
             at: /tmp/workspace
       - setup_remote_docker
-      - write-version
-      - store_artifacts:
-          path: version.json
       - run:
           name: Load Docker image from workspace
           command: docker load -i /tmp/workspace/merinopy.tar.gz
@@ -225,9 +224,6 @@ jobs:
       - attach_workspace:
             at: /tmp/workspace
       - setup_remote_docker
-      - write-version
-      - store_artifacts:
-          path: version.json
       - run:
             name: Load Docker image from workspace
             command: docker load -i /tmp/workspace/merinopy.tar.gz

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,6 +154,7 @@ jobs:
       - checkout
       - setup_remote_docker:
             docker_layer_caching: true
+      - write-version
       - run:
             name: Build image
             command: make docker-build


### PR DESCRIPTION
This ensures that the `version.json` file exists so that it can be available during the build process.