### PR TITLE
[DISCO-2264] changing docker contract test caching due to client errors 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,13 +153,13 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-            docker_layer_caching: true
+          docker_layer_caching: true
       - write-version
       - store_artifacts:
-            path: version.json
+          path: version.json
       - run:
-            name: Build image
-            command: make docker-build
+          name: Build image
+          command: make docker-build
       - run:
           name: Save image into workspace
           command: |
@@ -172,16 +172,16 @@ jobs:
             - merinopy.tar.gz
   contract-tests:
     machine:
-      docker_layer_caching: true
+      docker_layer_caching: false
       image: ubuntu-2004:202101-01 # Ubuntu 20.04, Docker v20.10.2, Docker Compose v1.28.2
     working_directory: ~/merino
     steps:
       - checkout
       - attach_workspace:
-            at: /tmp/workspace
+          at: /tmp/workspace
       - run:
-            name: Load Docker image from workspace
-            command: docker load -i /tmp/workspace/merinopy.tar.gz
+          name: Load Docker image from workspace
+          command: docker load -i /tmp/workspace/merinopy.tar.gz
       - run:
           name: Contract tests
           command: |
@@ -194,7 +194,7 @@ jobs:
       - checkout
       - skip-if-do-not-deploy
       - attach_workspace:
-            at: /tmp/workspace
+          at: /tmp/workspace
       - setup_remote_docker
       - run:
           name: Load Docker image from workspace
@@ -222,11 +222,11 @@ jobs:
       - checkout
       - skip-if-do-not-deploy
       - attach_workspace:
-            at: /tmp/workspace
+          at: /tmp/workspace
       - setup_remote_docker
       - run:
-            name: Load Docker image from workspace
-            command: docker load -i /tmp/workspace/merinopy.tar.gz
+          name: Load Docker image from workspace
+          command: docker load -i /tmp/workspace/merinopy.tar.gz
       - dockerhub-login
       - run:
           name: Push to Docker Hub (prod)


### PR DESCRIPTION
This bug was raised when working on contract tests for version endpoint. See [JIRA issue](https://mozilla-hub.atlassian.net/browse/DISCO-2264) for specifics. Changes in test client locally were not being reflected and new scenarios were causing test failures in CI. After digging, it was discovered that caching the docker image for contract tests was the issue. 

 Verified by @Trinaa 