### PR TITLE
[DISCO-2234] chore: Add redis for development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,6 +145,18 @@ doc-preview:  ##  Preview Merino docs via the default browser
 profile:  ## Profile Merino with Scalene
 	MERINO_LOGGING__FORMAT=mozlog MERINO_LOGGING__LEVEL=INFO python -m scalene merino/main.py
 
+.PHONY: docker-compose-up
+docker-compose-up:  ## Run `docker-compose up` in `./dev`
+	docker-compose -f dev/docker-compose.yaml up
+
+.PHONY: docker-compose-up-daemon
+docker-compose-up-daemon:  ## Run `docker-compose up -d` in `./dev`
+	docker-compose -f dev/docker-compose.yaml up -d
+
+.PHONY: docker-compose-down
+docker-compose-down:  ## Run `docker-compose down` in `./dev`
+	docker-compose -f dev/docker-compose.yaml down
+
 .PHONY: help
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -1,0 +1,14 @@
+version: "3"
+services:
+  redis:
+    image: redis
+    ports:
+      - "6379:6379"
+
+  redis-commander:
+    image: ghcr.io/joeferner/redis-commander:latest
+    restart: always
+    environment:
+      - REDIS_HOSTS=local:redis:6379
+    ports:
+      - "8081:8081"

--- a/docs/dev/dependencies.md
+++ b/docs/dev/dependencies.md
@@ -1,5 +1,7 @@
 # Development Dependencies
 
+## Package Dependencies
+
 This project uses [Poetry][1] for dependency management. While you can use the
 vanilla virtualenv to set up the dev environment, we highly recommend to check
 out [pyenv][2] and [pyenv-virtualenv][3], as they work nicely with Poetry.
@@ -29,6 +31,41 @@ $ poetry run uvicorn merino.main:app --reload
 $ poetry shell
 $ uvicorn merino.main:app --reload
 ```
+
+## Service Dependencies
+
+Merino uses a Redis-based caching system, and so requires a Redis instance to
+connect to.
+
+To make things simple, Redis (and any future service dependencies) can be
+started with Docker Compose, using the `docker-compose.yaml` file in the `dev/`
+directory. Notably, this does not run any Merino components that have source
+code in this repository.
+
+```shell
+$ cd dev
+$ docker-compose up
+
+# Or run services in deamon mode
+$ docker-compose up -d
+
+# Stop it
+$ docker-compose down
+```
+
+Redis is listening on port 6397 and can be connected via `redis://localhost:6397`.
+
+This Dockerized set up is optional. Feel free to run the dependent services by
+any other means as well.
+
+### Dev Helpers
+
+The docker-compose setup also includes some services that can help during
+development.
+
+- Redis Commander, http://localhost:8081 - Explore the Redis database started
+  above.
+
 
 [1]: https://python-poetry.org/
 [2]: https://github.com/pyenv/pyenv

--- a/docs/dev/dependencies.md
+++ b/docs/dev/dependencies.md
@@ -51,6 +51,12 @@ $ docker-compose up -d
 
 # Stop it
 $ docker-compose down
+
+
+# Shortcuts are also provided
+$ make docker-compose-up
+$ make docker-compose-up-daemon
+$ make docker-compose-down
 ```
 
 Redis is listening on port 6397 and can be connected via `redis://localhost:6397`.


### PR DESCRIPTION
This fixes [DISCO-2234](https://docs.github.com/articles/authenticating-to-a-github-organization-with-saml-single-sign-on/ )

[DISCO-2234]: https://mozilla-hub.atlassian.net/browse/DISCO-2234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ