### PR TITLE
Periodically fetch and update AMO information

### DIFF
--- a/docs/operations/configs.md
+++ b/docs/operations/configs.md
@@ -279,6 +279,8 @@ These are production providers that generate suggestions.
   as a floating point number. Defaults to 0.3.
 - `min_chars` (`MERINO_PROVIDERS__AMO__MIN_CHARS`) - The minimum number of characters
   to process a querystring.
+- `resync_interval_sec` (`MERINO_PROVIDERS__AMO__RESYNC_INTERVAL_SEC`) - The re-syncing frequency 
+  for the AMO data. Defaults to daily.
 
 #### Top Picks Provider
 - Top Picks - Provides suggestions from a static domain list of the 1000 most visited websites.

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -135,6 +135,8 @@ score = 0.3
 backend = "dynamic"
 # The minimum number of characters to be considered for matching.
 min_chars = 4
+# The re-syncing frequency for the AMO data. Defaults to daily.
+resync_interval_sec = 86400
 
 
 [default.providers.top_picks]

--- a/merino/jobs/amo_rs_uploader/__init__.py
+++ b/merino/jobs/amo_rs_uploader/__init__.py
@@ -110,7 +110,7 @@ async def _upload(
 ):
     logger.info("Fetching addons data from AMO")
     backend = DynamicAmoBackend(config.amo.dynamic.api_url)
-    await backend.initialize_addons()
+    await backend.fetch_and_cache_addons_info()
 
     with ChunkedRemoteSettingsUploader(
         auth=auth,

--- a/merino/providers/amo/backends/dynamic.py
+++ b/merino/providers/amo/backends/dynamic.py
@@ -63,8 +63,8 @@ class DynamicAmoBackend:
 
         return None
 
-    async def initialize_addons(self) -> None:
-        """Initialize the dynamic AMO information via the Addons API.
+    async def fetch_and_cache_addons_info(self) -> None:
+        """Get the dynamic AMO information via the Addons API.
         Allow for partial initialization if the response object is not available
         at the moment. We do not want to block initialization or take down the
         provider for some missing information.

--- a/merino/providers/amo/backends/protocol.py
+++ b/merino/providers/amo/backends/protocol.py
@@ -33,5 +33,5 @@ class AmoBackend(Protocol):
         Raise a `BackendError` if the addon key is missing.
         """
 
-    async def initialize_addons(self) -> None:
+    async def fetch_and_cache_addons_info(self) -> None:
         """Initialize addons to be stored."""

--- a/merino/providers/amo/backends/static.py
+++ b/merino/providers/amo/backends/static.py
@@ -53,8 +53,8 @@ class StaticAmoBackend:
     tests and potentially a fallback if the API is broken.
     """
 
-    async def initialize_addons(self) -> None:
-        """Initialize Addons. Pass for static Addons."""
+    async def fetch_and_cache_addons_info(self) -> None:
+        """Get extra addons information. Pass for static Addons."""
         pass
 
     async def get_addon(self, addon_key: SupportedAddon) -> Addon:

--- a/tests/unit/jobs/amo_rs_uploader/test_amo_rs_uploader.py
+++ b/tests/unit/jobs/amo_rs_uploader/test_amo_rs_uploader.py
@@ -84,7 +84,7 @@ def do_upload_test(mocker, delete_existing_records: bool) -> None:
     # Mock `DynamicAmoBackend`.
     mock_backend_ctor = mocker.patch("merino.jobs.amo_rs_uploader.DynamicAmoBackend")
     mock_backend = mock_backend_ctor.return_value
-    type(mock_backend).initialize_addons = mocker.AsyncMock()
+    type(mock_backend).fetch_and_cache_addons_info = mocker.AsyncMock()
 
     # Mock the addons data.
     mock_addons_data(mocker, mock_backend)
@@ -109,7 +109,7 @@ def do_upload_test(mocker, delete_existing_records: bool) -> None:
 
     # Check calls.
     mock_backend_ctor.assert_called_once()
-    mock_backend.initialize_addons.assert_called_once()
+    mock_backend.fetch_and_cache_addons_info.assert_called_once()
 
     mock_uploader_ctor.assert_called_once_with(**uploader_kwargs)
 

--- a/tests/unit/providers/amo/backends/test_dynamic.py
+++ b/tests/unit/providers/amo/backends/test_dynamic.py
@@ -43,22 +43,22 @@ def _patch_addons_api_calls(mocker: MockerFixture) -> None:
 
 
 @pytest.mark.asyncio
-async def test_initialize_addons_succeed(
+async def test_fetch_addons_succeed(
     mocker: MockerFixture, dynamic_backend: DynamicAmoBackend
 ):
-    """Test that initialize populates the Addons."""
+    """Test that fetch populates the Addons."""
     _patch_addons_api_calls(mocker)
 
     assert dynamic_backend.dynamic_data == {}
-    await dynamic_backend.initialize_addons()
+    await dynamic_backend.fetch_and_cache_addons_info()
     assert len(dynamic_backend.dynamic_data) == len(SupportedAddon)
 
 
 @pytest.mark.asyncio
-async def test_initialize_addons_skipped_api_failure(
+async def test_fetch_addons_skipped_api_failure(
     mocker: MockerFixture, caplog: LogCaptureFixture, dynamic_backend: DynamicAmoBackend
 ):
-    """Test that initialize fails raises error when Addon request fails."""
+    """Test that fetch fails raises error when Addon request fails."""
     sample_addon_resp = json.dumps(
         {
             "icon_url": "https://this.is.image",
@@ -88,7 +88,7 @@ async def test_initialize_addons_skipped_api_failure(
 
     mocker.patch.object(AsyncClient, "get", side_effect=return_values)
 
-    await dynamic_backend.initialize_addons()
+    await dynamic_backend.fetch_and_cache_addons_info()
 
     assert len(dynamic_backend.dynamic_data) == len(SupportedAddon) - 1
     assert len(caplog.messages) == 1
@@ -98,10 +98,10 @@ async def test_initialize_addons_skipped_api_failure(
 
 
 @pytest.mark.asyncio
-async def test_initialize_addons_skipped_bad_response(
+async def test_fetch_addons_skipped_bad_response(
     mocker: MockerFixture, caplog: LogCaptureFixture, dynamic_backend: DynamicAmoBackend
 ):
-    """Test that initialize fails raises error when Addon request fails."""
+    """Test that fetch fails raises error when Addon request fails."""
     sample_addon_resp = json.dumps(
         {
             "icon_url": "https://this.is.image",
@@ -129,7 +129,7 @@ async def test_initialize_addons_skipped_bad_response(
     )
     mocker.patch.object(AsyncClient, "get", side_effect=return_values)
 
-    await dynamic_backend.initialize_addons()
+    await dynamic_backend.fetch_and_cache_addons_info()
 
     assert len(dynamic_backend.dynamic_data) == len(SupportedAddon) - 1
     assert len(caplog.messages) == 1
@@ -140,7 +140,7 @@ async def test_initialize_addons_skipped_bad_response(
 
 
 @pytest.mark.asyncio
-async def test_initialize_addons_handled_task_group_exceptions(
+async def test_fetch_addons_handled_task_group_exceptions(
     mocker: MockerFixture, dynamic_backend: DynamicAmoBackend
 ):
     """Test that `TaskGroup` exceptions are captured and propagated as `AmoBackendError`."""
@@ -149,7 +149,7 @@ async def test_initialize_addons_handled_task_group_exceptions(
     )
 
     with pytest.raises(AmoBackendError):
-        await dynamic_backend.initialize_addons()
+        await dynamic_backend.fetch_and_cache_addons_info()
 
 
 @pytest.mark.asyncio
@@ -158,7 +158,7 @@ async def test_get_addon_request(
 ):
     """Test that we can get the Addons details."""
     _patch_addons_api_calls(mocker)
-    await dynamic_backend.initialize_addons()
+    await dynamic_backend.fetch_and_cache_addons_info()
 
     addons = await dynamic_backend.get_addon(SupportedAddon.VIDEO_DOWNLOADER)
 
@@ -183,7 +183,7 @@ async def test_get_addon_key_error(
 ):
     """Test that we raise the right error for Key Error."""
     _patch_addons_api_calls(mocker)
-    await dynamic_backend.initialize_addons()
+    await dynamic_backend.fetch_and_cache_addons_info()
     del dynamic_backend.dynamic_data[SupportedAddon.VIDEO_DOWNLOADER]
 
     with pytest.raises(DynamicAmoBackendException) as ex:

--- a/tests/unit/providers/amo/test_provider.py
+++ b/tests/unit/providers/amo/test_provider.py
@@ -25,8 +25,8 @@ class AmoErrorBackend:
         """
         raise AmoBackendError("Error!!!")
 
-    async def initialize_addons(self) -> None:
-        """Initialize addons to be stored."""
+    async def fetch_and_cache_addons_info(self) -> None:
+        """Fetch addons to be stored."""
         pass
 
 
@@ -39,7 +39,7 @@ class AmoInitErrorBackend:
         """
         raise AmoBackendError("Addon key missing!")
 
-    async def initialize_addons(self) -> None:
+    async def fetch_and_cache_addons_info(self) -> None:
         """Initialize addons to be stored."""
         raise AmoBackendError("Error!!!")
 
@@ -175,10 +175,10 @@ async def test_query_error(
 
 
 @pytest.mark.asyncio
-async def test_initialize_addons_error(
+async def test_fetch_addon_info_error(
     caplog: LogCaptureFixture, keywords: dict[SupportedAddon, set[str]]
 ):
-    """Test that provider can handle initialization errors."""
+    """Test that provider can handle fetch errors."""
     provider = AddonsProvider(
         backend=AmoInitErrorBackend(),
         keywords=keywords,
@@ -186,7 +186,7 @@ async def test_initialize_addons_error(
         score=0.3,
         min_chars=4,
     )
-    await provider.initialize()
+    await provider._fetch_addon_info()
 
     assert len(caplog.messages) == 1
-    assert caplog.messages[0].startswith("Failed to initialize addon backend:")
+    assert caplog.messages[0].startswith("Failed to fetch addon information:")


### PR DESCRIPTION
## References

JIRA: [DISCO-2358](https://mozilla-hub.atlassian.net/browse/DISCO-2358)

## Description
The Addons data will be updated on a daily basis via a cron job. The cron will just iterate through the list of Addons and query the Addon API and replace the currently cached data.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[do not deploy]` and `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
