### PR TITLE
[DISCO-2236] AdM Provider Internal Server Error During Initialization

### DIFF
--- a/merino/providers/adm/provider.py
+++ b/merino/providers/adm/provider.py
@@ -82,6 +82,9 @@ class Provider(BaseProvider):
         self.score = score
         self.score_wikipedia = score_wikipedia
         self.resync_interval_sec = resync_interval_sec
+        self.suggestion_content = SuggestionContent(
+            suggestions={}, full_keywords=[], results=[], icons={}
+        )
         self._name = name
         self._enabled_by_default = enabled_by_default
         super().__init__(**kwargs)

--- a/tests/unit/providers/adm/conftest.py
+++ b/tests/unit/providers/adm/conftest.py
@@ -12,6 +12,17 @@ from merino.providers.adm.backends.protocol import AdmBackend, SuggestionContent
 from merino.providers.adm.provider import Provider
 
 
+@pytest.fixture(name="adm_uninitialized_suggestion_content")
+def fixture_adm_uninitialized_suggestion_content() -> SuggestionContent:
+    """Define empty suggestion content prior to provider initialization call."""
+    return SuggestionContent(
+        suggestions={},
+        full_keywords=[],
+        results=[],
+        icons={},
+    )
+
+
 @pytest.fixture(name="adm_suggestion_content")
 def fixture_adm_suggestion_content() -> SuggestionContent:
     """Define backend suggestion content for test."""

--- a/tests/unit/providers/adm/conftest.py
+++ b/tests/unit/providers/adm/conftest.py
@@ -12,17 +12,6 @@ from merino.providers.adm.backends.protocol import AdmBackend, SuggestionContent
 from merino.providers.adm.provider import Provider
 
 
-@pytest.fixture(name="adm_uninitialized_suggestion_content")
-def fixture_adm_uninitialized_suggestion_content() -> SuggestionContent:
-    """Define empty suggestion content prior to provider initialization call."""
-    return SuggestionContent(
-        suggestions={},
-        full_keywords=[],
-        results=[],
-        icons={},
-    )
-
-
 @pytest.fixture(name="adm_suggestion_content")
 def fixture_adm_suggestion_content() -> SuggestionContent:
     """Define backend suggestion content for test."""

--- a/tests/unit/providers/adm/test_provider.py
+++ b/tests/unit/providers/adm/test_provider.py
@@ -81,6 +81,7 @@ async def test_initialize_remote_settings_failure(
     filter_caplog: FilterCaplogFixture,
     backend_mock: Any,
     adm: Provider,
+    adm_uninitialized_suggestion_content: SuggestionContent,
 ) -> None:
     """Test exception handling for the initialize() method."""
     error_message: str = "The remote server was unreachable"
@@ -98,6 +99,8 @@ async def test_initialize_remote_settings_failure(
     assert len(records) == 1
     assert records[0].__dict__["error message"] == error_message
     assert adm.last_fetch_at == 0
+    # SuggestionContent should be empty as initialize was unsuccessful.
+    assert adm.suggestion_content == adm_uninitialized_suggestion_content
 
 
 @pytest.mark.parametrize("query", ["firefox"])

--- a/tests/unit/providers/adm/test_provider.py
+++ b/tests/unit/providers/adm/test_provider.py
@@ -25,6 +25,15 @@ def test_hidden(adm: Provider) -> None:
     assert adm.hidden() is False
 
 
+def test_init_uninitialized(
+    adm: Provider, adm_uninitialized_suggestion_content: SuggestionContent
+) -> None:
+    """Test provider creation prior to initialize _fetch calls.
+    Ensure empty SuggestionContent object created but is empty.
+    """
+    assert adm.suggestion_content == adm_uninitialized_suggestion_content
+
+
 @pytest.mark.asyncio
 async def test_initialize(
     adm: Provider, adm_suggestion_content: SuggestionContent


### PR DESCRIPTION
## References

JIRA: [DISCO-2236](https://mozilla-hub.atlassian.net/browse/DISCO-2236)
GitHub: [#193 ](https://github.com/mozilla-services/merino-py/issues/193)

## Description

This solution will ensure the provider is initialized with empty data and that queries will instead provide no result, opposed to raising a server error. An empty `suggestion_content` object will be used until the cron job gets a chance to retry the lookup of suggestion data. The retry cron has a fairly low latency so having no data to serve during that timeframe should be fine. This error should be rare in practice and since there is a retry mechanism in place, we do not need to take any other actions. 

The solution is to implement the initialization of an empty SuggestionContent object at the initialization of the AdM provider in the rare case this issue crops up.

See Jira ticket for more relevant information.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [x] `[do not deploy]` and `[load test: (abort|warn)]` keywords are applied (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2236]: https://mozilla-hub.atlassian.net/browse/DISCO-2236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ