### PR TITLE
Configure Merino to talk to cluster

### DIFF
--- a/docs/ops.md
+++ b/docs/ops.md
@@ -249,14 +249,12 @@ The provider that is backed by the locally indexed Wikipedia through Elasticsear
 
 - `enabled_by_default` (`MERINO_PROVIDERS__WIKIPEDIA__ENABLED_BY_DEFAULT`) - Whether
   or not this provider is enabled by default.
-  - `backend` (`MERINO_PROVIDERS__WIKIPEDIA__backend`) - The backend of the provider.
-    Either `elasticsearch` or `test`.
+- `backend` (`MERINO_PROVIDERS__WIKIPEDIA__backend`) - The backend of the provider.
+  Either `elasticsearch` or `test`.
 - `es_cloud_id` (`MERINO_PROVIDERS__WIKIPEDIA__ES_CLOUD_ID`) - The Cloud ID of the
   Elasticsearch cluster.
-- `es_user` (`MERINO_PROVIDERS__WIKIPEDIA__ES_USER`) - The user name of the Elasticsearch
-  cluster.
-- `es_password` (`MERINO_PROVIDERS__WIKIPEDIA__ES_PASSWORD`) - The password for
-  accessing the Elasticsearch cluster.
+- `es_url` (`MERINO_PROVIDERS__WIKIPEDIA__ES_URL`) - The URL 
+  of the Elasticsearch cluster that we want to access.
 - `es_index` (`MERINO_PROVIDERS__WIKIPEDIA__ES_INDEX`) - The index identifier
   of Wikipedia in Elasticsearch.
 - `es_max_suggestions` (`MERINO_PROVIDERS__WIKIPEDIA__ES_MAX_SUGGESTIONS`) - The

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -113,6 +113,12 @@ top_picks_file_path = "dev/top_picks.json"
 enabled_by_default = false
 # The backend of the provider. Either "elasticsearch" or "test".
 backend = "elasticsearch"
+# Elasticsearch Cloud ID. The following one is *fake* and will be
+# overridden in production.
+# es_cloud_id = """
+#   testing:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyRjZWM2ZjI2MWE3NGJmMjRjZ
+#   TMzYmI4ODExYjg0Mjk0ZiRjNmMyY2E2ZDA0MjI0OWFmMGNjN2Q3YTllOTYyNTc0Mw==
+# """
 es_url = ""
 # Elasticsearch index
 es_index = "enwiki_merino_test"

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -113,18 +113,9 @@ top_picks_file_path = "dev/top_picks.json"
 enabled_by_default = false
 # The backend of the provider. Either "elasticsearch" or "test".
 backend = "elasticsearch"
-# Elasticsearch Cloud ID. The following one is *fake* and will be
-# overridden in production.
-es_cloud_id = """
-  testing:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyRjZWM2ZjI2MWE3NGJmMjRjZ
-  TMzYmI4ODExYjg0Mjk0ZiRjNmMyY2E2ZDA0MjI0OWFmMGNjN2Q3YTllOTYyNTc0Mw==
-"""
-# Elasticsearch user
-es_user = ""
-# Elasticsearch password
-es_password = ""
+es_url = ""
 # Elasticsearch index
-es_index = "enwiki"
+es_index = "enwiki_merino_test"
 # The maximum suggestions for each search request.
 es_max_suggestions = 3
 # The timeout (in millisecond) for each request to ES

--- a/merino/providers/__init__.py
+++ b/merino/providers/__init__.py
@@ -92,13 +92,11 @@ async def init_providers() -> None:
                 providers["wikipedia"] = WikipediaProvider(
                     backend=(
                         ElasticBackend(
-                            cloud_id=setting.es_cloud_id,
-                            user=setting.es_user,
-                            password=setting.es_password,
-                        )  # type: ignore [arg-type]
-                        if setting.backend == "elasticsearch"
-                        else FakeWikipediaBackend()
-                    ),
+                            url=setting.es_url, cloud_id=setting.get("es_cloud_id")
+                        )
+                    )  # type: ignore [arg-type]
+                    if setting.backend == "elasticsearch" and setting.es_url != ""
+                    else FakeWikipediaBackend(),
                     name=provider_type,
                     enabled_by_default=setting.enabled_by_default,
                 )

--- a/merino/providers/wikipedia/backends/elastic.py
+++ b/merino/providers/wikipedia/backends/elastic.py
@@ -1,5 +1,5 @@
 """The Elasticsearch backend for Dynamic Wikipedia."""
-from typing import Any, Final
+from typing import Any, Final, Optional
 from urllib.parse import quote
 
 from elasticsearch import AsyncElasticsearch
@@ -19,9 +19,15 @@ class ElasticBackend:
 
     client: AsyncElasticsearch
 
-    def __init__(self, *, cloud_id: str, user: str, password: str) -> None:
+    def __init__(self, *, url: str, cloud_id: Optional[str]) -> None:
         """Initialize."""
-        self.client = AsyncElasticsearch(cloud_id=cloud_id, basic_auth=(user, password))
+        # Only one of `cloud_id` or `hosts` can be passed.
+        # If the `cloud_id` is specified, then use that.
+        # Otherwise fallback to using the specified URL.
+        if cloud_id:
+            self.client = AsyncElasticsearch(cloud_id=cloud_id)
+        else:
+            self.client = AsyncElasticsearch(url)
 
     async def shutdown(self) -> None:
         """Shut down the connection to the ES cluster."""

--- a/tests/unit/providers/wikipedia/backends/test_elastic.py
+++ b/tests/unit/providers/wikipedia/backends/test_elastic.py
@@ -28,9 +28,8 @@ def fixture_wikipedia() -> Provider:
 def fixture_es_backend() -> ElasticBackend:
     """Return an ES backend instance."""
     return ElasticBackend(
-        cloud_id=settings.providers.wikipedia.es_cloud_id,
-        user=settings.providers.wikipedia.es_user,
-        password=settings.providers.wikipedia.es_password,
+        url="http://localhost:9200",
+        cloud_id=None,
     )
 
 

--- a/tests/unit/providers/wikipedia/test_provider.py
+++ b/tests/unit/providers/wikipedia/test_provider.py
@@ -1,0 +1,68 @@
+"""Unit tests for the Merino v1 suggest API endpoint for the Wikipedia Provider."""
+import pytest
+from pytest_mock import MockerFixture
+
+from merino.config import settings
+from merino.providers.wikipedia.backends.fake_backends import FakeEchoWikipediaBackend
+from merino.providers.wikipedia.provider import (
+    ADVERTISER,
+    ICON,
+    Provider,
+    WikipediaSuggestion,
+)
+from tests.unit.types import SuggestionRequestFixture
+
+
+@pytest.fixture(name="wikipedia")
+def fixture_wikipedia() -> Provider:
+    """Return a Wikipedia provider that uses a test backend."""
+    return Provider(backend=FakeEchoWikipediaBackend())
+
+
+def test_enabled_by_default(wikipedia: Provider) -> None:
+    """Test for the enabled_by_default method."""
+    assert wikipedia.enabled_by_default
+
+
+def test_hidden(wikipedia: Provider) -> None:
+    """Test for the hidden method."""
+    assert not wikipedia.hidden()
+
+
+@pytest.mark.asyncio
+async def test_shutdown(wikipedia: Provider, mocker: MockerFixture) -> None:
+    """Test for the shutdown method."""
+    spy = mocker.spy(FakeEchoWikipediaBackend, "shutdown")
+    await wikipedia.shutdown()
+    spy.assert_called_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ["query", "expected_title"],
+    [("foo", "foo"), ("foo bar", "foo_bar"), ("foØ bÅr", "fo%C3%98_b%C3%85r")],
+)
+async def test_query(
+    wikipedia: Provider,
+    srequest: SuggestionRequestFixture,
+    query: str,
+    expected_title: str,
+) -> None:
+    """Test for the query method."""
+    suggestions = await wikipedia.query(srequest(query))
+
+    assert suggestions == [
+        WikipediaSuggestion(
+            title=query,
+            full_keyword=query,
+            url=f"https://en.wikipedia.org/wiki/{expected_title}",
+            advertiser=ADVERTISER,
+            is_sponsored=False,
+            provider="wikipedia",
+            score=settings.providers.wikipedia.score,
+            icon=ICON,
+            block_id=0,
+            impression_url=None,
+            click_url=None,
+        )
+    ]


### PR DESCRIPTION
This change enables Merino to get configured to communicate with the Elasticsearch cluster. The cluster details will be grabbed from the environment variables.

The staging configuration depends on: https://github.com/mozilla-services/cloudops-infra/pull/4646 