### PR TITLE
Improve favicon scraping for navigational suggestions

### DIFF
--- a/merino/jobs/navigational_suggestions/utils.py
+++ b/merino/jobs/navigational_suggestions/utils.py
@@ -1,14 +1,29 @@
 """Utilities for navigational suggestions job"""
 
+import logging
+from typing import Optional
+
 import requests
 from pydantic import BaseModel
 
-FIREFOX_UA: str = (
-    "Mozilla/5.0 (Macintosh; Intel Mac OS X 13.3; rv:111.0) Gecko/20100101 "
-    "Firefox/111.0"
-)
+REQUEST_HEADERS: dict[str, str] = {
+    "User-Agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/114.0"
+    ),
+    "Accept": (
+        "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8"
+    ),
+    "Accept-Language": "en-GB,en-US;q=0.9,en;q=0.8",
+    "DNT": "1",
+    "Upgrade-Insecure-Requests": "1",
+    "Sec-Fetch-Dest": "document",
+    "Sec-Fetch-Mode": "navigate",
+    "Sec-Fetch-User": "?1",
+}
 
 TIMEOUT: int = 10
+
+logger = logging.getLogger(__name__)
 
 
 class FaviconImage(BaseModel):
@@ -21,7 +36,7 @@ class FaviconImage(BaseModel):
 class FaviconDownloader:
     """Download favicon from the web"""
 
-    def download_favicon(self, url: str) -> FaviconImage:
+    def download_favicon(self, url: str) -> Optional[FaviconImage]:
         """Download the favicon from the given url.
 
         Args:
@@ -29,12 +44,32 @@ class FaviconDownloader:
         Returns:
             FaviconImage: favicon image content and associated metadata
         """
-        response = requests.get(
-            url,
-            headers={"User-agent": FIREFOX_UA},
-            timeout=TIMEOUT,
-        )
-        return FaviconImage(
-            content=response.content,
-            content_type=str(response.headers.get("Content-Type")),
-        )
+        try:
+            response = requests_get(url)
+            return (
+                FaviconImage(
+                    content=response.content,
+                    content_type=str(response.headers.get("Content-Type")),
+                )
+                if response
+                else None
+            )
+        except Exception as e:
+            logger.info(f"Exception {e} while downloading favicon {url}")
+            return None
+
+
+def requests_get(url: str) -> Optional[requests.Response]:
+    """Open a given url and return the response.
+
+    Args:
+        url: URL to open
+    Returns:
+        Optional[requests.Response]: Response object
+    """
+    response: requests.Response = requests.get(
+        url,
+        headers=REQUEST_HEADERS,
+        timeout=TIMEOUT,
+    )
+    return response if response.status_code == 200 else None

--- a/tests/unit/jobs/navigational_suggestions/test_domain_metadata_extractor.py
+++ b/tests/unit/jobs/navigational_suggestions/test_domain_metadata_extractor.py
@@ -17,6 +17,7 @@ from merino.jobs.navigational_suggestions.utils import FaviconDownloader, Favico
 
 DomainMetadataScenario = tuple[
     FaviconData | None,
+    list[dict[str, Any]],
     list[FaviconImage] | None,
     list[tuple[int, int]] | None,
     str | None,
@@ -28,7 +29,8 @@ DomainMetadataScenario = tuple[
 
 DOMAIN_METADATA_SCENARIOS: list[DomainMetadataScenario] = [
     (
-        FaviconData(links=[], metas=[]),
+        FaviconData(links=[], metas=[], manifests=[]),
+        [],
         [
             FaviconImage(content=b"\\x00", content_type="image/x-icon"),
         ],
@@ -65,7 +67,9 @@ DOMAIN_METADATA_SCENARIOS: list[DomainMetadataScenario] = [
                 },
             ],
             metas=[],
+            manifests=[],
         ),
+        [],
         [
             FaviconImage(content=b"\\x00", content_type="image/png"),
         ],
@@ -104,7 +108,9 @@ DOMAIN_METADATA_SCENARIOS: list[DomainMetadataScenario] = [
                     ),
                 }
             ],
+            manifests=[],
         ),
+        [],
         [
             FaviconImage(content=b"\\x00", content_type="image/jpg"),
         ],
@@ -132,7 +138,53 @@ DOMAIN_METADATA_SCENARIOS: list[DomainMetadataScenario] = [
         ],
     ),
     (
+        FaviconData(
+            links=[],
+            metas=[],
+            manifests=[
+                {
+                    "rel": ["manifest"],
+                    "href": "/data/manifest/",
+                    "crossorigin": "use-credentials",
+                }
+            ],
+        ),
+        [
+            {
+                "src": "https://static.xx.fbcdn.net/rsrc.php/v3/ya/r/hsAgIHTE80C.png",
+                "sizes": "192x192",
+                "type": "image/png",
+            }
+        ],
+        [
+            FaviconImage(content=b"\\x00", content_type="image/jpg"),
+        ],
+        [(32, 32)],
         None,
+        "https://www.facebook.com/",
+        "dummy_title",
+        [
+            {
+                "rank": 2,
+                "domain": "facebook.com",
+                "host": "m.facebook.com",
+                "origin": "https://m.facebook.com",
+                "suffix": "com",
+                "categories": ["Social Networks"],
+            },
+        ],
+        [
+            {
+                "url": "https://www.facebook.com",
+                "title": "dummy_title",
+                "icon": "https://static.xx.fbcdn.net/rsrc.php/v3/ya/r/hsAgIHTE80C.png",
+                "domain": "facebook",
+            }
+        ],
+    ),
+    (
+        None,
+        [],
         None,
         None,
         None,
@@ -170,8 +222,9 @@ DOMAIN_METADATA_SCENARIOS: list[DomainMetadataScenario] = [
                 },
             ],
             metas=[],
-            url="",
+            manifests=[],
         ),
+        [],
         [
             FaviconImage(content=b"\\x00", content_type="image/svg+xml"),
         ],
@@ -214,7 +267,9 @@ DOMAIN_METADATA_SCENARIOS: list[DomainMetadataScenario] = [
                 },
             ],
             metas=[],
+            manifests=[],
         ),
+        [],
         [
             FaviconImage(content=b"\\x00", content_type="image/png"),
             FaviconImage(content=b"\\x01", content_type="image/svg+xml"),
@@ -253,8 +308,9 @@ DOMAIN_METADATA_SCENARIOS: list[DomainMetadataScenario] = [
                 },
             ],
             metas=[{"name": "apple-touch-icon", "content": "data:favicon2.ico"}],
-            url="https://www.fakedomain.gov/",
+            manifests=[],
         ),
+        [],
         None,
         None,
         None,
@@ -290,9 +346,12 @@ DOMAIN_METADATA_SCENARIOS: list[DomainMetadataScenario] = [
                 },
             ],
             metas=[{"name": "apple-touch-icon", "content": "favicon2.ico"}],
+            manifests=[],
         ),
+        [],
         [
             FaviconImage(content=b"\\x00", content_type="image/x-icon"),
+            FaviconImage(content=b"\\x01", content_type="image/x-icon"),
         ],
         [(64, 64), (32, 32)],
         None,
@@ -327,7 +386,9 @@ DOMAIN_METADATA_SCENARIOS: list[DomainMetadataScenario] = [
                 },
             ],
             metas=[],
+            manifests=[],
         ),
+        [],
         [
             FaviconImage(content=b"\\x00", content_type="image/x-icon"),
         ],
@@ -365,7 +426,9 @@ DOMAIN_METADATA_SCENARIOS: list[DomainMetadataScenario] = [
                 },
             ],
             metas=[],
+            manifests=[],
         ),
+        [],
         [
             FaviconImage(content=b"\\x00", content_type="text/html"),
         ],
@@ -394,6 +457,7 @@ DOMAIN_METADATA_SCENARIOS: list[DomainMetadataScenario] = [
     ),
     (
         None,
+        [],
         None,
         None,
         None,
@@ -420,6 +484,7 @@ DOMAIN_METADATA_SCENARIOS: list[DomainMetadataScenario] = [
     ),
     (
         None,
+        [],
         None,
         None,
         None,
@@ -446,6 +511,7 @@ DOMAIN_METADATA_SCENARIOS: list[DomainMetadataScenario] = [
     ),
     (
         None,
+        [],
         None,
         None,
         None,
@@ -471,7 +537,8 @@ DOMAIN_METADATA_SCENARIOS: list[DomainMetadataScenario] = [
         ],
     ),
     (
-        FaviconData(links=[], metas=[]),
+        FaviconData(links=[], metas=[], manifests=[]),
+        [],
         [
             FaviconImage(content=b"\\x00", content_type="image/x-icon"),
         ],
@@ -504,6 +571,7 @@ DOMAIN_METADATA_SCENARIOS: list[DomainMetadataScenario] = [
 @pytest.mark.parametrize(
     [
         "favicon_data",
+        "scraped_favicons_from_manifest",
         "favicon_images",
         "favicon_image_sizes",
         "default_favicon",
@@ -517,6 +585,7 @@ DOMAIN_METADATA_SCENARIOS: list[DomainMetadataScenario] = [
         "favicon_found_in_default_path",
         "favicon_found_via_link_tag",
         "favicon_found_via_meta_tag",
+        "favicon_found_via_manifest",
         "no_favicon",
         "masked_svg_favicon_skipped",
         "favicon_always_non_masked_svg_favicon_when_present",
@@ -533,6 +602,7 @@ DOMAIN_METADATA_SCENARIOS: list[DomainMetadataScenario] = [
 def test_get_domain_metadata(
     mocker: MockerFixture,
     favicon_data: FaviconData | None,
+    scraped_favicons_from_manifest: list[dict[str, Any]],
     favicon_images: list[FaviconImage] | None,
     favicon_image_sizes: list[tuple[int, int]] | None,
     default_favicon: str | None,
@@ -544,6 +614,9 @@ def test_get_domain_metadata(
     """Test that DomainMetadataExtractor returns favicons as expected"""
     scraper_mock: Any = mocker.Mock(spec=Scraper)
     scraper_mock.scrape_favicon_data.return_value = favicon_data
+    scraper_mock.scrape_favicons_from_manifest.return_value = (
+        scraped_favicons_from_manifest
+    )
     scraper_mock.get_default_favicon.return_value = default_favicon
     scraper_mock.open.return_value = scraped_url
     scraper_mock.scrape_title.return_value = scraped_title

--- a/tests/unit/jobs/navigational_suggestions/test_domain_metadata_uploader.py
+++ b/tests/unit/jobs/navigational_suggestions/test_domain_metadata_uploader.py
@@ -122,11 +122,13 @@ def test_upload_favicons_return_favicon_with_cdnhostname_when_provided(
         assert CDN_HOSTNAME in uploaded_favicon
 
 
-def test_upload_favicons_exception_returns_empty_urls(
+def test_upload_favicons_return_empty_url_for_failed_favicon_download(
     mock_gcs_client, mock_favicon_downloader
 ):
-    """Test if an exception results into returning an empty url"""
-    mock_favicon_downloader.download_favicon.side_effect = Exception("Error")
+    """Test if a failure in downloading favicon from the scraped url returns an empty
+    uploaded favicon url
+    """
+    mock_favicon_downloader.download_favicon.return_value = None
 
     domain_metadata_uploader = DomainMetadataUploader(
         "dummy_gcp_project", "dummy_gcs_bucket", None, False, mock_favicon_downloader


### PR DESCRIPTION

## References
JIRA: [DENG-916](https://mozilla-hub.atlassian.net/browse/DENG-916)
GitHub: 

## Description
This PR is an attempt in the direction of fixing [DENG-916](https://mozilla-hub.atlassian.net/browse/DENG-916) and does following:

- Add the logic to scrape favicons from [web app manifest](https://developer.mozilla.org/en-US/docs/Web/Manifest)
- More detailed http headers while scraping for domain metadata 
- Refactor code specific to requests.get() API call
- Corresponding unit tests
- Remove some of the uncommon image types from metadata upload [as per this comment](https://github.com/mozilla-services/merino-py/pull/290#issuecomment-1549714761)

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DENG-916]: https://mozilla-hub.atlassian.net/browse/DENG-916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DENG-916]: https://mozilla-hub.atlassian.net/browse/DENG-916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ