### PR TITLE
Add a lifecycle policy for `enwiki` index

### DIFF
--- a/docs/ops.md
+++ b/docs/ops.md
@@ -288,3 +288,27 @@ The provider that is backed by the locally indexed Wikipedia through Elasticsear
   as a floating point number. Defaults to 0.23.
 
 [log]:../merino/config_logging.py
+
+
+### Elasticsearch Index Policy
+
+We want to ensure that the index expire after 3 months,
+so we need to add a lifecycle policy for this deletion to happen.
+
+The command to run in Kibana to add this policy:
+
+```
+PUT _ilm/policy/enwiki_policy
+{
+  "policy": {
+    "phases": {
+      "delete": {
+        "min_age": "90d",
+        "actions": {
+          "delete": {}
+        }
+      }
+    }
+  }
+}
+```

--- a/merino/jobs/wikipedia_indexer/settings/v1.py
+++ b/merino/jobs/wikipedia_indexer/settings/v1.py
@@ -31,6 +31,7 @@ SUGGEST_SETTINGS = {
     "number_of_replicas": "1",
     "refresh_interval": "-1",
     "number_of_shards": "2",
+    "index.lifecycle.name": "enwiki_policy",
     "analysis": {
         "filter": {
             "stop_filter": {


### PR DESCRIPTION
This lifecycle policy will expire the index after 90 days (around 3 months). We need to add the lifecycle policy to the cluster before we can merge this code change.