### PR TITLE
Use GCS bucket CDN hostname for uploaded favicon url

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -167,3 +167,5 @@ source_gcp_project = ""
 destination_gcp_project = ""
 # GCS bucket name where domain metadata will be uploaded
 destination_gcs_bucket = ""
+# CDN hostname of the GCS bucket where domain metadata will be uploaded
+destination_cdn_hostname = ""

--- a/merino/jobs/navigational_suggestions/__init__.py
+++ b/merino/jobs/navigational_suggestions/__init__.py
@@ -38,6 +38,12 @@ destination_gcs_bucket_option = typer.Option(
     help="GCS bucket where the domain metadata for navigational suggestions will be stored",
 )
 
+destination_gcs_cdn_hostname_option = typer.Option(
+    job_settings.destination_cdn_hostname,
+    "--dst-cdn-hostname",
+    help="GCS cdn hostname where the domain metadata for navigational suggestions will be stored",
+)
+
 navigational_suggestions_cmd = typer.Typer(
     name="navigational-suggestions",
     help="Command for preparing top domain metadata for navigational suggestions",
@@ -70,6 +76,7 @@ def prepare_domain_metadata(
     source_gcp_project: str = source_gcp_project_option,
     destination_gcp_project: str = destination_gcp_project_option,
     destination_gcs_bucket: str = destination_gcs_bucket_option,
+    destination_cdn_hostname: str = destination_gcs_cdn_hostname_option,
 ):
     """Prepare domain metadata for navigational suggestions"""
     # download top domains data
@@ -88,7 +95,7 @@ def prepare_domain_metadata(
 
     # upload favicons and get their public urls
     domain_metadata_uploader = DomainMetadataUploader(
-        destination_gcp_project, destination_gcs_bucket
+        destination_gcp_project, destination_gcs_bucket, destination_cdn_hostname
     )
     uploaded_favicons = domain_metadata_uploader.upload_favicons(favicons)
     logger.info("domain favicons uploaded to gcs")

--- a/merino/jobs/navigational_suggestions/domain_metadata_uploader.py
+++ b/merino/jobs/navigational_suggestions/domain_metadata_uploader.py
@@ -3,6 +3,7 @@ import datetime
 import hashlib
 import logging
 import time
+from urllib.parse import urljoin
 
 import requests
 from google.cloud.storage import Blob, Client
@@ -83,7 +84,12 @@ class DomainMetadataUploader:
     def _get_favicon_public_url(self, blob: Blob, favicon_name: str) -> str:
         """Get public url for the uploaded favicon"""
         if self.cdn_hostname:
-            return "https://" + self.cdn_hostname + "/" + favicon_name
+            base_url = (
+                f"https://{self.cdn_hostname}"
+                if "https" not in self.cdn_hostname
+                else self.cdn_hostname
+            )
+            return urljoin(base_url, favicon_name)
         else:
             return str(blob.public_url)
 

--- a/tests/unit/jobs/navigational_suggestions/test_domain_metadata_uploader.py
+++ b/tests/unit/jobs/navigational_suggestions/test_domain_metadata_uploader.py
@@ -26,7 +26,7 @@ def test_upload_top_picks(mock_gcs_client):
     mock_dst_blob = mock_gcs_bucket.blob.return_value
 
     domain_metadata_uploader = DomainMetadataUploader(
-        "dummy_gcp_project", "dummy_gcs_bucket"
+        "dummy_gcp_project", "dummy_gcs_bucket", None
     )
     domain_metadata_uploader.upload_top_picks(dummy_top_picks)
 
@@ -36,7 +36,7 @@ def test_upload_top_picks(mock_gcs_client):
 
 
 def test_upload_favicons_upload_if_not_present(mock_gcs_client, mocker):
-    """Test if top picks are uploaded only if not already present in GCS"""
+    """Test if favicons are uploaded only if not already present in GCS"""
     dummy_src_favicons = ["favicon1.png"]
     mock_gcs_bucket = mock_gcs_client.bucket.return_value
     mock_dst_blob = mock_gcs_bucket.blob.return_value
@@ -53,7 +53,7 @@ def test_upload_favicons_upload_if_not_present(mock_gcs_client, mocker):
     mock___download_favicon.return_value = (bytes(255), "image/png")
 
     domain_metadata_uploader = DomainMetadataUploader(
-        "dummy_gcp_project", "dummy_gcs_bucket"
+        "dummy_gcp_project", "dummy_gcs_bucket", None
     )
     uploaded_favicons = domain_metadata_uploader.upload_favicons(dummy_src_favicons)
 
@@ -66,12 +66,50 @@ def test_upload_favicons_upload_if_not_present(mock_gcs_client, mocker):
     assert uploaded_favicons[0] == "uploaded_favicon1.png"
 
 
+def test_upload_favicons_return_favicon_with_cdnhostname_when_provided(
+    mock_gcs_client, mocker
+):
+    """Test if uploaded favicon url has cdn hostname when provided"""
+    dummy_src_favicons = ["favicon1.png"]
+    dummy_cdn_hostname = "dummy.cdn.hostname"
+    dummy_destination_favicon_name = "dummy_destination_favicon_name"
+    expected_destination_favicon_url = (
+        "https://" + dummy_cdn_hostname + "/" + dummy_destination_favicon_name
+    )
+
+    mock_dst_blob = mock_gcs_client.bucket.return_value.blob.return_value
+    mock_dst_blob.exists.return_value = True
+
+    mocker.patch(
+        (
+            "merino.jobs.navigational_suggestions.domain_metadata_uploader."
+            "DomainMetadataUploader._download_favicon"
+        )
+    ).return_value = (bytes(255), "image/png")
+
+    mocker.patch(
+        (
+            "merino.jobs.navigational_suggestions.domain_metadata_uploader."
+            "DomainMetadataUploader._destination_favicon_name"
+        )
+    ).return_value = dummy_destination_favicon_name
+
+    domain_metadata_uploader = DomainMetadataUploader(
+        "dummy_gcp_project", "dummy_gcs_bucket", dummy_cdn_hostname
+    )
+    uploaded_favicons = domain_metadata_uploader.upload_favicons(dummy_src_favicons)
+
+    mock_dst_blob.public_url.assert_not_called()
+    assert len(uploaded_favicons) == len(dummy_src_favicons)
+    assert uploaded_favicons[0] == expected_destination_favicon_url
+
+
 def test_upload_favicons_exception_returns_empty_urls(mock_gcs_client, mocker):
     """Test if an exception results into returning an empty url"""
     dummy_src_favicons = ["invalid_favicon.png"]
 
     domain_metadata_uploader = DomainMetadataUploader(
-        "dummy_gcp_project", "dummy_gcs_bucket"
+        "dummy_gcp_project", "dummy_gcs_bucket", None
     )
     uploaded_favicons = domain_metadata_uploader.upload_favicons(dummy_src_favicons)
 


### PR DESCRIPTION
Fixes [DENG-833](https://mozilla-hub.atlassian.net/browse/DENG-833)

## References

JIRA: https://mozilla-hub.atlassian.net/browse/DENG-833

## Description
Use GCS bucket CDN hostname (provided as cli options) for uploaded favicon url. When CDN hostname is not provided then use the public url of the uploaded favicon.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[do not deploy]` and `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DENG-833]: https://mozilla-hub.atlassian.net/browse/DENG-833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ