### PR TITLE
[DISCO-2292] Add query string normalization to Merino

### DIFF
--- a/merino/providers/adm/backends/fake_backends.py
+++ b/merino/providers/adm/backends/fake_backends.py
@@ -3,7 +3,7 @@
 from merino.providers.adm.backends.protocol import SuggestionContent
 
 
-class FakeAdmBackend:
+class FakeAdmBackend:  # pragma: no cover
     """A fake backend that always returns empty results."""
 
     async def fetch(self) -> SuggestionContent:

--- a/merino/providers/adm/provider.py
+++ b/merino/providers/adm/provider.py
@@ -125,7 +125,7 @@ class Provider(BaseProvider):
 
     def _normalize_query(self, query: str) -> str:
         """Convert a query string to lowercase and remove trailing spaces."""
-        return query.rstrip().lower()
+        return query.strip().lower()
 
     async def query(self, srequest: SuggestionRequest) -> list[BaseSuggestion]:
         """Provide suggestion for a given query."""

--- a/merino/providers/adm/provider.py
+++ b/merino/providers/adm/provider.py
@@ -123,16 +123,13 @@ class Provider(BaseProvider):
     def hidden(self) -> bool:  # noqa: D102
         return False
 
-    def normalize_query(self, query: str) -> str:
-        """Normalize the query string when passed to the provider.
-        For AdM, queries should be case-insensitive and trailing space should
-        be removed.
-        """
+    def _normalize_query(self, query: str) -> str:
+        """Convert a query string to lowercase and remove trailing spaces."""
         return query.rstrip().lower()
 
     async def query(self, srequest: SuggestionRequest) -> list[BaseSuggestion]:
         """Provide suggestion for a given query."""
-        q: str = self.normalize_query(srequest.query)
+        q: str = self._normalize_query(srequest.query)
         if (suggest_look_ups := self.suggestion_content.suggestions.get(q)) is not None:
             results_id, fkw_id = suggest_look_ups
             res = self.suggestion_content.results[results_id]

--- a/merino/providers/adm/provider.py
+++ b/merino/providers/adm/provider.py
@@ -129,7 +129,7 @@ class Provider(BaseProvider):
 
     async def query(self, srequest: SuggestionRequest) -> list[BaseSuggestion]:
         """Provide suggestion for a given query."""
-        q: str = self.normalize_query(srequest.query)
+        q: str = srequest.query
         if (suggest_look_ups := self.suggestion_content.suggestions.get(q)) is not None:
             results_id, fkw_id = suggest_look_ups
             res = self.suggestion_content.results[results_id]

--- a/merino/providers/adm/provider.py
+++ b/merino/providers/adm/provider.py
@@ -125,7 +125,7 @@ class Provider(BaseProvider):
 
     def normalize_query(self, query: str) -> str:
         """Normalize the query string when passed to the provider.
-        For AdM, queries should be case-insensitive and tailing space should
+        For AdM, queries should be case-insensitive and trailing space should
         be removed.
         """
         return query.rstrip().lower()

--- a/merino/providers/adm/provider.py
+++ b/merino/providers/adm/provider.py
@@ -123,9 +123,16 @@ class Provider(BaseProvider):
     def hidden(self) -> bool:  # noqa: D102
         return False
 
+    def normalize_query(self, query: str) -> str:
+        """Normalize the query string when passed to the provider.
+        For AdM, queries should be case-insensitive and tailing space should
+        be removed.
+        """
+        return query.rstrip().lower()
+
     async def query(self, srequest: SuggestionRequest) -> list[BaseSuggestion]:
         """Provide suggestion for a given query."""
-        q = srequest.query
+        q: str = self.normalize_query(srequest.query)
         if (suggest_look_ups := self.suggestion_content.suggestions.get(q)) is not None:
             results_id, fkw_id = suggest_look_ups
             res = self.suggestion_content.results[results_id]

--- a/merino/providers/adm/provider.py
+++ b/merino/providers/adm/provider.py
@@ -123,13 +123,13 @@ class Provider(BaseProvider):
     def hidden(self) -> bool:  # noqa: D102
         return False
 
-    def _normalize_query(self, query: str) -> str:
+    def normalize_query(self, query: str) -> str:
         """Convert a query string to lowercase and remove trailing spaces."""
         return query.strip().lower()
 
     async def query(self, srequest: SuggestionRequest) -> list[BaseSuggestion]:
         """Provide suggestion for a given query."""
-        q: str = self._normalize_query(srequest.query)
+        q: str = self.normalize_query(srequest.query)
         if (suggest_look_ups := self.suggestion_content.suggestions.get(q)) is not None:
             results_id, fkw_id = suggest_look_ups
             res = self.suggestion_content.results[results_id]

--- a/merino/providers/base.py
+++ b/merino/providers/base.py
@@ -57,16 +57,16 @@ class BaseProvider(ABC):
         """
         ...
 
-    def normalize_query(self, query: str) -> str:  # pragma: no cover
+    def _normalize_query(self, query: str) -> str:  # pragma: no cover
         """Normalize the query string when passed to the provider.
         Each provider can extend this class given its requirements. Can be used to
-        strip whitespace, handle case sensitivity, etc. Default is no-op.
+        strip whitespace, handle case sensitivity, etc. Default is to return query unchanged.
 
         Trailing spaces are not stripped in Firefox, so stripping trailing spaces
         is advised. Each provider will have its specific use cases, and others
         will not require any logic for query normalization.
         """
-        ...
+        return query
 
     @property
     def enabled_by_default(self) -> bool:

--- a/merino/providers/base.py
+++ b/merino/providers/base.py
@@ -35,23 +35,36 @@ class BaseProvider(ABC):
     _query_timeout_sec: float = settings.runtime.query_timeout_sec
 
     @abstractmethod
-    async def initialize(self) -> None:
+    async def initialize(self) -> None:  # pragma: no cover
         """Abstract method for defining an initialize method for bootstrapping the Provider.
         This allows us to use Async API's within as well as initialize providers in parallel
 
         """
         ...
 
-    async def shutdown(self) -> None:
+    async def shutdown(self) -> None:  # pragma: no cover
         """Shut down the Provider. The default implementaion is no-op."""
         return
 
     @abstractmethod
-    async def query(self, srequest: SuggestionRequest) -> list[BaseSuggestion]:
+    async def query(
+        self, srequest: SuggestionRequest
+    ) -> list[BaseSuggestion]:  # pragma: no cover
         """Query against this provider.
 
         Args:
           - `srequest`: the suggestion request.
+        """
+        ...
+
+    def normalize_query(self, query: str) -> str:  # pragma: no cover
+        """Normalize the query string when passed to the provider.
+        Each provider can extend this class given its requirements. Can be used to
+        strip whitespace, handle case sensitivity, etc. Default is no-op.
+
+        Trailing spaces are not stripped in Firefox, so stripping trailing spaces
+        is advised. Each provider will have its specific use cases, and others
+        will not require any logic for query normalization.
         """
         ...
 

--- a/merino/providers/base.py
+++ b/merino/providers/base.py
@@ -57,7 +57,7 @@ class BaseProvider(ABC):
         """
         ...
 
-    def _normalize_query(self, query: str) -> str:  # pragma: no cover
+    def normalize_query(self, query: str) -> str:  # pragma: no cover
         """Normalize the query string when passed to the provider.
         Each provider can extend this class given its requirements. Can be used to
         strip whitespace, handle case sensitivity, etc. Default is to return query unchanged.

--- a/merino/providers/top_picks/backends/top_picks.py
+++ b/merino/providers/top_picks/backends/top_picks.py
@@ -77,7 +77,7 @@ class TopPicksBackend:
 
         for record in domain_list["domains"]:
             index_key: int = len(results)
-            domain = record["domain"]
+            domain = record["domain"].strip().lower()
 
             if len(domain) > query_max:
                 query_max = len(domain)

--- a/merino/providers/top_picks/provider.py
+++ b/merino/providers/top_picks/provider.py
@@ -52,6 +52,13 @@ class Provider(BaseProvider):
     def hidden(self) -> bool:  # noqa: D102
         return False
 
+    def normalize_query(self, query: str) -> str:
+        """Normalize the query string when passed to the provider.
+        For Top Picks, queries should be case-insensitive and tailing space should
+        be removed.
+        """
+        return query.rstrip().lower()
+
     async def query(self, srequest: SuggestionRequest) -> list[BaseSuggestion]:
         """Query Top Pick data and return suggestions."""
         # Ignore https:// and http://
@@ -59,7 +66,7 @@ class Provider(BaseProvider):
             return []
 
         qlen: int = len(srequest.query)
-        query: str = srequest.query.lower()
+        query: str = self.normalize_query(srequest.query)
         ids: Optional[list[int]]
 
         match qlen:

--- a/merino/providers/top_picks/provider.py
+++ b/merino/providers/top_picks/provider.py
@@ -63,7 +63,7 @@ class Provider(BaseProvider):
             return []
 
         qlen: int = len(srequest.query)
-        query: str = self.normalize_query(srequest.query)
+        query: str = srequest.query
         ids: Optional[list[int]]
 
         match qlen:

--- a/merino/providers/top_picks/provider.py
+++ b/merino/providers/top_picks/provider.py
@@ -54,7 +54,7 @@ class Provider(BaseProvider):
 
     def _normalize_query(self, query: str) -> str:
         """Convert a query string to lowercase and remove trailing spaces."""
-        return query.rstrip().lower()
+        return query.strip().lower()
 
     async def query(self, srequest: SuggestionRequest) -> list[BaseSuggestion]:
         """Query Top Pick data and return suggestions."""

--- a/merino/providers/top_picks/provider.py
+++ b/merino/providers/top_picks/provider.py
@@ -54,7 +54,7 @@ class Provider(BaseProvider):
 
     def normalize_query(self, query: str) -> str:
         """Normalize the query string when passed to the provider.
-        For Top Picks, queries should be case-insensitive and tailing space should
+        For Top Picks, queries should be case-insensitive and trailing space should
         be removed.
         """
         return query.rstrip().lower()

--- a/merino/providers/top_picks/provider.py
+++ b/merino/providers/top_picks/provider.py
@@ -52,11 +52,8 @@ class Provider(BaseProvider):
     def hidden(self) -> bool:  # noqa: D102
         return False
 
-    def normalize_query(self, query: str) -> str:
-        """Normalize the query string when passed to the provider.
-        For Top Picks, queries should be case-insensitive and trailing space should
-        be removed.
-        """
+    def _normalize_query(self, query: str) -> str:
+        """Convert a query string to lowercase and remove trailing spaces."""
         return query.rstrip().lower()
 
     async def query(self, srequest: SuggestionRequest) -> list[BaseSuggestion]:
@@ -66,7 +63,7 @@ class Provider(BaseProvider):
             return []
 
         qlen: int = len(srequest.query)
-        query: str = self.normalize_query(srequest.query)
+        query: str = self._normalize_query(srequest.query)
         ids: Optional[list[int]]
 
         match qlen:

--- a/merino/providers/top_picks/provider.py
+++ b/merino/providers/top_picks/provider.py
@@ -59,7 +59,7 @@ class Provider(BaseProvider):
             return []
 
         qlen: int = len(srequest.query)
-        query: str = srequest.query
+        query: str = srequest.query.lower()
         ids: Optional[list[int]]
 
         match qlen:

--- a/merino/providers/top_picks/provider.py
+++ b/merino/providers/top_picks/provider.py
@@ -52,7 +52,7 @@ class Provider(BaseProvider):
     def hidden(self) -> bool:  # noqa: D102
         return False
 
-    def _normalize_query(self, query: str) -> str:
+    def normalize_query(self, query: str) -> str:
         """Convert a query string to lowercase and remove trailing spaces."""
         return query.strip().lower()
 
@@ -63,7 +63,7 @@ class Provider(BaseProvider):
             return []
 
         qlen: int = len(srequest.query)
-        query: str = self._normalize_query(srequest.query)
+        query: str = self.normalize_query(srequest.query)
         ids: Optional[list[int]]
 
         match qlen:

--- a/merino/providers/weather/backends/fake_backends.py
+++ b/merino/providers/weather/backends/fake_backends.py
@@ -5,7 +5,7 @@ from merino.middleware.geolocation import Location
 from merino.providers.weather.backends.protocol import WeatherReport
 
 
-class FakeWeatherBackend:
+class FakeWeatherBackend:  # pragma: no cover
     """A fake backend that always returns empty results."""
 
     def cache_inputs_for_weather_report(self, geolocation: Location) -> Optional[bytes]:

--- a/merino/providers/wikipedia/backends/fake_backends.py
+++ b/merino/providers/wikipedia/backends/fake_backends.py
@@ -35,7 +35,7 @@ class FakeEchoWikipediaBackend:
         ]
 
 
-class FakeExceptionWikipediaBackend:
+class FakeExceptionWikipediaBackend:  # pragma: no cover
     """A fake backend that raises a `BackendError` for any given query."""
 
     async def shutdown(self) -> None:

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -85,12 +85,11 @@ async def suggest(
     else:
         search_from = default_providers
 
-    srequest = SuggestionRequest(
-        query=q, geolocation=request.scope[ScopeKey.GEOLOCATION]
-    )
-
     lookups: list[Task] = []
     for p in search_from:
+        srequest = SuggestionRequest(
+            query=p.normalize_query(q), geolocation=request.scope[ScopeKey.GEOLOCATION]
+        )
         task = metrics_client.timeit_task(
             p.query(srequest), f"providers.{p.name}.query"
         )

--- a/tests/integration/api/v1/suggest/test_suggest_top_picks.py
+++ b/tests/integration/api/v1/suggest/test_suggest_top_picks.py
@@ -53,9 +53,11 @@ def fixture_providers(
     return {"top_picks": Provider(backend=backend, **top_picks_parameters)}
 
 
-@pytest.mark.parametrize("query", ["exam", "exxa", "example"])
+@pytest.mark.parametrize("query", ["exam", "exxa", "example", "Exam", "EXAM", "EXXa"])
 def test_top_picks_query(client: TestClient, query: str) -> None:
-    """Test if Top Picks provider returns result for indexed Top Pick"""
+    """Test if Top Picks provider returns result for indexed Top Pick.
+    Also checks case insensitivity.
+    """
     expected_suggestion: list[Suggestion] = [
         Suggestion(
             block_id=0,

--- a/tests/integration/api/v1/suggest/test_suggest_top_picks.py
+++ b/tests/integration/api/v1/suggest/test_suggest_top_picks.py
@@ -126,3 +126,21 @@ def test_top_picks_short_domains(
 
     result = response.json()
     assert Suggestion(**result["suggestions"][0]) == expected_suggestion[0]
+
+
+@pytest.mark.parametrize(
+    ["query", "expected_title"], [("example  ", "Example"), ("EXAMPLE ", "Example")]
+)
+def test_query_normalization(
+    client: TestClient, query: str, expected_title: str
+) -> None:
+    """Test that the provider request is normalized, given a query term
+    that has space and uppercase characters, and returns a valid matching suggestion.
+    """
+    response = client.get(f"/api/v1/suggest?q={query}")
+    assert response.status_code == 200
+
+    result = response.json()
+    assert len(result["suggestions"]) == 1
+    assert result["suggestions"][0]["title"] == expected_title
+    assert result["request_id"] is not None

--- a/tests/integration/api/v1/suggest/test_suggest_top_picks.py
+++ b/tests/integration/api/v1/suggest/test_suggest_top_picks.py
@@ -126,21 +126,3 @@ def test_top_picks_short_domains(
 
     result = response.json()
     assert Suggestion(**result["suggestions"][0]) == expected_suggestion[0]
-
-
-@pytest.mark.parametrize(
-    ["query", "expected_title"], [("example  ", "Example"), ("EXAMPLE ", "Example")]
-)
-def test_query_normalization(
-    client: TestClient, query: str, expected_title: str
-) -> None:
-    """Test that the provider request is normalized, given a query term
-    that has trailing space and uppercase characters, and returns a valid matching suggestion.
-    """
-    response = client.get(f"/api/v1/suggest?q={query}")
-    assert response.status_code == 200
-
-    result = response.json()
-    assert len(result["suggestions"]) == 1
-    assert result["suggestions"][0]["title"] == expected_title
-    assert result["request_id"] is not None

--- a/tests/integration/api/v1/suggest/test_suggest_top_picks.py
+++ b/tests/integration/api/v1/suggest/test_suggest_top_picks.py
@@ -135,7 +135,7 @@ def test_query_normalization(
     client: TestClient, query: str, expected_title: str
 ) -> None:
     """Test that the provider request is normalized, given a query term
-    that has space and uppercase characters, and returns a valid matching suggestion.
+    that has trailing space and uppercase characters, and returns a valid matching suggestion.
     """
     response = client.get(f"/api/v1/suggest?q={query}")
     assert response.status_code == 200

--- a/tests/unit/providers/adm/test_provider.py
+++ b/tests/unit/providers/adm/test_provider.py
@@ -25,6 +25,21 @@ def test_hidden(adm: Provider) -> None:
     assert adm.hidden() is False
 
 
+@pytest.mark.parametrize(
+    ["query", "expected"],
+    [
+        ("FIREFOX    ", "firefox"),
+        ("ExAmPlE", "example"),
+        ("MozILLA  ", "mozilla"),
+    ],
+)
+def test_normalize_query(adm: Provider, query: str, expected: str) -> None:
+    """Test for the query normalization method to strip trailing space and
+    convert to lowercase.
+    """
+    assert adm.normalize_query(query) == expected
+
+
 @pytest.mark.asyncio
 async def test_initialize(
     adm: Provider, adm_suggestion_content: SuggestionContent

--- a/tests/unit/providers/adm/test_provider.py
+++ b/tests/unit/providers/adm/test_provider.py
@@ -91,7 +91,7 @@ async def test_initialize_remote_settings_failure(
     assert adm.last_fetch_at == 0
 
 
-@pytest.mark.parametrize("query", ["firefox", "FIREFOX", "FiREFox  "])
+@pytest.mark.parametrize("query", ["firefox"])
 @pytest.mark.asyncio
 async def test_query_success(
     srequest: SuggestionRequestFixture,

--- a/tests/unit/providers/adm/test_provider.py
+++ b/tests/unit/providers/adm/test_provider.py
@@ -43,14 +43,20 @@ async def test_initialize(
         ("EXAMPLE", "example"),
         ("ExAmPlE", "example"),
         ("example ", "example"),
+        (" example ", "example"),
+        ("  example", "example"),
         ("example   ", "example"),
+        ("   example   ", "example"),
     ],
     ids={
         "normalized",
         "uppercase",
         "mixed-case",
         "tail space",
+        "leading space",
+        "multi-leading space",
         "multi-tail space",
+        "leading and trailing space",
     },
 )
 def test_normalize_query(adm: Provider, query: str, expected: str) -> None:

--- a/tests/unit/providers/adm/test_provider.py
+++ b/tests/unit/providers/adm/test_provider.py
@@ -63,7 +63,7 @@ def test_normalize_query(adm: Provider, query: str, expected: str) -> None:
     """Test for the query normalization method to strip trailing space and
     convert to lowercase.
     """
-    assert adm._normalize_query(query) == expected
+    assert adm.normalize_query(query) == expected
 
 
 @pytest.mark.asyncio

--- a/tests/unit/providers/top_picks/test_provider.py
+++ b/tests/unit/providers/top_picks/test_provider.py
@@ -28,6 +28,21 @@ def test_hidden(top_picks: Provider) -> None:
     assert top_picks.hidden() is False
 
 
+@pytest.mark.parametrize(
+    ["query", "expected"],
+    [
+        ("FIREFOX    ", "firefox"),
+        ("ExAmPlE", "example"),
+        ("MozILLA  ", "mozilla"),
+    ],
+)
+def test_normalize_query(top_picks: Provider, query: str, expected: str) -> None:
+    """Test for the query normalization method to strip trailing space and
+    convert to lowercase.
+    """
+    assert top_picks.normalize_query(query) == expected
+
+
 @pytest.mark.asyncio
 async def test_initialize(top_picks: Provider, backend: TopPicksBackend) -> None:
     """Test initialization of top pick provider"""

--- a/tests/unit/providers/top_picks/test_provider.py
+++ b/tests/unit/providers/top_picks/test_provider.py
@@ -64,7 +64,7 @@ def test_normalize_query(top_picks: Provider, query: str, expected: str) -> None
     """Test for the query normalization method to strip trailing space and
     convert to lowercase.
     """
-    assert top_picks._normalize_query(query) == expected
+    assert top_picks.normalize_query(query) == expected
 
 
 @pytest.mark.asyncio

--- a/tests/unit/providers/top_picks/test_provider.py
+++ b/tests/unit/providers/top_picks/test_provider.py
@@ -44,14 +44,20 @@ async def test_initialize(top_picks: Provider, backend: TopPicksBackend) -> None
         ("EXAMPLE", "example"),
         ("ExAmPlE", "example"),
         ("example ", "example"),
+        (" example ", "example"),
+        ("  example", "example"),
         ("example   ", "example"),
+        ("   example   ", "example"),
     ],
     ids={
         "normalized",
         "uppercase",
         "mixed-case",
         "tail space",
+        "leading space",
+        "multi-leading space",
         "multi-tail space",
+        "leading and trailing space",
     },
 )
 def test_normalize_query(top_picks: Provider, query: str, expected: str) -> None:

--- a/tests/unit/providers/top_picks/test_provider.py
+++ b/tests/unit/providers/top_picks/test_provider.py
@@ -93,9 +93,6 @@ async def test_initialize_failure(
         ("exam", "Example", "https://example.com"),
         ("exxamp", "Example", "https://example.com"),
         ("example", "Example", "https://example.com"),
-        ("Exam", "Example", "https://example.com"),
-        ("EXAm", "Example", "https://example.com"),
-        ("ExAmPlE", "Example", "https://example.com"),
     ],
 )
 @pytest.mark.asyncio


### PR DESCRIPTION
# Description
## Add query string normalization to Merino
The navigational top picks and AdM suggestion lookups are only triggered if the keyword it's written in all lowercase. Upper case or mixed case keywords do not currently result in a lookup.

# Acceptance Criteria:

- Top Picks and AdM return suggestions irrespective of case, regardless of what character may or may not be capitalized in the query string.
- As an added precaution, ensure domain property is lowercased and stripped during indexing (top picks)
- Create a default implementation of` normalize_query()` in the Provider abstract class so providers can implement their own normalization logic, based on their unique needs.
- Add relevant testing

# Changes :
- Added `normalize_query()` class for `Provider`, is extended for AdM and Top Picks
- Added logic to top picks backend to strip and lowercase domains as an added layer of backup, should the json data have inaccuracies. 
- Added unit tests
- Added integration tests
- Added `# no cover` annotations in `base.py` for abstract classes

# Issue(s)
#240  | [DISCO-2292](https://mozilla-hub.atlassian.net/browse/DISCO-2292) | [Bugzilla-1806970](https://bugzilla.mozilla.org/show_bug.cgi?id=1806970)


[DISCO-2292]: https://mozilla-hub.atlassian.net/browse/DISCO-2292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ