### PR TITLE
[DISCO-2228] Group HTTP calls for concise reporting in load tests

### DIFF
--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -136,10 +136,7 @@ Follow the steps bellow to execute the distributed load tests on GCP:
       to errors in the load test execution, not Merino
     * Optionally, the locust reports can be saved and linked in the 
       [Merino Load Test Spreadsheet][merino_spreadsheet]:
-      * Download the results via command: 
-      
-          **WARNING!** Gathering logs via the Locust UI may cause the service to crash.
-          
+      * Download the results via command:
           ```bash
           kubectl cp <master-pod-name>:/home/locust/merino_stats.csv merino_stats.csv
           kubectl cp <master-pod-name>:/home/locust/merino_exceptions.csv merino_exceptions.csv
@@ -148,11 +145,6 @@ Follow the steps bellow to execute the distributed load tests on GCP:
         The `master-pod-name` can be found at the top of the pod list:
           ```bash 
           kubectl get pods -o wide
-          ```
-      * Aggregate the merino_stats.csv file:
-          ```bash
-          cat merino_stats.csv | grep -Ev "^GET," > merino_stats.csv.tmp
-          mv merino_stats.csv.tmp merino_stats.csv
           ```
       * Upload the files to [gist][gist] and record the links
 

--- a/tests/load/locust_tests/locustfile.py
+++ b/tests/load/locust_tests/locustfile.py
@@ -101,7 +101,11 @@ def request_suggestions(client: HttpSession, query: str) -> None:
     }
 
     with client.get(
-        url=SUGGEST_API, params=params, headers=headers, catch_response=True
+        url=SUGGEST_API,
+        params=params,
+        headers=headers,
+        catch_response=True,
+        name=SUGGEST_API,  # group all requests under the 'name' entry
     ) as response:
         # This contextmanager returns a response that provides the ability to
         # manually control if an HTTP request should be marked as successful or


### PR DESCRIPTION
# Description
* Group all requests under the same category of URL to consolidate stats reporting and reduce output file size.
* Update the README documentation to remove UI crash warning and post exportation file aggregation

# Issue(s)
#188 | [DISCO-2228](https://mozilla-hub.atlassian.net/browse/DISCO-2228)

[DISCO-2228]: https://mozilla-hub.atlassian.net/browse/DISCO-2228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ