### PR TITLE
[DISCO-2345] chore: Set the cache TTL for weather to match against Firefox

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -83,7 +83,7 @@ cache = "none"
 enabled_by_default = false
 score = 0.3
 query_timeout_sec = 5.0
-cached_report_ttl_sec = 7200 # 2 hours.
+cached_report_ttl_sec = 1800 # 30 mins.
 
 [default.accuweather]
 # Our API key used to access the AccuWeather API.


### PR DESCRIPTION
## References

JIRA: [DISCO-2345](https://mozilla-hub.atlassian.net/browse/DISCO-2345)
GitHub: [#TODO](https://github.com/mozilla-services/merino-py/issues/TODO)

## Description
This patch reduces the cache TTL for the weather provider from 2 hours to 30 minutes, which matches against the refresh cadence of Firefox.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[do not deploy]` and `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2345]: https://mozilla-hub.atlassian.net/browse/DISCO-2345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ