### PR TITLE
feat: add score to AMO RS suggestions and fallback scores to chunked RS uploader

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -209,3 +209,6 @@ min_favicon_width = 52
 [default.jobs.amo_rs_uploader]
 # The "type" of each remote settings record
 record_type = "amo-suggestions"
+# While the addon experiment is active, addon suggestions should be preferred
+# over all other types.
+score = 1.0

--- a/merino/jobs/amo_rs_uploader/__init__.py
+++ b/merino/jobs/amo_rs_uploader/__init__.py
@@ -66,6 +66,12 @@ record_type_option = typer.Option(
     help="The `type` of each remote settings record",
 )
 
+score_option = typer.Option(
+    job_settings.score,
+    "--score",
+    help="The score of each suggestion",
+)
+
 amo_rs_uploader_cmd = typer.Typer(
     name="amo-rs-uploader",
     help="Command for uploading AMO add-on suggestions to remote settings",
@@ -81,6 +87,7 @@ def upload(
     delete_existing_records: bool = delete_existing_records_option,
     dry_run: bool = dry_run_option,
     record_type: str = record_type_option,
+    score: float = score_option,
     server: str = server_option,
 ):
     """Upload AMO suggestions to remote settings."""
@@ -93,6 +100,7 @@ def upload(
             delete_existing_records=delete_existing_records,
             dry_run=dry_run,
             record_type=record_type,
+            score=score,
             server=server,
         )
     )
@@ -106,6 +114,7 @@ async def _upload(
     delete_existing_records: bool,
     dry_run: bool,
     record_type: str,
+    score: float,
     server: str,
 ):
     logger.info("Fetching addons data from AMO")
@@ -120,6 +129,7 @@ async def _upload(
         dry_run=dry_run,
         record_type=record_type,
         server=server,
+        suggestion_score_fallback=score,
     ) as uploader:
         if delete_existing_records:
             uploader.delete_records()

--- a/merino/jobs/amo_rs_uploader/chunked_rs_uploader.py
+++ b/merino/jobs/amo_rs_uploader/chunked_rs_uploader.py
@@ -110,7 +110,7 @@ class ChunkedRemoteSettingsUploader:
         will be uploaded before this method returns.
         """
         if self.suggestion_score_fallback and "score" not in suggestion:
-            suggestion = suggestion | {"score": self.suggestion_score_fallback}
+            suggestion |= {"score": self.suggestion_score_fallback}
         self.current_chunk.add_suggestion(suggestion)
         if self.current_chunk.size == self.chunk_size:
             self._finish_current_chunk()


### PR DESCRIPTION
## Description

Modify the AMO RS uploader job by adding scores to AMO RS suggestions. The purpose of this is to give AMO RS suggestions a high score to ensure the client will prefer them to adM suggestions when there are keyword collisions. (There are currently 22 collisions total.)

This is intended as a quick fix for the upcoming AMO suggestions experiment. The client already looks for a `score` property in AMO suggestions, but currently none is defined, so the default 0.2 score is used. If/when AMO suggestions are enabled by default instead of being enabled only in experiments, we will want to revisit this.

To implement this in a way that can be used for all RS suggestion types, add a param to the chunked RS uploader that lets the consumer specify a fallback score for suggestions. If a suggestion doesn't include a score and a fallback is defined, the fallback value will be added to the suggestion as its score.


## PR Review Checklist

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
