### PR TITLE
fix: AccuWeather backend raises Error for undefined API key

### DIFF
--- a/merino/configs/development.toml
+++ b/merino/configs/development.toml
@@ -16,3 +16,6 @@ dev_logger = true
 # Any of "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"
 level = "DEBUG"
 format = "pretty"
+
+[development.providers.accuweather]
+api_key = "test"


### PR DESCRIPTION
# Description

When executing Merino in a development environment, an error is raised if the AccuWeather API key is set to an empty value. This pull request sets the value to 'test'.

Example Error:
<img width="914" alt="image" src="https://user-images.githubusercontent.com/3422688/210882602-eff046c6-de3b-49ee-aac5-61acf2824083.png">

