### PR TITLE
chore(deps): bump redis from 4.5.3 to 4.5.4

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1940,15 +1940,18 @@ files = [
 
 [[package]]
 name = "redis"
-version = "4.5.3"
+version = "4.5.4"
 description = "Python client for Redis database and key-value store"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "redis-4.5.3-py3-none-any.whl", hash = "sha256:7df17a0a2b72a4c8895b462dd07616c51b1dcb48fdd7ecb7b6f4bf39ecb2e94e"},
-    {file = "redis-4.5.3.tar.gz", hash = "sha256:56732e156fe31801c4f43396bd3ca0c2a7f6f83d7936798531b9848d103381aa"},
+    {file = "redis-4.5.4-py3-none-any.whl", hash = "sha256:2c19e6767c474f2e85167909061d525ed65bea9301c0770bb151e041b7ac89a2"},
+    {file = "redis-4.5.4.tar.gz", hash = "sha256:73ec35da4da267d6847e47f68730fdd5f62e2ca69e3ef5885c6a78a9374c3893"},
 ]
+
+[package.dependencies]
+async-timeout = {version = ">=4.0.2", markers = "python_version <= \"3.11.2\""}
 
 [package.extras]
 hiredis = ["hiredis (>=1.0.0)"]
@@ -2798,4 +2801,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "2765b6ead6bc8acf9907e6f47977405e6748fc3cac6decdd7ccd4e04669e3865"
+content-hash = "eb38c9d514836209363044378ed30e6c967cb8c3543a1b0d40e000d9f78a92d4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ wrapt = "^1.14.1"
 elasticsearch = {extras = ["async"], version = "^8.5.0"}
 google-cloud-storage = "^2.6.0"
 typer = "^0.7.0"
-redis = "^4.5.3"
+redis = "^4.5.4"
 
 [tool.poetry.dev-dependencies]
 black = "^22.6.0"

--- a/tests/load/poetry.lock
+++ b/tests/load/poetry.lock
@@ -1584,15 +1584,18 @@ cffi = {version = "*", markers = "implementation_name == \"pypy\""}
 
 [[package]]
 name = "redis"
-version = "4.5.3"
+version = "4.5.4"
 description = "Python client for Redis database and key-value store"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "redis-4.5.3-py3-none-any.whl", hash = "sha256:7df17a0a2b72a4c8895b462dd07616c51b1dcb48fdd7ecb7b6f4bf39ecb2e94e"},
-    {file = "redis-4.5.3.tar.gz", hash = "sha256:56732e156fe31801c4f43396bd3ca0c2a7f6f83d7936798531b9848d103381aa"},
+    {file = "redis-4.5.4-py3-none-any.whl", hash = "sha256:2c19e6767c474f2e85167909061d525ed65bea9301c0770bb151e041b7ac89a2"},
+    {file = "redis-4.5.4.tar.gz", hash = "sha256:73ec35da4da267d6847e47f68730fdd5f62e2ca69e3ef5885c6a78a9374c3893"},
 ]
+
+[package.dependencies]
+async-timeout = {version = ">=4.0.2", markers = "python_version <= \"3.11.2\""}
 
 [package.extras]
 hiredis = ["hiredis (>=1.0.0)"]
@@ -2005,4 +2008,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "411683f9f7846b8af2972bd59c768e3dff97f522ae737e1a419850d6cac1ccad"
+content-hash = "1a132988fd472411e1ef36a115a5b02e5d8bd10b7b4dc48c471133342cb8206c"

--- a/tests/load/pyproject.toml
+++ b/tests/load/pyproject.toml
@@ -16,7 +16,7 @@ httpx = "^0.23.3"
 kinto-http = "^11.0.0"
 locust = "^2.14.2"
 pydantic = "^1.10.4"
-redis = "^4.5.3"
+redis = "^4.5.4"
 starlette = "^0.25.0"
 wrapt = "^1.14.1"
 


### PR DESCRIPTION
Redis 4.5.4 has a workaround for redis/redis-py#2633, which was causing cache misses to raise an uncaught `CancelledError` in the weather backend.