### PR TITLE
[DISCO-2178] Version Contract Tests for all environments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,11 +183,6 @@ jobs:
           name: Load Docker image from workspace
           command: docker load -i /tmp/workspace/merinopy.tar.gz
       - run:
-          name: var check
-          command: |
-            echo "testing CI variable exposure"
-            echo ${CIRCLECI}
-      - run:
           name: Contract tests
           command: |
             sudo chown 1000:1000 tests/contract/kinto-attachments

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,13 +153,13 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-            docker_layer_caching: true
+          docker_layer_caching: true
       - write-version
       - store_artifacts:
-            path: version.json
+          path: version.json
       - run:
-            name: Build image
-            command: make docker-build
+          name: Build image
+          command: make docker-build
       - run:
           name: Save image into workspace
           command: |
@@ -178,10 +178,15 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-            at: /tmp/workspace
+          at: /tmp/workspace
       - run:
-            name: Load Docker image from workspace
-            command: docker load -i /tmp/workspace/merinopy.tar.gz
+          name: Load Docker image from workspace
+          command: docker load -i /tmp/workspace/merinopy.tar.gz
+      - run:
+          name: Contract tests pre-clean
+          command: |
+            make contract-tests-clean
+            docker rmi client
       - run:
           name: Contract tests
           command: |
@@ -194,7 +199,7 @@ jobs:
       - checkout
       - skip-if-do-not-deploy
       - attach_workspace:
-            at: /tmp/workspace
+          at: /tmp/workspace
       - setup_remote_docker
       - run:
           name: Load Docker image from workspace
@@ -222,11 +227,11 @@ jobs:
       - checkout
       - skip-if-do-not-deploy
       - attach_workspace:
-            at: /tmp/workspace
+          at: /tmp/workspace
       - setup_remote_docker
       - run:
-            name: Load Docker image from workspace
-            command: docker load -i /tmp/workspace/merinopy.tar.gz
+          name: Load Docker image from workspace
+          command: docker load -i /tmp/workspace/merinopy.tar.gz
       - dockerhub-login
       - run:
           name: Push to Docker Hub (prod)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,11 +188,6 @@ jobs:
             echo "testing CI variable exposure"
             echo ${CIRCLECI}
       - run:
-          name: Contract tests pre-clean
-          command: |
-            make contract-tests-clean
-            docker rmi client
-      - run:
           name: Contract tests
           command: |
             sudo chown 1000:1000 tests/contract/kinto-attachments

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,7 +188,7 @@ jobs:
             sudo chown 1000:1000 tests/contract/kinto-attachments
             make run-contract-tests
           environment:
-            MERINO_ENV: "ci"
+            TEST_ENV: "ci"
   docker-image-publish-stage:
     docker:
       - image: cimg/base:2022.08

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,8 +187,6 @@ jobs:
           command: |
             sudo chown 1000:1000 tests/contract/kinto-attachments
             make run-contract-tests
-          environment:
-            TEST_ENV: "ci"
   docker-image-publish-stage:
     docker:
       - image: cimg/base:2022.08

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,6 +187,8 @@ jobs:
           command: |
             sudo chown 1000:1000 tests/contract/kinto-attachments
             make run-contract-tests
+          environment:
+            MERINO_ENV: "ci"
   docker-image-publish-stage:
     docker:
       - image: cimg/base:2022.08

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,7 +172,7 @@ jobs:
             - merinopy.tar.gz
   contract-tests:
     machine:
-      docker_layer_caching: true
+      docker_layer_caching: false
       image: ubuntu-2004:202101-01 # Ubuntu 20.04, Docker v20.10.2, Docker Compose v1.28.2
     working_directory: ~/merino
     steps:
@@ -182,6 +182,11 @@ jobs:
       - run:
           name: Load Docker image from workspace
           command: docker load -i /tmp/workspace/merinopy.tar.gz
+      - run:
+          name: var check
+          command: |
+            echo "testing CI variable exposure"
+            echo ${CIRCLECI}
       - run:
           name: Contract tests pre-clean
           command: |

--- a/Makefile
+++ b/Makefile
@@ -113,11 +113,12 @@ run-contract-tests:  ##  Run contract tests using docker compose
 contract-tests: docker-build run-contract-tests  ## Run contract tests, with build step
 
 .PHONY: contract-tests-clean
-contract-tests-clean:  ##  Stop and remove containers and networks for contract tests
+contract-tests-clean:  ##  Stop and remove containers and networks for contract tests, delete client
 	docker-compose \
       -f $(CONTRACT_TEST_DIR)/docker-compose.yml \
       -p merino-py-contract-tests \
       down
+	  docker rmi client kinto-setup
 
 .PHONY: run-load-tests
 run-load-tests:  ##  Run local execution of (Locust) load tests using existing merino-py docker image

--- a/tests/contract/README.md
+++ b/tests/contract/README.md
@@ -50,7 +50,9 @@ For more details see the Remote Settings [documentation][kinto_docs]
 
 ## Local Execution
 
-To run the contract tests locally, execute the following from the repository root:
+Local execution can be expedited by simply running `make contract-tests`, from the repository
+root. This creates the Docker containers with kinto, merino and the test client and runs the test
+scenarios against them.
 
 ```shell
 make contract-tests
@@ -62,6 +64,10 @@ the repository root:
 ```shell
 make contract-tests-clean
 ```
+Failing to run this clean command between code changes may result in your changes not being
+reflected.
+
+See [Makefile][makefile] for details.
 
 [client_readme]: ./client/README.md
 [kinto_docs]: https://remote-settings.readthedocs.io/en/latest/
@@ -70,3 +76,4 @@ make contract-tests-clean
 [merino_readme]: ../../README.md
 [sequence_diagram]: sequence_diagram.jpg
 [sequence_diagram_miro]: https://miro.com/app/board/uXjVOje8DN4=/
+[makefile]: ../../../Makefile

--- a/tests/contract/client/README.md
+++ b/tests/contract/client/README.md
@@ -118,6 +118,16 @@ virtual environment, set environment variables, expose the Merino and Kinto API 
 in the `docker-compose.yml` and use a pytest command. It is recommended to execute the
 tests within a Python virtual environment to prevent dependency cross contamination.
 
+Local execution can be expedited by simply running `make contract-tests`, which essentially
+creates the Docker containers with kinto, merino and the test client and runs the test
+scenarios against them.
+
+Be aware that when making changes to the client code, you should stop and remove the contract
+test containers and networks and delete the client before running the tests again. Otherwise,
+you may not see your changes reflected. This can be done by running the following two commands:
+1. `make-contract-tests-clean` see [Makefile][makefile]
+2. `docker rmi client`
+
 1. Create a Virtual Environment
 
     The [Developer documentation for working on Merino][merino_dev_docs], provides
@@ -189,3 +199,4 @@ tests within a Python virtual environment to prevent dependency cross contaminat
 [contract_tests_readme]: ../README.md
 [merino_dev_docs]: ../../../docs/dev/index.md
 [pytest-k]: https://docs.pytest.org/en/latest/example/markers.html#using-k-expr-to-select-tests-based-on-their-name
+[makefile]: ../../../Makefile

--- a/tests/contract/client/README.md
+++ b/tests/contract/client/README.md
@@ -118,16 +118,6 @@ virtual environment, set environment variables, expose the Merino and Kinto API 
 in the `docker-compose.yml` and use a pytest command. It is recommended to execute the
 tests within a Python virtual environment to prevent dependency cross contamination.
 
-Local execution can be expedited by simply running `make contract-tests`, which essentially
-creates the Docker containers with kinto, merino and the test client and runs the test
-scenarios against them.
-
-Be aware that when making changes to the client code, you should stop and remove the contract
-test containers and networks and delete the client before running the tests again. Otherwise,
-you may not see your changes reflected. This can be done by running the following two commands:
-1. `make-contract-tests-clean` see [Makefile][makefile]
-2. `docker rmi client`
-
 1. Create a Virtual Environment
 
     The [Developer documentation for working on Merino][merino_dev_docs], provides
@@ -199,4 +189,3 @@ you may not see your changes reflected. This can be done by running the followin
 [contract_tests_readme]: ../README.md
 [merino_dev_docs]: ../../../docs/dev/index.md
 [pytest-k]: https://docs.pytest.org/en/latest/example/markers.html#using-k-expr-to-select-tests-based-on-their-name
-[makefile]: ../../../Makefile

--- a/tests/contract/client/tests/models.py
+++ b/tests/contract/client/tests/models.py
@@ -5,10 +5,10 @@
 """Contract tests client models."""
 
 from enum import Enum
-from typing import Any, Literal, Optional
+from typing import Literal, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, Extra, Field
+from pydantic import BaseModel, Extra, Field, HttpUrl
 
 
 class Service(Enum):
@@ -78,11 +78,20 @@ class ResponseContent(BaseModel):
     request_id: Optional[UUID] = Field(...)
 
 
+class VersionResponseContent(BaseModel):
+    """Class that contains __version__ endpoint data populated by version.json file."""
+
+    source: HttpUrl = Field(...)
+    version: str = Field(...)
+    commit: str = Field(...)
+    build: str = Field(...)
+
+
 class Response(BaseModel):
     """Class that holds information about an HTTP response from Merino."""
 
     status_code: int
-    content: ResponseContent | Any
+    content: ResponseContent | VersionResponseContent
 
 
 class Step(BaseModel):

--- a/tests/contract/client/tests/models.py
+++ b/tests/contract/client/tests/models.py
@@ -81,10 +81,10 @@ class ResponseContent(BaseModel):
 class VersionResponseContent(BaseModel):
     """Class that contains __version__ endpoint data populated by version.json file."""
 
-    source: HttpUrl = Field(...)
-    version: str = Field(...)
-    commit: str = Field(...)
-    build: str = Field(...)
+    source: HttpUrl
+    version: str
+    commit: str
+    build: HttpUrl | str
 
 
 class Response(BaseModel):

--- a/tests/contract/client/tests/test_merino.py
+++ b/tests/contract/client/tests/test_merino.py
@@ -10,7 +10,6 @@ import time
 from typing import Any, Callable
 
 import pytest
-from pydantic import HttpUrl
 import requests
 from kinto import (
     KintoEnvironment,
@@ -29,6 +28,7 @@ from models import (
     Suggestion,
     VersionResponseContent,
 )
+from pydantic import HttpUrl
 from requests import Response as RequestsResponse
 
 # We need to exclude the following fields on the response level:

--- a/tests/contract/client/tests/test_merino.py
+++ b/tests/contract/client/tests/test_merino.py
@@ -218,9 +218,9 @@ def assert_200_version_endpoint_response(
     """
     expected_content_dict = step_content
     merino_content_dict = merino_version_content
-    assert expected_content_dict.source == merino_content_dict.source
+    assert expected_content_dict.source != merino_content_dict.source
 
-    if os.environ.get("MERINO_ENV") == "ci":
+    if os.environ.get("TEST_ENV") == "ci":
         # The version data is constructed from the build of merino, including
         # the commit hash, a build url to circleci and then an empty value for version.
         # Source is identitical between local and production.

--- a/tests/contract/client/tests/test_merino.py
+++ b/tests/contract/client/tests/test_merino.py
@@ -124,8 +124,7 @@ def fixture_merino_step(
                 and type(step.response.content) == VersionResponseContent
             ):
                 assert_200_version_endpoint_response(
-                    # type ignored to appease mypy, does not infer 2 possible types.
-                    step_content=step.response.content,  # type: ignore
+                    step_content=step.response.content,
                     merino_version_content=VersionResponseContent(**response.json()),
                 )
 

--- a/tests/contract/client/tests/test_merino.py
+++ b/tests/contract/client/tests/test_merino.py
@@ -220,7 +220,7 @@ def assert_200_version_endpoint_response(
     merino_content_dict = merino_version_content
     assert expected_content_dict.source == merino_content_dict.source
 
-    if os.environ.get("CIRCLECI"):
+    if os.environ.get("MERINO_ENV") == "ci":
         # The version data is constructed from the build of merino, including
         # the commit hash, a build url to circleci and then an empty value for version.
         # Source is identitical between local and production.

--- a/tests/contract/client/tests/test_merino.py
+++ b/tests/contract/client/tests/test_merino.py
@@ -220,7 +220,7 @@ def assert_200_version_endpoint_response(
     merino_content_dict = merino_version_content
     assert expected_content_dict.source == merino_content_dict.source
 
-    if os.environ.get("CONTRACT_TEST_ENV") == "ci":
+    if os.environ.get("MERINO_ENV"):
         # The version data is constructed from the build of merino, including
         # the commit hash, a build url to circleci and then an empty value for version.
         # Source is identitical between local and production.

--- a/tests/contract/client/tests/test_merino.py
+++ b/tests/contract/client/tests/test_merino.py
@@ -218,17 +218,18 @@ def assert_200_version_endpoint_response(
     """
     expected_content_dict = step_content
     merino_content_dict = merino_version_content
+    # Source is identitical between local dev, stage and production.
     assert expected_content_dict.source == merino_content_dict.source
 
     if os.environ.get("MERINO_ENV"):
-        # The version data is constructed from the build of merino, including
-        # the commit hash, a build url to circleci and then an empty value for version.
-        # Source is identitical between local and production.
+        # The data in the version file is built during the CIRCLECI stage. The local dev
+        # version contains placeholders. Therefore, we cannot specify the expected output
+        # in scenarios, so checks made here to verify that a sha has been written, version
+        # is empty and the validator worked as expected to parse build as HttpUrl.
         assert merino_content_dict.version == ""
         sha_pattern = re.compile(r"\b[0-9a-f]{40}\b")
         assert re.match(sha_pattern, merino_content_dict.commit)
         assert type(merino_content_dict.build) is HttpUrl
-        raise Exception("CIRCLECI TEST")
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/tests/contract/client/tests/test_merino.py
+++ b/tests/contract/client/tests/test_merino.py
@@ -232,7 +232,6 @@ def assert_200_version_endpoint_response(
         sha_pattern = re.compile(r"\b[0-9a-f]{40}\b")
         assert re.match(sha_pattern, merino_content_dict.commit)
         assert type(merino_content_dict.build) is HttpUrl
-        raise Exception("test failure")
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/tests/contract/client/tests/test_merino.py
+++ b/tests/contract/client/tests/test_merino.py
@@ -4,7 +4,6 @@
 
 """Contract tests client."""
 
-import logging
 import os
 import re
 import time
@@ -44,8 +43,6 @@ SUGGESTION_EXCLUDE: set[str] = {"icon"}
 
 
 StepFunction = Callable[[Step], None]
-
-logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="session", name="merino_url")
@@ -123,7 +120,6 @@ def fixture_merino_step(
             # content for this step in the test scenario.
 
             if step.request.path == "/__version__":
-                logger.warning("PATH")
                 assert_200_version_endpoint_response(
                     # type ignored to appease mypy, does not infer 2 possible types.
                     step_content=step.response.content,  # type: ignore
@@ -223,10 +219,8 @@ def assert_200_version_endpoint_response(
     expected_content_dict = step_content
     merino_content_dict = merino_version_content
     assert expected_content_dict.source == merino_content_dict.source
-    logger.warning("NO CI")
-    logger.warning(merino_content_dict)
+
     if os.environ.get("CIRCLECI"):
-        logger.warning("IN CI")
         # The version data is constructed from the build of merino, including
         # the commit hash, a build url to circleci and then an empty value for version.
         # Source is identitical between local and production.

--- a/tests/contract/client/tests/test_merino.py
+++ b/tests/contract/client/tests/test_merino.py
@@ -119,13 +119,16 @@ def fixture_merino_step(
             # representation of the model instance with the expected response
             # content for this step in the test scenario.
 
-            if step.request.path == "/__version__":
+            if (
+                step.request.path == "/__version__"
+                and type(step.response.content) == VersionResponseContent
+            ):
                 assert_200_version_endpoint_response(
                     # type ignored to appease mypy, does not infer 2 possible types.
                     step_content=step.response.content,  # type: ignore
                     merino_version_content=VersionResponseContent(**response.json()),
                 )
-                return
+
             else:
                 assert_200_response(
                     # type ignored to appease mypy, does not infer 2 possible types.
@@ -133,7 +136,7 @@ def fixture_merino_step(
                     merino_content=ResponseContent(**response.json()),
                     fetch_kinto_icon_url=fetch_kinto_icon_url,
                 )
-                return
+            return
 
         if response.status_code == 204:
             # If the response status code is 204 No Content, load the response content

--- a/tests/contract/client/tests/test_merino.py
+++ b/tests/contract/client/tests/test_merino.py
@@ -232,6 +232,7 @@ def assert_200_version_endpoint_response(
         sha_pattern = re.compile(r"\b[0-9a-f]{40}\b")
         assert re.match(sha_pattern, merino_content_dict.commit)
         assert type(merino_content_dict.build) is HttpUrl
+        raise Exception("test failure")
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/tests/contract/client/tests/test_merino.py
+++ b/tests/contract/client/tests/test_merino.py
@@ -4,10 +4,13 @@
 
 """Contract tests client."""
 
+import os
+import re
 import time
 from typing import Any, Callable
 
 import pytest
+from pydantic import HttpUrl
 import requests
 from kinto import (
     KintoEnvironment,
@@ -216,6 +219,15 @@ def assert_200_version_endpoint_response(
     expected_content_dict = step_content
     merino_content_dict = merino_version_content
     assert expected_content_dict.source == merino_content_dict.source
+
+    if os.environ.get("CIRCLECI"):
+        # The version data is constructed from the build of merino, including
+        # the commit hash, a build url to circleci and then an empty value for version.
+        # Source is identitical between local and production.
+        assert merino_content_dict.version == ""
+        sha_pattern = re.compile(r"\b[0-9a-f]{40}\b")
+        assert re.match(sha_pattern, merino_content_dict.commit)
+        assert HttpUrl(merino_content_dict.build)
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/tests/contract/client/tests/test_merino.py
+++ b/tests/contract/client/tests/test_merino.py
@@ -220,7 +220,7 @@ def assert_200_version_endpoint_response(
     merino_content_dict = merino_version_content
     assert expected_content_dict.source == merino_content_dict.source
 
-    if os.environ.get("TEST_ENV") == "ci":
+    if os.environ.get("CONTRACT_TEST_ENV") == "ci":
         # The version data is constructed from the build of merino, including
         # the commit hash, a build url to circleci and then an empty value for version.
         # Source is identitical between local and production.

--- a/tests/contract/client/tests/test_merino.py
+++ b/tests/contract/client/tests/test_merino.py
@@ -228,6 +228,7 @@ def assert_200_version_endpoint_response(
         sha_pattern = re.compile(r"\b[0-9a-f]{40}\b")
         assert re.match(sha_pattern, merino_content_dict.commit)
         assert HttpUrl(merino_content_dict.build)
+        raise Exception("CIRCLECI TEST")
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/tests/contract/client/tests/test_merino.py
+++ b/tests/contract/client/tests/test_merino.py
@@ -227,7 +227,7 @@ def assert_200_version_endpoint_response(
         assert merino_content_dict.version == ""
         sha_pattern = re.compile(r"\b[0-9a-f]{40}\b")
         assert re.match(sha_pattern, merino_content_dict.commit)
-        assert HttpUrl(merino_content_dict.build)
+        assert type(merino_content_dict.build) is HttpUrl
         raise Exception("CIRCLECI TEST")
 
 

--- a/tests/contract/client/tests/test_merino.py
+++ b/tests/contract/client/tests/test_merino.py
@@ -4,6 +4,7 @@
 
 """Contract tests client."""
 
+import logging
 import os
 import re
 import time
@@ -43,6 +44,8 @@ SUGGESTION_EXCLUDE: set[str] = {"icon"}
 
 
 StepFunction = Callable[[Step], None]
+
+logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="session", name="merino_url")
@@ -120,6 +123,7 @@ def fixture_merino_step(
             # content for this step in the test scenario.
 
             if step.request.path == "/__version__":
+                logger.warning("PATH")
                 assert_200_version_endpoint_response(
                     # type ignored to appease mypy, does not infer 2 possible types.
                     step_content=step.response.content,  # type: ignore
@@ -219,8 +223,10 @@ def assert_200_version_endpoint_response(
     expected_content_dict = step_content
     merino_content_dict = merino_version_content
     assert expected_content_dict.source == merino_content_dict.source
-
+    logger.warning("NO CI")
+    logger.warning(merino_content_dict)
     if os.environ.get("CIRCLECI"):
+        logger.warning("IN CI")
         # The version data is constructed from the build of merino, including
         # the commit hash, a build url to circleci and then an empty value for version.
         # Source is identitical between local and production.

--- a/tests/contract/client/tests/test_merino.py
+++ b/tests/contract/client/tests/test_merino.py
@@ -218,7 +218,7 @@ def assert_200_version_endpoint_response(
     """
     expected_content_dict = step_content
     merino_content_dict = merino_version_content
-    assert expected_content_dict.source != merino_content_dict.source
+    assert expected_content_dict.source == merino_content_dict.source
 
     if os.environ.get("TEST_ENV") == "ci":
         # The version data is constructed from the build of merino, including

--- a/tests/contract/docker-compose.yml
+++ b/tests/contract/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       - ../../dev/wait-for-it.sh:/wait-for-it.sh
     environment:
       MERINO_URL: http://merino:8000
+      MERINO_ENV: "$CIRCLECI"
       SCENARIOS_FILE: /tmp/client/scenarios.yml
       KINTO_URL: http://kinto:8888
       KINTO_BUCKET: main

--- a/tests/contract/volumes/client/scenarios.yml
+++ b/tests/contract/volumes/client/scenarios.yml
@@ -546,3 +546,23 @@ scenarios:
                 is_sponsored: true
                 icon: null
                 score: 0.3
+
+  - name: version_endpoint
+    description: Test that returns correct json response from __version__ endpoint.
+    steps:
+      - request:
+          service: merino
+          method: GET
+          path: "/__version__"
+          headers:
+            - name: User-Agent
+              value: "Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0"
+            - name: Accept-Language
+              value: "en-US"
+        response:
+          status_code: 200
+          content:
+            source: "https://github.com/mozilla-services/merino-py"
+            version: "dev"
+            commit: "TBD"
+            build: "TBD"


### PR DESCRIPTION
# Description
* Version endpoint contract tests. 
* Took alternative path to cover all environments and to not simply skip in local. Achieved through:
- regex validation of sha-1 hash
- type check for HttpUrl to verify type check variance
- empty version string once in stage/prod

# Issue(s)
#170 | [DISCO-2178](https://mozilla-hub.atlassian.net/browse/DISCO-2178)

Replaces [old branch](https://github.com/mozilla-services/merino-py/pull/205) that was created when dealing with blocking cache bug that was resolved [DISCO-2264](https://mozilla-hub.atlassian.net/browse/DISCO-2264)



[DISCO-2178]: https://mozilla-hub.atlassian.net/browse/DISCO-2178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DISCO-2264]: https://mozilla-hub.atlassian.net/browse/DISCO-2264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ