### PR TITLE
Redirect home to docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -2,6 +2,10 @@
 
 This page describes the API endpoints available on Merino.
 
+You can also run the app and visit the /docs endpoint 
+(the home endpoint should also redirect here) for a labeled,
+interactive list of the endpoints and their inputs.
+
 ## Suggest
 
 Endpoint: `/api/v1/suggest`

--- a/merino/web/dockerflow.py
+++ b/merino/web/dockerflow.py
@@ -2,13 +2,17 @@
 import logging
 
 from fastapi import APIRouter, HTTPException
-from fastapi.responses import Response
+from fastapi.responses import Response, RedirectResponse
 
 from merino.utils.version import Version, fetch_app_version_from_file
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
 
+@router.get("/")
+async def redirect_home_to_docs():
+    response = RedirectResponse(url='/docs')
+    return response
 
 @router.get(
     "/__version__",

--- a/tests/integration/api/test_home.py
+++ b/tests/integration/api/test_home.py
@@ -1,0 +1,15 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Integration tests for the Merino home API endpoint."""
+
+from fastapi.testclient import TestClient
+
+def test_home__redirects_to_docs(client: TestClient) -> None:
+    """Test that the home endpoint redirects to the interactive documentation"""
+    home_response = client.get("/")
+    docs_response = client.get("/docs")
+
+    assert home_response.status_code == 200
+    assert home_response.content == docs_response.content


### PR DESCRIPTION
## Description

As Merino represents a critical piece of our workflow, it's helpful to leverage dynamic documentation to keep down the amount of doc maintenance _we_ have to do while allowing folks to explore, understand, and update the repo with ease.

FastAPI comes equipped with an interactive API explorer. This PR redirects Merino's root endpoint (currently unused, as far as I can tell) to the docs endpoint provided by FastAPI so folks can quickly find it after setting up Merino and can explore the endpoints from there. 

This was not requested by a ticket; it is, however, a living documentation step I take by default on FastAPI services, so I figured I'd submit it for review here. 

Static documentation also updated to indicate the existence of this resource. 

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[do not deploy]` and `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
