### PR TITLE
[DISCO-2410] fix: Use a dummy block_id for dynamic wikipedia suggestions

### DIFF
--- a/merino/providers/wikipedia/provider.py
+++ b/merino/providers/wikipedia/provider.py
@@ -14,6 +14,7 @@ ICON: Final[
     str
 ] = "chrome://activity-stream/content/data/content/tippytop/favicons/wikipedia-org.ico"
 ADVERTISER: Final[str] = "dynamic-wikipedia"
+BLOCK_ID: Final[int] = 0
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +28,7 @@ class WikipediaSuggestion(BaseSuggestion):
 
     full_keyword: str
     advertiser: str
-    block_id: int = 0
+    block_id: int
     impression_url: Optional[HttpUrl] = None
     click_url: Optional[HttpUrl] = None
 
@@ -77,6 +78,7 @@ class Provider(BaseProvider):
 
         return [
             WikipediaSuggestion(
+                block_id=BLOCK_ID,
                 advertiser=ADVERTISER,
                 is_sponsored=False,
                 icon=ICON,

--- a/tests/integration/api/v1/suggest/test_suggest_wikipedia.py
+++ b/tests/integration/api/v1/suggest/test_suggest_wikipedia.py
@@ -99,6 +99,7 @@ def test_suggest_wikipedia(
         suggestion = result["suggestions"][0]
 
         assert suggestion == {
+            "block_id": 0,
             "title": query,
             "full_keyword": query,
             "url": f"https://en.wikipedia.org/wiki/{expected_title}",


### PR DESCRIPTION
## References

JIRA: [DISCO-2413](https://mozilla-hub.atlassian.net/browse/DISCO-2413)
GitHub: N/A

## Description

Regressed by the DISCO-2410 because we are not specifying the `block_id` for Dynamic Wikipedia suggestions but using the default value which will be excluded from the API reponse. Though `block_id` is a required field for Contextual Services impressions/clicks.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[do not deploy]` and `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2413]: https://mozilla-hub.atlassian.net/browse/DISCO-2413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ