### PR TITLE
chore: Pin Redis to 6_X

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,7 +159,7 @@ jobs:
   contract-tests:
     machine:
       docker_layer_caching: false
-      image: ubuntu-2004:202101-01 # Ubuntu 20.04, Docker v20.10.2, Docker Compose v1.28.2
+      image: ubuntu-2004:2023.04.2
     working_directory: ~/merino
     steps:
       - checkout

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   redis:
-    image: redis
+    image: redis:6.2
     ports:
       - "6379:6379"
 

--- a/tests/contract/docker-compose.yml
+++ b/tests/contract/docker-compose.yml
@@ -80,5 +80,5 @@ services:
       /wait-for-it.sh kinto:8888 --strict -- python main.py
 
   redis:
-    image: redis:7.0.8
+    image: redis:6.2
     container_name: redis


### PR DESCRIPTION
## References

JIRA: N/A
GitHub: N/A

## Description
Pin Redis to the stable 6_X as what we use in production.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
