### PR TITLE
[DISCO-2332] Remove 'main' branch checks in Merino CI Docker Hub publication Jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,38 +199,27 @@ jobs:
           # modifying the Docker image tag name. The convention looks as follows:
           #^(?P<environment>stage|prod)(?:-(?P<task>\w+)-(?P<onfailure>warn|abort))?-(?P<commit>[a-z0-9]+)$
           command: |
-            if [ "${CIRCLE_BRANCH}" == "main" ]; then
-              PROD_DOCKER_TAG="prod-${CIRCLE_SHA1}"
-              if git log -1 "$CIRCLE_SHA1" | grep -q '\[load test: warn\]'; then
-                echo "Load test requested. Slack warning will be output if test fails and deployment workflow for prod will proceed."
-                STAGE_DOCKER_TAG="stage-loadtest-warn-${CIRCLE_SHA1}"
-              elif git log -1 "$CIRCLE_SHA1" | grep -q '\[load test: abort\]'; then
-                echo "Load test requested. Deployment workflow for prod will abort if load test fails."
-                STAGE_DOCKER_TAG="stage-loadtest-abort-${CIRCLE_SHA1}"
-              else
-                STAGE_DOCKER_TAG="stage-${CIRCLE_SHA1}"
-              fi
-            fi
-
-            if [ -n "${STAGE_DOCKER_TAG}" ]; then
-              echo "${DOCKERHUB_REPO}:${STAGE_DOCKER_TAG}"
-              docker tag app:build "${DOCKERHUB_REPO}:${STAGE_DOCKER_TAG}"
-              docker images
-              docker push "${DOCKERHUB_REPO}:${STAGE_DOCKER_TAG}"
+            if git log -1 "$CIRCLE_SHA1" | grep -q '\[load test: warn\]'; then
+              echo "Load test requested. Slack warning will be output if test fails and deployment workflow for prod will proceed."
+              STAGE_DOCKER_TAG="stage-loadtest-warn-${CIRCLE_SHA1}"
+            elif git log -1 "$CIRCLE_SHA1" | grep -q '\[load test: abort\]'; then
+              echo "Load test requested. Deployment workflow for prod will abort if load test fails."
+              STAGE_DOCKER_TAG="stage-loadtest-abort-${CIRCLE_SHA1}"
             else
-              echo "Not pushing stage to dockerhub for tag=${CIRCLE_TAG} branch=${CIRCLE_BRANCH}"
+              STAGE_DOCKER_TAG="stage-${CIRCLE_SHA1}"
             fi
+            echo "${DOCKERHUB_REPO}:${STAGE_DOCKER_TAG}"
+            docker tag app:build "${DOCKERHUB_REPO}:${STAGE_DOCKER_TAG}"
+            docker images
+            docker push "${DOCKERHUB_REPO}:${STAGE_DOCKER_TAG}"
 
-            if [ -n "${PROD_DOCKER_TAG}" ]; then
-              echo "${DOCKERHUB_REPO}:${PROD_DOCKER_TAG}"
-              docker tag app:build "${DOCKERHUB_REPO}:${PROD_DOCKER_TAG}"
-              docker tag app:build "${DOCKERHUB_REPO}:latest"
-              docker images
-              docker push "${DOCKERHUB_REPO}:${PROD_DOCKER_TAG}"
-              docker push "${DOCKERHUB_REPO}:latest"
-            else
-              echo "Not pushing prod to dockerhub for tag=${CIRCLE_TAG} branch=${CIRCLE_BRANCH}"
-            fi
+            PROD_DOCKER_TAG="prod-${CIRCLE_SHA1}"
+            echo "${DOCKERHUB_REPO}:${PROD_DOCKER_TAG}"
+            docker tag app:build "${DOCKERHUB_REPO}:${PROD_DOCKER_TAG}"
+            docker tag app:build "${DOCKERHUB_REPO}:latest"
+            docker images
+            docker push "${DOCKERHUB_REPO}:${PROD_DOCKER_TAG}"
+            docker push "${DOCKERHUB_REPO}:latest"
   docker-image-publish-locust:
     docker:
       - image: cimg/base:2022.08

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -252,20 +252,13 @@ jobs:
       - run:
           name: Push to Docker Hub
           command: |
-            if [ "${CIRCLE_BRANCH}" == "main" ]; then
-              DOCKER_TAG="${CIRCLE_SHA1}"
-            fi
-
-            if [ -n "${DOCKER_TAG}" ]; then
-              echo ${DOCKERHUB_MERINO_LOCUST_REPO}:${DOCKER_TAG}
-              docker tag merino-locust ${DOCKERHUB_MERINO_LOCUST_REPO}:${DOCKER_TAG}
-              docker tag merino-locust ${DOCKERHUB_MERINO_LOCUST_REPO}:latest
-              docker images
-              docker push "${DOCKERHUB_MERINO_LOCUST_REPO}:${DOCKER_TAG}"
-              docker push "${DOCKERHUB_MERINO_LOCUST_REPO}:latest"
-            else
-              echo "Not pushing to dockerhub for tag=${CIRCLE_TAG} branch=${CIRCLE_BRANCH}"
-            fi
+            DOCKER_TAG="${CIRCLE_SHA1}"
+            echo ${DOCKERHUB_MERINO_LOCUST_REPO}:${DOCKER_TAG}
+            docker tag merino-locust ${DOCKERHUB_MERINO_LOCUST_REPO}:${DOCKER_TAG}
+            docker tag merino-locust ${DOCKERHUB_MERINO_LOCUST_REPO}:latest
+            docker images
+            docker push "${DOCKERHUB_MERINO_LOCUST_REPO}:${DOCKER_TAG}"
+            docker push "${DOCKERHUB_MERINO_LOCUST_REPO}:latest"
   docs-build:
     docker:
       - image: cimg/rust:1.64


### PR DESCRIPTION
## References

JIRA: [DISCO-2332](https://mozilla-hub.atlassian.net/browse/DISCO-2332)
GitHub: N/A

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->
Remove the “main“ branch check from the `docker-image-publish` job and`docker-image-publish-locust` job in the Merino-py CI workflow. These jobs only run in the `main-workflow`, so the check is seemingly unneeded.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [x] `[do not deploy]` and `[load test: (abort|warn)]` keywords are applied (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2332]: https://mozilla-hub.atlassian.net/browse/DISCO-2332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ