### PR TITLE
Add mbbook-mermaid to compile Mermaid diagrams in mdbook [do not deploy]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -253,6 +253,8 @@ jobs:
           name: Setup Build docs
           command: |
             cargo install mdbook
+            cargo install mdbook-mermaid
+            mdbook-mermaid install ./
       - run:
           name: Build docs
           command: |

--- a/book.toml
+++ b/book.toml
@@ -5,5 +5,9 @@ multilingual = false
 src = "docs"
 title = "Merino Book"
 
+[preprocessor.mermaid]
+command = "mdbook-mermaid"
+
 [output.html]
 site-url = "/merino/"
+additional-js = ["mermaid.min.js", "mermaid-init.js"]


### PR DESCRIPTION
This should fix the issue with the architecture diagram not compiling in mdbook.