### PR TITLE
Capitalize only fallback titles for navigational suggestions

### DIFF
--- a/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
+++ b/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
@@ -217,8 +217,8 @@ class DomainMetadataExtractor:
             # if no valid title is present then fallback to use the second level domain as title
             if title is None:
                 title = self._get_second_level_domain(domain_data)
+                title = title.capitalize()
 
-            title = title.capitalize()
             logger.info(f"url {url} and title {title}")
             result.append({"url": url, "title": title})
 


### PR DESCRIPTION
## References

JIRA:
GitHub:

## Description
PR https://github.com/mozilla-services/merino-py/pull/274 capitalized all the titles. For lots of domains, this resulted into weird titles. e.g.

`YouTube` changed to `Youtube`
`Cloud Computing Services | Microsoft Azure` changed to `Cloud computing services | microsoft azure`
`OpenAI` changed to `Openai`
`MSN` changed to `Msn`

=> Capitalizing only fallback titles and leaving all the other ones same as scraped from the webpage.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[do not deploy]` and `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
