### PR TITLE
Tag and push a `latest` image to docker hub.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,8 +239,10 @@ jobs:
             if [ -n "${DOCKER_TAG}" ]; then
               echo ${DOCKERHUB_REPO}:${DOCKER_TAG}
               docker tag app:build ${DOCKERHUB_REPO}:${DOCKER_TAG}
+              docker tag app:build ${DOCKERHUB_REPO}:latest
               docker images
               docker push "${DOCKERHUB_REPO}:${DOCKER_TAG}"
+              docker push "${DOCKERHUB_REPO}:latest"
             else
               echo "Not pushing to dockerhub for tag=${CIRCLE_TAG} branch=${CIRCLE_BRANCH}"
             fi


### PR DESCRIPTION
I talked to jbuck about creating a new docker hub repo for `merino-jobs` however after some back and forth we decided to test how awkward it is to override the entrypoint in the job. To do that we need a stable tag for the docker image so this pr should tag and push a `latest` when we push to prod