### PR TITLE
fix: update dependency for docker-image-publish-merino-locust to docker-image-publish-stage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,10 +73,7 @@ workflows:
       - docker-image-publish-merino-locust:
           <<: *main-filters
           requires:
-            - checks
-            - unit-tests
-            - integration-tests
-            - test-coverage-check
+            - docker-image-publish-stage
       # The following job will require manual approval in the CircleCI web application.
       # Once provided, and when all the requirements are fullfilled (e.g. tests)
       - unhold-to-deploy-to-prod:


### PR DESCRIPTION
# Description
- update dependency for docker-image-publish-merino-locust to docker-image-publish-stage

# Issue(s)
#224 | [DISCO-2274](https://mozilla-hub.atlassian.net/browse/DISCO-2274)

[DISCO-2274]: https://mozilla-hub.atlassian.net/browse/DISCO-2274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ