### PR TITLE
Add and return `guid` to AMO suggestions

### DIFF
--- a/merino/providers/amo/addons_data.py
+++ b/merino/providers/amo/addons_data.py
@@ -28,6 +28,7 @@ ADDON_DATA: dict[SupportedAddon, dict[str, str]] = {
             "YouTube, Facebook, Vimeo, Twitch, and more."
         ),
         "url": "https://addons.mozilla.org/en-US/firefox/addon/video-downloadhelper/",
+        "guid": "{b9db16a4-6edc-47ec-a1f4-b86292ed211d}",
     },
     SupportedAddon.LANGAUGE_TOOL: {
         "name": "LanguageTool",
@@ -36,6 +37,7 @@ ADDON_DATA: dict[SupportedAddon, dict[str, str]] = {
             "social media, email, docs, and more."
         ),
         "url": "https://addons.mozilla.org/en-US/firefox/addon/languagetool/",
+        "guid": "languagetool-webextension@languagetool.org",
     },
     SupportedAddon.PRIVATE_RELAY: {
         "name": "Firefox Relay",
@@ -44,6 +46,7 @@ ADDON_DATA: dict[SupportedAddon, dict[str, str]] = {
             "from hackers and junk mail."
         ),
         "url": "https://addons.mozilla.org/en-US/firefox/addon/private-relay/",
+        "guid": "private-relay@firefox.com",
     },
     SupportedAddon.SEARCH_BY_IMAGE: {
         "name": "Search by Image",
@@ -52,6 +55,7 @@ ADDON_DATA: dict[SupportedAddon, dict[str, str]] = {
             "Find similar images, identify sources and more."
         ),
         "url": "https://addons.mozilla.org/en-US/firefox/addon/search_by_image/",
+        "guid": "{2e5ff8c8-32fe-46d0-9fc8-6b8986621f3c}",
     },
     SupportedAddon.DARKREADER: {
         "name": "Dark Reader",
@@ -60,6 +64,7 @@ ADDON_DATA: dict[SupportedAddon, dict[str, str]] = {
             "Adjust colors and reduce eye strain."
         ),
         "url": "https://addons.mozilla.org/en-US/firefox/addon/darkreader/",
+        "guid": "addon@darkreader.org",
     },
     SupportedAddon.PRIVACY_BADGER: {
         "name": "Privacy Badger",
@@ -68,6 +73,7 @@ ADDON_DATA: dict[SupportedAddon, dict[str, str]] = {
             "Protect your privacy online."
         ),
         "url": "https://addons.mozilla.org/en-US/firefox/addon/privacy-badger17/",
+        "guid": "jid1-MnnxcxisBPnSXQ@jetpack",
     },
     SupportedAddon.UBLOCK_ORIGIN: {
         "name": "uBlock Origin",
@@ -76,6 +82,7 @@ ADDON_DATA: dict[SupportedAddon, dict[str, str]] = {
             "this efficient content blocker."
         ),
         "url": "https://addons.mozilla.org/en-US/firefox/addon/ublock-origin/",
+        "guid": "uBlock0@raymondhill.net",
     },
     SupportedAddon.READ_ALOUD: {
         "name": "Read Aloud: A Text to Speech Reader",
@@ -85,6 +92,7 @@ ADDON_DATA: dict[SupportedAddon, dict[str, str]] = {
             "Supports PDF and EPUB."
         ),
         "url": "https://addons.mozilla.org/firefox/addon/read-aloud/",
+        "guid": "{ddc62400-f22d-4dd3-8b4a-05837de53c2e}",
     },
 }
 

--- a/merino/providers/amo/backends/dynamic.py
+++ b/merino/providers/amo/backends/dynamic.py
@@ -107,4 +107,5 @@ class DynamicAmoBackend:
             icon=icon_and_rating["icon"],
             rating=icon_and_rating["rating"],
             number_of_ratings=icon_and_rating["number_of_ratings"],
+            guid=static_info["guid"],
         )

--- a/merino/providers/amo/backends/protocol.py
+++ b/merino/providers/amo/backends/protocol.py
@@ -22,6 +22,7 @@ class Addon(BaseModel):
     icon: str
     rating: str
     number_of_ratings: int
+    guid: str
 
 
 class AmoBackend(Protocol):

--- a/merino/providers/amo/backends/static.py
+++ b/merino/providers/amo/backends/static.py
@@ -69,4 +69,5 @@ class StaticAmoBackend:
             icon=icon_and_rating["icon"],
             rating=icon_and_rating["rating"],
             number_of_ratings=icon_and_rating["number_of_ratings"],
+            guid=static_info["guid"],
         )

--- a/merino/providers/amo/provider.py
+++ b/merino/providers/amo/provider.py
@@ -108,7 +108,9 @@ class Provider(BaseProvider):
                 icon=addon.icon,
                 custom_details=CustomDetails(
                     amo=AmoDetails(
-                        rating=addon.rating, number_of_ratings=addon.number_of_ratings
+                        rating=addon.rating,
+                        number_of_ratings=addon.number_of_ratings,
+                        guid=addon.guid,
                     )
                 ),
             )

--- a/merino/providers/custom_details.py
+++ b/merino/providers/custom_details.py
@@ -7,6 +7,7 @@ class AmoDetails(BaseModel):
 
     rating: str
     number_of_ratings: int
+    guid: str
 
 
 class CustomDetails(BaseModel, arbitrary_types_allowed=False):

--- a/tests/unit/providers/amo/backends/test_dynamic.py
+++ b/tests/unit/providers/amo/backends/test_dynamic.py
@@ -171,6 +171,7 @@ async def test_get_addon_request(
             icon="https://this.is.image",
             rating="4.1",
             number_of_ratings=1234,
+            guid=video_downloader["guid"],
         )
         == addons
     )

--- a/tests/unit/providers/amo/backends/test_static.py
+++ b/tests/unit/providers/amo/backends/test_static.py
@@ -29,6 +29,7 @@ async def test_get_addon_success(static_backend: StaticAmoBackend):
             icon=vd_icon_rating["icon"],
             rating=vd_icon_rating["rating"],
             number_of_ratings=vd_icon_rating["number_of_ratings"],
+            guid=video_downloader["guid"],
         )
         == addons
     )

--- a/tests/unit/providers/amo/test_provider.py
+++ b/tests/unit/providers/amo/test_provider.py
@@ -145,6 +145,7 @@ async def test_query_return_match(
                 amo=AmoDetails(
                     rating=expected_icon_rating["rating"],
                     number_of_ratings=expected_icon_rating["number_of_ratings"],
+                    guid=expected_info["guid"],
                 )
             ),
         )


### PR DESCRIPTION
## Description
Since the `guid` is unlikely to change, we have added it to the static data of the addon. If we're finding that it _does_ change, can move it back to the API.

cc: @0c0w3 

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [x] `[do not deploy]` and `[load test: (abort|warn)]` keywords are applied (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
