### PR TITLE
[DISCO-2295] Add Pull Request Template to Merino-py [do not deploy]

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## References
+
+JIRA: [DISCO-TODO](https://mozilla-hub.atlassian.net/browse/DISCO-TODO)
+GitHub: [#TODO](https://github.com/mozilla-services/merino-py/issues/TODO)
+
+## Description
+<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->
+
+
+
+## PR Review Checklist
+
+_Put an `x` in the boxes that apply_
+
+- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
+- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
+- [ ] `[do not deploy]` and `[load test: (abort|warn)]` keywords are applied (if applicable)
+- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
+- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


### PR DESCRIPTION
## References

JIRA: [DISCO-2295](https://mozilla-hub.atlassian.net/browse/DISCO-2295)
GitHub: N/A

## Description
<!-- Detail the reason and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->
Proposal to add a PR template to this project. All ideas, modifications and suggestions welcome!

[Github - Creating a pull request template for your repository](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository)

Examples\Inspo:

- [fxa template](https://github.com/mozilla/fxa/blob/main/.github/PULL_REQUEST_TEMPLATE.md)
- firefox-ios
  - [template](https://github.com/mozilla-mobile/firefox-ios/blob/main/PULL_REQUEST_TEMPLATE)
  - [Pull Request Naming Guide](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [firefox-android template](https://github.com/mozilla-mobile/firefox-android/blob/main/.github/pull_request_template.md)
- [experimenter template](https://github.com/mozilla/experimenter/blob/main/PULL_REQUEST_TEMPLATE.md)
- [blurts-server template](https://github.com/mozilla/blurts-server/blob/main/.github/pull_request_template.md)

## DoD Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] `[do not deploy]` and `[load test: (abort|warn)]` keywords are applied (if applicable)
- [x] Documentation has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2295]: https://mozilla-hub.atlassian.net/browse/DISCO-2295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ