### PR TITLE
[SNT-689] feat: add job to upload AMO suggestions to remote settings

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -191,3 +191,15 @@ destination_cdn_hostname = ""
 force_upload = false
 # Minimum width of the domain favicon required for it to be a part of domain metadata
 min_favicon_width = 52
+
+[default.jobs.amo_rs_uploader]
+# Remote settings authorization token
+auth = ""
+# Remote settings collection ID
+cid = "quicksuggest"
+# Log the records that would be uploaded but don't upload them
+dry_run = false
+# Remote settings server
+server = "https://remote-settings.mozilla.org/v1"
+# Remote settings workspace
+workspace = "main-workspace"

--- a/merino/jobs/amo_rs_uploader/__init__.py
+++ b/merino/jobs/amo_rs_uploader/__init__.py
@@ -1,0 +1,120 @@
+"""CLI commands for the amo_rs_uploader module"""
+import asyncio
+import hashlib
+import logging
+from typing import Any
+
+import typer
+
+from merino.config import settings as config
+from merino.jobs.amo_rs_uploader.remote_settings import RemoteSettings
+from merino.providers.amo.addons_data import ADDON_DATA, ADDON_KEYWORDS
+from merino.providers.amo.backends.dynamic import DynamicAmoBackend
+
+logger = logging.getLogger(__name__)
+
+job_settings = config.jobs.amo_rs_uploader
+
+# Options
+auth_option = typer.Option(
+    job_settings.auth,
+    "--auth",
+    help="Remote settings authorization token",
+)
+
+cid_option = typer.Option(
+    job_settings.cid,
+    "--cid",
+    help="Remote settings collection ID",
+)
+
+dry_run_option = typer.Option(
+    job_settings.dry_run,
+    "--dry-run",
+    help="Log the records that would be uploaded but don't upload them",
+)
+
+server_option = typer.Option(
+    job_settings.server,
+    "--server",
+    help="Remote settings server",
+)
+
+workspace_option = typer.Option(
+    job_settings.workspace,
+    "--workspace",
+    help="Remote settings workspace",
+)
+
+amo_rs_uploader_cmd = typer.Typer(
+    name="amo-rs-uploader",
+    help="Command for uploading AMO add-on suggestions to remote settings",
+)
+
+
+@amo_rs_uploader_cmd.command()
+def upload(
+    auth: str = auth_option,
+    dry_run: bool = dry_run_option,
+    cid: str = cid_option,
+    server: str = server_option,
+    workspace: str = workspace_option,
+):
+    """Upload AMO suggestions to remote settings"""
+    asyncio.run(_upload(auth, dry_run, cid, server, workspace))
+
+
+async def _upload(
+    auth: str,
+    dry_run: bool,
+    cid: str,
+    server: str,
+    workspace: str,
+):
+    # Fetch the dynamic addons data from AMO.
+    logger.info("Fetching addons data from AMO")
+    backend = DynamicAmoBackend(config.amo.dynamic.api_url)
+    await backend.initialize_addons()
+
+    # Create suggestion record data for each addon.
+    logger.info("Creating data for remote settings")
+    records = []
+    for addon, dynamic_data in backend.dynamic_data.items():
+        # Merge static and dynamic addon data.
+        suggestion: dict[str, Any] = ADDON_DATA[addon] | dynamic_data
+
+        # Add keywords.
+        keywords: list[str] = []
+        for kw in ADDON_KEYWORDS[addon]:
+            keywords.append(kw.lower())
+        suggestion["keywords"] = keywords
+
+        # Compute the record ID. We can't use addon guids directly because they
+        # can contain characters that are invalid in record IDs, so use the hex
+        # digest instead.
+        m = hashlib.md5(usedforsecurity=False)
+        m.update(suggestion["guid"].encode("utf-8"))
+        hex_id = m.hexdigest()
+        record_id = f"amo_suggestion_{hex_id}"
+
+        records.append(
+            {
+                "id": record_id,
+                "type": "amo_suggestion",
+                "amo_suggestion": suggestion,
+            }
+        )
+
+    if dry_run:
+        logger.info(records)
+        return
+
+    # Upload the records.
+    logger.info(f"Uploading to {server}")
+    rs = RemoteSettings(
+        auth=auth,
+        cid=cid,
+        server=server,
+        workspace=workspace,
+    )
+    await rs.upload_records(records)

--- a/merino/jobs/amo_rs_uploader/remote_settings.py
+++ b/merino/jobs/amo_rs_uploader/remote_settings.py
@@ -1,0 +1,52 @@
+"""A simple remote settings client"""
+from asyncio import Task, TaskGroup
+from typing import Any
+
+from httpx import AsyncClient
+
+
+class RemoteSettings:
+    """A simple remote settings client"""
+
+    server: str
+    workspace: str
+    cid: str
+    auth: str
+
+    def __init__(self, server: str, workspace: str, cid: str, auth: str):
+        """Initialize RemoteSettings"""
+        self.server = server
+        self.workspace = workspace
+        self.cid = cid
+        self.auth = auth
+
+    async def upload_record(self, client: AsyncClient, record: dict[str, Any]):
+        """Upload a single record"""
+        url = (
+            f"{self.server}/buckets/{self.workspace}/collections/{self.cid}/"
+            f"records/{record['id']}"
+        )
+        res = await client.put(
+            url,
+            json={"data": record},
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": self.auth,
+            },
+        )
+        res.raise_for_status()
+
+    async def upload_records(self, records: list[dict[str, Any]]):
+        """Upload multiple records"""
+        tasks: list[Task] = []
+
+        async with (AsyncClient() as client, TaskGroup() as group):
+            for record in records:
+                tasks.append(
+                    group.create_task(
+                        self.upload_record(client, record), name=record["id"]
+                    )
+                )
+
+        for task in tasks:
+            await task

--- a/merino/jobs/cli.py
+++ b/merino/jobs/cli.py
@@ -2,6 +2,7 @@
 import typer
 
 from merino.config_logging import configure_logging
+from merino.jobs.amo_rs_uploader import amo_rs_uploader_cmd
 from merino.jobs.navigational_suggestions import navigational_suggestions_cmd
 from merino.jobs.wikipedia_indexer import indexer_cmd
 
@@ -11,6 +12,9 @@ cli.add_typer(indexer_cmd, no_args_is_help=True)
 
 # Add the navigational suggestions subcommands
 cli.add_typer(navigational_suggestions_cmd, no_args_is_help=True)
+
+# Add the AMO suggestions subcommands
+cli.add_typer(amo_rs_uploader_cmd, no_args_is_help=True)
 
 
 @cli.callback("setup")


### PR DESCRIPTION
## References

JIRA: [SNT-689](https://mozilla-hub.atlassian.net/browse/SNT-689)

## Description

This adds a Merino job that uploads AMO suggestions to remote settings. It uses
the static addons list and dynamic backend of the AMO provider to generate the
records.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[do not deploy]` and `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
