### PR TITLE
feat: Add flag to write Airflow XCom metadata.

### DIFF
--- a/merino/jobs/navigational_suggestions/__init__.py
+++ b/merino/jobs/navigational_suggestions/__init__.py
@@ -47,7 +47,13 @@ destination_gcs_cdn_hostname_option = typer.Option(
 force_upload_option = typer.Option(
     job_settings.force_upload,
     "--force-upload",
-    help="Upload the domain metadata to GCS bucket even if it aleady exists there",
+    help="Upload the domain metadata to GCS bucket even if it already exists there",
+)
+
+write_xcom_option = typer.Option(
+    False,
+    "--write-xcom",
+    help="Write job results to Airflow XCom File",
 )
 
 navigational_suggestions_cmd = typer.Typer(
@@ -77,6 +83,11 @@ def _construct_top_picks(
     return json.dumps(top_picks, indent=4)
 
 
+def _write_xcom_file(xcom_data: dict):
+    with open("/airflow/xcom/return.json", "w") as file:
+        json.dump(xcom_data, file)
+
+
 @navigational_suggestions_cmd.command()
 def prepare_domain_metadata(
     source_gcp_project: str = source_gcp_project_option,
@@ -84,6 +95,7 @@ def prepare_domain_metadata(
     destination_gcs_bucket: str = destination_gcs_bucket_option,
     destination_cdn_hostname: str = destination_gcs_cdn_hostname_option,
     force_upload: bool = force_upload_option,
+    write_xcom: bool = write_xcom_option,
 ):
     """Prepare domain metadata for navigational suggestions"""
     # download top domains data
@@ -114,5 +126,10 @@ def prepare_domain_metadata(
     top_picks = _construct_top_picks(
         domain_data, uploaded_favicons, urls_and_titles, second_level_domains
     )
-    domain_metadata_uploader.upload_top_picks(top_picks)
-    logger.info("top pick contents uploaded to gcs")
+    top_pick_blob = domain_metadata_uploader.upload_top_picks(top_picks)
+    logger.info(
+        "top pick contents uploaded to gcs",
+        extra={"public_url": top_pick_blob.public_url},
+    )
+    if write_xcom is True:
+        _write_xcom_file({"top_pick_url": top_pick_blob.public_url})

--- a/merino/jobs/navigational_suggestions/domain_metadata_uploader.py
+++ b/merino/jobs/navigational_suggestions/domain_metadata_uploader.py
@@ -37,12 +37,13 @@ class DomainMetadataUploader:
         self.cdn_hostname = destination_cdn_hostname
         self.force_upload = force_upload
 
-    def upload_top_picks(self, top_picks: str) -> None:
+    def upload_top_picks(self, top_picks: str) -> Blob:
         """Upload the top pick contents to gcs."""
         bucket = self.storage_client.bucket(self.bucket_name)
         dst_top_pick_name = self._destination_top_pick_name()
         dst_blob = bucket.blob(dst_top_pick_name)
         dst_blob.upload_from_string(top_picks)
+        return dst_blob
 
     def _destination_top_pick_name(self) -> str:
         """Return the name of the top pick file to be used for uploading to GCS"""


### PR DESCRIPTION
## Description
Adds a flag to the nav suggestion job to write Airflow xcom data

See https://airflow.apache.org/docs/apache-airflow-providers-cncf-kubernetes/stable/operators.html#how-does-xcom-work and https://airflow.apache.org/docs/apache-airflow/stable/core-concepts/xcoms.html for more detail.

Complement to https://github.com/mozilla/telemetry-airflow/pull/1700


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[do not deploy]` and `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
