### PR TITLE
[bugzilla-1830535] Fix broken favicons for navigational suggestions

### DIFF
--- a/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
+++ b/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
@@ -218,32 +218,20 @@ class DomainMetadataExtractor:
                 # If favicon mime type is not "image" then skip it
                 continue
 
-            sizes = favicon.get("sizes")
-            if sizes:
-                try:
-                    width = int(sizes.split("x")[0])
-                except Exception as e:
-                    logger.info(
-                        f"{e} while deducing size from sizes attribute of favicon {favicon}"
-                    )
-                    pass
-
-            if width is None:
-                # If favicon is an SVG, then return this as the best favicon because SVG favicons
-                # are scalable, can be printed with high quality at any resolution and SVG
-                # graphics do NOT lose any quality if they are zoomed or resized.
-                if favicon_image.content_type == "image/svg+xml":
-                    # Firefox doesn't support masked favicons yet. Return if not masked.
-                    if "mask" not in favicon:
-                        return url
-                    else:
-                        logger.info(f"Masked SVG favicon {favicon} found; skipping it")
-                        continue
-                try:
-                    width = self._get_favicon_smallest_dimension(favicon_image.content)
-                except Exception as e:
-                    logger.info(f"Exception {e} for favicon {favicon}")
-                    pass
+            # If favicon is an SVG, then return this as the best favicon because SVG favicons
+            # are scalable, can be printed with high quality at any resolution and SVG
+            # graphics do NOT lose any quality if they are zoomed or resized.
+            if favicon_image.content_type == "image/svg+xml":
+                # Firefox doesn't support masked favicons yet. Return if not masked.
+                if "mask" not in favicon:
+                    return url
+                else:
+                    logger.info(f"Masked SVG favicon {favicon} found; skipping it")
+                    continue
+            try:
+                width = self._get_favicon_smallest_dimension(favicon_image.content)
+            except Exception as e:
+                logger.info(f"Exception {e} for favicon {favicon}")
 
             if width and width > best_favicon_width:
                 best_favicon_url = url

--- a/tests/unit/jobs/navigational_suggestions/test_domain_metadata_extractor.py
+++ b/tests/unit/jobs/navigational_suggestions/test_domain_metadata_extractor.py
@@ -162,87 +162,6 @@ DOMAIN_METADATA_SCENARIOS: list[DomainMetadataScenario] = [
             links=[
                 {
                     "rel": ["icon"],
-                    "type": "image/png",
-                    "sizes": "192x192",
-                    "href": (
-                        "https://www.redditstatic.com/desktop2x/img/favicon/"
-                        "android-icon-192x192.png"
-                    ),
-                },
-            ],
-            metas=[],
-        ),
-        [
-            FaviconImage(content=b"\\x00", content_type="image/png"),
-        ],
-        [(192, 192)],
-        None,
-        "https://www.reddit.com",
-        "dummy_title",
-        [
-            {
-                "rank": 24,
-                "domain": "reddit.com",
-                "host": "old.reddit.com",
-                "origin": "https://old.reddit.com",
-                "suffix": "com",
-                "categories": ["Forums"],
-            }
-        ],
-        [
-            {
-                "url": "https://www.reddit.com",
-                "title": "dummy_title",
-                "icon": (
-                    "https://www.redditstatic.com/desktop2x/img/favicon/android-icon-192x192.png"
-                ),
-                "domain": "reddit",
-            }
-        ],
-    ),
-    (
-        FaviconData(
-            links=[
-                {
-                    "rel": ["icon"],
-                    "type": "image/x-icon",
-                    "sizes": "any",
-                    "href": "https://www.whitehouse.gov/favicon.ico",
-                },
-            ],
-            metas=[],
-        ),
-        [
-            FaviconImage(content=b"\\x00", content_type="image/x-icon"),
-        ],
-        [(32, 32)],
-        None,
-        "https://www.whitehouse.gov/",
-        "dummy_title",
-        [
-            {
-                "rank": 272,
-                "domain": "whitehouse.gov",
-                "host": "www.whitehouse.gov",
-                "origin": "https://www.whitehouse.gov",
-                "suffix": "gov",
-                "categories": ["Politics, Advocacy, and Government-Related"],
-            }
-        ],
-        [
-            {
-                "url": "https://www.whitehouse.gov",
-                "title": "dummy_title",
-                "icon": "https://www.whitehouse.gov/favicon.ico",
-                "domain": "whitehouse",
-            }
-        ],
-    ),
-    (
-        FaviconData(
-            links=[
-                {
-                    "rel": ["icon"],
                     "sizes": "any",
                     "mask": "",
                     "href": (
@@ -571,8 +490,6 @@ DOMAIN_METADATA_SCENARIOS: list[DomainMetadataScenario] = [
         "favicon_found_via_link_tag",
         "favicon_found_via_meta_tag",
         "no_favicon",
-        "favicon_with_size_in_right_format",
-        "favicon_with_size_in_wrong_format",
         "masked_svg_favicon_skipped",
         "favicon_always_non_masked_svg_favicon_when_present",
         "favicon_url_starting_with_data_skipped",


### PR DESCRIPTION
## References
Fixes [broken favicon for xfinity](https://bugzilla.mozilla.org/show_bug.cgi?id=1830535#c5) along with other favicons that might be broken because of the same reason.

JIRA:
GitHub:

## Description
 - Avoid using 'sizes' attribute as the preferred and sufficient way to compute favicon size as some corrupted favicons ([like xfinity](https://bugzilla.mozilla.org/show_bug.cgi?id=1830535#c5)) made it to the top pick file by just having their sizes specificed via 'sizes' attribute

 - Always compute favicon size via Pillow library to make sure the favicon itself is not corrupted
    - this library is already being used to compute favicon sizes for the domains that don't specify size via 'sizes' attribute

 - Removed obsolete unit test cases


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[do not deploy]` and `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
