### PR TITLE
[DISCO-2389] Remove [do not deploy]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,7 +178,6 @@ jobs:
       - image: cimg/base:2022.08
     steps:
       - checkout
-      - skip-if-do-not-deploy
   docker-image-publish:
     # Pushing a new production Docker image to the Docker Hub registry triggers a
     # webhook that starts the Jenkins deployment workflow
@@ -320,22 +319,3 @@ commands:
             "$CIRCLE_PROJECT_USERNAME" \
             "$CIRCLE_PROJECT_REPONAME" \
             "$CIRCLE_BUILD_URL" > version.json
-
-  skip-if-do-not-deploy:
-    steps:
-      - run:
-          name: Check if deployment is disallowed
-          # This relies on the [do not deploy] text to be available in the
-          # merge commit when merging the PR to 'main'.
-          command: |
-            if git log -1 "$CIRCLE_SHA1" | grep -q '\[do not deploy\]'; then
-                echo "Skipping remaining steps in this job: deployment was disabled for this commit."
-                circleci-agent step halt
-
-                # No need to deploy, just cancel the rest of jobs of the workflow.
-                # See API detail: https://circleci.com/docs/api/v2/index.html#operation/cancelWorkflow
-
-                curl -X POST https://circleci.com/api/v2/workflow/${CIRCLE_WORKFLOW_ID}/cancel \
-                -H 'Accept: application/json' \
-                -H "Circle-Token: ${SKIP_DEPLOY_API_TOKEN}"
-            fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,6 @@ Before submitting a PR:
   pass and the code has been reviewed.
 - Ideally, your patch should include new tests that cover your changes. It is your and
   your reviewer's responsibility to ensure your patch includes adequate tests.
-- If you're solely updating documentation, you may wish to avoid deployment. Please see the [Preventing deployment via [do not deploy]][release-process] documentation.
 - If making changes that may impact performance, it is recommended to execute a load test. Please see [Load Testing Opt-In [load test: (abort|warn)]][release-process] documentation for more information.
 - For more information on understanding the release process, please see relevant information contained in the [release-process.md][release-process] 
 documentation.

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -14,6 +14,6 @@ _Put an `x` in the boxes that apply_
 
 - [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
 - [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
-- [ ] `[do not deploy]` and `[load test: (abort|warn)]` keywords are applied (if applicable)
+- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
 - [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
 - [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)

--- a/docs/dev/release-process.md
+++ b/docs/dev/release-process.md
@@ -20,21 +20,6 @@ Please see the [CONTRIBUTING.md][contributing] docs on commit guidelines and pul
 ## Versioning
 The commit hash of the deployed code is considered its version identifier. The commit hash can be retrieved locally via `git rev-parse HEAD`.
 
-## Preventing deployment via [do not deploy]
-Occasionally developers might want to prevent a commit from triggering the deployment pipeline. While this should be discouraged, there are some legitimate cases for doing so (e.g. docs only changes).
-In order to prevent the deployment of the code from a PR when merging to `main`, the **title of that PR** must contain the `[do not deploy]` text. When generating the merge commit for a branch within the GitHub UI, ensure that `[do not deploy]` is still present in the description, especially if you change or rename the PR later on.
-
-For example:
-
-```
-# PR title (NOT the commit message)
-doc: Add documentation for the release process [do not deploy]
-```
-
-While the `[do not deploy]` can be anywhere in the title, it is recommended to place it at its end in order to better integrate with the current PR title practices and improve readability.
-
-The deployment pipeline will analyze the message of the merge commit (which will contain the PR title) and make a decision based on it.
-
 ## Load Testing
 Load testing can be run locally or as a part of the deployment process. Local execution does not require any labeling in commit messages. For deployment, you have to add a label to the message of the commit that you wish to deploy in the form of: `[load test: (abort|warn)]`. In most cases this will be the merge commit created by merging a GitHub pull request.
 


### PR DESCRIPTION
## References

JIRA: [DISCO-2389](https://mozilla-hub.atlassian.net/browse/DISCO-2389)
GitHub: [#312 ](https://github.com/mozilla-services/merino-py/issues/312)

## Description
In order to assure fast feedback and accountability for all contributions, deploy all changes to the Merino-py main branch.

Acceptance Criteria

- Remove the skip-if-do-not-deploy command and it’s invocation from jobs in the CircleCI config

- Remove references to 'do not deploy' in documentation, including:

- docs/release_process.md

- CONTRIBUTING.md

- PULL_REQUEST_TEMPLATE.md



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [x] `[do not deploy]` and `[load test: (abort|warn)]` keywords are applied (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2389]: https://mozilla-hub.atlassian.net/browse/DISCO-2389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ