### PR TITLE
[DISCO-2388] Add load tests for AMO provider [load test: abort]

### DIFF
--- a/merino/providers/amo/provider.py
+++ b/merino/providers/amo/provider.py
@@ -29,7 +29,6 @@ class AddonSuggestion(BaseSuggestion):
 
 def invert_and_expand_index_keywords(
     keywords: dict[SupportedAddon, set[str]],
-    min_chars: int,
 ) -> dict[str, SupportedAddon]:
     """Invert the keywords index.
     param keywords: mapping of addon key -> keywords
@@ -96,9 +95,7 @@ class Provider(BaseProvider):
         )
         self.cron_task = asyncio.create_task(cron_job())
 
-        self.addon_keywords = invert_and_expand_index_keywords(
-            self.keywords, self.min_chars
-        )
+        self.addon_keywords = invert_and_expand_index_keywords(self.keywords)
 
     def normalize_query(self, query: str) -> str:
         """Ensure query string is case insensitive."""

--- a/tests/unit/providers/amo/test_provider.py
+++ b/tests/unit/providers/amo/test_provider.py
@@ -93,7 +93,7 @@ def test_reverse_and_expand_keywords(keywords: dict[SupportedAddon, set[str]]):
         "download helpe": SupportedAddon.VIDEO_DOWNLOADER,
         "download helper": SupportedAddon.VIDEO_DOWNLOADER,
         "dictionary": SupportedAddon.LANGAUGE_TOOL,
-    } == invert_and_expand_index_keywords(keywords, 4)
+    } == invert_and_expand_index_keywords(keywords)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## References

JIRA: [DISCO-2388](https://mozilla-hub.atlassian.net/browse/DISCO-2388)

## Description
This adds some load tests for the AMO. AMO's keywords are hard coded, we can just import them to get some results.

Screenshot below of how it looks in Locust UI:
![Screenshot 2023-06-13 at 15 59 31](https://github.com/mozilla-services/merino-py/assets/829597/52022ad1-cf9e-4dbd-ae14-eb3969f58cae)

I hope that's sufficient for reporting purposes.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2388]: https://mozilla-hub.atlassian.net/browse/DISCO-2388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ