### PR TITLE
Fix logic to check the presence of default favicon

### DIFF
--- a/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
+++ b/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
@@ -60,7 +60,9 @@ class DomainMetadataExtractor:
         """Return the default favicon for a url if it exists"""
         default_favicon_url = f"{url}/favicon.ico"
         response = requests.get(
-            url, headers={"User-agent": self.FIREFOX_UA}, timeout=self.TIMEOUT
+            default_favicon_url,
+            headers={"User-agent": self.FIREFOX_UA},
+            timeout=self.TIMEOUT,
         )
         return default_favicon_url if response.status_code == 200 else None
 

--- a/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
+++ b/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
@@ -58,7 +58,7 @@ class DomainMetadataExtractor:
 
     def _get_default_favicon(self, url: str) -> Optional[str]:
         """Return the default favicon for a url if it exists"""
-        default_favicon_url = f"{url}/favicon.ico"
+        default_favicon_url = urljoin(url, "favicon.ico")
         response = requests.get(
             default_favicon_url,
             headers={"User-agent": self.FIREFOX_UA},


### PR DESCRIPTION
## References

JIRA:
GitHub:

## Description
This PR fixes following:
1. To test the presence of a domain's default favicon, we were wrongly checking whether the domain url is reachable or not instead of domain's default favicon url.
2. Robust generation of default favicon url (using `urllib.parse.urljoin` for generation)

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[do not deploy]` and `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
