### PR TITLE
Add Merino Jobs Operational Documentation [do not deploy]

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -6,7 +6,6 @@
 
 - [Using the HTTP API](./api.md)
 - [Configuring Firefox and Merino Environments](./firefox.md)
-- [Configuring Merino (Operations)](./ops.md)
 - [Data collection](./data.md)
 - [Working on the code](./dev/index.md)
   - [Content Moderation](./dev/content-moderation.md)
@@ -17,3 +16,7 @@
   - [Testing Strategies](./dev/testing.md)
   - [Release Process](./dev/release-process.md)
   - [Profiling](./dev/profiling.md)
+- [Operations](./operations/index.md)
+  - [Configs](./operations/configs.md)
+  - [Elasticsearch](./operations/elasticsearch.md)
+  - [Jobs](./operations/jobs.md)

--- a/docs/dev/index.md
+++ b/docs/dev/index.md
@@ -129,7 +129,7 @@ pretty-print logging and debugging enabled. For settings that you wish to change
 development configuration, you have two options, listed below.
 
 > For full details, make sure to check out the documentation for
-> [Merino's setting system (ops.md)](../ops.md).
+> [Merino's setting system (operations/configs.md)](../operations/configs.md).
 
 ### Update the defaults
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -14,9 +14,6 @@ for more details.
 Merino in Firefox and lists the endpoints for the service in Production,
 State and Dev.
 
-[ops.md - Configuring Merino - Operations][3] describes configuration management
-of the project, Dynaconf setup, and the configuration of the HTTP server, logging, metrics, Remote Settings, and Sentry.
-
 [data.md - Data, Metrics, Logging][4] describes all metrics and logs.
 
 [dev/index.md - Basic Developer Docs][5] describes basics of working on Merino.
@@ -32,9 +29,18 @@ dependencies required for Merino.
 
 [dev/profiling.md - Profiling][10] describes how to profile Merino to address performance issues.
 
+[operations/configs.md - Configuring Merino][3] describes configuration management
+of the project, Dynaconf setup, and the configuration of the HTTP server, logging, metrics, Remote Settings, and Sentry.
+
+[operations/elasticsearch.md - Elasticsearch Operations][11] describes some functionality and operations that
+we do on the Elasticsearch cluster.
+
+[operations/jobs.md - Merino Jobs][12] describes the jobs that are configured in Merino. Indicate where the jobs
+exist and link to the details for how the jobs are run.
+
 [1]: ./api.md
 [2]: ./firefox.md
-[3]: ./ops.md
+[3]: ./operations/configs.md
 [4]: ./data.md
 [5]: ./dev/index.md
 [6]: ./dev/dependencies.md
@@ -42,6 +48,8 @@ dependencies required for Merino.
 [8]: ./dev/release-process.md
 [9]: ./dev/testing.md
 [10]: ./dev/profiling.md
+[11]: ./operations/elasticsearch.md
+[12]: ./operations/jobs.md
 
 ## Architecture
 

--- a/docs/operations/configs.md
+++ b/docs/operations/configs.md
@@ -307,28 +307,4 @@ These are production providers that generate suggestions.
   - `score` (`MERINO_PROVIDERS__WIKIPEDIA__SCORE`) - The ranking score for this provider
     as a floating point number. Defaults to 0.23.
 
-[log]:../merino/config_logging.py
-
-
-### Elasticsearch Index Policy
-
-We want to ensure that the index expire after 3 months,
-so we need to add a lifecycle policy for this deletion to happen.
-
-The command to run in Kibana to add this policy:
-
-```
-PUT _ilm/policy/enwiki_policy
-{
-  "policy": {
-    "phases": {
-      "delete": {
-        "min_age": "90d",
-        "actions": {
-          "delete": {}
-        }
-      }
-    }
-  }
-}
-```
+[log]:../../merino/config_logging.py

--- a/docs/operations/elasticsearch.md
+++ b/docs/operations/elasticsearch.md
@@ -1,0 +1,27 @@
+# Elasticsearch Operations
+
+We use Elasticsearch as a source of data for one of our providers.
+This page documents some of the commands that we want to run on the cluster.
+
+### Elasticsearch Index Policy
+
+We want to ensure that the index expire after 30 days,
+so we need to add a lifecycle policy for this deletion to happen.
+
+The command to run in Kibana to add this policy:
+
+```
+PUT _ilm/policy/enwiki_policy
+{
+  "policy": {
+    "phases": {
+      "delete": {
+        "min_age": "30d",
+        "actions": {
+          "delete": {}
+        }
+      }
+    }
+  }
+}
+```

--- a/docs/operations/index.md
+++ b/docs/operations/index.md
@@ -1,0 +1,6 @@
+# Operations
+
+This is where we put operational documentation for Merino.
+
+
+

--- a/docs/operations/jobs.md
+++ b/docs/operations/jobs.md
@@ -1,0 +1,20 @@
+# Merino Jobs Operations
+
+## Dynamic Wikipedia
+
+Merino currently builds the Elasticsearch indexing job that runs in Airflow.
+Airflow takes the `latest` image built as the base image.
+The reasons to keep the job code close to the application code are:
+
+1. Data models can be shared between the indexing job and application more easily. 
+   This means that data migrations will be simpler.
+2. All the logic regarding Merino functionality can be found in one place.
+3. Eliminates unintended differences in functionality due to dependency mismatch.
+
+### Where to find and modify the jobs
+
+The job is configured in [`telemetry-airflow`](https://github.com/mozilla/telemetry-airflow).
+
+You can access the job in the 
+[Airflow Console](https://workflow.telemetry.mozilla.org/dags/merino_jobs/grid?search=merino_jobs).
+


### PR DESCRIPTION
Adding and refactoring the documentations so that we are explicit about Merino Jobs operations. [do not deploy]