### PR TITLE
[DISCO-2274] Add 'latest' tag for merino load test docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -249,8 +249,10 @@ jobs:
             if [ -n "${DOCKER_TAG}" ]; then
               echo ${DOCKERHUB_MERINO_LOCUST_REPO}:${DOCKER_TAG}
               docker tag merino-locust ${DOCKERHUB_MERINO_LOCUST_REPO}:${DOCKER_TAG}
+              docker tag merino-locust ${DOCKERHUB_MERINO_LOCUST_REPO}:latest
               docker images
               docker push "${DOCKERHUB_MERINO_LOCUST_REPO}:${DOCKER_TAG}"
+              docker push "${DOCKERHUB_MERINO_LOCUST_REPO}:latest"
             else
               echo "Not pushing to dockerhub for tag=${CIRCLE_TAG} branch=${CIRCLE_BRANCH}"
             fi


### PR DESCRIPTION
## References

JIRA: [DISCO-2274](https://mozilla-hub.atlassian.net/browse/DISCO-2274)
GitHub: N/A

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->
- add 'latest' tag for merino load test docker image


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [x] `[do not deploy]` and `[load test: (abort|warn)]` keywords are applied (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2274]: https://mozilla-hub.atlassian.net/browse/DISCO-2274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ