### PR TITLE
fix: Bump mdbook rust version to 1.69.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,7 +250,7 @@ jobs:
             docker push "${DOCKERHUB_MERINO_LOCUST_REPO}:latest"
   docs-build:
     docker:
-      - image: cimg/rust:1.64
+      - image: cimg/rust:1.69
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Getting a CI failure for `docs-build` saying that mdbook now requires `rust` version `1.65` or greater. 