### PR TITLE
[DISCO-2410] fix: Exclude optional fields from the API response

### DIFF
--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -128,7 +128,9 @@ async def suggest(
         if client_variants
         else [],
     )
-    return JSONResponse(content=jsonable_encoder(response))
+    return JSONResponse(
+        content=jsonable_encoder(response, exclude_unset=True, exclude_none=True)
+    )
 
 
 def emit_suggestions_per_metrics(

--- a/tests/contract/volumes/client/scenarios.yml
+++ b/tests/contract/volumes/client/scenarios.yml
@@ -32,8 +32,6 @@ scenarios:
                 is_sponsored: false
                 icon: "https://en.wikipedia.org/favicon.ico"
                 score: 0.0
-                custom_details: null
-                description: null
 
   - name: wiki_fruit__apple_with_client_variants
     description: Test that Merino successfully returns client variants
@@ -67,8 +65,6 @@ scenarios:
                 is_sponsored: false
                 icon: "https://en.wikipedia.org/favicon.ico"
                 score: 0.0
-                custom_details: null
-                description: null
 
   - name: wiki_fruit__cherry
     description: Test that Merino successfully returns a WikiFruit suggestion
@@ -100,8 +96,6 @@ scenarios:
                 is_sponsored: false
                 icon: "https://en.wikipedia.org/favicon.ico"
                 score: 0.0
-                custom_details: null
-                description: null
 
   - name: remote_settings__coffee
     description: Test that Merino successfully returns a Remote Settings suggestion
@@ -145,8 +139,6 @@ scenarios:
                 # The client test framework knows how to interpret a value of `null` for this field.
                 icon: null
                 score: 0.3
-                custom_details: null
-                description: null
 
   - name: multiple_providers__banana
     description: Test that Merino successfully returns suggestions from multiple providers
@@ -189,8 +181,6 @@ scenarios:
                 is_sponsored: false
                 icon: https://en.wikipedia.org/favicon.ico
                 score: 0.0
-                custom_details: null
-                description: null
               - block_id: 2
                 full_keyword: "banana"
                 title: "Banana"
@@ -202,8 +192,6 @@ scenarios:
                 is_sponsored: false
                 icon: null
                 score: 0.3
-                custom_details: null
-                description: null
 
   - name: top_picks__keyword_match
     description: >
@@ -234,8 +222,6 @@ scenarios:
                 is_top_pick: true
                 score: 0.25
                 icon: ""
-                custom_details: null
-                description: null
 
   - name: top_picks__characters
     description: >
@@ -266,8 +252,6 @@ scenarios:
                 is_top_pick: true
                 score: 0.25
                 icon: ""
-                custom_details: null
-                description: null
       - request:
           service: merino
           method: GET
@@ -292,8 +276,6 @@ scenarios:
                 is_top_pick: true
                 score: 0.25
                 icon: ""
-                custom_details: null
-                description: null
 
   - name: top_picks__secondary_similars_match
     description: >
@@ -324,8 +306,6 @@ scenarios:
                 is_top_pick: true
                 score: 0.25
                 icon: ""
-                custom_details: null
-                description: null
       - request:
           service: merino
           method: GET
@@ -350,8 +330,6 @@ scenarios:
                 is_top_pick: true
                 score: 0.25
                 icon: ""
-                custom_details: null
-                description: null
 
   - name: top_picks__short_domain_match
     description: >
@@ -383,8 +361,6 @@ scenarios:
                 is_top_pick: true
                 score: 0.25
                 icon: ""
-                custom_details: null
-                description: null
       - request:
           service: merino
           method: GET
@@ -409,8 +385,6 @@ scenarios:
                 is_top_pick: true
                 score: 0.25
                 icon: ""
-                custom_details: null
-                description: null
 
   - name: remote_settings__offline_expansion_orange
     description: Test that Merino successfully returns a Remote Settings suggestion for Offline Expansion
@@ -457,8 +431,6 @@ scenarios:
                 # The client test framework knows how to interpret a value of `null` for this field.
                 icon: null
                 score: 0.3
-                custom_details: null
-                description: null
 
   - name: remote_settings__refresh
     description: >
@@ -498,8 +470,6 @@ scenarios:
                 is_sponsored: true
                 icon: null
                 score: 0.3
-                custom_details: null
-                description: null
       - request:
           service: merino
           method: GET
@@ -549,8 +519,6 @@ scenarios:
                 is_sponsored: true
                 icon: null
                 score: 0.3
-                custom_details: null
-                description: null
       - request:
           service: merino
           method: GET
@@ -578,8 +546,6 @@ scenarios:
                 is_sponsored: true
                 icon: null
                 score: 0.3
-                custom_details: null
-                description: null
 
 
   - name: version_endpoint

--- a/tests/integration/api/v1/suggest/test_suggest_weather.py
+++ b/tests/integration/api/v1/suggest/test_suggest_weather.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import pytest
 from fastapi.testclient import TestClient
+from pydantic import parse_obj_as
 from pytest import LogCaptureFixture
 from pytest_mock import MockerFixture
 
@@ -102,7 +103,7 @@ def test_suggest_with_weather_report(client: TestClient, backend_mock: Any) -> N
 
     assert response.status_code == 200
     result = response.json()
-    assert result["suggestions"] == expected_suggestion
+    assert expected_suggestion == parse_obj_as(list[Suggestion], result["suggestions"])
 
 
 def test_suggest_without_weather_report(client: TestClient, backend_mock: Any) -> None:

--- a/tests/integration/api/v1/suggest/test_suggest_wikipedia.py
+++ b/tests/integration/api/v1/suggest/test_suggest_wikipedia.py
@@ -107,11 +107,6 @@ def test_suggest_wikipedia(
             "provider": "wikipedia",
             "score": settings.providers.wikipedia.score,
             "icon": ICON,
-            "block_id": 0,
-            "impression_url": None,
-            "click_url": None,
-            "custom_details": None,
-            "description": None,
         }
 
     # Check logs for the timed out query(-ies)


### PR DESCRIPTION
## References

JIRA: [DISCO-2410](https://mozilla-hub.atlassian.net/browse/DISCO-2410)
GitHub: N/A

## Description
Merino includes all the optional fields (with the value set to null if unspecified - see discussion [here](https://github.com/mozilla-services/merino-py/pull/273#discussion_r1183193064)), which has accidentally changed the semantics in reporting. Specifically, Firefox used to omit those optional fields in telemetry if their values are set to `undefined`, but now they are `null`, which is not a valid value for reporting_url([schema def](https://github.com/mozilla-services/mozilla-pipeline-schemas/blob/main/templates/contextual-services/quicksuggest-impression/quicksuggest-impression.1.schema.json#L36-L39)).

This patch prevents Merino from sending nulls for optional fields in the response payload.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[do not deploy]` and `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2410]: https://mozilla-hub.atlassian.net/browse/DISCO-2410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ