### PR TITLE
Capitalize titles for navigational suggestions

### DIFF
--- a/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
+++ b/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
@@ -215,6 +215,8 @@ class DomainMetadataExtractor:
             # if no valid title is present then fallback to use the second level domain as title
             if title is None:
                 title = self._get_second_level_domain(domain_data)
+
+            title = title.capitalize()
             logger.info(f"url {url} and title {title}")
             result.append({"url": url, "title": title})
 

--- a/tests/integration/jobs/navigational_suggestions/test_domain_metadata_extractor.py
+++ b/tests/integration/jobs/navigational_suggestions/test_domain_metadata_extractor.py
@@ -173,7 +173,7 @@ TITLE_SCENARIOS: list[Scenario] = [
                 "categories": ["Economy & Finance"],
             },
         ],
-        ["investing"],
+        ["Investing"],
     ),
     # title as second level domain name because domain unreachable
     (
@@ -187,7 +187,7 @@ TITLE_SCENARIOS: list[Scenario] = [
                 "categories": ["Technology"],
             },
         ],
-        ["amazonaws"],
+        ["Amazonaws"],
     ),
 ]
 


### PR DESCRIPTION
## References

JIRA:
GitHub:

## Description
Somains for which scraper library couldn't scrape the title were assigned second level domain name as fallback title. The second level domain name always starts with lowercase letter. Hence capitalizing it made sense.

**Just to be consistent, I am capitalizing all the titles and not just the fallback ones.**



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[do not deploy]` and `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
