### PR TITLE
Update Merino to grab the talk to the Elastico Elasticsearch

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -119,18 +119,14 @@ es_cloud_id = """
   testing:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyRjZWM2ZjI2MWE3NGJmMjRjZ
   TMzYmI4ODExYjg0Mjk0ZiRjNmMyY2E2ZDA0MjI0OWFmMGNjN2Q3YTllOTYyNTc0Mw==
 """
-# Elasticsearch url
-es_url = ""
-# Elasticsearch user
-es_user = ""
-# Elasticsearch password
-es_password = ""
+es_api_key = ""
 # Elasticsearch index
-es_index = "enwiki"
+es_index = "enwiki-v1"
 # The maximum suggestions for each search request.
 es_max_suggestions = 3
 # The timeout (in millisecond) for each request to ES
-es_request_timeout_ms = 200
+es_request_timeout_ms = 5000
+query_timeout_sec = 5.0
 # Suggestion score
 score = 0.23
 

--- a/merino/providers/__init__.py
+++ b/merino/providers/__init__.py
@@ -92,14 +92,14 @@ async def init_providers() -> None:
                 providers["wikipedia"] = WikipediaProvider(
                     backend=(
                         ElasticBackend(
+                            api_key=setting.es_api_key,
                             cloud_id=setting.es_cloud_id,
-                            user=setting.es_user,
-                            password=setting.es_password,
-                        )  # type: ignore [arg-type]
-                        if setting.backend == "elasticsearch"
-                        else FakeWikipediaBackend()
-                    ),
+                        )
+                    )  # type: ignore [arg-type]
+                    if setting.backend == "elasticsearch"
+                    else FakeWikipediaBackend(),
                     name=provider_type,
+                    query_timeout_sec=setting.query_timeout_sec,
                     enabled_by_default=setting.enabled_by_default,
                 )
             case _:

--- a/merino/providers/wikipedia/backends/elastic.py
+++ b/merino/providers/wikipedia/backends/elastic.py
@@ -19,9 +19,9 @@ class ElasticBackend:
 
     client: AsyncElasticsearch
 
-    def __init__(self, *, cloud_id: str, user: str, password: str) -> None:
+    def __init__(self, *, api_key: str, cloud_id: str) -> None:
         """Initialize."""
-        self.client = AsyncElasticsearch(cloud_id=cloud_id, basic_auth=(user, password))
+        self.client = AsyncElasticsearch(cloud_id=cloud_id, api_key=api_key)
 
     async def shutdown(self) -> None:
         """Shut down the connection to the ES cluster."""

--- a/merino/providers/wikipedia/provider.py
+++ b/merino/providers/wikipedia/provider.py
@@ -43,6 +43,7 @@ class Provider(BaseProvider):
         backend: WikipediaBackend,
         name: str = "wikipedia",
         enabled_by_default: bool = True,
+        query_timeout_sec: float = settings.providers.wikipedia.query_timeout_sec,
         score=settings.providers.wikipedia.score,
         **kwargs: Any,
     ) -> None:
@@ -50,6 +51,7 @@ class Provider(BaseProvider):
         self.backend = backend
         self._name = name
         self._enabled_by_default = enabled_by_default
+        self._query_timeout_sec = query_timeout_sec
         self.score = score
         super().__init__(**kwargs)
 

--- a/tests/unit/providers/wikipedia/backends/test_elastic.py
+++ b/tests/unit/providers/wikipedia/backends/test_elastic.py
@@ -1,4 +1,4 @@
-"""Unit tests for the Merino v1 suggest API endpoint for the Wikipedia provider."""
+"""Unit tests for the Elastic Backend."""
 from unittest.mock import AsyncMock
 
 import pytest
@@ -8,20 +8,6 @@ from pytest_mock import MockerFixture
 from merino.config import settings
 from merino.exceptions import BackendError
 from merino.providers.wikipedia.backends.elastic import SUGGEST_ID, ElasticBackend
-from merino.providers.wikipedia.backends.fake_backends import FakeEchoWikipediaBackend
-from merino.providers.wikipedia.provider import (
-    ADVERTISER,
-    ICON,
-    Provider,
-    WikipediaSuggestion,
-)
-from tests.unit.types import SuggestionRequestFixture
-
-
-@pytest.fixture(name="wikipedia")
-def fixture_wikipedia() -> Provider:
-    """Return a Wikipedia provider that uses a test backend."""
-    return Provider(backend=FakeEchoWikipediaBackend())
 
 
 @pytest.fixture(name="es_backend")
@@ -29,58 +15,8 @@ def fixture_es_backend() -> ElasticBackend:
     """Return an ES backend instance."""
     return ElasticBackend(
         cloud_id=settings.providers.wikipedia.es_cloud_id,
-        user=settings.providers.wikipedia.es_user,
-        password=settings.providers.wikipedia.es_password,
+        api_key=settings.providers.wikipedia.es_api_key,
     )
-
-
-def test_enabled_by_default(wikipedia: Provider) -> None:
-    """Test for the enabled_by_default method."""
-    assert wikipedia.enabled_by_default
-
-
-def test_hidden(wikipedia: Provider) -> None:
-    """Test for the hidden method."""
-    assert not wikipedia.hidden()
-
-
-@pytest.mark.asyncio
-async def test_shutdown(wikipedia: Provider, mocker: MockerFixture) -> None:
-    """Test for the shutdown method."""
-    spy = mocker.spy(FakeEchoWikipediaBackend, "shutdown")
-    await wikipedia.shutdown()
-    spy.assert_called_once()
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    ["query", "expected_title"],
-    [("foo", "foo"), ("foo bar", "foo_bar"), ("foØ bÅr", "fo%C3%98_b%C3%85r")],
-)
-async def test_query(
-    wikipedia: Provider,
-    srequest: SuggestionRequestFixture,
-    query: str,
-    expected_title: str,
-) -> None:
-    """Test for the query method."""
-    suggestions = await wikipedia.query(srequest(query))
-
-    assert suggestions == [
-        WikipediaSuggestion(
-            title=query,
-            full_keyword=query,
-            url=f"https://en.wikipedia.org/wiki/{expected_title}",
-            advertiser=ADVERTISER,
-            is_sponsored=False,
-            provider="wikipedia",
-            score=settings.providers.wikipedia.score,
-            icon=ICON,
-            block_id=0,
-            impression_url=None,
-            click_url=None,
-        )
-    ]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/providers/wikipedia/test_provider.py
+++ b/tests/unit/providers/wikipedia/test_provider.py
@@ -1,0 +1,71 @@
+"""Unit tests for the Merino v1 suggest API endpoint for the Wikipedia provider."""
+import pytest
+from pytest_mock import MockerFixture
+
+from merino.config import settings
+from merino.providers.wikipedia.backends.fake_backends import FakeEchoWikipediaBackend
+from merino.providers.wikipedia.provider import (
+    ADVERTISER,
+    ICON,
+    Provider,
+    WikipediaSuggestion,
+)
+from tests.unit.types import SuggestionRequestFixture
+
+
+@pytest.fixture(name="wikipedia")
+def fixture_wikipedia() -> Provider:
+    """Return a Wikipedia provider that uses a test backend."""
+    return Provider(
+        backend=FakeEchoWikipediaBackend(),
+        query_timeout_sec=0.2,
+    )
+
+
+def test_enabled_by_default(wikipedia: Provider) -> None:
+    """Test for the enabled_by_default method."""
+    assert wikipedia.enabled_by_default
+
+
+def test_hidden(wikipedia: Provider) -> None:
+    """Test for the hidden method."""
+    assert not wikipedia.hidden()
+
+
+@pytest.mark.asyncio
+async def test_shutdown(wikipedia: Provider, mocker: MockerFixture) -> None:
+    """Test for the shutdown method."""
+    spy = mocker.spy(FakeEchoWikipediaBackend, "shutdown")
+    await wikipedia.shutdown()
+    spy.assert_called_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ["query", "expected_title"],
+    [("foo", "foo"), ("foo bar", "foo_bar"), ("foØ bÅr", "fo%C3%98_b%C3%85r")],
+)
+async def test_query(
+    wikipedia: Provider,
+    srequest: SuggestionRequestFixture,
+    query: str,
+    expected_title: str,
+) -> None:
+    """Test for the query method."""
+    suggestions = await wikipedia.query(srequest(query))
+
+    assert suggestions == [
+        WikipediaSuggestion(
+            title=query,
+            full_keyword=query,
+            url=f"https://en.wikipedia.org/wiki/{expected_title}",
+            advertiser=ADVERTISER,
+            is_sponsored=False,
+            provider="wikipedia",
+            score=settings.providers.wikipedia.score,
+            icon=ICON,
+            block_id=0,
+            impression_url=None,
+            click_url=None,
+        )
+    ]


### PR DESCRIPTION
Elastico requires a Cloud ID and API key to be passed to the client.

The provider times out when I try to connect to it locally, so I've increased the provider's timeout. Once we get an idea of what the distribution for the request looks like, we can reduce the timeout. The connection _should_ be faster in GCP, but not insignificant (around 170ms).