### PR TITLE
Allow Indexer job to configure URL Elasticsearch connection

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -129,7 +129,9 @@ es_cloud_id = """
   testing:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyRjZWM2ZjI2MWE3NGJmMjRjZ
   TMzYmI4ODExYjg0Mjk0ZiRjNmMyY2E2ZDA0MjI0OWFmMGNjN2Q3YTllOTYyNTc0Mw==
 """
-# The URL of the cluster that we want to connect to
+# The URL of the cluster that we want to connect to.
+# This takes precedent over the Cloud ID (i.e. if you pass both,
+# we will choose the URL over the Cloud ID).
 es_url = ""
 # The base64 key used to authenticate on the Elasticsearch cluster
 es_api_key = ""
@@ -145,6 +147,10 @@ score = 0.23
 
 
 [default.jobs.wikipedia_indexer]
+# The URL of the Elasticsearch cluster for indexing job.
+# This takes precedent over the Cloud ID (i.e. if you pass both,
+# we will choose the URL over the Cloud ID).
+es_url = ""
 # Elasticsearch cloud ID for indexing job
 es_cloud_id = ""
 # Elasticsearch API key for indexing job

--- a/merino/jobs/wikipedia_indexer/__init__.py
+++ b/merino/jobs/wikipedia_indexer/__init__.py
@@ -2,12 +2,14 @@
 import logging
 
 import typer
-from elasticsearch import Elasticsearch
 
 from merino.config import settings as config
 from merino.jobs.wikipedia_indexer.filemanager import FileManager
 from merino.jobs.wikipedia_indexer.indexer import Indexer
-from merino.jobs.wikipedia_indexer.util import create_blocklist
+from merino.jobs.wikipedia_indexer.util import (
+    create_blocklist,
+    create_elasticsearch_client,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +43,7 @@ indexer_cmd = typer.Typer(
 
 @indexer_cmd.command()
 def index(
+    elasticsearch_url: str = job_settings.es_url,
     elasticsearch_cloud_id: str = job_settings.es_cloud_id,
     elasticsearch_api_key: str = job_settings.es_api_key,
     elasticsearch_alias: str = job_settings.es_alias,
@@ -51,10 +54,8 @@ def index(
     gcp_project: str = gcp_project_option,
 ):
     """Index file from GCS to Elasticsearch"""
-    es_client = Elasticsearch(
-        cloud_id=elasticsearch_cloud_id,
-        api_key=elasticsearch_api_key,
-        request_timeout=60,
+    es_client = create_elasticsearch_client(
+        elasticsearch_url, elasticsearch_cloud_id, elasticsearch_api_key
     )
 
     file_manager = FileManager(gcs_path, gcp_project, "")

--- a/merino/jobs/wikipedia_indexer/util.py
+++ b/merino/jobs/wikipedia_indexer/util.py
@@ -4,6 +4,7 @@ from io import StringIO
 from logging import Logger
 
 import requests
+from elasticsearch import Elasticsearch
 
 
 class ProgressReporter:
@@ -50,3 +51,23 @@ def create_blocklist(blocklist_file_url: str) -> set[str]:
     file_like_io = StringIO(block_list)
     csv_reader = csv.DictReader(file_like_io, delimiter=",")
     return set(row["name"] for row in csv_reader)
+
+
+def create_elasticsearch_client(
+    elasticsearch_url: str,
+    elasticsearch_cloud_id: str,
+    elasticsearch_api_key: str,
+) -> Elasticsearch:
+    """Create the Elasticsearch client."""
+    if elasticsearch_url:
+        return Elasticsearch(
+            elasticsearch_url,
+            api_key=elasticsearch_api_key,
+            request_timeout=60,
+        )
+
+    return Elasticsearch(
+        cloud_id=elasticsearch_cloud_id,
+        api_key=elasticsearch_api_key,
+        request_timeout=60,
+    )

--- a/tests/unit/jobs/wikipedia_indexer/test_utils.py
+++ b/tests/unit/jobs/wikipedia_indexer/test_utils.py
@@ -2,11 +2,18 @@
 
 
 import logging
+from unittest.mock import ANY
 
 import pytest
+from elasticsearch import Elasticsearch
 from pytest import LogCaptureFixture
+from pytest_mock import MockerFixture
 
-from merino.jobs.wikipedia_indexer.util import ProgressReporter, create_blocklist
+from merino.jobs.wikipedia_indexer.util import (
+    ProgressReporter,
+    create_blocklist,
+    create_elasticsearch_client,
+)
 
 
 @pytest.fixture()
@@ -64,3 +71,43 @@ def test_progress_reporter(
         else:
             assert len(caplog.records) == 1
             assert caplog.records[0].message == f"Test progress: {expected_perc}%"
+
+
+def test_create_elasticsearch_client_url(mocker: MockerFixture):
+    """Test that Elasticsearch client is created with the URL."""
+    es_new_mock = mocker.patch.object(Elasticsearch, "__new__")
+
+    api_key = "mMyY2E2ZDA0MjI0OWFmMGNjN2Q3YTllOTYyNTc0Mw=="
+    url = "http://localhost:9200"
+
+    # Have the cloud id for checking that it doesn't get called with this.
+    cloud_id = (
+        "testing:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyRjZ"
+        "WM2ZjI2MWE3NGJmMjRjZTMzYmI4ODExYjg0Mjk0Zi"
+        "RjNmMyY2E2ZDA0MjI0OWFmMGNjN2Q3YTllOTYyNTc0Mw=="
+    )
+
+    create_elasticsearch_client(url, cloud_id, api_key)
+
+    # First argument is "self", which I've stubbed with ANY
+    es_new_mock.assert_called_with(ANY, url, api_key=api_key, request_timeout=60)
+
+
+def test_create_elasticsearch_client_cloud_id(mocker: MockerFixture):
+    """Test that Elasticsearch client is created with the Cloud."""
+    es_new_mock = mocker.patch.object(Elasticsearch, "__new__")
+
+    api_key = "mMyY2E2ZDA0MjI0OWFmMGNjN2Q3YTllOTYyNTc0Mw=="
+    url = ""
+    cloud_id = (
+        "testing:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyRjZ"
+        "WM2ZjI2MWE3NGJmMjRjZTMzYmI4ODExYjg0Mjk0Zi"
+        "RjNmMyY2E2ZDA0MjI0OWFmMGNjN2Q3YTllOTYyNTc0Mw=="
+    )
+
+    create_elasticsearch_client(url, cloud_id, api_key)
+
+    # First argument is "self", which I've stubbed with ANY
+    es_new_mock.assert_called_with(
+        ANY, cloud_id=cloud_id, api_key=api_key, request_timeout=60
+    )


### PR DESCRIPTION
This change will allow us to use the Elasticsearch URL if it is configured. If it doesn't exist, then fallback to using the Cloud ID.

@quiiver You should be able to configure the URL either with command line: `--elasticsearch_url` or setting the environment variable `MERINO__JOBS__WIKIPEDIA_INDEXER__ES_URL`.