### PR TITLE
Split the `lint` command to be able to run all in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ jobs:
       - checkout
       - run:
           name: Code linting
-          command: make lint
+          command: make -k lint
   unit-tests:
     docker:
       - image: cimg/python:3.11

--- a/Makefile
+++ b/Makefile
@@ -19,14 +19,32 @@ $(INSTALL_STAMP): pyproject.toml poetry.lock
 	$(POETRY) install
 	touch $(INSTALL_STAMP)
 
-.PHONY: lint
-lint: $(INSTALL_STAMP)  ##  Run various linters
+.PHONY: isort
+isort: $(INSTALL_STAMP)  ##  Run isort
 	$(POETRY) run isort --check-only $(APP_AND_TEST_DIRS)
+
+.PHONY: black
+black: $(INSTALL_STAMP)  ##  Run black
 	$(POETRY) run black --quiet --diff --check merino $(APP_AND_TEST_DIRS)
+
+.PHONY: flake8
+flake8: $(INSTALL_STAMP)  ##  Run flake8
 	$(POETRY) run flake8 $(APP_AND_TEST_DIRS)
+
+.PHONY: bandit
+bandit: $(INSTALL_STAMP)  ##  Run bandit
 	$(POETRY) run bandit --quiet -r $(APP_AND_TEST_DIRS) -c "pyproject.toml"
+
+.PHONY: pydocstyle
+pydocstyle: $(INSTALL_STAMP)  ##  Run pydocstyle
 	$(POETRY) run pydocstyle $(APP_AND_TEST_DIRS) --config="pyproject.toml"
+
+.PHONY: mypy
+mypy: $(INSTALL_STAMP)  ##  Run mypy
 	$(POETRY) run mypy $(APP_AND_TEST_DIRS) --config-file="pyproject.toml"
+
+.PHONY: lint
+lint: $(INSTALL_STAMP) isort black flake8 bandit pydocstyle mypy ##  Run various linters
 
 .PHONY: format
 format: $(INSTALL_STAMP)  ##  Sort imports and reformat code

--- a/docs/dev/index.md
+++ b/docs/dev/index.md
@@ -32,8 +32,26 @@ $ make help
 # Just like `poetry install`
 $ make install
 
+# Run isort
+$ make isort
+
+# Run black
+$ make black
+
+# Run flake8
+$ make flake8
+
+# Run bandit
+$ make bandit
+
+# Run pydocstyle
+$ make pydocstyle
+
+# Run mypy
+$ make mypy
+
 # Run all linting checks
-$ make lint
+$ make -k lint
 
 # Run all formatters
 $ make format


### PR DESCRIPTION
We have multiple lint commands that are currently run sequentially. However, this makes it inefficient, as we will need to re-run the linter to get errors for subsequent commands. 

This change will allow us to use the `Makefile`'s `--keep-going` (`-k`) so that it can run all the dependant targets in the `lint` target regardless of whether it fails the checks. I opted for this approach over using multiple CircleCI jobs as it feels kind of overkill to bootstrap another job container to do all these small checks.  

Devs will also need to update their workflow to run `make -k lint` rather than `make lint` to get the advantage of parallelism (I'll make an announcement on Slack).
