### PR TITLE
Match full first word for AMO suggestions

### DIFF
--- a/merino/providers/amo/provider.py
+++ b/merino/providers/amo/provider.py
@@ -37,11 +37,13 @@ def invert_and_expand_index_keywords(
     """
     inverted_index = {}
     for addon_name, kws in keywords.items():
-        for word in kws:
-            word = word.lower()
+        for phrase in kws:
+            phrase = phrase.lower()
+            first_word = phrase.split()[0]
+            inverted_index[first_word] = addon_name
             # do the keyword expansion
-            for i in range(min_chars, len(word) + 1):
-                inverted_index[word[:i]] = addon_name
+            for i in range(len(first_word), len(phrase) + 1):
+                inverted_index[phrase[:i]] = addon_name
     return inverted_index
 
 

--- a/tests/integration/api/v1/suggest/test_suggest_amo.py
+++ b/tests/integration/api/v1/suggest/test_suggest_amo.py
@@ -23,21 +23,21 @@ SCENARIOS: dict[str, Scenario] = {
         providers={
             "addons": Provider(backend=StaticAmoBackend(), keywords=ADDON_KEYWORDS)
         },
-        query="nigh",
+        query="night mo",
         expected_title="Dark Reader",
     ),
     "Case-II: No Addon Matches": Scenario(
         providers={
             "addons": Provider(backend=StaticAmoBackend(), keywords=ADDON_KEYWORDS)
         },
-        query="asdf",
+        query="nigh",
         expected_title=None,
     ),
     "Case-III: Case Insensitive Match": Scenario(
         providers={
             "addons": Provider(backend=StaticAmoBackend(), keywords=ADDON_KEYWORDS)
         },
-        query="NIgh",
+        query="NIghT",
         expected_title="Dark Reader",
     ),
 }

--- a/tests/unit/providers/amo/test_provider.py
+++ b/tests/unit/providers/amo/test_provider.py
@@ -83,12 +83,7 @@ def fixture_addon_provider(
 def test_reverse_and_expand_keywords(keywords: dict[SupportedAddon, set[str]]):
     """Test that we expand the keywords properly for the lookup table."""
     assert {
-        "addo": SupportedAddon.VIDEO_DOWNLOADER,
         "addon": SupportedAddon.VIDEO_DOWNLOADER,
-        "down": SupportedAddon.VIDEO_DOWNLOADER,
-        "downl": SupportedAddon.VIDEO_DOWNLOADER,
-        "downlo": SupportedAddon.VIDEO_DOWNLOADER,
-        "downloa": SupportedAddon.VIDEO_DOWNLOADER,
         "download": SupportedAddon.VIDEO_DOWNLOADER,
         "download ": SupportedAddon.VIDEO_DOWNLOADER,
         "download h": SupportedAddon.VIDEO_DOWNLOADER,
@@ -97,12 +92,6 @@ def test_reverse_and_expand_keywords(keywords: dict[SupportedAddon, set[str]]):
         "download help": SupportedAddon.VIDEO_DOWNLOADER,
         "download helpe": SupportedAddon.VIDEO_DOWNLOADER,
         "download helper": SupportedAddon.VIDEO_DOWNLOADER,
-        "dict": SupportedAddon.LANGAUGE_TOOL,
-        "dicti": SupportedAddon.LANGAUGE_TOOL,
-        "dictio": SupportedAddon.LANGAUGE_TOOL,
-        "diction": SupportedAddon.LANGAUGE_TOOL,
-        "dictiona": SupportedAddon.LANGAUGE_TOOL,
-        "dictionar": SupportedAddon.LANGAUGE_TOOL,
         "dictionary": SupportedAddon.LANGAUGE_TOOL,
     } == invert_and_expand_index_keywords(keywords, 4)
 


### PR DESCRIPTION
## Description
The logic that we want to use for AMO is to match the first word _exactly_ and then keyword expand the rest. This is as specified in the [Addons Suggest spec section 4.1.](https://docs.google.com/document/d/1XdEfA2Yr7x060hjCFo2dDBHfgBrVwH3on8OvKkRNL24/edit)


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
