### PR TITLE
[DISCO-2254] Add keyword to Docker image tag for running load tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,6 +212,7 @@ jobs:
                 DOCKER_TAG="stage-loadtest-abort-${CIRCLE_SHA1}"
               else
                 DOCKER_TAG="stage-${CIRCLE_SHA1}"
+              fi
             fi
 
             if [ -n "${DOCKER_TAG}" ]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,16 +206,16 @@ jobs:
           command: |
             if [ "${CIRCLE_BRANCH}" == "main" ]; then
               DOCKER_TAG="${CIRCLE_SHA1}"
-            fi
 
-            if git log -1 "$CIRCLE_SHA1" | grep -q '\[load test: warn\]'; then
-                echo "Load test requested. Slack warning will be output if test fails. Stage deploy will proceed."
-                DOCKER_TAG="stage-loadtest-warn-"${CIRCLE_SHA1}"
-            fi
+              if git log -1 "$CIRCLE_SHA1" | grep -q '\[load test: warn\]'; then
+                  echo "Load test requested. Slack warning will be output if test fails. Stage deploy will proceed."
+                  DOCKER_TAG="stage-loadtest-warn-"${CIRCLE_SHA1}"
+              fi
 
-            if git log -1 "$CIRCLE_SHA1" | grep -q '\[load test: abort\]'; then
-                echo "Load test requested. Stage deploy will abort if load test fails."
-                DOCKER_TAG="stage-loadtest-abort-"${CIRCLE_SHA1}"
+              if git log -1 "$CIRCLE_SHA1" | grep -q '\[load test: abort\]'; then
+                  echo "Load test requested. Stage deploy will abort if load test fails."
+                  DOCKER_TAG="stage-loadtest-abort-"${CIRCLE_SHA1}"
+              fi
             fi
 
             if [ -n "${DOCKER_TAG}" ]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,7 +209,6 @@ jobs:
                   echo "Load test requested. Slack warning will be output if test fails and deployment workflow for prod will proceed."
                   DOCKER_TAG="stage-loadtest-warn-${CIRCLE_SHA1}"
               fi
-
               if git log -1 "$CIRCLE_SHA1" | grep -q '\[load test: abort\]'; then
                   echo "Load test requested. Deployment workflow for prod will abort if load test fails."
                   DOCKER_TAG="stage-loadtest-abort-${CIRCLE_SHA1}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,19 +201,17 @@ jobs:
           command: docker load -i /tmp/workspace/merinopy.tar.gz
       - dockerhub-login
       - run:
-          name: Push to Docker Hub & check for Load Test flag
-          # The Load Tests are triggered though [load test: (abort|warn)] text in git comment.
+          name: Push to Docker Hub # Load tests are triggered though [load test: (abort|warn)] label.
           command: |
             if [ "${CIRCLE_BRANCH}" == "main" ]; then
               DOCKER_TAG="${CIRCLE_SHA1}"
-
               if git log -1 "$CIRCLE_SHA1" | grep -q '\[load test: warn\]'; then
-                  echo "Load test requested. Slack warning will be output if test fails. Stage deploy will proceed."
+                  echo "Load test requested. Slack warning will be output if test fails and deployment workflow for prod will proceed."
                   DOCKER_TAG="stage-loadtest-warn-"${CIRCLE_SHA1}"
               fi
 
               if git log -1 "$CIRCLE_SHA1" | grep -q '\[load test: abort\]'; then
-                  echo "Load test requested. Stage deploy will abort if load test fails."
+                  echo "Load test requested. Deployment workflow for prod will abort if load test fails."
                   DOCKER_TAG="stage-loadtest-abort-"${CIRCLE_SHA1}"
               fi
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,6 +216,7 @@ jobs:
               fi
             fi
 
+
             if [ -n "${DOCKER_TAG}" ]; then
               echo ${DOCKERHUB_REPO}:${DOCKER_TAG}
               docker tag app:build ${DOCKERHUB_REPO}:${DOCKER_TAG}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,13 +217,8 @@ jobs:
             fi
 
             if git log -1 "$CIRCLE_SHA1" | grep -q '\[load test: abort\]'; then
-                echo "Load test requested. Stage deploy will halt if load test fails."
+                echo "Load test requested. Stage deploy will abort if load test fails."
                 DOCKER_TAG="stage-loadtest-abort-"${CIRCLE_SHA1}"
-
-                circleci-agent step halt
-
-                # Will not deploy, just cancel the rest of jobs of the workflow.
-                # See API detail: https://circleci.com/docs/api/v2/index.html#operation/cancelWorkflow
             fi
 
             if [ -n "${DOCKER_TAG}" ]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -204,15 +204,14 @@ jobs:
           name: Push to Docker Hub # Load tests are triggered though [load test: (abort|warn)] label.
           command: |
             if [ "${CIRCLE_BRANCH}" == "main" ]; then
-              DOCKER_TAG="${CIRCLE_SHA1}"
               if git log -1 "$CIRCLE_SHA1" | grep -q '\[load test: warn\]'; then
-                  echo "Load test requested. Slack warning will be output if test fails and deployment workflow for prod will proceed."
-                  DOCKER_TAG="stage-loadtest-warn-${CIRCLE_SHA1}"
-              fi
-              if git log -1 "$CIRCLE_SHA1" | grep -q '\[load test: abort\]'; then
-                  echo "Load test requested. Deployment workflow for prod will abort if load test fails."
-                  DOCKER_TAG="stage-loadtest-abort-${CIRCLE_SHA1}"
-              fi
+                echo "Load test requested. Slack warning will be output if test fails and deployment workflow for prod will proceed."
+                DOCKER_TAG="stage-loadtest-warn-${CIRCLE_SHA1}"
+              elif git log -1 "$CIRCLE_SHA1" | grep -q '\[load test: abort\]'; then
+                echo "Load test requested. Deployment workflow for prod will abort if load test fails."
+                DOCKER_TAG="stage-loadtest-abort-${CIRCLE_SHA1}"
+              else
+                DOCKER_TAG="stage-${CIRCLE_SHA1}"
             fi
 
             if [ -n "${DOCKER_TAG}" ]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,10 +201,29 @@ jobs:
           command: docker load -i /tmp/workspace/merinopy.tar.gz
       - dockerhub-login
       - run:
-          name: Push to Docker Hub
+          name: Push to Docker Hub & check for Load Test flag
+          # The Load Tests are triggered though [load test: (abort|warn)] text being
+          # included in the merge commit when merging the PR to 'main'. Examples:
+          # feat: Add feature ABC [load test: warn]
+          # feat: Add feature XYZ [load test: abort]
           command: |
             if [ "${CIRCLE_BRANCH}" == "main" ]; then
               DOCKER_TAG="${CIRCLE_SHA1}"
+            fi
+
+            if git log -1 "$CIRCLE_SHA1" | grep -q '\[load test: warn\]'; then
+                echo "Load test requested. Slack warning will be output if test fails. Stage deploy will proceed."
+                DOCKER_TAG="stage-loadtest-warn-"${CIRCLE_SHA1}"
+            fi
+
+            if git log -1 "$CIRCLE_SHA1" | grep -q '\[load test: abort\]'; then
+                echo "Load test requested. Stage deploy will halt if load test fails."
+                DOCKER_TAG="stage-loadtest-abort-"${CIRCLE_SHA1}"
+
+                circleci-agent step halt
+
+                # Will not deploy, just cancel the rest of jobs of the workflow.
+                # See API detail: https://circleci.com/docs/api/v2/index.html#operation/cancelWorkflow
             fi
 
             if [ -n "${DOCKER_TAG}" ]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,10 +202,7 @@ jobs:
       - dockerhub-login
       - run:
           name: Push to Docker Hub & check for Load Test flag
-          # The Load Tests are triggered though [load test: (abort|warn)] text being
-          # included in the merge commit when merging the PR to 'main'. Examples:
-          # feat: Add feature ABC [load test: warn]
-          # feat: Add feature XYZ [load test: abort]
+          # The Load Tests are triggered though [load test: (abort|warn)] text in git comment.
           command: |
             if [ "${CIRCLE_BRANCH}" == "main" ]; then
               DOCKER_TAG="${CIRCLE_SHA1}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,15 +207,14 @@ jobs:
               DOCKER_TAG="${CIRCLE_SHA1}"
               if git log -1 "$CIRCLE_SHA1" | grep -q '\[load test: warn\]'; then
                   echo "Load test requested. Slack warning will be output if test fails and deployment workflow for prod will proceed."
-                  DOCKER_TAG="stage-loadtest-warn-"${CIRCLE_SHA1}"
+                  DOCKER_TAG="stage-loadtest-warn-${CIRCLE_SHA1}"
               fi
 
               if git log -1 "$CIRCLE_SHA1" | grep -q '\[load test: abort\]'; then
                   echo "Load test requested. Deployment workflow for prod will abort if load test fails."
-                  DOCKER_TAG="stage-loadtest-abort-"${CIRCLE_SHA1}"
+                  DOCKER_TAG="stage-loadtest-abort-${CIRCLE_SHA1}"
               fi
             fi
-
 
             if [ -n "${DOCKER_TAG}" ]; then
               echo ${DOCKERHUB_REPO}:${DOCKER_TAG}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Before submitting a PR:
   pass and the code has been reviewed.
 - Ideally, your patch should include new tests that cover your changes. It is your and
   your reviewer's responsibility to ensure your patch includes adequate tests.
-- If making documentation changes or minor revisions, you may wish to avoid deployment. Please see the [Preventing deployment via [do not deploy]][release-process] documentation.
+- If you're solely updating documentation, you may wish to avoid deployment. Please see the [Preventing deployment via [do not deploy]][release-process] documentation.
 - If making changes that may impact performance, it is recommended to execute a load test. Please see [Load Testing Opt-In [load test: (abort|warn)]][release-process] documentation for more information.
 - For more information on understanding the release process, please see relevant information contained in the [release-process.md][release-process] 
 documentation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,8 +23,9 @@ Before submitting a PR:
 - Ideally, your patch should include new tests that cover your changes. It is your and
   your reviewer's responsibility to ensure your patch includes adequate tests.
 - If making documentation changes or minor revisions, you may wish to avoid deployment. Please see the [Preventing deployment via [do not deploy]][release-process] documentation.
-- If running load testing, please see the [load testing documentation][load-testing-docs] documentation on local execution or adding the opt-in annotations to your commit. Ex. [load test: abort|warn]
-- For more information on understanding the release process, please see relevant documentation contained in the [release-process.md][release-process] documentation.
+- If making changes that may impact performance, it is recommended to execute a load test. Please see [Load Testing Opt-In [load test: (abort|warn)]][release-process] documentation for more information.
+- For more information on understanding the release process, please see relevant information contained in the [release-process.md][release-process] 
+documentation.
 
 When submitting a PR:
 - You agree to license your code under the project's open source license

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,9 @@ Before submitting a PR:
   pass and the code has been reviewed.
 - Ideally, your patch should include new tests that cover your changes. It is your and
   your reviewer's responsibility to ensure your patch includes adequate tests.
+- If making documentation changes or minor revisions, you may wish to avoid deployment. Please see the [Preventing deployment via [do not deploy]][release-process] documentation.
+- If running load testing, please see the [load testing documentation][load-testing-docs] documentation on local execution or adding the opt-in annotations to your commit. Ex. [load test: abort|warn]
+- For more information on understanding the release process, please see relevant documentation contained in the [release-process.md][release-process] documentation.
 
 When submitting a PR:
 - You agree to license your code under the project's open source license
@@ -101,3 +104,5 @@ BREAKING CHANGE: This patch requires developer to lower expectations about
 
 Closes #314, #975
 ```
+[release-process]: /docs/dev/release-process.md
+[load-testing-docs]: /tests/load/README.md

--- a/docs/dev/release-process.md
+++ b/docs/dev/release-process.md
@@ -32,7 +32,8 @@ While the `[do not deploy]` can be anywhere in the title, it is recommended to p
 The deployment pipeline will analyze the message of the merge commit (which will contain the PR title) and make a decision based on it.
 
 ## Load Testing
-Load testing can be run locally or as a part of the deployment process. Local execution does not require any labeling in commit messages. For deployment, you have to add a label to your commit messages in the form of: `[load test: (abort|warn)]`.
+Load testing can be run locally or as a part of the deployment process. Local execution does not require any labeling in commit messages. For deployment, you have to add a label to the message of the commit that you wish to deploy in the form of: `[load test: (abort|warn)]`. In most cases this will be the merge commit created by merging a GitHub pull request.
+
 Abort will prevent deployment should the load testing fail while warn will simply warn via Slack and continue deployment. For detailed specifics on load testing and this convention, please see the relevant documentation: [load-testing-docs]: /tests/load/README.md].
 
 ## Releasing to production

--- a/docs/dev/release-process.md
+++ b/docs/dev/release-process.md
@@ -31,6 +31,10 @@ While the `[do not deploy]` can be anywhere in the title, it is recommended to p
 
 The deployment pipeline will analyze the message of the merge commit (which will contain the PR title) and make a decision based on it.
 
+
+## Load Testing Opt-In [load test: (abort|warn)]
+Load testing can be run as a part of the deployment process. In order to initiate, you have to add tagging to your commit messages in the form of `[load test: (abort|warn)]`. Abort will prevent deployment should the load testing fail while warn will simply warn via Slack and continue deployment. For detailed specifics on load testing and this convention, please see the relevant documentation: [load-testing-docs]: /tests/load/README.md].
+
 ## Releasing to production
 Developers with write access to the Merino repository can initiate a deployment to production after a Pull-Request on the Merino GitHub repository is merged to the `main` branch.
 While any developer with write access can trigger the deployment to production, the _expectation_ is that individual(s) who authored and merged the Pull-Request should do so, as they are the ones most familiar with their changes and who can tell, by looking at the data, if anything looks anomalous.
@@ -59,3 +63,4 @@ don't panic and follow the instructions below:
 
 [incident_docs]: https://mozilla-hub.atlassian.net/wiki/spaces/MIR/overview
 [contributing]: ../../CONTRIBUTING.md
+[load-testing-docs]: /tests/load/README.md

--- a/docs/dev/release-process.md
+++ b/docs/dev/release-process.md
@@ -33,7 +33,8 @@ The deployment pipeline will analyze the message of the merge commit (which will
 
 
 ## Load Testing Opt-In [load test: (abort|warn)]
-Load testing can be run as a part of the deployment process. In order to initiate, you have to add tagging to your commit messages in the form of `[load test: (abort|warn)]`. Abort will prevent deployment should the load testing fail while warn will simply warn via Slack and continue deployment. For detailed specifics on load testing and this convention, please see the relevant documentation: [load-testing-docs]: /tests/load/README.md].
+Load testing can be run locally or as a part of the deployment process. In order to initiate, you have to add tagging to your commit messages in the form of
+`[load test: (abort|warn)]`. Abort will prevent deployment should the load testing fail while warn will simply warn via Slack and continue deployment. For detailed specifics on load testing and this convention, please see the relevant documentation: [load-testing-docs]: /tests/load/README.md].
 
 ## Releasing to production
 Developers with write access to the Merino repository can initiate a deployment to production after a Pull-Request on the Merino GitHub repository is merged to the `main` branch.

--- a/docs/dev/release-process.md
+++ b/docs/dev/release-process.md
@@ -31,10 +31,9 @@ While the `[do not deploy]` can be anywhere in the title, it is recommended to p
 
 The deployment pipeline will analyze the message of the merge commit (which will contain the PR title) and make a decision based on it.
 
-
-## Load Testing Opt-In [load test: (abort|warn)]
-Load testing can be run locally or as a part of the deployment process. In order to initiate, you have to add tagging to your commit messages in the form of
-`[load test: (abort|warn)]`. Abort will prevent deployment should the load testing fail while warn will simply warn via Slack and continue deployment. For detailed specifics on load testing and this convention, please see the relevant documentation: [load-testing-docs]: /tests/load/README.md].
+## Load Testing
+Load testing can be run locally or as a part of the deployment process. Local execution does not require any labeling in commit messages. For deployment, you have to add a label to your commit messages in the form of: `[load test: (abort|warn)]`.
+Abort will prevent deployment should the load testing fail while warn will simply warn via Slack and continue deployment. For detailed specifics on load testing and this convention, please see the relevant documentation: [load-testing-docs]: /tests/load/README.md].
 
 ## Releasing to production
 Developers with write access to the Merino repository can initiate a deployment to production after a Pull-Request on the Merino GitHub repository is merged to the `main` branch.

--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -8,6 +8,20 @@ This directory contains source code for the load tests for Merino.
 * [Merino Load Test History][merino_history_doc]
 * [Merino Load Test Spreadsheet][merino_spreadsheet]
 
+## Opt-In Execution in Staging
+
+To automatically kick off load testing in staging along with your pull request commit, you have to include
+a signal tag in your git commit. This tag is in the form of: `[load test: (abort|warn)]`. Take careful note
+of correct syntax and spacing within the tag. There are two options for load tests, being `abort` and `warn`.
+
+The abort flag will prevent a stage deployment should the load test fail.
+Ex. `feat: Add feature ABC [load test: warn]`.
+
+The warn flag will output a Slack warning should the load test fail, but still allow for the stage deployment.
+Ex. `feat: Add feature XYZ [load test: abort]`.
+
+The commit tag signals load test instructions to Jenkins by modifying the Docker image tag name. The convention looks as follows:
+`^(?P<environment>stage|prod)(?:-(?P<task>\w+)-(?P<onfailure>warn|abort))?-(?P<commit>[a-z0-9]+)$`
 
 ## Local Execution
 

--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -11,16 +11,16 @@ This directory contains source code for the load tests for Merino.
 ## Opt-In Execution in Staging
 
 To automatically kick off load testing in staging along with your pull request commit, you have to include
-a signal tag in your git commit. This tag is in the form of: `[load test: (abort|warn)]`. Take careful note
-of correct syntax and spacing within the tag. There are two options for load tests, being `abort` and `warn`.
+a label in your git commit. This must be the merge commit on the `main` branch, since only the most recent commit is checked for the label. This label is in the form of: `[load test: (abort|warn)]`. Take careful note
+of correct syntax and spacing within the label. There are two options for load tests, being `abort` and `warn`.
 
-The abort flag will prevent a stage deployment should the load test fail.
-Ex. `feat: Add feature ABC [load test: warn]`.
+The `abort` label will prevent a `prod` deployment should the load test fail.
+Ex. `feat: Add feature ABC [load test: abort]`.
 
-The warn flag will output a Slack warning should the load test fail, but still allow for the stage deployment.
-Ex. `feat: Add feature XYZ [load test: abort]`.
+The `warn` label will output a Slack warning should the load test fail, but still allow for `prod` deployment.
+Ex. `feat: Add feature XYZ [load test: warn]`.
 
-The commit tag signals load test instructions to Jenkins by modifying the Docker image tag name. The convention looks as follows:
+The commit tag signals load test instructions to Jenkins by modifying the Docker image tag. The Jenkins deployment workflow first deploys to `stage` and then runs load tests if requested. The Docker image tag passed to Jenkins appears as follows:
 `^(?P<environment>stage|prod)(?:-(?P<task>\w+)-(?P<onfailure>warn|abort))?-(?P<commit>[a-z0-9]+)$`.
 
 ## Local Execution

--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -21,7 +21,7 @@ The warn flag will output a Slack warning should the load test fail, but still a
 Ex. `feat: Add feature XYZ [load test: abort]`.
 
 The commit tag signals load test instructions to Jenkins by modifying the Docker image tag name. The convention looks as follows:
-`^(?P<environment>stage|prod)(?:-(?P<task>\w+)-(?P<onfailure>warn|abort))?-(?P<commit>[a-z0-9]+)$`
+`^(?P<environment>stage|prod)(?:-(?P<task>\w+)-(?P<onfailure>warn|abort))?-(?P<commit>[a-z0-9]+)$`.
 
 ## Local Execution
 


### PR DESCRIPTION
# Description
* Add tagging functionality to trigger load tests.
The tag should take the form [load test: (abort|warn)]. 
The abort flag will prevent a stage deployment should the load test fail. 
The warn flag will output a Slack warning should the load test fail, but still allow for the stage deployment.

# Changes
* Added shell script commands
* Annotated commands with comments
* Updated contributing docs
* Updated load test docs.
* Updated release-process.md docs

# Issue(s)
#222 | [DISCO-2254](https://mozilla-hub.atlassian.net/browse/DISCO-2254)

[DISCO-2254]: https://mozilla-hub.atlassian.net/browse/DISCO-2254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ