### PR TITLE
Use `cron_interval_sec` for AdM cron ticker

### DIFF
--- a/merino/providers/adm/provider.py
+++ b/merino/providers/adm/provider.py
@@ -74,6 +74,7 @@ class Provider(BaseProvider):
         score_wikipedia: float,
         name: str,
         resync_interval_sec: float,
+        cron_interval_sec: float,
         enabled_by_default: bool = True,
         **kwargs: Any,
     ) -> None:
@@ -82,6 +83,7 @@ class Provider(BaseProvider):
         self.score = score
         self.score_wikipedia = score_wikipedia
         self.resync_interval_sec = resync_interval_sec
+        self.cron_interval_sec = cron_interval_sec
         self.suggestion_content = SuggestionContent(
             suggestions={}, full_keywords=[], results=[], icons={}
         )
@@ -105,7 +107,7 @@ class Provider(BaseProvider):
         # Run a cron job that resyncs data from Remote Settings in the background.
         cron_job = cron.Job(
             name="resync_rs_data",
-            interval=self.resync_interval_sec,
+            interval=self.cron_interval_sec,
             condition=self._should_fetch,
             task=self._fetch,
         )

--- a/merino/providers/manager.py
+++ b/merino/providers/manager.py
@@ -106,6 +106,7 @@ def _create_provider(provider_id: str, setting: Settings) -> BaseProvider:
                 score_wikipedia=setting.score_wikipedia,
                 name=provider_id,
                 resync_interval_sec=setting.resync_interval_sec,
+                cron_interval_sec=setting.cron_interval_sec,
                 enabled_by_default=setting.enabled_by_default,
             )
         case ProviderType.TOP_PICKS:

--- a/tests/unit/providers/adm/conftest.py
+++ b/tests/unit/providers/adm/conftest.py
@@ -50,6 +50,7 @@ def fixture_adm_parameters() -> dict[str, Any]:
         "score_wikipedia": 0.2,
         "name": "adm",
         "resync_interval_sec": 10800,
+        "cron_interval_sec": 60,
     }
 
 

--- a/tests/unit/providers/amo/test_provider.py
+++ b/tests/unit/providers/amo/test_provider.py
@@ -1,5 +1,6 @@
 """Test Addon Provider"""
 import datetime
+import time
 
 import freezegun
 import pytest
@@ -212,3 +213,17 @@ async def test_fetch_addon(
             year=2012, month=1, day=14, hour=3, minute=21, second=34
         ).timestamp()
     )
+
+
+def test_should_fetch_false(addons_provider: AddonsProvider):
+    """Test that provider should fetch is false."""
+    addons_provider.last_fetch_at = time.time()
+    assert addons_provider._should_fetch() is False
+
+
+def test_should_fetch_true(addons_provider: AddonsProvider):
+    """Test that provider should fetch is true."""
+    addons_provider.last_fetch_at = (
+        time.time() - addons_provider.resync_interval_sec - 100
+    )
+    assert addons_provider._should_fetch()


### PR DESCRIPTION
## Description
It's currently not using this, even though it's been defined. Fixing it so that it's refreshed more frequently.

Also added some more tests for AMO because I missed testing a line in the previous change.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [x] `[do not deploy]` and `[load test: (abort|warn)]` keywords are applied (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
