### PR TITLE
[DISCO-2445] chore: Speedup the build-docs job in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -249,17 +249,25 @@ jobs:
             docker push "${DOCKERHUB_MERINO_LOCUST_REPO}:latest"
   docs-build:
     docker:
-      - image: cimg/rust:1.69
+      - image: cimg/base:2022.08
     steps:
       - checkout
       - run:
           name: Setup Build docs
           command: |
-            make doc-install-deps
-            mdbook-mermaid install ./
+            mkdir bin
+            echo 'export PATH=$(pwd)/bin:"$PATH"' >> "$BASH_ENV"
+            source "$BASH_ENV"
+            curl -sSL \
+              https://github.com/rust-lang/mdBook/releases/download/v0.4.24/mdbook-v0.4.24-x86_64-unknown-linux-gnu.tar.gz \
+              | tar -xz --directory=bin
+            curl -sSL \
+              https://github.com/badboy/mdbook-mermaid/releases/download/v0.12.6/mdbook-mermaid-v0.12.6-x86_64-unknown-linux-gnu.tar.gz \
+              | tar -xz --directory=bin
       - run:
           name: Build docs
           command: |
+            mdbook-mermaid install ./
             ./dev/make-all-docs.sh
             mkdir workspace
             cp -r ./book workspace/doc


### PR DESCRIPTION
## References

JIRA: [DISCO-2445](https://mozilla-hub.atlassian.net/browse/DISCO-2445)
GitHub: N/A

## Description
Due to the Rust build overhead, the "build-docs" job in CI is now the long pole in the tent of our CI workflow. This patch switches to use the pre-built binaries which cut the job duration from 4 minutes to 4 seconds. The setup step looks messier but the gain is quite significant. 



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2445]: https://mozilla-hub.atlassian.net/browse/DISCO-2445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ