### PR TITLE
Improve quality of the titles for navigational suggestions

### DIFF
--- a/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
+++ b/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
@@ -41,6 +41,8 @@ class DomainMetadataExtractor:
         "This page is either unavailable or restricted",
         "Let's Get Your Identity Verified",
         "Your Access To This Website Has Been Blocked",
+        "Error",
+        "This page is not allowed",
     ]
 
     browser: RoboBrowser

--- a/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
+++ b/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
@@ -186,12 +186,13 @@ class DomainMetadataExtractor:
         try:
             self.browser.open(url, timeout=self.TIMEOUT)
             title = self.browser.find("head").find("title").string
+            title = " ".join(title.split())
         except Exception as e:
             logger.info(f"Exception: {e} while extracting title from document")
             pass
 
         return (
-            title.strip()
+            title
             if title
             and not [t for t in self.INVALID_TITLES if t.casefold() in title.casefold()]
             else None
@@ -212,7 +213,7 @@ class DomainMetadataExtractor:
             # if no valid title is present then fallback to use the second level domain as title
             if title is None:
                 title = self._get_second_level_domain(domain_data)
-
+            logger.info(f"url {url} and title {title}")
             result.append({"url": url, "title": title})
 
         return result


### PR DESCRIPTION
## References

JIRA:
GitHub:

## Description
1. Removed non-leading and non-trailing duplicate whitespace/newline from title
    1. As per the [comment](https://mozilla-hub.atlassian.net/browse/DENG-832?focusedCommentId=675222) in [DENG-832](https://mozilla-hub.atlassian.net/browse/DENG-832), this fixed the issue with the title for the domain "zara" observed in the [latest top picks](https://merino-images.services.mozilla.com/1682101445000.0_top_picks.json) file.
3. Added "Error" and "This page is not allowed" to the invalid title list
    1. As per the [latest top picks](https://merino-images.services.mozilla.com/1682101445000.0_top_picks.json) file that was added via the [PR](https://github.com/mozilla-services/merino-py/pull/271) in this repo:
        - 25 whatsapp, title: “Error”
        - 269 hotstar, title: “Error”
        - 721 ycombinator, title: “Y Combinator | Internal Server Error”
        - 977 uptobox, title: "This page is not allowed in the US"

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[do not deploy]` and `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DENG-832]: https://mozilla-hub.atlassian.net/browse/DENG-832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ