### PR TITLE
Initialize the Elasticsearch client with URL

### DIFF
--- a/docs/ops.md
+++ b/docs/ops.md
@@ -293,6 +293,9 @@ These are production providers that generate suggestions.
     Either `elasticsearch` or `test`.
   - `es_cloud_id` (`MERINO_PROVIDERS__WIKIPEDIA__ES_CLOUD_ID`) - The Cloud ID of the
     Elasticsearch cluster.
+  - `es_url` (`MERINO_PROVIDERS__WIKIPEDIA__ES_URL`) - The URL of the cluster that we
+    want to connect to. This takes precedent over the Cloud ID (i.e. if you pass both,
+    we will choose the URL over the Cloud ID.).
   - `es_api_key` (`MERINO_PROVIDERS__WIKIPEDIA__ES_API_KEY`) - The base64 key used to
     authenticate on the Elasticsearch cluster specified by `es_cloud_id`.
   - `es_index` (`MERINO_PROVIDERS__WIKIPEDIA__ES_INDEX`) - The index identifier

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -129,6 +129,9 @@ es_cloud_id = """
   testing:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyRjZWM2ZjI2MWE3NGJmMjRjZ
   TMzYmI4ODExYjg0Mjk0ZiRjNmMyY2E2ZDA0MjI0OWFmMGNjN2Q3YTllOTYyNTc0Mw==
 """
+# The URL of the cluster that we want to connect to
+es_url = ""
+# The base64 key used to authenticate on the Elasticsearch cluster
 es_api_key = ""
 # Elasticsearch index
 es_index = "enwiki-v1"

--- a/merino/providers/manager.py
+++ b/merino/providers/manager.py
@@ -106,6 +106,7 @@ def _create_provider(provider_id: str, setting: Settings) -> BaseProvider:
                     ElasticBackend(
                         api_key=setting.es_api_key,
                         cloud_id=setting.es_cloud_id,
+                        url=setting.es_url,
                     )
                 )  # type: ignore [arg-type]
                 if setting.backend == "elasticsearch"

--- a/tests/unit/providers/wikipedia/backends/test_elastic.py
+++ b/tests/unit/providers/wikipedia/backends/test_elastic.py
@@ -7,7 +7,11 @@ from pytest_mock import MockerFixture
 
 from merino.config import settings
 from merino.exceptions import BackendError
-from merino.providers.wikipedia.backends.elastic import SUGGEST_ID, ElasticBackend
+from merino.providers.wikipedia.backends.elastic import (
+    SUGGEST_ID,
+    ElasticBackend,
+    ElasticBackendError,
+)
 
 
 @pytest.fixture(name="es_backend")
@@ -16,6 +20,25 @@ def fixture_es_backend() -> ElasticBackend:
     return ElasticBackend(
         cloud_id=settings.providers.wikipedia.es_cloud_id,
         api_key=settings.providers.wikipedia.es_api_key,
+    )
+
+
+def test_es_backend_initialize_with_url():
+    """Test that backend initializes when we pass a URL."""
+    backend = ElasticBackend(
+        url="https://localhost:9200",
+        api_key=settings.providers.wikipedia.es_api_key,
+    )
+    assert backend
+
+
+def test_es_backend_initialize_error():
+    """Test that the backend errors out when we initialize it without URL or cloud id."""
+    with pytest.raises(ElasticBackendError) as eb_error:
+        ElasticBackend(api_key=settings.providers.wikipedia.es_api_key)
+    assert (
+        "Require one of {url, cloud_id} to initialize Elasticsearch client."
+        == eb_error.value.args[0]
     )
 
 


### PR DESCRIPTION
I'm saving the cloud id path just in case we want to still have it used for staging. It should be removed when we have some local development set up that involves a docker bootstrapped version of Elasticsearch.