### PR TITLE
DENG-880 DENG-881 Update domain category filters

### DIFF
--- a/merino/jobs/navigational_suggestions/domain_data_downloader.py
+++ b/merino/jobs/navigational_suggestions/domain_data_downloader.py
@@ -41,12 +41,14 @@ with apex_names as (
         SELECT * FROM UNNEST(categories) AS c
         WHERE
           c.parent_id in (
-            2, -- Adult Theme
+            2,  -- Adult Theme
+            8,  -- Gambling
             17, -- Questionable Content
             21, -- Security Threats
-            28, -- Violence
+            29, -- Violence
             31, -- Blocked
-            32  -- Security Risks
+            32, -- Security Risks
+            33  -- Military & Weapons
           )
         OR
           c.id IN (81) -- Content Servers


### PR DESCRIPTION
## References

[DENG-880](https://mozilla-hub.atlassian.net/browse/DENG-880)
[DENG-881](https://mozilla-hub.atlassian.net/browse/DENG-881)

## Description
Update the domain category filter to remove `Weapons` and `Gambling` categories from the top domain query results. There was also a typo in the domain category id for `Violence` that has been fixed. 



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[do not deploy]` and `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DENG-880]: https://mozilla-hub.atlassian.net/browse/DENG-880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DENG-881]: https://mozilla-hub.atlassian.net/browse/DENG-881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ