### PR TITLE
[DISCO-2442] Merino Contract Tests Failing In CI With Redis Error

### DIFF
--- a/tests/contract/client/Dockerfile
+++ b/tests/contract/client/Dockerfile
@@ -12,7 +12,7 @@ RUN python -m pip install --upgrade pip
 RUN python -m pip install --no-cache-dir --quiet poetry
 WORKDIR /tmp
 COPY ./pyproject.toml ./poetry.lock /tmp/
-RUN poetry export --no-interaction --dev --output requirements.txt --without-hashes
+RUN poetry export --no-interaction --with dev --output requirements.txt --without-hashes
 
 WORKDIR /
 RUN python -m pip install -r /tmp/requirements.txt

--- a/tests/contract/docker-compose.yml
+++ b/tests/contract/docker-compose.yml
@@ -80,5 +80,5 @@ services:
       /wait-for-it.sh kinto:8888 --strict -- python main.py
 
   redis:
-    image: redis
+    image: redis:7.0.8
     container_name: redis

--- a/tests/contract/kinto-setup/Dockerfile
+++ b/tests/contract/kinto-setup/Dockerfile
@@ -12,7 +12,7 @@ RUN python -m pip install --upgrade pip
 RUN python -m pip install --no-cache-dir --quiet poetry
 WORKDIR /tmp
 COPY ./pyproject.toml ./poetry.lock /tmp/
-RUN poetry export --no-interaction --dev --output requirements.txt --without-hashes
+RUN poetry export --no-interaction --with dev --output requirements.txt --without-hashes
 
 WORKDIR /
 RUN python -m pip install -r /tmp/requirements.txt


### PR DESCRIPTION
## References

JIRA: [DISCO-2442](https://mozilla-hub.atlassian.net/browse/DISCO-2442)
GitHub: N/A

## Description
- Fix the Poetry command in Contract Test DockerFiles

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2442]: https://mozilla-hub.atlassian.net/browse/DISCO-2442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ