### PR TITLE
[DISCO-2169] Delete CircleCI approval task for prod deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,24 +74,10 @@ workflows:
           <<: *main-filters
           requires:
             - docker-image-publish-stage
-      # The following job will require manual approval in the CircleCI web application.
-      # Once provided, and when all the requirements are fullfilled (e.g. tests)
-      - unhold-to-deploy-to-prod:
-          <<: *main-filters
-          type: approval
-          requires:
-            - checks
-            - unit-tests
-            - integration-tests
-            - test-coverage-check
-            - contract-tests
-            - docker-image-build
-      # On approval of the `unhold-to-deploy-to-prod` job, any successive job that requires it
-      # will run. In this case, it's manually triggering deployment to production.
       - docker-image-publish-prod:
           <<: *main-filters
           requires:
-            - unhold-to-deploy-to-prod
+            - docker-image-publish-merino-locust
 
 jobs:
   checks:


### PR DESCRIPTION
## References

JIRA: [DISCO-2169](https://mozilla-hub.atlassian.net/browse/DISCO-2169)
GitHub: N/A

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->
Remove the 'unhold-to-deploy-to-prod' CircleCI step in order to fulfill Rapid Release. 

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [x] `[do not deploy]` and `[load test: (abort|warn)]` keywords are applied (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
