### PR TITLE
chore: bump rust to 1.64 for mdbook

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -246,7 +246,7 @@ jobs:
             fi
   docs-build:
     docker:
-      - image: cimg/rust:1.63
+      - image: cimg/rust:1.64
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Mdbook now requires rustc 1.64. 