### PR TITLE
[DISCO-2387] refactor: Load addon data concurrently for the amo dynamic backend

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,4 +58,10 @@ repos:
           --warn-return-any,
           --warn-unused-ignores
         ]
-        additional_dependencies: ["pydantic", "types-geoip2", "types-PyYAML", "types-requests"]
+        additional_dependencies: [
+          "pydantic",
+          "types-geoip2",
+          "types-PyYAML",
+          "types-requests",
+          "types-redis"
+        ]

--- a/merino/providers/amo/backends/dynamic.py
+++ b/merino/providers/amo/backends/dynamic.py
@@ -48,24 +48,20 @@ class DynamicAmoBackend:
             res.raise_for_status()
 
             json_res = res.json()
-            icon = json_res["icon_url"]
-            rating = f"{(json_res['ratings']['average']):.1f}"
-            number_of_ratings = json_res["ratings"]["count"]
+            return {
+                "icon": json_res["icon_url"],
+                "rating": f"{(json_res['ratings']['average']):.1f}",
+                "number_of_ratings": json_res["ratings"]["count"],
+            }
         except httpx.HTTPError:
             logger.error(f"Addons API could not find key: {addon_key}")
-            return None
         except (KeyError, JSONDecodeError):
             logger.error(
                 "Problem with Addons API formatting. "
                 "Check that the API response structure hasn't changed."
             )
-            return None
 
-        return {
-            "icon": icon,
-            "rating": rating,
-            "number_of_ratings": number_of_ratings,
-        }
+        return None
 
     async def initialize_addons(self) -> None:
         """Initialize the dynamic AMO information via the Addons API.

--- a/merino/providers/amo/provider.py
+++ b/merino/providers/amo/provider.py
@@ -72,7 +72,11 @@ class Provider(BaseProvider):
 
     async def initialize(self) -> None:
         """Initialize"""
-        await self.backend.initialize_addons()
+        try:
+            await self.backend.initialize_addons()
+        except AmoBackendError as e:
+            # Do not propagate the error as it can be recovered later by retrying.
+            logger.warning(f"Failed to initialize addon backend: {e}")
         self.addon_keywords = invert_and_expand_index_keywords(
             self.keywords, self.min_chars
         )

--- a/tests/unit/providers/amo/backends/test_dynamic.py
+++ b/tests/unit/providers/amo/backends/test_dynamic.py
@@ -11,7 +11,7 @@ from merino.providers.amo.backends.dynamic import (
     DynamicAmoBackend,
     DynamicAmoBackendException,
 )
-from merino.providers.amo.backends.protocol import Addon
+from merino.providers.amo.backends.protocol import Addon, AmoBackendError
 
 
 @pytest.fixture(name="dynamic_backend")
@@ -137,6 +137,19 @@ async def test_initialize_addons_skipped_bad_response(
         caplog.messages[0] == "Problem with Addons API formatting. "
         "Check that the API response structure hasn't changed."
     )
+
+
+@pytest.mark.asyncio
+async def test_initialize_addons_handled_task_group_exceptions(
+    mocker: MockerFixture, dynamic_backend: DynamicAmoBackend
+):
+    """Test that `TaskGroup` exceptions are captured and propagated as `AmoBackendError`."""
+    mocker.patch.object(
+        dynamic_backend, "_fetch_addon", side_effect=Exception("mocked error")
+    )
+
+    with pytest.raises(AmoBackendError):
+        await dynamic_backend.initialize_addons()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/providers/amo/test_provider.py
+++ b/tests/unit/providers/amo/test_provider.py
@@ -37,7 +37,7 @@ class AmoInitErrorBackend:
         """Get an Addon based on the addon_key.
         Raise a `BackendError` if the addon key is missing.
         """
-        pass
+        raise AmoBackendError("Addon key missing!")
 
     async def initialize_addons(self) -> None:
         """Initialize addons to be stored."""
@@ -177,7 +177,7 @@ async def test_query_error(
 async def test_initialize_addons_error(
     caplog: LogCaptureFixture, keywords: dict[SupportedAddon, set[str]]
 ):
-    """Test that provider can handle query error."""
+    """Test that provider can handle initialization errors."""
     provider = AddonsProvider(
         backend=AmoInitErrorBackend(),
         keywords=keywords,

--- a/tests/unit/providers/amo/test_provider.py
+++ b/tests/unit/providers/amo/test_provider.py
@@ -30,6 +30,20 @@ class AmoErrorBackend:
         pass
 
 
+class AmoInitErrorBackend:
+    """AmoBackend that raises an error during initialization."""
+
+    async def get_addon(self, addon_key: SupportedAddon) -> Addon:  # pragma: no cover
+        """Get an Addon based on the addon_key.
+        Raise a `BackendError` if the addon key is missing.
+        """
+        pass
+
+    async def initialize_addons(self) -> None:
+        """Initialize addons to be stored."""
+        raise AmoBackendError("Error!!!")
+
+
 @pytest.fixture(name="keywords")
 def fixture_keywords() -> dict[SupportedAddon, set[str]]:
     """Fixture for the keywords."""
@@ -157,3 +171,21 @@ async def test_query_error(
 
     assert len(caplog.messages) == 1
     assert caplog.messages[0].startswith("Error getting AMO suggestion:")
+
+
+@pytest.mark.asyncio
+async def test_initialize_addons_error(
+    caplog: LogCaptureFixture, keywords: dict[SupportedAddon, set[str]]
+):
+    """Test that provider can handle query error."""
+    provider = AddonsProvider(
+        backend=AmoInitErrorBackend(),
+        keywords=keywords,
+        name="addons",
+        score=0.3,
+        min_chars=4,
+    )
+    await provider.initialize()
+
+    assert len(caplog.messages) == 1
+    assert caplog.messages[0].startswith("Failed to initialize addon backend:")


### PR DESCRIPTION
## References

JIRA: [DISCO-2387](https://mozilla-hub.atlassian.net/browse/DISCO-2387)
GitHub: N/A

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->
Noticed Merino's startup latency increased a lot when running Merino locally. The metrics suggested that the `amo` provider was the regressor. This patch makes the backend load addon data concurrently which speeds up its initialization on my box (from 3.8 seconds to 1.4 seconds). 



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[do not deploy]` and `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2387]: https://mozilla-hub.atlassian.net/browse/DISCO-2387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ