### PR TITLE
[DISCO-2446] chore: Disable Sentry transactions

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -83,7 +83,7 @@ dsn = ""
 # Any of "prod", "stage", or "dev".
 env = "dev"
 # A setting for the tracing sample rate. Should be a float in range [0, 1.0].
-traces_sample_rate = 0.1
+traces_sample_rate = 0
 
 [default.providers.accuweather]
 type = "accuweather"


### PR DESCRIPTION
## References

JIRA: [DISCO-2446](https://mozilla-hub.atlassian.net/browse/DISCO-2446)
GitHub: N/A

## Description
Sentry sent an email indicating this feature is out of beta and will become a subscripted service. We don’t find this super useful for Merino, so let’s disable it.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2446]: https://mozilla-hub.atlassian.net/browse/DISCO-2446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ