### PR TITLE
[DISCO-2174] Refactor Merino AdM Protocol and Backends

### DIFF
--- a/merino/providers/__init__.py
+++ b/merino/providers/__init__.py
@@ -7,9 +7,9 @@ from timeit import default_timer as timer
 from merino import metrics
 from merino.config import settings
 from merino.exceptions import InvalidProviderError
-from merino.providers.adm.backends.remotesettings import LiveBackend
+from merino.providers.adm.backends.remotesettings import RemoteSettingsBackend
+from merino.providers.adm.backends.testbackend import TestBackend
 from merino.providers.adm.provider import Provider as AdmProvider
-from merino.providers.adm.provider import TestBackend
 from merino.providers.base import BaseProvider
 from merino.providers.top_picks import Provider as TopPicksProvider
 from merino.providers.weather.backends.accuweather import AccuweatherBackend
@@ -67,11 +67,18 @@ async def init_providers() -> None:
             case ProviderType.ADM:
                 providers["adm"] = AdmProvider(
                     backend=(
-                        LiveBackend()  # type: ignore [arg-type]
+                        RemoteSettingsBackend(
+                            server=settings.remote_settings.server,
+                            collection=settings.remote_settings.collection,
+                            bucket=settings.remote_settings.bucket,
+                        )  # type: ignore [arg-type]
                         if setting.backend == "remote-settings"
                         else TestBackend()
                     ),
+                    score=setting.score,
+                    score_wikipedia=setting.score_wikipedia,
                     name=provider_type,
+                    resync_interval_sec=setting.resync_interval_sec,
                     enabled_by_default=setting.enabled_by_default,
                 )
             case ProviderType.TOP_PICKS:

--- a/merino/providers/__init__.py
+++ b/merino/providers/__init__.py
@@ -7,8 +7,8 @@ from timeit import default_timer as timer
 from merino import metrics
 from merino.config import settings
 from merino.exceptions import InvalidProviderError
+from merino.providers.adm.backends.fake_backends import FakeAdmBackend
 from merino.providers.adm.backends.remotesettings import RemoteSettingsBackend
-from merino.providers.adm.backends.testbackend import TestBackend
 from merino.providers.adm.provider import Provider as AdmProvider
 from merino.providers.base import BaseProvider
 from merino.providers.top_picks import Provider as TopPicksProvider
@@ -16,9 +16,7 @@ from merino.providers.weather.backends.accuweather import AccuweatherBackend
 from merino.providers.weather.provider import Provider as WeatherProvider
 from merino.providers.wiki_fruit import WikiFruitProvider
 from merino.providers.wikipedia.backends.elastic import ElasticBackend
-from merino.providers.wikipedia.backends.test_backends import (
-    TestBackend as WikipediaTestBackend,
-)
+from merino.providers.wikipedia.backends.fake_backends import FakeWikipediaBackend
 from merino.providers.wikipedia.provider import Provider as WikipediaProvider
 
 providers: dict[str, BaseProvider] = {}
@@ -73,7 +71,7 @@ async def init_providers() -> None:
                             bucket=settings.remote_settings.bucket,
                         )  # type: ignore [arg-type]
                         if setting.backend == "remote-settings"
-                        else TestBackend()
+                        else FakeAdmBackend()
                     ),
                     score=setting.score,
                     score_wikipedia=setting.score_wikipedia,
@@ -99,7 +97,7 @@ async def init_providers() -> None:
                             password=setting.es_password,
                         )  # type: ignore [arg-type]
                         if setting.backend == "elasticsearch"
-                        else WikipediaTestBackend()
+                        else FakeWikipediaBackend()
                     ),
                     name=provider_type,
                     enabled_by_default=setting.enabled_by_default,

--- a/merino/providers/adm/backends/fake_backends.py
+++ b/merino/providers/adm/backends/fake_backends.py
@@ -3,8 +3,8 @@
 from merino.providers.adm.backends.protocol import SuggestionContent
 
 
-class TestBackend:
-    """A test backend that always returns empty results for tests."""
+class FakeAdmBackend:
+    """A fake backend that always returns empty results."""
 
     async def fetch(self) -> SuggestionContent:
         """Get fake Content from partner."""

--- a/merino/providers/adm/backends/protocol.py
+++ b/merino/providers/adm/backends/protocol.py
@@ -22,7 +22,7 @@ class Content(BaseModel):
 
 
 class AdmBackend(Protocol):
-    """Protocol for a Remote Settings backend that this provider depends on.
+    """Protocol for an AdM backend that this provider depends on.
 
     Note: This only defines the methods used by the provider. The actual backend
     might define additional methods and attributes which this provider doesn't

--- a/merino/providers/adm/backends/protocol.py
+++ b/merino/providers/adm/backends/protocol.py
@@ -1,7 +1,24 @@
 """Protocol for the AdM provider backends."""
 from typing import Any, Protocol
 
-import httpx
+from pydantic import BaseModel
+
+
+class Content(BaseModel):
+    """Class that holds the result from a fetch operation."""
+
+    # A dictionary keyed on suggestion keywords, each value stores an index
+    # (pointer) to one entry of the suggestion result list.
+    suggestions: dict[str, tuple[int, int]]
+
+    # A list of full keywords
+    full_keywords: list[str]
+
+    # A list of suggestion results.
+    results: list[dict[str, Any]]
+
+    # A dictionary of icon IDs to icon URLs.
+    icons: dict[int, str]
 
 
 class AdmBackend(Protocol):
@@ -12,16 +29,6 @@ class AdmBackend(Protocol):
     directly depend on.
     """
 
-    async def get(self) -> list[dict[str, Any]]:  # pragma: no cover
-        """Get records from Remote Settings."""
-        ...
-
-    async def fetch_attachment(
-        self, attachment_uri: str
-    ) -> httpx.Response:  # pragma: no cover
-        """Fetch the attachment for the given URI."""
-        ...
-
-    def get_icon_url(self, icon_uri: str) -> str:  # pragma: no cover
-        """Get the icon URL for the given URI."""
+    async def fetch(self) -> Content:  # pragma: no cover
+        """Get suggestion content from partner."""
         ...

--- a/merino/providers/adm/backends/protocol.py
+++ b/merino/providers/adm/backends/protocol.py
@@ -4,7 +4,7 @@ from typing import Any, Protocol
 from pydantic import BaseModel
 
 
-class Content(BaseModel):
+class SuggestionContent(BaseModel):
     """Class that holds the result from a fetch operation."""
 
     # A dictionary keyed on suggestion keywords, each value stores an index
@@ -29,6 +29,6 @@ class AdmBackend(Protocol):
     directly depend on.
     """
 
-    async def fetch(self) -> Content:  # pragma: no cover
+    async def fetch(self) -> SuggestionContent:  # pragma: no cover
         """Get suggestion content from partner."""
         ...

--- a/merino/providers/adm/backends/protocol.py
+++ b/merino/providers/adm/backends/protocol.py
@@ -1,0 +1,27 @@
+"""Protocol for the AdM provider backends."""
+from typing import Any, Protocol
+
+import httpx
+
+
+class AdmBackend(Protocol):
+    """Protocol for a Remote Settings backend that this provider depends on.
+
+    Note: This only defines the methods used by the provider. The actual backend
+    might define additional methods and attributes which this provider doesn't
+    directly depend on.
+    """
+
+    async def get(self) -> list[dict[str, Any]]:  # pragma: no cover
+        """Get records from Remote Settings."""
+        ...
+
+    async def fetch_attachment(
+        self, attachment_uri: str
+    ) -> httpx.Response:  # pragma: no cover
+        """Fetch the attachment for the given URI."""
+        ...
+
+    def get_icon_url(self, icon_uri: str) -> str:  # pragma: no cover
+        """Get the icon URL for the given URI."""
+        ...

--- a/merino/providers/adm/backends/remotesettings.py
+++ b/merino/providers/adm/backends/remotesettings.py
@@ -6,7 +6,7 @@ from urllib.parse import urljoin
 import httpx
 import kinto_http
 
-from merino.providers.adm.backends.protocol import Content
+from merino.providers.adm.backends.protocol import SuggestionContent
 
 
 class RemoteSettingsBackend:
@@ -18,7 +18,7 @@ class RemoteSettingsBackend:
     collection: str
 
     def __init__(self, server: str, collection: str, bucket: str) -> None:
-        """Init Remote Settings Client
+        """Init the Remote Settings backend and create a new client.
 
         Args:
           - `server`: the server address
@@ -44,7 +44,7 @@ class RemoteSettingsBackend:
         return cast(str, server_info["capabilities"]["attachments"]["base_url"])
 
     async def get(self) -> list[dict[str, Any]]:
-        """Get records from Remote Settings server."""
+        """Get records from the Remote Settings server."""
         return cast(
             list[dict[str, Any]],
             await self.client.get_records(
@@ -72,7 +72,7 @@ class RemoteSettingsBackend:
         """
         return urljoin(self.attachment_host, icon_uri)
 
-    async def fetch(self) -> Content:
+    async def fetch(self) -> SuggestionContent:
         """Fetch suggestions, keywords, and icons from Remote Settings."""
         suggestions: dict[str, tuple[int, int]] = {}
         full_keywords: list[str] = []
@@ -116,7 +116,7 @@ class RemoteSettingsBackend:
             id = int(icon["id"].replace("icon-", ""))
             icons[id] = self.get_icon_url(icon["attachment"]["location"])
 
-        return Content(
+        return SuggestionContent(
             suggestions=suggestions,
             full_keywords=full_keywords,
             results=results,

--- a/merino/providers/adm/backends/remotesettings.py
+++ b/merino/providers/adm/backends/remotesettings.py
@@ -1,9 +1,12 @@
 """A thin wrapper around the Remote Settings client."""
+from asyncio import as_completed
 from typing import Any, cast
 from urllib.parse import urljoin
 
 import httpx
 import kinto_http
+
+from merino.providers.adm.backends.protocol import Content
 
 
 class RemoteSettingsBackend:
@@ -21,6 +24,9 @@ class RemoteSettingsBackend:
           - `server`: the server address
           - `collection`: the collection name
           - `bucket`: the bucket name
+        Raises:
+            ValueError: If 'server', 'collection' or 'bucket' parameters are None or
+                        empty.
         """
         if not server or not collection or not bucket:
             raise ValueError(
@@ -65,3 +71,54 @@ class RemoteSettingsBackend:
           - `icon_uri`: a URI path for an icon stored on Remote Settings
         """
         return urljoin(self.attachment_host, icon_uri)
+
+    async def fetch(self) -> Content:
+        """Fetch suggestions, keywords, and icons from Remote Settings."""
+        suggestions: dict[str, tuple[int, int]] = {}
+        full_keywords: list[str] = []
+        results: list[dict[str, Any]] = []
+        icons: dict[int, str] = {}
+
+        suggest_settings = await self.get()
+
+        # Falls back to "data" records if "offline-expansion-data" records do not exist
+        records = [
+            record
+            for record in suggest_settings
+            if record["type"] == "offline-expansion-data"
+        ] or [record for record in suggest_settings if record["type"] == "data"]
+
+        fetch_tasks = [
+            self.fetch_attachment(item["attachment"]["location"]) for item in records
+        ]
+        fkw_index = 0
+        for done_task in as_completed(fetch_tasks):
+            res = await done_task
+
+            for suggestion in res.json():
+                result_id = len(results)
+                keywords = suggestion.pop("keywords", [])
+                full_keywords_tuples = suggestion.pop("full_keywords", [])
+                begin = 0
+                for full_keyword, n in full_keywords_tuples:
+                    for query in keywords[begin : begin + n]:
+                        # Note that for adM suggestions, each keyword can only be
+                        # mapped to a single suggestion.
+                        suggestions[query] = (result_id, fkw_index)
+                    begin += n
+                    full_keywords.append(full_keyword)
+                    fkw_index = len(full_keywords)
+                results.append(suggestion)
+        icon_record = [
+            record for record in suggest_settings if record["type"] == "icon"
+        ]
+        for icon in icon_record:
+            id = int(icon["id"].replace("icon-", ""))
+            icons[id] = self.get_icon_url(icon["attachment"]["location"])
+
+        return Content(
+            suggestions=suggestions,
+            full_keywords=full_keywords,
+            results=results,
+            icons=icons,
+        )

--- a/merino/providers/adm/backends/testbackend.py
+++ b/merino/providers/adm/backends/testbackend.py
@@ -1,11 +1,11 @@
 """Test backend for the AdM provider."""
 
-from merino.providers.adm.backends.protocol import Content
+from merino.providers.adm.backends.protocol import SuggestionContent
 
 
 class TestBackend:
     """A test backend that always returns empty results for tests."""
 
-    async def fetch(self) -> Content:
+    async def fetch(self) -> SuggestionContent:
         """Get fake Content from partner."""
-        return Content()
+        return SuggestionContent()

--- a/merino/providers/adm/backends/testbackend.py
+++ b/merino/providers/adm/backends/testbackend.py
@@ -1,0 +1,20 @@
+"""Test backend for the AdM provider."""
+from typing import Any
+
+import httpx
+
+
+class TestBackend:
+    """A test backend that always returns empty results for tests."""
+
+    async def get(self) -> list[dict[str, Any]]:
+        """Return fake records."""
+        return []
+
+    async def fetch_attachment(self, attachment_uri: str) -> httpx.Response:
+        """Return a fake attachment for the given URI."""
+        return httpx.Response(200, text="")
+
+    def get_icon_url(self, icon_uri: str) -> str:
+        """Return a fake icon URL for the given URI."""
+        return ""

--- a/merino/providers/adm/backends/testbackend.py
+++ b/merino/providers/adm/backends/testbackend.py
@@ -1,20 +1,11 @@
 """Test backend for the AdM provider."""
-from typing import Any
 
-import httpx
+from merino.providers.adm.backends.protocol import Content
 
 
 class TestBackend:
     """A test backend that always returns empty results for tests."""
 
-    async def get(self) -> list[dict[str, Any]]:
-        """Return fake records."""
-        return []
-
-    async def fetch_attachment(self, attachment_uri: str) -> httpx.Response:
-        """Return a fake attachment for the given URI."""
-        return httpx.Response(200, text="")
-
-    def get_icon_url(self, icon_uri: str) -> str:
-        """Return a fake icon URL for the given URI."""
-        return ""
+    async def fetch(self) -> Content:
+        """Get fake Content from partner."""
+        return Content()

--- a/merino/providers/wikipedia/backends/fake_backends.py
+++ b/merino/providers/wikipedia/backends/fake_backends.py
@@ -5,8 +5,8 @@ from urllib.parse import quote
 from merino.exceptions import BackendError
 
 
-class TestBackend:  # pragma: no cover
-    """A mock backend for testing."""
+class FakeWikipediaBackend:  # pragma: no cover
+    """A fake backend that always returns empty results."""
 
     async def shutdown(self) -> None:
         """Nothing to shut down."""
@@ -17,11 +17,8 @@ class TestBackend:  # pragma: no cover
         return []
 
 
-class TestEchoBackend:
-    """A mock backend for testing.
-
-    It returns the exact same query as the search result.
-    """
+class FakeEchoWikipediaBackend:
+    """A fake backend that returns the exact same query as the search result."""
 
     async def shutdown(self) -> None:
         """Nothing to shut down."""
@@ -38,11 +35,8 @@ class TestEchoBackend:
         ]
 
 
-class TestExceptionBackend:
-    """A mock backend for testing.
-
-    It raises a `BackendError` for any given query.
-    """
+class FakeExceptionWikipediaBackend:
+    """A fake backend that raises a `BackendError` for any given query."""
 
     async def shutdown(self) -> None:
         """Nothing to shut down."""

--- a/tests/integration/api/v1/suggest/test_suggest_wikipedia.py
+++ b/tests/integration/api/v1/suggest/test_suggest_wikipedia.py
@@ -8,9 +8,9 @@ from fastapi.testclient import TestClient
 from pytest import LogCaptureFixture
 
 from merino.config import settings
-from merino.providers.wikipedia.backends.test_backends import (
-    TestEchoBackend,
-    TestExceptionBackend,
+from merino.providers.wikipedia.backends.fake_backends import (
+    FakeEchoWikipediaBackend,
+    FakeExceptionWikipediaBackend,
 )
 from merino.providers.wikipedia.provider import ADVERTISER, ICON, Provider
 from tests.types import FilterCaplogFixture
@@ -28,14 +28,14 @@ Scenario = namedtuple(
 
 SCENARIOS: dict[str, Scenario] = {
     "Case-I: Backend returns": Scenario(
-        providers={"wikipedia": Provider(backend=TestEchoBackend())},
+        providers={"wikipedia": Provider(backend=FakeEchoWikipediaBackend())},
         query="foo bar",
         expected_suggestion_count=1,
         expected_title="foo_bar",
         expected_logs=set(),
     ),
     "Case-II: Backend raises": Scenario(
-        providers={"wikipedia": Provider(backend=TestExceptionBackend())},
+        providers={"wikipedia": Provider(backend=FakeExceptionWikipediaBackend())},
         query="foo bar",
         expected_suggestion_count=0,
         expected_title=None,

--- a/tests/unit/providers/adm/backends/test_remotesettings.py
+++ b/tests/unit/providers/adm/backends/test_remotesettings.py
@@ -3,7 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """Unit tests for the Remote Settings backend module."""
-import json
 from typing import Any
 
 import httpx
@@ -12,7 +11,7 @@ import pytest
 from pytest_mock import MockerFixture
 
 from merino.providers import RemoteSettingsBackend
-from merino.providers.adm.backends.protocol import Content
+from merino.providers.adm.backends.protocol import SuggestionContent
 
 
 @pytest.fixture(name="rs_parameters")
@@ -147,7 +146,7 @@ def fixture_rs_attachment_response() -> httpx.Response:
             ("mozilla firefox accounts", 4),
         ],
     }
-    return httpx.Response(200, text=json.dumps([attachment]))
+    return httpx.Response(200, json=[attachment])
 
 
 @pytest.mark.parametrize(
@@ -195,7 +194,7 @@ async def test_fetch_attachment_host(
 @pytest.mark.parametrize(
     "attachment_host",
     ["", "attachment-host/"],
-    ids=["attachment_host_defined", "attachment_host_undefined"],
+    ids=["attachment_host_undefined", "attachment_host_defined"],
 )
 async def test_fetch_attachment(
     mocker: MockerFixture,
@@ -224,7 +223,7 @@ async def test_fetch_attachment(
 @pytest.mark.parametrize(
     "attachment_host",
     ["", "attachment-host/"],
-    ids=["attachment_host_defined", "attachment_host_undefined"],
+    ids=["attachment_host_undefined", "attachment_host_defined"],
 )
 def test_get_icon_url(rs_backend: RemoteSettingsBackend, attachment_host: str) -> None:
     """Test that the get_icon_url method returns a proper icon url."""
@@ -244,7 +243,7 @@ async def test_fetch(
     rs_get_records_response: list[dict[str, Any]],
     rs_server_info_response: dict[str, Any],
     rs_attachment_response: httpx.Response,
-    adm_suggestion_content: Content,
+    adm_suggestion_content: SuggestionContent,
 ) -> None:
     """Test that the fetch method returns the proper suggestion content."""
     rs_backend.attachment_host = "attachment-host/"
@@ -256,6 +255,6 @@ async def test_fetch(
     )
     mocker.patch.object(httpx.AsyncClient, "get", return_value=rs_attachment_response)
 
-    content: Content = await rs_backend.fetch()
+    suggestion_content: SuggestionContent = await rs_backend.fetch()
 
-    assert content == adm_suggestion_content
+    assert suggestion_content == adm_suggestion_content

--- a/tests/unit/providers/adm/backends/test_remotesettings.py
+++ b/tests/unit/providers/adm/backends/test_remotesettings.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """Unit tests for the Remote Settings backend module."""
-
+import json
 from typing import Any
 
 import httpx
@@ -12,10 +12,11 @@ import pytest
 from pytest_mock import MockerFixture
 
 from merino.providers import RemoteSettingsBackend
+from merino.providers.adm.backends.protocol import Content
 
 
-@pytest.fixture(name="remote_settings_parameters")
-def fixture_remote_settings_parameters() -> dict[str, str]:
+@pytest.fixture(name="rs_parameters")
+def fixture_rs_parameters() -> dict[str, str]:
     """Define default Remote Settings parameters for test."""
     return {
         "server": "test://test",
@@ -24,16 +25,61 @@ def fixture_remote_settings_parameters() -> dict[str, str]:
     }
 
 
-@pytest.fixture(name="remote_settings")
-def fixture_remote_settings(
-    remote_settings_parameters: dict[str, str]
-) -> RemoteSettingsBackend:
+@pytest.fixture(name="rs_backend")
+def fixture_rs_backend(rs_parameters: dict[str, str]) -> RemoteSettingsBackend:
     """Create a RemoteSettingsBackend object for test."""
-    return RemoteSettingsBackend(**remote_settings_parameters)
+    return RemoteSettingsBackend(**rs_parameters)
 
 
-@pytest.fixture(name="remote_settings_server_info_response")
-def fixture_remote_settings_server_info_response() -> dict[str, Any]:
+@pytest.fixture(name="rs_get_records_response")
+def fixture_rs_get_records_response() -> list[dict[str, Any]]:
+    """Return response content for Remote Settings get_records() method."""
+    return [
+        {
+            "type": "data",
+            "schema": 123,
+            "attachment": {
+                "hash": "abcd",
+                "size": 1,
+                "filename": "data-01.json",
+                "location": "main-workspace/quicksuggest/attachmment-01.json",
+                "mimetype": "application/octet-stream",
+            },
+            "id": "data-01",
+            "last_modified": 123,
+        },
+        {
+            "type": "offline-expansion-data",
+            "schema": 111,
+            "attachment": {
+                "hash": "efgh",
+                "size": 1,
+                "filename": "offline-expansion-data-01.json",
+                "location": "main-workspace/quicksuggest/attachment-02.json",
+                "mimetype": "application/octet-stream",
+            },
+            "id": "offline-expansion-data-01",
+            "last_modified": 123,
+        },
+        {
+            "type": "icon",
+            "schema": 456,
+            "attachment": {
+                "hash": "efghabcasd",
+                "size": 1,
+                "filename": "icon-01",
+                "location": "main-workspace/quicksuggest/icon-01",
+                "mimetype": "application/octet-stream",
+            },
+            "content_type": "image/png",
+            "id": "icon-01",
+            "last_modified": 123,
+        },
+    ]
+
+
+@pytest.fixture(name="rs_server_info_response")
+def fixture_rs_server_info_response() -> dict[str, Any]:
     """Return response content for Remote Settings server_info() method."""
     return {
         "project_name": "Remote Settings PROD",
@@ -70,10 +116,38 @@ def fixture_remote_settings_server_info_response() -> dict[str, Any]:
                 "description": "Add file attachments to records",
                 "url": "https://github.com/Kinto/kinto-attachment/",
                 "version": "6.3.1",
-                "base_url": "https://firefox-settings-attachments.cdn.mozilla.net/",
+                "base_url": "attachment-host/",
             },
         },
     }
+
+
+@pytest.fixture(name="rs_attachment_response")
+def fixture_rs_attachment_response() -> httpx.Response:
+    """Return response content for a Remote Settings attachment."""
+    attachment: dict[str, Any] = {
+        "id": 2,
+        "url": "https://example.org/target/mozfirefoxaccounts",
+        "click_url": "https://example.org/click/mozilla",
+        "iab_category": "5 - Education",
+        "icon": "01",
+        "advertiser": "Example.org",
+        "title": "Mozilla Firefox Accounts",
+        "keywords": [
+            "firefox",
+            "firefox account",
+            "firefox accounts",
+            "mozilla",
+            "mozilla firefox",
+            "mozilla firefox account",
+            "mozilla firefox accounts",
+        ],
+        "full_keywords": [
+            ("firefox accounts", 3),
+            ("mozilla firefox accounts", 4),
+        ],
+    }
+    return httpx.Response(200, text=json.dumps([attachment]))
 
 
 @pytest.mark.parametrize(
@@ -81,7 +155,7 @@ def fixture_remote_settings_server_info_response() -> dict[str, Any]:
     ["server", "collection", "bucket"],
 )
 def test_init_invalid_remote_settings_parameter_error(
-    remote_settings_parameters: dict[str, str], parameter: str
+    rs_parameters: dict[str, str], parameter: str
 ) -> None:
     """Test that a ValueError is raised if initializing with empty Remote Settings
     values.
@@ -90,10 +164,10 @@ def test_init_invalid_remote_settings_parameter_error(
         "The Remote Settings 'server', 'collection' or 'bucket' parameters are not "
         "specified"
     )
-    remote_settings_parameters[parameter] = ""
+    rs_parameters[parameter] = ""
 
     with pytest.raises(ValueError) as error:
-        RemoteSettingsBackend(**remote_settings_parameters)
+        RemoteSettingsBackend(**rs_parameters)
 
     assert str(error.value) == expected_error_value
 
@@ -101,20 +175,18 @@ def test_init_invalid_remote_settings_parameter_error(
 @pytest.mark.asyncio
 async def test_fetch_attachment_host(
     mocker: MockerFixture,
-    remote_settings: RemoteSettingsBackend,
-    remote_settings_server_info_response: dict[str, Any],
+    rs_backend: RemoteSettingsBackend,
+    rs_server_info_response: dict[str, Any],
 ) -> None:
     """Test that the fetch_attachment_host method returns the proper server info."""
-    expected_attachment_host: str = (
-        "https://firefox-settings-attachments.cdn.mozilla.net/"
-    )
+    expected_attachment_host: str = "attachment-host/"
     mocker.patch.object(
         kinto_http.AsyncClient,
         "server_info",
-        return_value=remote_settings_server_info_response,
+        return_value=rs_server_info_response,
     )
 
-    attachment_host: str = await remote_settings.fetch_attachment_host()
+    attachment_host: str = await rs_backend.fetch_attachment_host()
 
     assert attachment_host == expected_attachment_host
 
@@ -122,49 +194,68 @@ async def test_fetch_attachment_host(
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "attachment_host",
-    ["", "https://firefox-settings-attachments.cdn.mozilla.net/"],
+    ["", "attachment-host/"],
     ids=["attachment_host_defined", "attachment_host_undefined"],
 )
 async def test_fetch_attachment(
     mocker: MockerFixture,
-    remote_settings: RemoteSettingsBackend,
-    remote_settings_server_info_response: dict[str, Any],
+    rs_backend: RemoteSettingsBackend,
+    rs_server_info_response: dict[str, Any],
     attachment_host: str,
 ) -> None:
     """Test that the fetch_attachment method sends proper queries to Remote Settings."""
     attachment_uri: str = (
         "main-workspace/quicksuggest/6129d437-b3c1-48b5-b343-535e045d341a.json"
     )
-    expected_uri: str = (
-        f"https://firefox-settings-attachments.cdn.mozilla.net/{attachment_uri}"
-    )
-    remote_settings.attachment_host = attachment_host
+    expected_uri: str = f"attachment-host/{attachment_uri}"
+    rs_backend.attachment_host = attachment_host
     mocker.patch.object(
         kinto_http.AsyncClient,
         "server_info",
-        return_value=remote_settings_server_info_response,
+        return_value=rs_server_info_response,
     )
     httpx_client_mock = mocker.patch.object(httpx.AsyncClient, "get")
 
-    await remote_settings.fetch_attachment(attachment_uri)
+    await rs_backend.fetch_attachment(attachment_uri)
 
     httpx_client_mock.assert_called_once_with(expected_uri)
 
 
 @pytest.mark.parametrize(
     "attachment_host",
-    ["", "https://firefox-settings-attachments.cdn.mozilla.net/"],
+    ["", "attachment-host/"],
     ids=["attachment_host_defined", "attachment_host_undefined"],
 )
-def test_get_icon_url(
-    remote_settings: RemoteSettingsBackend,
-    attachment_host: str,
-) -> None:
+def test_get_icon_url(rs_backend: RemoteSettingsBackend, attachment_host: str) -> None:
     """Test that the get_icon_url method returns a proper icon url."""
     icon_uri: str = "main-workspace/quicksuggest/05f7ba7a-f7cf-4288-a89f-8fad6970a3c9"
     expected_icon_url: str = f"{attachment_host}{icon_uri}"
-    remote_settings.attachment_host = attachment_host
+    rs_backend.attachment_host = attachment_host
 
-    icon_url: str = remote_settings.get_icon_url(icon_uri)
+    icon_url: str = rs_backend.get_icon_url(icon_uri)
 
     assert icon_url == expected_icon_url
+
+
+@pytest.mark.asyncio
+async def test_fetch(
+    mocker: MockerFixture,
+    rs_backend: RemoteSettingsBackend,
+    rs_get_records_response: list[dict[str, Any]],
+    rs_server_info_response: dict[str, Any],
+    rs_attachment_response: httpx.Response,
+    adm_suggestion_content: Content,
+) -> None:
+    """Test that the fetch method returns the proper suggestion content."""
+    rs_backend.attachment_host = "attachment-host/"
+    mocker.patch.object(
+        kinto_http.AsyncClient, "get_records", return_value=rs_get_records_response
+    )
+    mocker.patch.object(
+        kinto_http.AsyncClient, "server_info", return_value=rs_server_info_response
+    )
+    mocker.patch.object(httpx.AsyncClient, "get", return_value=rs_attachment_response)
+
+    content: Content = await rs_backend.fetch()
+
+    assert content == adm_suggestion_content

--- a/tests/unit/providers/adm/backends/test_remotesettings.py
+++ b/tests/unit/providers/adm/backends/test_remotesettings.py
@@ -1,0 +1,170 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Unit tests for the Remote Settings backend module."""
+
+from typing import Any
+
+import httpx
+import kinto_http
+import pytest
+from pytest_mock import MockerFixture
+
+from merino.providers import RemoteSettingsBackend
+
+
+@pytest.fixture(name="remote_settings_parameters")
+def fixture_remote_settings_parameters() -> dict[str, str]:
+    """Define default Remote Settings parameters for test."""
+    return {
+        "server": "test://test",
+        "bucket": "main",
+        "collection": "quicksuggest",
+    }
+
+
+@pytest.fixture(name="remote_settings")
+def fixture_remote_settings(
+    remote_settings_parameters: dict[str, str]
+) -> RemoteSettingsBackend:
+    """Create a RemoteSettingsBackend object for test."""
+    return RemoteSettingsBackend(**remote_settings_parameters)
+
+
+@pytest.fixture(name="remote_settings_server_info_response")
+def fixture_remote_settings_server_info_response() -> dict[str, Any]:
+    """Return response content for Remote Settings server_info() method."""
+    return {
+        "project_name": "Remote Settings PROD",
+        "project_version": "15.0.0",
+        "http_api_version": "1.22",
+        "project_docs": "https://remote-settings.readthedocs.io",
+        "url": "https://firefox.settings.services.mozilla.com/v1/",
+        "settings": {
+            "batch_max_requests": 25,
+            "readonly": True,
+            "explicit_permissions": False,
+        },
+        "capabilities": {
+            "changes": {
+                "description": (
+                    "Track modifications of records in Kinto and store the collection "
+                    "timestamps into a specific bucket and collection."
+                ),
+                "url": (
+                    "http://kinto.readthedocs.io/en/latest/tutorials/"
+                    "synchronisation.html#polling-for-remote-changes"
+                ),
+                "version": "30.1.1",
+                "collections": [
+                    "/buckets/blocklists",
+                    "/buckets/blocklists-preview",
+                    "/buckets/main",
+                    "/buckets/main-preview",
+                    "/buckets/security-state",
+                    "/buckets/security-state-preview",
+                ],
+            },
+            "attachments": {
+                "description": "Add file attachments to records",
+                "url": "https://github.com/Kinto/kinto-attachment/",
+                "version": "6.3.1",
+                "base_url": "https://firefox-settings-attachments.cdn.mozilla.net/",
+            },
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    "parameter",
+    ["server", "collection", "bucket"],
+)
+def test_init_invalid_remote_settings_parameter_error(
+    remote_settings_parameters: dict[str, str], parameter: str
+) -> None:
+    """Test that a ValueError is raised if initializing with empty Remote Settings
+    values.
+    """
+    expected_error_value: str = (
+        "The Remote Settings 'server', 'collection' or 'bucket' parameters are not "
+        "specified"
+    )
+    remote_settings_parameters[parameter] = ""
+
+    with pytest.raises(ValueError) as error:
+        RemoteSettingsBackend(**remote_settings_parameters)
+
+    assert str(error.value) == expected_error_value
+
+
+@pytest.mark.asyncio
+async def test_fetch_attachment_host(
+    mocker: MockerFixture,
+    remote_settings: RemoteSettingsBackend,
+    remote_settings_server_info_response: dict[str, Any],
+) -> None:
+    """Test that the fetch_attachment_host method returns the proper server info."""
+    expected_attachment_host: str = (
+        "https://firefox-settings-attachments.cdn.mozilla.net/"
+    )
+    mocker.patch.object(
+        kinto_http.AsyncClient,
+        "server_info",
+        return_value=remote_settings_server_info_response,
+    )
+
+    attachment_host: str = await remote_settings.fetch_attachment_host()
+
+    assert attachment_host == expected_attachment_host
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "attachment_host",
+    ["", "https://firefox-settings-attachments.cdn.mozilla.net/"],
+    ids=["attachment_host_defined", "attachment_host_undefined"],
+)
+async def test_fetch_attachment(
+    mocker: MockerFixture,
+    remote_settings: RemoteSettingsBackend,
+    remote_settings_server_info_response: dict[str, Any],
+    attachment_host: str,
+) -> None:
+    """Test that the fetch_attachment method sends proper queries to Remote Settings."""
+    attachment_uri: str = (
+        "main-workspace/quicksuggest/6129d437-b3c1-48b5-b343-535e045d341a.json"
+    )
+    expected_uri: str = (
+        f"https://firefox-settings-attachments.cdn.mozilla.net/{attachment_uri}"
+    )
+    remote_settings.attachment_host = attachment_host
+    mocker.patch.object(
+        kinto_http.AsyncClient,
+        "server_info",
+        return_value=remote_settings_server_info_response,
+    )
+    httpx_client_mock = mocker.patch.object(httpx.AsyncClient, "get")
+
+    await remote_settings.fetch_attachment(attachment_uri)
+
+    httpx_client_mock.assert_called_once_with(expected_uri)
+
+
+@pytest.mark.parametrize(
+    "attachment_host",
+    ["", "https://firefox-settings-attachments.cdn.mozilla.net/"],
+    ids=["attachment_host_defined", "attachment_host_undefined"],
+)
+def test_get_icon_url(
+    remote_settings: RemoteSettingsBackend,
+    attachment_host: str,
+) -> None:
+    """Test that the get_icon_url method returns a proper icon url."""
+    icon_uri: str = "main-workspace/quicksuggest/05f7ba7a-f7cf-4288-a89f-8fad6970a3c9"
+    expected_icon_url: str = f"{attachment_host}{icon_uri}"
+    remote_settings.attachment_host = attachment_host
+
+    icon_url: str = remote_settings.get_icon_url(icon_uri)
+
+    assert icon_url == expected_icon_url

--- a/tests/unit/providers/adm/conftest.py
+++ b/tests/unit/providers/adm/conftest.py
@@ -1,0 +1,66 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Module for test configurations for the AdM provider unit test directory."""
+from typing import Any
+
+import pytest
+from pytest_mock import MockerFixture
+
+from merino.providers.adm.backends.protocol import AdmBackend, Content
+from merino.providers.adm.provider import Provider
+
+
+@pytest.fixture(name="adm_suggestion_content")
+def fixture_adm_suggestion_content() -> Content:
+    """Define backend suggestion content for test."""
+    return Content(
+        suggestions={
+            "firefox": (0, 0),
+            "firefox account": (0, 0),
+            "firefox accounts": (0, 0),
+            "mozilla": (0, 1),
+            "mozilla firefox": (0, 1),
+            "mozilla firefox account": (0, 1),
+            "mozilla firefox accounts": (0, 1),
+        },
+        full_keywords=["firefox accounts", "mozilla firefox accounts"],
+        results=[
+            {
+                "id": 2,
+                "url": "https://example.org/target/mozfirefoxaccounts",
+                "click_url": "https://example.org/click/mozilla",
+                "iab_category": "5 - Education",
+                "icon": "01",
+                "advertiser": "Example.org",
+                "title": "Mozilla Firefox Accounts",
+            }
+        ],
+        icons={1: "attachment-host/main-workspace/quicksuggest/icon-01"},
+    )
+
+
+@pytest.fixture(name="adm_parameters")
+def fixture_adm_parameters() -> dict[str, Any]:
+    """Define provider parameters for test."""
+    return {
+        "score": 0.3,
+        "score_wikipedia": 0.2,
+        "name": "adm",
+        "resync_interval_sec": 10800,
+    }
+
+
+@pytest.fixture(name="backend_mock")
+def fixture_backend_mock(mocker: MockerFixture, adm_suggestion_content: Content) -> Any:
+    """Create an AdmBackend mock object for test."""
+    backend_mock: Any = mocker.AsyncMock(spec=AdmBackend)
+    backend_mock.fetch.return_value = adm_suggestion_content
+    return backend_mock
+
+
+@pytest.fixture(name="adm")
+def fixture_adm(backend_mock: Any, adm_parameters: dict[str, Any]) -> Provider:
+    """Create an AdM Provider for test."""
+    return Provider(backend=backend_mock, **adm_parameters)

--- a/tests/unit/providers/adm/conftest.py
+++ b/tests/unit/providers/adm/conftest.py
@@ -8,14 +8,14 @@ from typing import Any
 import pytest
 from pytest_mock import MockerFixture
 
-from merino.providers.adm.backends.protocol import AdmBackend, Content
+from merino.providers.adm.backends.protocol import AdmBackend, SuggestionContent
 from merino.providers.adm.provider import Provider
 
 
 @pytest.fixture(name="adm_suggestion_content")
-def fixture_adm_suggestion_content() -> Content:
+def fixture_adm_suggestion_content() -> SuggestionContent:
     """Define backend suggestion content for test."""
-    return Content(
+    return SuggestionContent(
         suggestions={
             "firefox": (0, 0),
             "firefox account": (0, 0),
@@ -53,7 +53,9 @@ def fixture_adm_parameters() -> dict[str, Any]:
 
 
 @pytest.fixture(name="backend_mock")
-def fixture_backend_mock(mocker: MockerFixture, adm_suggestion_content: Content) -> Any:
+def fixture_backend_mock(
+    mocker: MockerFixture, adm_suggestion_content: SuggestionContent
+) -> Any:
     """Create an AdmBackend mock object for test."""
     backend_mock: Any = mocker.AsyncMock(spec=AdmBackend)
     backend_mock.fetch.return_value = adm_suggestion_content

--- a/tests/unit/providers/adm/test_provider.py
+++ b/tests/unit/providers/adm/test_provider.py
@@ -9,7 +9,7 @@ from typing import Any
 import pytest
 from pytest import LogCaptureFixture
 
-from merino.providers.adm.backends.protocol import Content
+from merino.providers.adm.backends.protocol import SuggestionContent
 from merino.providers.adm.provider import NonsponsoredSuggestion, Provider
 from tests.types import FilterCaplogFixture
 from tests.unit.types import SuggestionRequestFixture
@@ -26,11 +26,13 @@ def test_hidden(adm: Provider) -> None:
 
 
 @pytest.mark.asyncio
-async def test_initialize(adm: Provider, adm_suggestion_content: Content) -> None:
+async def test_initialize(
+    adm: Provider, adm_suggestion_content: SuggestionContent
+) -> None:
     """Test for the initialize() method of the adM provider."""
     await adm.initialize()
 
-    assert adm.content == adm_suggestion_content
+    assert adm.suggestion_content == adm_suggestion_content
     assert adm.last_fetch_at > 0
 
 

--- a/tests/unit/providers/adm/test_provider.py
+++ b/tests/unit/providers/adm/test_provider.py
@@ -4,129 +4,15 @@
 
 """Unit tests for the adm provider module."""
 
-import json
 from typing import Any
 
-import httpx
 import pytest
 from pytest import LogCaptureFixture
-from pytest_mock import MockerFixture
 
-from merino.providers.adm.backends.protocol import AdmBackend
+from merino.providers.adm.backends.protocol import Content
 from merino.providers.adm.provider import NonsponsoredSuggestion, Provider
 from tests.types import FilterCaplogFixture
 from tests.unit.types import SuggestionRequestFixture
-
-
-class FakeBackend:
-    """Fake Remote Settings backend that returns suggest data for tests."""
-
-    async def get(self) -> list[dict[str, Any]]:
-        """Return fake records."""
-        return [
-            {
-                "type": "data",
-                "schema": 123,
-                "attachment": {
-                    "hash": "abcd",
-                    "size": 1,
-                    "filename": "data-01.json",
-                    "location": "main-workspace/quicksuggest/attachmment-01.json",
-                    "mimetype": "application/octet-stream",
-                },
-                "id": "data-01",
-                "last_modified": 123,
-            },
-            {
-                "type": "offline-expansion-data",
-                "schema": 111,
-                "attachment": {
-                    "hash": "efgh",
-                    "size": 1,
-                    "filename": "offline-expansion-data-01.json",
-                    "location": "main-workspace/quicksuggest/attachment-02.json",
-                    "mimetype": "application/octet-stream",
-                },
-                "id": "offline-expansion-data-01",
-                "last_modified": 123,
-            },
-            {
-                "type": "icon",
-                "schema": 456,
-                "attachment": {
-                    "hash": "efghabcasd",
-                    "size": 1,
-                    "filename": "icon-01",
-                    "location": "main-workspace/quicksuggest/icon-01",
-                    "mimetype": "application/octet-stream",
-                },
-                "content_type": "image/png",
-                "id": "icon-01",
-                "last_modified": 123,
-            },
-        ]
-
-    async def fetch_attachment(self, attachment_uri: str) -> httpx.Response:
-        """Return a fake attachment for the given URI."""
-        attachments = {
-            "main-workspace/quicksuggest/attachmment-01.json": {
-                "id": 1,
-                "url": "https://example.com/target/helloworld",
-                "click_url": "https://example.com/click/helloworld",
-                "impression_url": "https://example.com/impression/helloworld",
-                "iab_category": "22 - Shopping",
-                "icon": "01",
-                "advertiser": "Example.com",
-                "title": "Hello World",
-                "keywords": ["hello", "world", "hello world"],
-                "full_keywords": [("hello world", 3)],
-            },
-            "main-workspace/quicksuggest/attachment-02.json": {
-                "id": 2,
-                "url": "https://example.org/target/mozfirefoxaccounts",
-                "click_url": "https://example.org/click/mozilla",
-                "iab_category": "5 - Education",
-                "icon": "01",
-                "advertiser": "Example.org",
-                "title": "Mozilla Firefox Accounts",
-                "keywords": [
-                    "firefox",
-                    "firefox account",
-                    "firefox accounts",
-                    "mozilla",
-                    "mozilla firefox",
-                    "mozilla firefox account",
-                    "mozilla firefox accounts",
-                ],
-                "full_keywords": [
-                    ("firefox accounts", 3),
-                    ("mozilla firefox accounts", 4),
-                ],
-            },
-        }
-
-        return httpx.Response(200, text=json.dumps([attachments[attachment_uri]]))
-
-    def get_icon_url(self, icon_uri: str) -> str:
-        """Return a fake icon URL for the given URI."""
-        return f"attachment-host/{icon_uri}"
-
-
-@pytest.fixture(name="adm_parameters")
-def fixture_adm_parameters() -> dict[str, Any]:
-    """Define provider parameters for test."""
-    return {
-        "score": 0.3,
-        "score_wikipedia": 0.2,
-        "name": "adm",
-        "resync_interval_sec": 10800,
-    }
-
-
-@pytest.fixture(name="adm")
-def fixture_adm(adm_parameters: dict[str, Any]) -> Provider:
-    """Create an AdM Provider for test using a fake backend."""
-    return Provider(backend=FakeBackend(), **adm_parameters)
 
 
 def test_enabled_by_default(adm: Provider) -> None:
@@ -140,45 +26,25 @@ def test_hidden(adm: Provider) -> None:
 
 
 @pytest.mark.asyncio
-async def test_initialize(adm: Provider) -> None:
+async def test_initialize(adm: Provider, adm_suggestion_content: Content) -> None:
     """Test for the initialize() method of the adM provider."""
     await adm.initialize()
 
-    assert adm.suggestions == {
-        "firefox": (0, 0),
-        "firefox account": (0, 0),
-        "firefox accounts": (0, 0),
-        "mozilla": (0, 1),
-        "mozilla firefox": (0, 1),
-        "mozilla firefox account": (0, 1),
-        "mozilla firefox accounts": (0, 1),
-    }
-    assert adm.results == [
-        {
-            "id": 2,
-            "url": "https://example.org/target/mozfirefoxaccounts",
-            "click_url": "https://example.org/click/mozilla",
-            "iab_category": "5 - Education",
-            "icon": "01",
-            "advertiser": "Example.org",
-            "title": "Mozilla Firefox Accounts",
-        }
-    ]
-    assert adm.icons == {1: "attachment-host/main-workspace/quicksuggest/icon-01"}
+    assert adm.content == adm_suggestion_content
+    assert adm.last_fetch_at > 0
 
 
 @pytest.mark.asyncio
 async def test_initialize_remote_settings_failure(
-    mocker: MockerFixture,
     caplog: LogCaptureFixture,
     filter_caplog: FilterCaplogFixture,
-    adm_parameters: dict[str, Any],
+    backend_mock: Any,
+    adm: Provider,
 ) -> None:
     """Test exception handling for the initialize() method."""
     error_message: str = "The remote server was unreachable"
-    backend_mock: Any = mocker.AsyncMock(spec=AdmBackend)
-    backend_mock.get.side_effect = Exception(error_message)
-    adm: Provider = Provider(backend=backend_mock, **adm_parameters)
+    # override default mocked behavior for fetch
+    backend_mock.fetch.side_effect = Exception(error_message)
 
     try:
         await adm.initialize()
@@ -194,7 +60,9 @@ async def test_initialize_remote_settings_failure(
 
 
 @pytest.mark.asyncio
-async def test_query_success(srequest: SuggestionRequestFixture, adm: Provider) -> None:
+async def test_query_success(
+    srequest: SuggestionRequestFixture, adm: Provider, adm_parameters: dict[str, Any]
+) -> None:
     """Test for the query() method of the adM provider."""
     await adm.initialize()
 
@@ -211,7 +79,7 @@ async def test_query_success(srequest: SuggestionRequestFixture, adm: Provider) 
             advertiser="Example.org",
             is_sponsored=False,
             icon="attachment-host/main-workspace/quicksuggest/icon-01",
-            score=0.3,
+            score=adm_parameters["score"],
         )
     ]
 

--- a/tests/unit/providers/adm/test_provider_wikipedia.py
+++ b/tests/unit/providers/adm/test_provider_wikipedia.py
@@ -10,7 +10,6 @@ from typing import Any
 import httpx
 import pytest
 
-from merino.config import settings
 from merino.providers.adm.provider import NonsponsoredSuggestion, Provider
 from tests.unit.types import SuggestionRequestFixture
 
@@ -18,7 +17,7 @@ from tests.unit.types import SuggestionRequestFixture
 class FakeBackend:
     """Fake Remote Settings backend that returns suggest data for tests."""
 
-    async def get(self, bucket: str, collection: str) -> list[dict[str, Any]]:
+    async def get(self) -> list[dict[str, Any]]:
         """Return fake records."""
         return [
             {
@@ -72,10 +71,21 @@ class FakeBackend:
         return f"attachment-host/{icon_uri}"
 
 
+@pytest.fixture(name="adm_parameters")
+def fixture_adm_parameters() -> dict[str, Any]:
+    """Define provider parameters for test."""
+    return {
+        "score": 0.3,
+        "score_wikipedia": 0.2,
+        "name": "adm",
+        "resync_interval_sec": 10800,
+    }
+
+
 @pytest.fixture(name="adm")
-def fixture_adm() -> Provider:
-    """Return an adM provider that uses a fake remote settings client."""
-    return Provider(backend=FakeBackend())
+def fixture_adm(adm_parameters: dict[str, Any]) -> Provider:
+    """Create an AdM Provider for test using a fake backend."""
+    return Provider(backend=FakeBackend(), **adm_parameters)
 
 
 @pytest.mark.asyncio
@@ -117,6 +127,6 @@ async def test_wikipedia_specific_score(
             advertiser="Wikipedia",
             is_sponsored=False,
             icon="attachment-host/main-workspace/quicksuggest/icon-01",
-            score=settings.providers.adm.score_wikipedia,
+            score=0.2,
         )
     ]

--- a/tests/unit/providers/adm/test_provider_wikipedia.py
+++ b/tests/unit/providers/adm/test_provider_wikipedia.py
@@ -8,17 +8,17 @@ from typing import Any
 
 import pytest
 
-from merino.providers.adm.backends.protocol import Content
+from merino.providers.adm.backends.protocol import SuggestionContent
 from merino.providers.adm.provider import NonsponsoredSuggestion, Provider
 from tests.unit.types import SuggestionRequestFixture
 
 
 @pytest.fixture(name="adm_suggestion_content")
-def fixture_adm_suggestion_content() -> Content:
+def fixture_adm_suggestion_content() -> SuggestionContent:
     """Define backend suggestion content for test.
     This fixture overrides a fixture of the same name in conftest.py
     """
-    return Content(
+    return SuggestionContent(
         suggestions={"mozilla": (0, 0)},
         full_keywords=["mozilla"],
         results=[
@@ -36,11 +36,13 @@ def fixture_adm_suggestion_content() -> Content:
 
 
 @pytest.mark.asyncio
-async def test_initialize(adm: Provider, adm_suggestion_content: Content) -> None:
+async def test_initialize(
+    adm: Provider, adm_suggestion_content: SuggestionContent
+) -> None:
     """Test for the initialize() method of the adM provider."""
     await adm.initialize()
 
-    assert adm.content == adm_suggestion_content
+    assert adm.suggestion_content == adm_suggestion_content
     assert adm.last_fetch_at > 0
 
 

--- a/tests/unit/providers/adm/test_provider_wikipedia.py
+++ b/tests/unit/providers/adm/test_provider_wikipedia.py
@@ -4,112 +4,49 @@
 
 """Unit tests for the adm-wikipedia provider module."""
 
-import json
 from typing import Any
 
-import httpx
 import pytest
 
+from merino.providers.adm.backends.protocol import Content
 from merino.providers.adm.provider import NonsponsoredSuggestion, Provider
 from tests.unit.types import SuggestionRequestFixture
 
 
-class FakeBackend:
-    """Fake Remote Settings backend that returns suggest data for tests."""
-
-    async def get(self) -> list[dict[str, Any]]:
-        """Return fake records."""
-        return [
+@pytest.fixture(name="adm_suggestion_content")
+def fixture_adm_suggestion_content() -> Content:
+    """Define backend suggestion content for test.
+    This fixture overrides a fixture of the same name in conftest.py
+    """
+    return Content(
+        suggestions={"mozilla": (0, 0)},
+        full_keywords=["mozilla"],
+        results=[
             {
-                "type": "data",
-                "schema": 111,
-                "attachment": {
-                    "hash": "efgh",
-                    "size": 1,
-                    "filename": "data-01.json",
-                    "location": "main-workspace/quicksuggest/attachment-01.json",
-                    "mimetype": "application/octet-stream",
-                },
-                "id": "data-01",
-                "last_modified": 123,
-            },
-            {
-                "type": "icon",
-                "schema": 456,
-                "attachment": {
-                    "hash": "efghabcasd",
-                    "size": 1,
-                    "filename": "icon-01",
-                    "location": "main-workspace/quicksuggest/icon-01",
-                    "mimetype": "application/octet-stream",
-                },
-                "content_type": "image/png",
-                "id": "icon-01",
-                "last_modified": 123,
-            },
-        ]
-
-    async def fetch_attachment(self, attachment_uri: str) -> httpx.Response:
-        """Return a fake attachment for the given URI."""
-        attachments = {
-            "main-workspace/quicksuggest/attachment-01.json": {
                 "id": 1,
                 "url": "https://wikipedia.org/en/Mozilla",
                 "iab_category": "5 - Education",
                 "icon": "01",
                 "advertiser": "Wikipedia",
                 "title": "Mozilla",
-                "keywords": ["mozilla"],
-                "full_keywords": [["mozilla", 1]],
-            },
-        }
-
-        return httpx.Response(200, text=json.dumps([attachments[attachment_uri]]))
-
-    def get_icon_url(self, icon_uri: str) -> str:
-        """Return a fake icon URL for the given URI."""
-        return f"attachment-host/{icon_uri}"
-
-
-@pytest.fixture(name="adm_parameters")
-def fixture_adm_parameters() -> dict[str, Any]:
-    """Define provider parameters for test."""
-    return {
-        "score": 0.3,
-        "score_wikipedia": 0.2,
-        "name": "adm",
-        "resync_interval_sec": 10800,
-    }
-
-
-@pytest.fixture(name="adm")
-def fixture_adm(adm_parameters: dict[str, Any]) -> Provider:
-    """Create an AdM Provider for test using a fake backend."""
-    return Provider(backend=FakeBackend(), **adm_parameters)
+            }
+        ],
+        icons={1: "attachment-host/main-workspace/quicksuggest/icon-01"},
+    )
 
 
 @pytest.mark.asyncio
-async def test_initialize(adm: Provider) -> None:
+async def test_initialize(adm: Provider, adm_suggestion_content: Content) -> None:
     """Test for the initialize() method of the adM provider."""
     await adm.initialize()
 
-    assert adm.suggestions == {"mozilla": (0, 0)}
-    assert adm.results == [
-        {
-            "id": 1,
-            "url": "https://wikipedia.org/en/Mozilla",
-            "iab_category": "5 - Education",
-            "icon": "01",
-            "advertiser": "Wikipedia",
-            "title": "Mozilla",
-        },
-    ]
-    assert adm.icons == {1: "attachment-host/main-workspace/quicksuggest/icon-01"}
+    assert adm.content == adm_suggestion_content
+    assert adm.last_fetch_at > 0
 
 
 @pytest.mark.asyncio
 async def test_wikipedia_specific_score(
-    srequest: SuggestionRequestFixture, adm: Provider
+    srequest: SuggestionRequestFixture, adm: Provider, adm_parameters: dict[str, Any]
 ) -> None:
     """Test for the query() method of the adM provider."""
     await adm.initialize()
@@ -127,6 +64,6 @@ async def test_wikipedia_specific_score(
             advertiser="Wikipedia",
             is_sponsored=False,
             icon="attachment-host/main-workspace/quicksuggest/icon-01",
-            score=0.2,
+            score=adm_parameters["score_wikipedia"],
         )
     ]

--- a/tests/unit/providers/wikipedia/backends/test_elastic.py
+++ b/tests/unit/providers/wikipedia/backends/test_elastic.py
@@ -8,7 +8,7 @@ from pytest_mock import MockerFixture
 from merino.config import settings
 from merino.exceptions import BackendError
 from merino.providers.wikipedia.backends.elastic import SUGGEST_ID, ElasticBackend
-from merino.providers.wikipedia.backends.test_backends import TestEchoBackend
+from merino.providers.wikipedia.backends.fake_backends import FakeEchoWikipediaBackend
 from merino.providers.wikipedia.provider import (
     ADVERTISER,
     ICON,
@@ -21,7 +21,7 @@ from tests.unit.types import SuggestionRequestFixture
 @pytest.fixture(name="wikipedia")
 def fixture_wikipedia() -> Provider:
     """Return a Wikipedia provider that uses a test backend."""
-    return Provider(backend=TestEchoBackend())
+    return Provider(backend=FakeEchoWikipediaBackend())
 
 
 @pytest.fixture(name="es_backend")
@@ -47,7 +47,7 @@ def test_hidden(wikipedia: Provider) -> None:
 @pytest.mark.asyncio
 async def test_shutdown(wikipedia: Provider, mocker: MockerFixture) -> None:
     """Test for the shutdown method."""
-    spy = mocker.spy(TestEchoBackend, "shutdown")
+    spy = mocker.spy(FakeEchoWikipediaBackend, "shutdown")
     await wikipedia.shutdown()
     spy.assert_called_once()
 


### PR DESCRIPTION
# Description
* move AdM protocol from `...\adm\provider.py` to `...\adm\backends\protocol.py`
* move `TestBackend` from `...\adm\provider.py` to `...\adm\backends\test_backend.py`
* rename `RemoteSettingsBackend` to `AdmBackend`
* rename `LiveBackend` to `RemoteSettingsBackend`
* rename `TestBackend` to `FakeAdmBackend` and carry this convention to Wikipedia backends
* inject `merino.config.settings` into AdM `Provider` and `RemoteSettingsBackend`
* change `AdmBackend` protocol to have one method `fetch`
    * move `fetch` method from AdM `Provider` to `RemoteSettingsBackend` 
* add unit tests for `RemoteSettingsBackend` 

**Note**
* Overall test coverage has increased from 97% to 98%

# Issue(s)
#167 | [DISCO-2166](https://mozilla-hub.atlassian.net/browse/DISCO-2174)

[DISCO-2166]: https://mozilla-hub.atlassian.net/browse/DISCO-2166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ