### PR TITLE
[DISCO-2372] Append an optional partner code to AccuWeather response URLs

### DIFF
--- a/docs/operations/configs.md
+++ b/docs/operations/configs.md
@@ -206,6 +206,11 @@ Configuration for using AccuWeather as a weather backend
     for postal codes.
   - `url_postalcodes_param_query` (`MERINO_ACCUWEATHER__URL_POSTALCODES_PARAM_QUERY`) -
     The query parameter for postal codes.
+  - `url_param_partner_code` (`MERINO_ACCUWEATHER__URL_PARAM_PARTNER_CODE`) -
+    The query parameter for the [partner code](https://apidev.accuweather.com/developers/partner-code)
+    to append to URLs in the current conditions and forecast responses.
+  - `partner_code` (`MERINO_ACCUWEATHER__PARTNER_CODE`) -
+    The partner code to append to URLs in the current conditions and forecast responses.
 
 ### AMO API 
 

--- a/merino/config.py
+++ b/merino/config.py
@@ -9,6 +9,13 @@ _validators = [
     Validator("metrics.dev_logger", is_type_of=bool),
     Validator("metrics.host", is_type_of=str),
     Validator("metrics.port", gte=0, is_type_of=int),
+    Validator(
+        "accuweather.url_param_partner_code",
+        is_type_of=str,
+        must_exist=True,
+        when=Validator("accuweather.partner_code", must_exist=True),
+    ),
+    Validator("accuweather.partner_code", is_type_of=str),
     Validator("amo.dynamic.api_url", is_type_of=str),
     Validator("providers.accuweather.enabled_by_default", is_type_of=bool),
     # The Redis server URL is required when at least one provider wants to use Redis for caching.

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -96,6 +96,10 @@ url_current_conditions_path = "/currentconditions/v1/{location_key}.json"
 url_forecasts_path = "/forecasts/v1/daily/1day/{location_key}.json"
 url_postalcodes_path = "/locations/v1/postalcodes/{country_code}/search.json"
 url_postalcodes_param_query = "q"
+# The name of the partner code query param appended to the current conditions and forecast links in
+# AccuWeather responses, as described in https://apidev.accuweather.com/developers/partner-code.
+# Note that this is the name of the partner code parameter, not the partner code itself.
+url_param_partner_code = "partner"
 
 [default.providers.adm]
 type = "adm"

--- a/merino/providers/manager.py
+++ b/merino/providers/manager.py
@@ -59,6 +59,10 @@ def _create_provider(provider_id: str, setting: Settings) -> BaseProvider:
                     url_postalcodes_param_query=settings.accuweather.url_postalcodes_param_query,
                     url_current_conditions_path=settings.accuweather.url_current_conditions_path,
                     url_forecasts_path=settings.accuweather.url_forecasts_path,
+                    url_param_partner_code=settings.accuweather.get(
+                        "url_param_partner_code"
+                    ),
+                    partner_code=settings.accuweather.get("partner_code"),
                 )  # type: ignore [arg-type]
                 if setting.backend == "accuweather"
                 else FakeWeatherBackend(),


### PR DESCRIPTION
## References

JIRA: [DISCO-2372](https://mozilla-hub.atlassian.net/browse/DISCO-2372)

## Description

According to https://apidev.accuweather.com/developers/partner-code, we should append our partner code to the current conditions and forecast URLs returned in the API responses from AccuWeather.

This value isn't secret—it'll be returned in Merino API responses, and users will see it when they open the suggestion—but it's Mozilla-specific, so I'll add it to our ConfigMap instead of here.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [x] `[do not deploy]` and `[load test: (abort|warn)]` keywords are applied (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2372]: https://mozilla-hub.atlassian.net/browse/DISCO-2372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ