### PR TITLE
Improve URL for navigational suggestions

### DIFF
--- a/merino/jobs/navigational_suggestions/__init__.py
+++ b/merino/jobs/navigational_suggestions/__init__.py
@@ -76,15 +76,16 @@ def _construct_top_picks(
 ) -> str:
     result = []
     for index, domain in enumerate(domain_data):
-        result.append(
-            {
-                "rank": domain["rank"],
-                "domain": second_level_domains[index],
-                "categories": domain["categories"],
-                **urls_and_titles[index],
-                "icon": favicons[index],
-            }
-        )
+        if urls_and_titles[index]["url"]:
+            result.append(
+                {
+                    "rank": domain["rank"],
+                    "domain": second_level_domains[index],
+                    "categories": domain["categories"],
+                    **urls_and_titles[index],
+                    "icon": favicons[index],
+                }
+            )
     top_picks = {"domains": result}
     return json.dumps(top_picks, indent=4)
 

--- a/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
+++ b/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
@@ -287,10 +287,15 @@ class DomainMetadataExtractor:
                 url = f"https://www.{domain}"
                 final_redirected_base_url, title = self._extract_url_and_title(url)
 
-            # if no valid title is present then fallback to use the second level domain as title
-            if title is None:
-                title = self._get_second_level_domain(domain_data)
-                title = title.capitalize()
+            # final redirected base url should contain domain as a substring
+            if final_redirected_base_url and domain in final_redirected_base_url:
+                # if no valid title is present then fallback to use second level domain as title
+                if title is None:
+                    title = self._get_second_level_domain(domain_data)
+                    title = title.capitalize()
+            else:
+                final_redirected_base_url = None
+                title = None
 
             logger.info(f"url {final_redirected_base_url} and title {title}")
             result.append({"url": final_redirected_base_url, "title": title})

--- a/tests/unit/jobs/navigational_suggestions/test_domain_metadata_extractor.py
+++ b/tests/unit/jobs/navigational_suggestions/test_domain_metadata_extractor.py
@@ -24,7 +24,9 @@ FaviconScenario = tuple[
     list[str],
 ]
 TitleScenario = tuple[
-    tuple[Optional[str], Optional[str]], list[dict[str, Any]], list[dict[str, str]]
+    tuple[Optional[str], Optional[str]],
+    list[dict[str, Any]],
+    list[dict[str, Optional[str]]],
 ]
 
 FAVICON_SCENARIOS: list[FaviconScenario] = [
@@ -418,13 +420,47 @@ TITLE_SCENARIOS: list[TitleScenario] = [
         ],
         [{"url": "https://www.minecraft.net", "title": "Minecraft"}],
     ),
+    (
+        ("https://aws.amazon.com", "Amazon AWS"),
+        [
+            {
+                "rank": 4,
+                "domain": "amazonaws.com",
+                "host": "lsrelay-config-production.s3.amazonaws.com",
+                "origin": "http://lsrelay-config-production.s3.amazonaws.com",
+                "suffix": "com",
+                "categories": ["Technology"],
+            },
+        ],
+        [{"url": None, "title": None}],
+    ),
+    (
+        (None, None),
+        [
+            {
+                "rank": 41,
+                "domain": "unreachable.com",
+                "host": "www.unreachable.com",
+                "origin": "http://www.unreachable.com",
+                "suffix": "com",
+                "categories": ["Technology"],
+            },
+        ],
+        [{"url": None, "title": None}],
+    ),
 ]
 
 
 @pytest.mark.parametrize(
     ["url_and_title", "domains_data", "expected_urls_and_titles"],
     TITLE_SCENARIOS,
-    ids=["title_from_document", "title_not_from_document", "redirected_base_url"],
+    ids=[
+        "title_from_document",
+        "title_not_from_document",
+        "url_containing_domain_accepted",
+        "url_not_containing_domain_skipped",
+        "unreachable_url_skipped",
+    ],
 )
 def test_get_urls_and_titles(
     mocker: MockerFixture,

--- a/tests/unit/jobs/navigational_suggestions/test_navigational_suggestions.py
+++ b/tests/unit/jobs/navigational_suggestions/test_navigational_suggestions.py
@@ -29,17 +29,28 @@ def test_prepare_domain_metadata_top_picks_construction(mocker):
             "origin": "https://www.dummy_domain.com",
             "suffix": "com",
             "categories": ["Search Engines"],
-        }
+        },
+        {
+            "rank": 2,
+            "domain": "dummy_unreachable_domain.com",
+            "host": "www.dummy_unreachable_domain.com",
+            "origin": "https://www.dummy_unreachable_domain.com",
+            "suffix": "com",
+            "categories": ["Search Engines"],
+        },
     ]
 
     mock_domain_metadata_extractor.get_urls_and_titles.return_value = [
-        {"url": "dummy_url", "title": "dummy_title"}
+        {"url": "dummy_url", "title": "dummy_title"},
+        {"url": None, "title": None},
     ]
     mock_domain_metadata_extractor.get_second_level_domains.return_value = [
-        "second_level_domain"
+        "dummy_domain",
+        "dummy_unreachable_domain",
     ]
     mock_domain_metadata_uploader.upload_favicons.return_value = [
-        "dummy_uploaded_favicon_url"
+        "dummy_uploaded_favicon_url",
+        "",
     ]
 
     prepare_domain_metadata(
@@ -50,7 +61,7 @@ def test_prepare_domain_metadata_top_picks_construction(mocker):
         "domains": [
             {
                 "rank": 1,
-                "domain": "second_level_domain",
+                "domain": "dummy_domain",
                 "categories": ["Search Engines"],
                 "url": "dummy_url",
                 "title": "dummy_title",


### PR DESCRIPTION
## References
~~Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1832555~~

JIRA:
GitHub:

## Description
 - Using scraping library with `allow_redirects=True`
 - Use final redirected base url returned by scraping library for top picks file
 - Skip domains for which the corresponding final redirected base url doesn't have domain itself as a substring
 - Skip domains that are unreachable
 - Updated unit test cases

~~Tested with `minecraft` and `facebook` domain to confirm that the final redirected base urls are being stored in top picks file.~~

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[do not deploy]` and `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
