### PR TITLE
Improve favicon scraping for navigational suggestions

### DIFF
--- a/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
+++ b/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
@@ -185,13 +185,10 @@ class DomainMetadataExtractor:
                     favicon["href"] = favicon_url
                 favicons.append(favicon)
 
-            # If we couldn't scrape any favicon data from link/meta tags for a domain then look
-            # for a default "favicon.ico" in domain root as some domains don't explicitly
-            # specify favicons via link/meta tags.
-            if len(favicons) == 0:
-                default_favicon_url = self.scraper.get_default_favicon(scraped_url)
-                if default_favicon_url is not None:
-                    favicons.append({"href": default_favicon_url})
+            # Include the default "favicon.ico" if it exists in domain root
+            default_favicon_url = self.scraper.get_default_favicon(scraped_url)
+            if default_favicon_url is not None:
+                favicons.append({"href": default_favicon_url})
 
         except Exception as e:
             logger.info(f"Exception {e} while extracting favicons for {scraped_url}")

--- a/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
+++ b/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
@@ -32,9 +32,12 @@ class Scraper:
     LINK_SELECTOR: str = (
         "link[rel=apple-touch-icon], link[rel=apple-touch-icon-precomposed],"
         'link[rel="icon shortcut"], link[rel="shortcut icon"], link[rel="icon"],'
-        'link[rel="SHORTCUT ICON"], link[rel="fluid-icon"]'
+        'link[rel="SHORTCUT ICON"], link[rel="fluid-icon"], link[rel="mask-icon"],'
+        'link[rel="apple-touch-startup-image"]'
     )
-    META_SELECTOR: str = "meta[name=apple-touch-icon]"
+    META_SELECTOR: str = (
+        "meta[name=apple-touch-icon], meta[name=msapplication-TileImage]"
+    )
 
     browser: RoboBrowser
 


### PR DESCRIPTION
An Attempt in the direction of fixing https://mozilla-hub.atlassian.net/browse/DENG-916

## References

JIRA: https://mozilla-hub.atlassian.net/browse/DENG-916
GitHub:

## Description
The PR improves favicon scraping by
- Always including the default "favicon.ico" (which is present in the root of the domain) in the list of scraped favicons irrespective of whether we could scrape any favicon from document or not
- More comprehensive link and meta selectors
    - Taken from favicongrabber source code [meta selectors](https://github.com/antongunov/favicongrabber.com/blob/master/server/api/grabber/browserconfig.js#LL4C35-L4C58) and [link selectors](https://github.com/antongunov/favicongrabber.com/blob/master/server/api/grabber/links.js#L6-L7)



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
