### PR TITLE
Enable force uploading in navigational suggestion job

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -169,3 +169,5 @@ destination_gcp_project = ""
 destination_gcs_bucket = ""
 # CDN hostname of the GCS bucket where domain metadata will be uploaded
 destination_cdn_hostname = ""
+# Flag to enable uploading the domain metadata to GCS bucket even if it aleady exists there
+force_upload = false

--- a/merino/jobs/navigational_suggestions/__init__.py
+++ b/merino/jobs/navigational_suggestions/__init__.py
@@ -44,6 +44,12 @@ destination_gcs_cdn_hostname_option = typer.Option(
     help="GCS cdn hostname where the domain metadata for navigational suggestions will be stored",
 )
 
+force_upload_option = typer.Option(
+    job_settings.force_upload,
+    "--force-upload",
+    help="Upload the domain metadata to GCS bucket even if it aleady exists there",
+)
+
 navigational_suggestions_cmd = typer.Typer(
     name="navigational-suggestions",
     help="Command for preparing top domain metadata for navigational suggestions",
@@ -77,6 +83,7 @@ def prepare_domain_metadata(
     destination_gcp_project: str = destination_gcp_project_option,
     destination_gcs_bucket: str = destination_gcs_bucket_option,
     destination_cdn_hostname: str = destination_gcs_cdn_hostname_option,
+    force_upload: bool = force_upload_option,
 ):
     """Prepare domain metadata for navigational suggestions"""
     # download top domains data
@@ -95,7 +102,10 @@ def prepare_domain_metadata(
 
     # upload favicons and get their public urls
     domain_metadata_uploader = DomainMetadataUploader(
-        destination_gcp_project, destination_gcs_bucket, destination_cdn_hostname
+        destination_gcp_project,
+        destination_gcs_bucket,
+        destination_cdn_hostname,
+        force_upload,
     )
     uploaded_favicons = domain_metadata_uploader.upload_favicons(favicons)
     logger.info("domain favicons uploaded to gcs")

--- a/merino/jobs/navigational_suggestions/domain_metadata_uploader.py
+++ b/merino/jobs/navigational_suggestions/domain_metadata_uploader.py
@@ -30,10 +30,12 @@ class DomainMetadataUploader:
         destination_gcp_project: str,
         destination_bucket_name: str,
         destination_cdn_hostname: str,
+        force_upload: bool,
     ) -> None:
         self.storage_client = Client(destination_gcp_project)
         self.bucket_name = destination_bucket_name
         self.cdn_hostname = destination_cdn_hostname
+        self.force_upload = force_upload
 
     def upload_top_picks(self, top_picks: str) -> None:
         """Upload the top pick contents to gcs."""
@@ -63,10 +65,12 @@ class DomainMetadataUploader:
                 dst_favicon_name = self._destination_favicon_name(content, content_type)
                 dst_blob = bucket.blob(dst_favicon_name)
 
-                # upload favicon to gcs if it doesn't already exist there and
+                # upload favicon to gcs if force upload is set or if it doesn't exist there and
                 # make it publicly accessible
-                if not dst_blob.exists():
-                    logger.info(f"blob {dst_favicon_name} doesn't exist. creating it..")
+                if self.force_upload or not dst_blob.exists():
+                    logger.info(
+                        f"Uploading favicon {src_favicon} to blob {dst_favicon_name}"
+                    )
                     dst_blob.upload_from_string(content, content_type=content_type)
                     dst_blob.make_public()
 


### PR DESCRIPTION
## References

JIRA:
GitHub:

## Description
We would like to be able to upload domain metadata to GCS even if the data already exists there.

_Why is this change necessary_?

Sometimes, it is necessary to update the entire domain metadata (see https://mozilla-hub.atlassian.net/browse/DENG-834 as a recent incident). Currently, the job avoids uploading the domain metadata to GCS if it already exists.

Due to the limitation of developers not having deletion rights in staging and prod environment, a force upload flag allows developers to re-upload the entire domain metadata to GCS staging and prod environment while simultaneously keeping the functionality to avoid re-uploading it if it already exists there.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[do not deploy]` and `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
