### PR TITLE
Reduce minimum favicon width criteria for navigational suggestions

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -204,7 +204,7 @@ destination_cdn_hostname = ""
 # Flag to enable uploading the domain metadata to GCS bucket even if it aleady exists there
 force_upload = false
 # Minimum width of the domain favicon required for it to be a part of domain metadata
-min_favicon_width = 52
+min_favicon_width = 48
 
 [default.jobs.amo_rs_uploader]
 # The "type" of each remote settings record


### PR DESCRIPTION
## References

JIRA: [DENG-916](https://mozilla-hub.atlassian.net/browse/DENG-916)
GitHub:

## Description
- Reduce the width from 52 to 48 to include a lot of top ranked domains who have 48-pixel wide favicons
    - Some of these domains are (as per local testing):  amazon, adobe, roblox, dailymail, bloomberg, cnbc, w3schools, snapchat, goodreads, ikea, expedia, accuweather
- It is worth to run the job with this change and let QA confirm us whether 48-pixel wide favicons also exhibit the same blurry behavior as was noticed in https://bugzilla.mozilla.org/show_bug.cgi?id=1830328



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DENG-916]: https://mozilla-hub.atlassian.net/browse/DENG-916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ