### PR TITLE
[Bugzilla-1830328] Fix blurry Top picks favicons

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -185,3 +185,5 @@ destination_gcs_bucket = ""
 destination_cdn_hostname = ""
 # Flag to enable uploading the domain metadata to GCS bucket even if it aleady exists there
 force_upload = false
+# Minimum width of the domain favicon required for it to be a part of domain metadata
+min_favicon_width = 52

--- a/merino/jobs/navigational_suggestions/__init__.py
+++ b/merino/jobs/navigational_suggestions/__init__.py
@@ -50,6 +50,12 @@ force_upload_option = typer.Option(
     help="Upload the domain metadata to GCS bucket even if it aleady exists there",
 )
 
+min_favicon_width_option = typer.Option(
+    job_settings.min_favicon_width,
+    "--min-favicon-width",
+    help="Minimum width of the domain favicon required for it to be a part of domain metadata",
+)
+
 navigational_suggestions_cmd = typer.Typer(
     name="navigational-suggestions",
     help="Command for preparing top domain metadata for navigational suggestions",
@@ -84,6 +90,7 @@ def prepare_domain_metadata(
     destination_gcs_bucket: str = destination_gcs_bucket_option,
     destination_cdn_hostname: str = destination_gcs_cdn_hostname_option,
     force_upload: bool = force_upload_option,
+    min_favicon_width: int = min_favicon_width_option,
 ):
     """Prepare domain metadata for navigational suggestions"""
     # download top domains data
@@ -93,7 +100,7 @@ def prepare_domain_metadata(
 
     # extract domain metadata of top domains
     domain_metadata_extractor = DomainMetadataExtractor()
-    favicons = domain_metadata_extractor.get_favicons(domain_data)
+    favicons = domain_metadata_extractor.get_favicons(domain_data, min_favicon_width)
     urls_and_titles = domain_metadata_extractor.get_urls_and_titles(domain_data)
     second_level_domains = domain_metadata_extractor.get_second_level_domains(
         domain_data

--- a/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
+++ b/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
@@ -109,8 +109,10 @@ class DomainMetadataExtractor:
 
         return favicons
 
-    def _get_best_favicon(self, favicons: list[dict]) -> str:
-        """Return the favicon with the highest resolution from a list of favicons"""
+    def _get_best_favicon(self, favicons: list[dict], min_width: int) -> str:
+        """Return the favicon with the highest resolution that satisfies the minimum width
+        criteria from a list of favicons.
+        """
         best_favicon_url = ""
         best_favicon_width = 0
         for favicon in favicons:
@@ -160,11 +162,14 @@ class DomainMetadataExtractor:
                 best_favicon_url = url
                 best_favicon_width = width
 
-        return best_favicon_url
+        logger.debug(f"best favicon url:{best_favicon_url}, width:{best_favicon_width}")
 
-    def get_favicons(self, domains_data: list[dict]) -> list[str]:
-        """Extract favicons for each domain and return the one with the highest resolution
-        for each.
+        return best_favicon_url if best_favicon_width >= min_width else ""
+
+    def get_favicons(self, domains_data: list[dict], min_width: int) -> list[str]:
+        """Extract favicons for each domain and return the one that satisfies the minimum width"
+        criteria for each domain. If multiple favicons satisfy the criteria then return the one
+        with the highest resolution.
         """
         result = []
         for domain_data in domains_data:
@@ -179,7 +184,7 @@ class DomainMetadataExtractor:
             logger.info(
                 f"{len(favicons)} favicons extracted for {url}. Favicons are: {favicons}"
             )
-            best_favicon = self._get_best_favicon(favicons)
+            best_favicon = self._get_best_favicon(favicons, min_width)
             result.append(best_favicon)
         return result
 

--- a/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
+++ b/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
@@ -167,7 +167,7 @@ class DomainMetadataExtractor:
         return best_favicon_url if best_favicon_width >= min_width else ""
 
     def get_favicons(self, domains_data: list[dict], min_width: int) -> list[str]:
-        """Extract favicons for each domain and return the one that satisfies the minimum width"
+        """Extract favicons for each domain and return the one that satisfies the minimum width
         criteria for each domain. If multiple favicons satisfy the criteria then return the one
         with the highest resolution.
         """

--- a/tests/integration/jobs/navigational_suggestions/test_domain_metadata_extractor.py
+++ b/tests/integration/jobs/navigational_suggestions/test_domain_metadata_extractor.py
@@ -115,7 +115,7 @@ FAVICON_SCENARIOS: list[Scenario] = [
         ],
         ["https://assets.nflxext.com/en_us/layout/ecweb/netflix-app-icon_152.jpg"],
     ),
-    # domain with non-square favicon
+    # domain not satisfying min width criteria of favicon
     (
         [
             {
@@ -127,7 +127,7 @@ FAVICON_SCENARIOS: list[Scenario] = [
                 "categories": ["Gaming"],
             }
         ],
-        ["https://xbox.com/favicon.ico"],
+        [""],
     ),
 ]
 
@@ -140,7 +140,7 @@ FAVICON_SCENARIOS: list[Scenario] = [
 def test_get_favicons(domains_data: list[dict], expected_favicons: list[str]):
     """Test that DomainMetadataExtractor returns favicons as expected"""
     metadata_extractor = DomainMetadataExtractor()
-    favicons = metadata_extractor.get_favicons(domains_data, min_width=8)
+    favicons = metadata_extractor.get_favicons(domains_data, min_width=16)
     assert len(favicons) == len(domains_data)
     for idx, favicon in enumerate(favicons):
         assert favicon == expected_favicons[idx]

--- a/tests/integration/jobs/navigational_suggestions/test_domain_metadata_extractor.py
+++ b/tests/integration/jobs/navigational_suggestions/test_domain_metadata_extractor.py
@@ -140,7 +140,7 @@ FAVICON_SCENARIOS: list[Scenario] = [
 def test_get_favicons(domains_data: list[dict], expected_favicons: list[str]):
     """Test that DomainMetadataExtractor returns favicons as expected"""
     metadata_extractor = DomainMetadataExtractor()
-    favicons = metadata_extractor.get_favicons(domains_data)
+    favicons = metadata_extractor.get_favicons(domains_data, min_width=8)
     assert len(favicons) == len(domains_data)
     for idx, favicon in enumerate(favicons):
         assert favicon == expected_favicons[idx]


### PR DESCRIPTION
## References
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1830328
JIRA:
GitHub:

## Description
- Added a criteria to filter all favicons below a certain specified width so that they don't look blurry in Firefox Address bar
- Width can be specified via cli option "--min-favicon-width"
- Added a test case


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[do not deploy]` and `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
