### PR TITLE
[DENG-917] Robust title extraction for navigational suggestions

### DIFF
--- a/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
+++ b/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
@@ -96,7 +96,7 @@ class Scraper:
             Optional[str]: The title extracted from header of a url
         """
         try:
-            return str(self.browser.find("head").find("title").string)
+            return str(self.browser.find("head").find("title").get_text())
         except Exception as e:
             logger.info(f"Exception: {e} while scraping title")
             return None


### PR DESCRIPTION
## References

JIRA: Fixes https://mozilla-hub.atlassian.net/browse/DENG-917
GitHub:

## Description
 - Using ["get_text()"](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#get-text) API to extract the text of "title" element instead of using ["string"](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#string) property

 - "string" property returns "None" for the elements containing no text while get_text() returns empty string which is the right outcome

Tested for "nordstrom" and "jobs2careers" and the title is "Nordstrom" and "Jobs2careers" respectively instead of "None".


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[do not deploy]` and `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
