### PR TITLE
[DENG-832-834] title whitespace strip, change of upload_from_string call

### DIFF
--- a/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
+++ b/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
@@ -40,6 +40,7 @@ class DomainMetadataExtractor:
         "Your request has been blocked",
         "This page is either unavailable or restricted",
         "Let's Get Your Identity Verified",
+        "Your Access To This Website Has Been Blocked",
     ]
 
     browser: RoboBrowser
@@ -190,7 +191,7 @@ class DomainMetadataExtractor:
             pass
 
         return (
-            title
+            title.strip()
             if title
             and not [t for t in self.INVALID_TITLES if t.casefold() in title.casefold()]
             else None

--- a/merino/jobs/navigational_suggestions/domain_metadata_uploader.py
+++ b/merino/jobs/navigational_suggestions/domain_metadata_uploader.py
@@ -61,7 +61,7 @@ class DomainMetadataUploader:
                 # make it publicly accessible
                 if not dst_blob.exists():
                     logger.info(f"blob {dst_favicon_name} doesn't exist. creating it..")
-                    dst_blob.upload_from_string(str(content))
+                    dst_blob.upload_from_string(content, content_type=content_type)
                     dst_blob.make_public()
 
                 dst_favicons.append(dst_blob.public_url)

--- a/tests/unit/jobs/navigational_suggestions/test_domain_metadata_uploader.py
+++ b/tests/unit/jobs/navigational_suggestions/test_domain_metadata_uploader.py
@@ -57,7 +57,9 @@ def test_upload_favicons_upload_if_not_present(mock_gcs_client, mocker):
     )
     uploaded_favicons = domain_metadata_uploader.upload_favicons(dummy_src_favicons)
 
-    mock_dst_blob.upload_from_string.assert_called_once_with(str(bytes(255)))
+    mock_dst_blob.upload_from_string.assert_called_once_with(
+        bytes(255), content_type="image/png"
+    )
     mock_dst_blob.make_public.assert_called_once()
 
     assert len(uploaded_favicons) == len(dummy_src_favicons)


### PR DESCRIPTION
## References

JIRA: [DENG-832](https://mozilla-hub.atlassian.net/browse/DENG-832)
JIRA: [DENG-834](https://mozilla-hub.atlassian.net/browse/DENG-834)


## Description
Post manual testing of new navigational suggestions job. Strips leading and trailing whitespace from the titles and corrects issue of image types not being set correctly.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[do not deploy]` and `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DENG-832]: https://mozilla-hub.atlassian.net/browse/DENG-832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DENG-834]: https://mozilla-hub.atlassian.net/browse/DENG-834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ