### PR TITLE
[bugzilla-1830535] Accept favicons with image mime type only

### DIFF
--- a/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
+++ b/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
@@ -187,6 +187,19 @@ class DomainMetadataExtractor:
         for favicon in favicons:
             url = self._fix_url(favicon["href"])
             width = None
+            favicon_image: FaviconImage = FaviconImage(
+                content_type="", content=bytes(0)
+            )
+            try:
+                favicon_image = self.favicon_downloader.download_favicon(url)
+            except Exception as e:
+                logger.info(f"Exception {e} for favicon {favicon}")
+                continue
+
+            if "image/" not in favicon_image.content_type:
+                # If favicon mime type is not "image" then skip it
+                continue
+
             sizes = favicon.get("sizes")
             if sizes:
                 try:
@@ -196,29 +209,24 @@ class DomainMetadataExtractor:
                         f"{e} while deducing size from sizes attribute of favicon {favicon}"
                     )
                     pass
+
             if width is None:
+                # If favicon is an SVG, then return this as the best favicon because SVG favicons
+                # are scalable, can be printed with high quality at any resolution and SVG
+                # graphics do NOT lose any quality if they are zoomed or resized.
+                if favicon_image.content_type == "image/svg+xml":
+                    # Firefox doesn't support masked favicons yet. Return if not masked.
+                    if "mask" not in favicon:
+                        return url
+                    else:
+                        logger.info(f"Masked SVG favicon {favicon} found; skipping it")
+                        continue
                 try:
-                    favicon_image: FaviconImage = (
-                        self.favicon_downloader.download_favicon(url)
-                    )
-
-                    # If it is an SVG, then return this as the best favicon because SVG favicons
-                    # are scalable, can be printed with high quality at any resolution and SVG
-                    # graphics do NOT lose any quality if they are zoomed or resized.
-                    if favicon_image.content_type == "image/svg+xml":
-                        # Firefox doesn't support masked favicons yet. Return if not masked.
-                        if "mask" not in favicon:
-                            return url
-                        else:
-                            logger.info(
-                                f"Masked SVG favicon {favicon} found; skipping it"
-                            )
-                            continue
-
                     width = self._get_favicon_smallest_dimension(favicon_image.content)
                 except Exception as e:
                     logger.info(f"Exception {e} for favicon {favicon}")
                     pass
+
             if width and width > best_favicon_width:
                 best_favicon_url = url
                 best_favicon_width = width

--- a/tests/unit/jobs/navigational_suggestions/test_domain_metadata_extractor.py
+++ b/tests/unit/jobs/navigational_suggestions/test_domain_metadata_extractor.py
@@ -315,6 +315,36 @@ FAVICON_SCENARIOS: list[FaviconScenario] = [
         ],
         [""],
     ),
+    (
+        FaviconData(
+            links=[
+                {
+                    "rel": ["icon"],
+                    "type": "image/png",
+                    "href": "https://www.researchgate.net/favicon-96x96.png",
+                    "sizes": "96x96",
+                },
+            ],
+            metas=[],
+            url="https://www.researchgate.net/",
+        ),
+        [
+            FaviconImage(content=b"\\x00", content_type="text/html"),
+        ],
+        [(96, 96)],
+        None,
+        [
+            {
+                "rank": 84,
+                "domain": "researchgate.net",
+                "host": "www.researchgate.net",
+                "origin": "https://www.researchgate.net",
+                "suffix": "net",
+                "categories": ["Education"],
+            }
+        ],
+        [""],
+    ),
 ]
 
 
@@ -339,6 +369,7 @@ FAVICON_SCENARIOS: list[FaviconScenario] = [
         "favicon_url_starting_with_data_skipped",
         "favicon_url_missing_scheme_handled",
         "low_resolution_favicon_skipped",
+        "favicon_with_non_image_mime_type_skipped",
     ],
 )
 def test_get_favicons(


### PR DESCRIPTION
## References
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1830535

JIRA: [DISCO-TODO](https://mozilla-hub.atlassian.net/browse/DISCO-TODO)
GitHub: [#TODO](https://github.com/mozilla-services/merino-py/issues/TODO)

## Description
 - Skip all favicons that don't have "image" in their mime type
 - Add test case

Tested with following domains:
`researchgate.net` -> No favicon is returned as all favicons with "image/*" mime type have lower resolution (< 52 px wide)
`politico.com` -> A favicon of mime type "image/png" is returned
`glassdoor.com` -> No favicon is returned as all of them are of "text/html" mime type




## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[do not deploy]` and `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
