### PR TITLE
[DISCO-2169] Fix the docker-image-publish job in CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,8 +213,8 @@ jobs:
             fi
 
             if [ -n "${STAGE_DOCKER_TAG}" ]; then
-              echo ${DOCKERHUB_REPO}:${STAGE_DOCKER_TAG}
-              docker tag app:build ${DOCKERHUB_REPO}:${STAGE_DOCKER_TAG}
+              echo "${DOCKERHUB_REPO}:${STAGE_DOCKER_TAG}"
+              docker tag app:build "${DOCKERHUB_REPO}:${STAGE_DOCKER_TAG}"
               docker images
               docker push "${DOCKERHUB_REPO}:${STAGE_DOCKER_TAG}"
             else
@@ -222,9 +222,9 @@ jobs:
             fi
 
             if [ -n "${PROD_DOCKER_TAG}" ]; then
-              echo ${DOCKERHUB_REPO}:${PROD_DOCKER_TAG}
-              docker tag app:build ${DOCKERHUB_REPO}:${PROD_DOCKER_TAG}
-              docker tag app:build ${DOCKERHUB_REPO}:latest
+              echo "${DOCKERHUB_REPO}:${PROD_DOCKER_TAG}"
+              docker tag app:build "${DOCKERHUB_REPO}:${PROD_DOCKER_TAG}"
+              docker tag app:build "${DOCKERHUB_REPO}:latest"
               docker images
               docker push "${DOCKERHUB_REPO}:${PROD_DOCKER_TAG}"
               docker push "${DOCKERHUB_REPO}:latest"
@@ -238,7 +238,7 @@ jobs:
       - checkout
       - run:
           name: Check for load test directive
-          command: | 
+          command: |
             if ! git log -1 "$CIRCLE_SHA1" | grep -q '\[load test: abort\|warn\]'; then
               echo "Skipping remaining steps in this job: load test not required."
               circleci-agent step halt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,17 +212,24 @@ jobs:
               fi
             fi
 
-            if [ -n "${DOCKER_TAG}" ]; then
-              echo ${DOCKERHUB_REPO}:${STAGE_DOCKER_TAG} ${DOCKERHUB_REPO}:${PROD_DOCKER_TAG}
+            if [ -n "${STAGE_DOCKER_TAG}" ]; then
+              echo ${DOCKERHUB_REPO}:${STAGE_DOCKER_TAG}
               docker tag app:build ${DOCKERHUB_REPO}:${STAGE_DOCKER_TAG}
+              docker images
+              docker push "${DOCKERHUB_REPO}:${STAGE_DOCKER_TAG}"
+            else
+              echo "Not pushing stage to dockerhub for tag=${CIRCLE_TAG} branch=${CIRCLE_BRANCH}"
+            fi
+
+            if [ -n "${PROD_DOCKER_TAG}" ]; then
+              echo ${DOCKERHUB_REPO}:${PROD_DOCKER_TAG}
               docker tag app:build ${DOCKERHUB_REPO}:${PROD_DOCKER_TAG}
               docker tag app:build ${DOCKERHUB_REPO}:latest
               docker images
-              docker push "${DOCKERHUB_REPO}:${STAGE_DOCKER_TAG}"
               docker push "${DOCKERHUB_REPO}:${PROD_DOCKER_TAG}"
               docker push "${DOCKERHUB_REPO}:latest"
             else
-              echo "Not pushing to dockerhub for tag=${CIRCLE_TAG} branch=${CIRCLE_BRANCH}"
+              echo "Not pushing prod to dockerhub for tag=${CIRCLE_TAG} branch=${CIRCLE_BRANCH}"
             fi
   docker-image-publish-locust:
     docker:


### PR DESCRIPTION
## References

JIRA: [DISCO-2169](https://mozilla-hub.atlassian.net/browse/DISCO-2169)
GitHub: N/A

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->
- Fix the docker-image-publish job in CircleCI config
    - Solution treats stage and prod Docker hub publishing distinctively, but another solution could be to use an or statement on the tag validation.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [x] `[do not deploy]` and `[load test: (abort|warn)]` keywords are applied (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2169]: https://mozilla-hub.atlassian.net/browse/DISCO-2169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ