### PR TITLE
[DISCO-2359] XFail 'test_get_favicons'

### DIFF
--- a/tests/integration/jobs/navigational_suggestions/test_domain_metadata_extractor.py
+++ b/tests/integration/jobs/navigational_suggestions/test_domain_metadata_extractor.py
@@ -132,6 +132,7 @@ FAVICON_SCENARIOS: list[Scenario] = [
 ]
 
 
+@pytest.mark.xfail(reason="Test Flake Detected (ref: DISCO-2359)")
 @pytest.mark.parametrize(
     ["domains_data", "expected_favicons"],
     FAVICON_SCENARIOS,


### PR DESCRIPTION
## References

JIRA: [DISCO-2359](https://mozilla-hub.atlassian.net/browse/DISCO-2359)
GitHub: N/A

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->
- Mark 'test_get_favicons' with xfail in order to mitigate the impact of test Flake on individual development and CI

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [x] `[do not deploy]` and `[load test: (abort|warn)]` keywords are applied (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2359]: https://mozilla-hub.atlassian.net/browse/DISCO-2359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ