### PR TITLE
[DISCO-2235] Exclude Sensitive Data from Sentry 

### DIFF
--- a/merino/config_sentry.py
+++ b/merino/config_sentry.py
@@ -1,5 +1,7 @@
 """Sentry Configuration"""
 
+from typing import Any
+
 import sentry_sdk
 from sentry_sdk.integrations.fastapi import FastApiIntegration
 from sentry_sdk.integrations.starlette import StarletteIntegration
@@ -22,9 +24,16 @@ def configure_sentry() -> None:  # pragma: no cover
         ],
         release=version_sha,
         debug="debug" == settings.sentry.mode,
+        before_send=strip_sensitive_data,  # type: ignore [arg-type]
         environment=settings.sentry.env,
         # Set traces_sample_rate to 1.0 to capture 100%
         # of transactions for performance monitoring.
         # We recommend adjusting this value in production,
         traces_sample_rate=settings.sentry.traces_sample_rate,
     )
+
+
+def strip_sensitive_data(event) -> Any:
+    """Filter out sensitive data from Sentry events."""
+    #  See: https://docs.sentry.io/platforms/python/configuration/filtering/
+    return event

--- a/merino/config_sentry.py
+++ b/merino/config_sentry.py
@@ -41,7 +41,7 @@ def strip_sensitive_data(event: dict, hint: dict) -> Any:
     """Filter out sensitive data from Sentry events."""
     #  See: https://docs.sentry.io/platforms/python/configuration/filtering/
     if event["request"]["query_string"]:
-        event["request"]["query_string"] = "query_str_foo"
+        event["request"]["query_string"] = ""
 
     if "exc_info" in hint:
         exc_type, exc_value, tb = hint["exc_info"]
@@ -49,20 +49,15 @@ def strip_sensitive_data(event: dict, hint: dict) -> Any:
             for entry in event["exception"]["values"][0]["stacktrace"]["frames"]:
                 try:
                     if entry["vars"].get("q"):
-                        entry["vars"]["q"] = "vars_foo"
+                        entry["vars"]["q"] = ""
                     if entry["vars"].get("query"):
-                        entry["vars"]["query"] = "picked_repl"
+                        entry["vars"]["query"] = ""
                     if entry["vars"].get("srequest"):
-                        entry["vars"]["srequest"] = "sreq_repl"
+                        entry["vars"]["srequest"] = ""
                     if entry["vars"]["values"].get("q"):
-                        entry["vars"]["values"]["q"] = "vars_values_foo"
+                        entry["vars"]["values"]["q"] = ""
                     if entry["vars"]["solved_result"][0].get("q"):
-                        entry["vars"]["solved_result"][0]["q"] = "solved_foo"
-
-                except KeyError as e:
-                    logger.debug(
-                        f"Sentry filtering RuntimeError query value not found: {e}"
-                    )
+                        entry["vars"]["solved_result"][0]["q"] = ""
+                except KeyError:
                     continue
-
     return event

--- a/merino/config_sentry.py
+++ b/merino/config_sentry.py
@@ -58,7 +58,9 @@ def strip_sensitive_data(event: dict, hint: dict) -> dict:
                 if entry["vars"]["solved_result"][0].get("q"):
                     entry["vars"]["solved_result"][0]["q"] = ""
 
-    except KeyError as e:
-        logger.warning(f"Encountered KeyError for key {e} while filtering Sentry data.")
+    except (KeyError, IndexError) as e:
+        logger.warning(
+            f"Encountered KeyError or IndexError for value {e} while filtering Sentry data."
+        )
 
     return event

--- a/merino/config_sentry.py
+++ b/merino/config_sentry.py
@@ -36,4 +36,8 @@ def configure_sentry() -> None:  # pragma: no cover
 def strip_sensitive_data(event) -> Any:
     """Filter out sensitive data from Sentry events."""
     #  See: https://docs.sentry.io/platforms/python/configuration/filtering/
+    if event.q:
+        delattr(event, "q")
+    if event.query:
+        delattr(event, "query")
     return event

--- a/merino/config_sentry.py
+++ b/merino/config_sentry.py
@@ -40,29 +40,25 @@ def strip_sensitive_data(event: dict, hint: dict) -> dict:
     if event.get("request", {}).get("query_string", {}):
         event["request"]["query_string"] = ""
 
-    if "exc_info" in hint:
-        exc_type, exc_value, tb = hint["exc_info"]
-        if isinstance(exc_value, Exception):
-            try:
-                for entry in event["exception"]["values"][0]["stacktrace"]["frames"]:
-                    if entry["vars"].get("q"):
-                        entry["vars"]["q"] = ""
-                    if entry["vars"].get("query"):
-                        entry["vars"]["query"] = ""
-                    if entry["vars"].get("srequest"):
-                        entry["vars"]["srequest"] = ""
-                    if entry["vars"].get("values", {}).get("q"):
-                        entry["vars"]["values"]["q"] = ""
-                    if (
-                        entry["vars"].get("solved_result", [])
-                        and len(entry["vars"].get("solved_result", [])) > 0
-                    ):
-                        if entry["vars"]["solved_result"][0].get("q"):
-                            entry["vars"]["solved_result"][0]["q"] = ""
-            except KeyError as e:
-                logger.warning(
-                    f"Encountered KeyError for key {e} while filtering Sentry data."
-                )
-                pass
+    try:
+        for entry in event["exception"]["values"][0]["stacktrace"]["frames"]:
+
+            if entry["vars"].get("q"):
+                entry["vars"]["q"] = ""
+            if entry["vars"].get("query"):
+                entry["vars"]["query"] = ""
+            if entry["vars"].get("srequest"):
+                entry["vars"]["srequest"] = ""
+            if entry["vars"].get("values", {}).get("q"):
+                entry["vars"]["values"]["q"] = ""
+            if (
+                entry["vars"].get("solved_result", [])
+                and len(entry["vars"].get("solved_result", [])) > 0
+            ):
+                if entry["vars"]["solved_result"][0].get("q"):
+                    entry["vars"]["solved_result"][0]["q"] = ""
+
+    except KeyError as e:
+        logger.warning(f"Encountered KeyError for key {e} while filtering Sentry data.")
 
     return event

--- a/merino/config_sentry.py
+++ b/merino/config_sentry.py
@@ -1,14 +1,12 @@
 """Sentry Configuration"""
 
 import logging
-from typing import Any
 
 import sentry_sdk
 from sentry_sdk.integrations.fastapi import FastApiIntegration
 from sentry_sdk.integrations.starlette import StarletteIntegration
 
 from merino.config import settings
-from merino.exceptions import BackendError
 from merino.utils.version import fetch_app_version_from_file
 
 logger = logging.getLogger(__name__)
@@ -37,27 +35,42 @@ def configure_sentry() -> None:  # pragma: no cover
     )
 
 
-def strip_sensitive_data(event: dict, hint: dict) -> Any:
+def strip_sensitive_data(event: dict, hint: dict) -> dict:
     """Filter out sensitive data from Sentry events."""
     #  See: https://docs.sentry.io/platforms/python/configuration/filtering/
-    if event["request"]["query_string"]:
-        event["request"]["query_string"] = ""
+    match event:
+        case {"request": {"query_string": _}}:
+            event["request"]["query_string"] = ""
+        case _:
+            pass
 
     if "exc_info" in hint:
         exc_type, exc_value, tb = hint["exc_info"]
-        if isinstance(exc_value, RuntimeError) or isinstance(exc_value, BackendError):
-            for entry in event["exception"]["values"][0]["stacktrace"]["frames"]:
-                try:
-                    if entry["vars"].get("q"):
-                        entry["vars"]["q"] = ""
-                    if entry["vars"].get("query"):
-                        entry["vars"]["query"] = ""
-                    if entry["vars"].get("srequest"):
-                        entry["vars"]["srequest"] = ""
-                    if entry["vars"]["values"].get("q"):
-                        entry["vars"]["values"]["q"] = ""
-                    if entry["vars"]["solved_result"][0].get("q"):
-                        entry["vars"]["solved_result"][0]["q"] = ""
-                except KeyError:
-                    continue
+        if isinstance(exc_value, Exception):
+            try:
+                for entry in event["exception"]["values"][0]["stacktrace"]["frames"]:
+                    try:
+                        if entry["vars"].get("q"):
+                            entry["vars"]["q"] = ""
+                        if entry["vars"].get("query"):
+                            entry["vars"]["query"] = ""
+                        if entry["vars"].get("srequest"):
+                            entry["vars"]["srequest"] = ""
+                        if entry["vars"].get("values", {}).get("q"):
+                            entry["vars"]["values"]["q"] = ""
+                        if (
+                            entry["vars"].get("solved_result", [])
+                            and len(entry["vars"].get("solved_result", [])) > 0
+                        ):
+                            if entry["vars"]["solved_result"][0].get("q"):
+                                entry["vars"]["solved_result"][0]["q"] = ""
+                    except KeyError:
+                        continue
+
+            except KeyError as e:
+                logger.warning(
+                    f"Error during Sentry strip_sensitive_data callback: {e}"
+                )
+                pass
+
     return event

--- a/merino/config_sentry.py
+++ b/merino/config_sentry.py
@@ -1,15 +1,11 @@
 """Sentry Configuration"""
 
-import logging
-
 import sentry_sdk
 from sentry_sdk.integrations.fastapi import FastApiIntegration
 from sentry_sdk.integrations.starlette import StarletteIntegration
 
 from merino.config import settings
 from merino.utils.version import fetch_app_version_from_file
-
-logger = logging.getLogger(__name__)
 
 
 def configure_sentry() -> None:  # pragma: no cover
@@ -38,39 +34,29 @@ def configure_sentry() -> None:  # pragma: no cover
 def strip_sensitive_data(event: dict, hint: dict) -> dict:
     """Filter out sensitive data from Sentry events."""
     #  See: https://docs.sentry.io/platforms/python/configuration/filtering/
-    match event:
-        case {"request": {"query_string": _}}:
-            event["request"]["query_string"] = ""
-        case _:
-            pass
+    if event.get("request", {}).get("query_string", {}):
+        event["request"]["query_string"] = ""
 
     if "exc_info" in hint:
         exc_type, exc_value, tb = hint["exc_info"]
         if isinstance(exc_value, Exception):
-            try:
-                for entry in event["exception"]["values"][0]["stacktrace"]["frames"]:
-                    try:
-                        if entry["vars"].get("q"):
-                            entry["vars"]["q"] = ""
-                        if entry["vars"].get("query"):
-                            entry["vars"]["query"] = ""
-                        if entry["vars"].get("srequest"):
-                            entry["vars"]["srequest"] = ""
-                        if entry["vars"].get("values", {}).get("q"):
-                            entry["vars"]["values"]["q"] = ""
-                        if (
-                            entry["vars"].get("solved_result", [])
-                            and len(entry["vars"].get("solved_result", [])) > 0
-                        ):
-                            if entry["vars"]["solved_result"][0].get("q"):
-                                entry["vars"]["solved_result"][0]["q"] = ""
-                    except KeyError:
-                        continue
-
-            except KeyError as e:
-                logger.warning(
-                    f"Error during Sentry strip_sensitive_data callback: {e}"
-                )
-                pass
+            for entry in event["exception"]["values"][0]["stacktrace"]["frames"]:
+                try:
+                    if entry["vars"].get("q"):
+                        entry["vars"]["q"] = ""
+                    if entry["vars"].get("query"):
+                        entry["vars"]["query"] = ""
+                    if entry["vars"].get("srequest"):
+                        entry["vars"]["srequest"] = ""
+                    if entry["vars"].get("values", {}).get("q"):
+                        entry["vars"]["values"]["q"] = ""
+                    if (
+                        entry["vars"].get("solved_result", [])
+                        and len(entry["vars"].get("solved_result", [])) > 0
+                    ):
+                        if entry["vars"]["solved_result"][0].get("q"):
+                            entry["vars"]["solved_result"][0]["q"] = ""
+                except KeyError:
+                    continue
 
     return event

--- a/tests/unit/test_config_sentry.py
+++ b/tests/unit/test_config_sentry.py
@@ -20,32 +20,6 @@ mock_sentry_event_data: dict = {
                 "stacktrace": {
                     "frames": [
                         {
-                            "request": {
-                                "method": "'GET'",
-                                "path": "'/api/v1/suggest'",
-                            },
-                            "solved_result": [
-                                {
-                                    "sources": [
-                                        {
-                                            "accuweather": "<merino.providers.weather>",
-                                            "adm": "<merino.providers.adm>",
-                                            "top_picks": "<merino.providers.top_picks>",
-                                            "wikipedia": "<merino.providers.wikipedia>",
-                                        },
-                                        ["<merino.providers.adm.provider>"],
-                                    ],
-                                    "q": "solved_foo",
-                                    "providers": "'top_picks,adm'",
-                                    "client_variants": "None",
-                                    "request": {
-                                        "method": "'GET'",
-                                        "path": "'/api/v1/suggest'",
-                                    },
-                                },
-                            ],
-                        },
-                        {
                             "filename": "merino/web/api_v1.py",
                             "module": "merino.web.api_v1",
                             "vars": {
@@ -97,30 +71,25 @@ mock_sentry_event_data: dict = {
 
 def test_strip_sensitive_data() -> None:
     """Test that strip_sensitive_data will remove sensitive data."""
-    sentry_event = strip_sensitive_data(mock_sentry_event_data, mock_sentry_hint)
+    sanitized_event = strip_sensitive_data(mock_sentry_event_data, mock_sentry_hint)
     # Asserts that the 'query_string' key was removed from the dictionary.
-    assert sentry_event["request"].get("query_string") == "query_str_foo"
+    assert sanitized_event["request"].get("query_string") == ""
     assert isinstance(mock_sentry_hint["exc_info"][1], RuntimeError)
     assert (
-        sentry_event["exception"]["values"][0]["stacktrace"]["frames"][0][
-            "solved_result"
-        ][0]["q"]
-        == "solved_foo"
+        sanitized_event["exception"]["values"][0]["stacktrace"]["frames"][0]["vars"][
+            "q"
+        ]
+        == ""
     )
     assert (
-        sentry_event["exception"]["values"][0]["stacktrace"]["frames"][1]["vars"]["q"]
-        == "vars_foo"
-    )
-
-    assert (
-        sentry_event["exception"]["values"][0]["stacktrace"]["frames"][2]["vars"][
+        sanitized_event["exception"]["values"][0]["stacktrace"]["frames"][1]["vars"][
             "values"
         ]["q"]
-        == "vars_values_foo"
+        == ""
     )
     assert (
-        sentry_event["exception"]["values"][0]["stacktrace"]["frames"][3]["vars"][
+        sanitized_event["exception"]["values"][0]["stacktrace"]["frames"][2]["vars"][
             "srequest"
         ]
-        == "sreq_repl"
+        == ""
     )

--- a/tests/unit/test_config_sentry.py
+++ b/tests/unit/test_config_sentry.py
@@ -3,7 +3,12 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """Unit tests for the config_sentry.py module."""
+import logging
+
+from pytest import LogCaptureFixture
+
 from merino.config_sentry import strip_sensitive_data
+from tests.types import FilterCaplogFixture
 
 mock_sentry_hint: dict[str, list] = {"exc_info": [RuntimeError, RuntimeError(), None]}
 
@@ -109,7 +114,9 @@ def test_strip_sensitive_data() -> None:
     sanitized_event = strip_sensitive_data(mock_sentry_event_data, mock_sentry_hint)
     # Asserts that the 'query_string' key was removed from the dictionary.
     assert sanitized_event["request"].get("query_string") == ""
+    assert "exc_info" in mock_sentry_hint
     assert isinstance(mock_sentry_hint["exc_info"][1], RuntimeError)
+
     assert (
         sanitized_event["exception"]["values"][0]["stacktrace"]["frames"][0]["vars"][
             "q"
@@ -134,4 +141,23 @@ def test_strip_sensitive_data() -> None:
             "solved_result"
         ][0]["q"]
         == ""
+    )
+
+
+def test_strip_sensitive_data_key_error(
+    caplog: LogCaptureFixture,
+    filter_caplog: FilterCaplogFixture,
+) -> None:
+    """Test that KeyError is emitted through logger when invalid key
+    detected."""
+    caplog.set_level(logging.WARNING)
+    strip_sensitive_data(
+        event={"bad_request": {}, "exception": {"invalid_values": [{}]}},
+        hint=mock_sentry_hint,
+    )
+
+    records = filter_caplog(caplog.records, "merino.config_sentry")
+    assert (
+        records[0].__dict__["msg"]
+        == "Encountered KeyError for key 'values' while filtering Sentry data."
     )

--- a/tests/unit/test_config_sentry.py
+++ b/tests/unit/test_config_sentry.py
@@ -112,7 +112,6 @@ mock_sentry_event_data: dict = {
 def test_strip_sensitive_data() -> None:
     """Test that strip_sensitive_data will remove sensitive data."""
     sanitized_event = strip_sensitive_data(mock_sentry_event_data, mock_sentry_hint)
-    # Asserts that the 'query_string' key was removed from the dictionary.
     assert sanitized_event["request"].get("query_string") == ""
     assert "exc_info" in mock_sentry_hint
     assert isinstance(mock_sentry_hint["exc_info"][1], RuntimeError)

--- a/tests/unit/test_config_sentry.py
+++ b/tests/unit/test_config_sentry.py
@@ -148,7 +148,8 @@ def test_strip_sensitive_data_key_error(
     filter_caplog: FilterCaplogFixture,
 ) -> None:
     """Test that KeyError is emitted through logger when invalid key
-    detected."""
+    detected.
+    """
     caplog.set_level(logging.WARNING)
     strip_sensitive_data(
         event={"bad_request": {}, "exception": {"invalid_values": [{}]}},

--- a/tests/unit/test_config_sentry.py
+++ b/tests/unit/test_config_sentry.py
@@ -159,5 +159,5 @@ def test_strip_sensitive_data_key_error(
     records = filter_caplog(caplog.records, "merino.config_sentry")
     assert (
         records[0].__dict__["msg"]
-        == "Encountered KeyError for key 'values' while filtering Sentry data."
+        == "Encountered KeyError or IndexError for value 'values' while filtering Sentry data."
     )

--- a/tests/unit/test_config_sentry.py
+++ b/tests/unit/test_config_sentry.py
@@ -143,12 +143,12 @@ def test_strip_sensitive_data() -> None:
     )
 
 
-def test_strip_sensitive_data_key_error(
+def test_strip_sensitive_data_lookup_error(
     caplog: LogCaptureFixture,
     filter_caplog: FilterCaplogFixture,
 ) -> None:
-    """Test that KeyError is emitted through logger when invalid key
-    detected.
+    """Test that KeyError or IndexError message is emitted through logger when invalid key
+    or index is detected.
     """
     caplog.set_level(logging.WARNING)
     strip_sensitive_data(

--- a/tests/unit/test_config_sentry.py
+++ b/tests/unit/test_config_sentry.py
@@ -3,7 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """Unit tests for the config_sentry.py module."""
-
 from merino.config_sentry import strip_sensitive_data
 
 mock_sentry_hint: dict[str, list] = {"exc_info": [RuntimeError, RuntimeError(), None]}
@@ -61,6 +60,42 @@ mock_sentry_event_data: dict = {
                                 "ids": "None",
                             },
                         },
+                        {
+                            "filename": "fastapi/routing.py",
+                            "function": "app",
+                            "module": "fastapi.routing",
+                            "lineno": 227,
+                            "vars": {
+                                "request": {
+                                    "type": "'http'",
+                                },
+                                "body": "None",
+                                "solved_result": [
+                                    {
+                                        "q": "foobar",
+                                        "providers": "'top_picks,adm'",
+                                        "client_variants": "None",
+                                        "request": {
+                                            "method": "'GET'",
+                                            "path": "'/api/v1/suggest'",
+                                        },
+                                    },
+                                ],
+                                "values": {
+                                    "sources": [
+                                        {
+                                            "accuweather": "<merino.providers.weather.provider>",
+                                            "adm": "<merino.providers.adm.provider.",
+                                            "top_picks": "<merino.providers.top_picks.provider>",
+                                            "wikipedia": "<merino.providers.wikipedia.provider>",
+                                        },
+                                    ],
+                                    "q": "'foobar'",
+                                    "providers": "'top_picks,adm'",
+                                    "client_variants": "None",
+                                },
+                            },
+                        },
                     ]
                 },
             }
@@ -91,5 +126,12 @@ def test_strip_sensitive_data() -> None:
         sanitized_event["exception"]["values"][0]["stacktrace"]["frames"][2]["vars"][
             "srequest"
         ]
+        == ""
+    )
+
+    assert (
+        sanitized_event["exception"]["values"][0]["stacktrace"]["frames"][3]["vars"][
+            "solved_result"
+        ][0]["q"]
         == ""
     )

--- a/tests/unit/test_config_sentry.py
+++ b/tests/unit/test_config_sentry.py
@@ -1,0 +1,15 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Unit tests for the config_sentry.py module."""
+
+import pytest
+
+from merino.config_sentry import configure_sentry
+
+
+@pytest.fixture(name="sentry_init")
+def sentry_init() -> None:
+    """Initialize sentry instance fixture."""
+    configure_sentry()

--- a/tests/unit/test_config_sentry.py
+++ b/tests/unit/test_config_sentry.py
@@ -75,6 +75,18 @@ mock_sentry_event_data: dict = {
                                 }
                             },
                         },
+                        {
+                            "filename": "merino/providers/top_picks/provider.py",
+                            "function": "query",
+                            "context_line": "raise BackendError()",
+                            "vars": {
+                                "self": "<merino.providers.top_picks.provider>",
+                                "srequest": "SuggestionRequest(query='foobar')",
+                                "qlen": "6",
+                                "query": "foobar",
+                                "ids": "None",
+                            },
+                        },
                     ]
                 },
             }
@@ -105,4 +117,10 @@ def test_strip_sensitive_data() -> None:
             "values"
         ]["q"]
         == "vars_values_foo"
+    )
+    assert (
+        sentry_event["exception"]["values"][0]["stacktrace"]["frames"][3]["vars"][
+            "srequest"
+        ]
+        == "sreq_repl"
     )

--- a/tests/unit/test_config_sentry.py
+++ b/tests/unit/test_config_sentry.py
@@ -4,22 +4,105 @@
 
 """Unit tests for the config_sentry.py module."""
 
-import pytest
-import sentry_sdk
+from merino.config_sentry import strip_sensitive_data
 
-from merino.config_sentry import configure_sentry
+mock_sentry_hint: dict[str, list] = {"exc_info": [RuntimeError, RuntimeError(), None]}
+
+mock_sentry_event_data: dict = {
+    "request": {
+        "method": "GET",
+        "url": "http://localhost:8000/api/v1/suggest",
+        "query_string": "query_str_foo",
+    },
+    "exception": {
+        "values": [
+            {
+                "stacktrace": {
+                    "frames": [
+                        {
+                            "request": {
+                                "method": "'GET'",
+                                "path": "'/api/v1/suggest'",
+                            },
+                            "solved_result": [
+                                {
+                                    "sources": [
+                                        {
+                                            "accuweather": "<merino.providers.weather>",
+                                            "adm": "<merino.providers.adm>",
+                                            "top_picks": "<merino.providers.top_picks>",
+                                            "wikipedia": "<merino.providers.wikipedia>",
+                                        },
+                                        ["<merino.providers.adm.provider>"],
+                                    ],
+                                    "q": "solved_foo",
+                                    "providers": "'top_picks,adm'",
+                                    "client_variants": "None",
+                                    "request": {
+                                        "method": "'GET'",
+                                        "path": "'/api/v1/suggest'",
+                                    },
+                                },
+                            ],
+                        },
+                        {
+                            "filename": "merino/web/api_v1.py",
+                            "module": "merino.web.api_v1",
+                            "vars": {
+                                "request": {
+                                    "type": "'http'",
+                                    "method": "'GET'",
+                                    "path": "'/api/v1/suggest'",
+                                },
+                                "q": "vars_foo",
+                                "providers": "'top_picks,adm'",
+                                "client_variants": "None",
+                            },
+                        },
+                        {
+                            "filename": "merino/web/api_v1.py",
+                            "module": "merino.web.api_v1",
+                            "vars": {
+                                "values": {
+                                    "request": {
+                                        "type": "'http'",
+                                        "method": "'GET'",
+                                        "path": "'/api/v1/suggest'",
+                                    },
+                                    "q": "vars_values_foo",
+                                    "providers": "'top_picks,adm'",
+                                    "client_variants": "None",
+                                }
+                            },
+                        },
+                    ]
+                },
+            }
+        ]
+    },
+}
 
 
-@pytest.fixture(name="sentry_init")
-def sentry_init() -> None:
-    """Initialize sentry instance fixture."""
-    configure_sentry()
-
-
-def test_strip_sensitive_data(monkeypatch, mocker, sentry_init) -> None:
+def test_strip_sensitive_data() -> None:
     """Test that strip_sensitive_data will remove sensitive data."""
-    sentry_client = sentry_sdk.Hub.current.client
-    # transport used by sentry to send events. Mocking allows
-    # testing of any processing.
-    transport = mocker.MagicMock()
-    monkeypatch.setattr(sentry_client, "transport", transport)
+    sentry_event = strip_sensitive_data(mock_sentry_event_data, mock_sentry_hint)
+    # Asserts that the 'query_string' key was removed from the dictionary.
+    assert sentry_event["request"].get("query_string") == "query_str_foo"
+    assert isinstance(mock_sentry_hint["exc_info"][1], RuntimeError)
+    assert (
+        sentry_event["exception"]["values"][0]["stacktrace"]["frames"][0][
+            "solved_result"
+        ][0]["q"]
+        == "solved_foo"
+    )
+    assert (
+        sentry_event["exception"]["values"][0]["stacktrace"]["frames"][1]["vars"]["q"]
+        == "vars_foo"
+    )
+
+    assert (
+        sentry_event["exception"]["values"][0]["stacktrace"]["frames"][2]["vars"][
+            "values"
+        ]["q"]
+        == "vars_values_foo"
+    )

--- a/tests/unit/test_config_sentry.py
+++ b/tests/unit/test_config_sentry.py
@@ -5,6 +5,7 @@
 """Unit tests for the config_sentry.py module."""
 
 import pytest
+import sentry_sdk
 
 from merino.config_sentry import configure_sentry
 
@@ -13,3 +14,12 @@ from merino.config_sentry import configure_sentry
 def sentry_init() -> None:
     """Initialize sentry instance fixture."""
     configure_sentry()
+
+
+def test_strip_sensitive_data(monkeypatch, mocker, sentry_init) -> None:
+    """Test that strip_sensitive_data will remove sensitive data."""
+    sentry_client = sentry_sdk.Hub.current.client
+    # transport used by sentry to send events. Mocking allows
+    # testing of any processing.
+    transport = mocker.MagicMock()
+    monkeypatch.setattr(sentry_client, "transport", transport)


### PR DESCRIPTION
## References

JIRA: [DISCO-2235](https://mozilla-hub.atlassian.net/browse/DISCO-2235)
GitHub: [#261 ](https://github.com/mozilla-services/merino-py/issues/261)

## Description
It is essential to filter out potentially sensitive data when emitting events to Sentry. Currently, query strings and search terms are the values to be filtered and removed.

Accessing this through sentry requires defining a callback function that is associated with the `before_send` parameter in sentry_init(). See [Sentry documentation here](https://sentry-docs-o2paie5ivq-uc.a.run.app/error-reporting/configuration/filtering/?platform=python). This function grants access to the `event` object, in which all context of stack frames exit.  

It was found that at the API request level, the `query_string` parameter passed to Sentry is found at `event["request"]["query_string"]`. 

What is more complicated is finding other instances of the query parameter for each provider, matching the key `q` or `query`. This requires iterating through `event['exception']['values'][0]['stacktrace']['frames']` where each frame is contained. This contained 3 possible locations where the `q` value occurred:
- `event["exception"]["values"][0]["stacktrace"]["frames"][<idx>]["vars"]["q"]`
-  `event["exception"]["values"][0]["stacktrace"]["frames"][<idx>]["vars"]["values"]["q"]`
- `event["exception"]["values"][0]["stacktrace"]["frames"][<idx>]["vars"]["solved_result"][0]["q"]`

Given the nested nature of these values, a simple `try/except` block with a `continue` statement when a `KeyError` is raised was used to minimize complexity.

To explore the event object, do the following:
1. Define `pdb.set_trace()` at the end of the `strip_sensitive_data` function, before the return of the event.
2.  Raise a `RuntimeException()` in `api_v1.py` [here](https://github.com/mozilla-services/merino-py/blob/dae6c05fe694fffa344706fd963781966cd6bb23/merino/web/api_v1.py#L99) 
3. Interactively explore the event object context. 

Note that currently, I have the values set to empty strings. Alternatively, the dictionary keys can be deleted. For testing sake, I had originally used discrete strings to make sure each case modified the actual query term. If there's a good reason to instead just delete all possible query keys, we could do that.
## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[do not deploy]` and `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2235]: https://mozilla-hub.atlassian.net/browse/DISCO-2235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ