### PR TITLE
[DENG-916][DENG-1036][DENG-1037] Use firefox favicons for navigationa…

### DIFF
--- a/merino/jobs/navigational_suggestions/utils.py
+++ b/merino/jobs/navigational_suggestions/utils.py
@@ -23,6 +23,14 @@ REQUEST_HEADERS: dict[str, str] = {
 
 TIMEOUT: int = 10
 
+# Some high resolution domain favicons that are internally packaged in Firefox
+FIREFOX_PACKAGED_FAVICONS: dict[str, str] = {
+    "google": "chrome://activity-stream/content/data/content/tippytop/images/google-com@2x.png",
+    "bing": "chrome://activity-stream/content/data/content/tippytop/images/bing-com@2x.svg",
+    "youtube": "chrome://activity-stream/content/data/content/tippytop/images/youtube-com@2x.png",
+    "twitter": "chrome://activity-stream/content/data/content/tippytop/images/twitter-com@2x.png",
+}
+
 logger = logging.getLogger(__name__)
 
 
@@ -73,3 +81,17 @@ def requests_get(url: str) -> Optional[requests.Response]:
         timeout=TIMEOUT,
     )
     return response if response.status_code == 200 else None
+
+
+def update_top_picks_with_firefox_favicons(
+    top_picks: dict[str, list[dict[str, str]]]
+) -> None:
+    """Update top picks with high resolution favicons that are internally packaged in firefox
+    for some of the selected domains for which favicon scraping didn't return anything
+    """
+    domains_metadata: list[dict[str, str]] = top_picks["domains"]
+    for domain_metadata in domains_metadata:
+        domain = domain_metadata["domain"]
+        firefox_favicon: Optional[str] = FIREFOX_PACKAGED_FAVICONS.get(domain)
+        if firefox_favicon:
+            domain_metadata["icon"] = firefox_favicon

--- a/tests/unit/jobs/navigational_suggestions/test_navigational_suggestions_utils.py
+++ b/tests/unit/jobs/navigational_suggestions/test_navigational_suggestions_utils.py
@@ -1,0 +1,78 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Unit tests for utils.py module."""
+
+from merino.jobs.navigational_suggestions.utils import (
+    update_top_picks_with_firefox_favicons,
+)
+
+
+def test_update_top_picks_with_firefox_favicons_favicon_added_for_special_domains():
+    """Test that top picks is updated with firefox favicon for special domains
+    when scraped available to top picks
+    """
+    input_top_picks = {
+        "domains": [
+            {
+                "rank": 1,
+                "domain": "google",
+                "categories": ["Search Engines"],
+                "url": "https://www.google.com",
+                "title": "Google",
+                "icon": "",
+            },
+        ]
+    }
+
+    updated_top_picks = {
+        "domains": [
+            {
+                "rank": 1,
+                "domain": "google",
+                "categories": ["Search Engines"],
+                "url": "https://www.google.com",
+                "title": "Google",
+                "icon": (
+                    "chrome://activity-stream/content/data/content/tippytop/"
+                    "images/google-com@2x.png"
+                ),
+            },
+        ]
+    }
+
+    update_top_picks_with_firefox_favicons(input_top_picks)
+    assert input_top_picks == updated_top_picks
+
+
+def test_update_top_picks_with_firefox_favicons_favicon_not_added_for_non_special_domains():
+    """Test that top picks is not updated with firefox favicon for non special domains"""
+    input_top_picks = {
+        "domains": [
+            {
+                "rank": 2,
+                "domain": "facebook",
+                "categories": ["Social Networks"],
+                "url": "https://www.facebook.com",
+                "title": "Facebook \u2013 log in or sign up",
+                "icon": "",
+            },
+        ]
+    }
+
+    updated_top_picks = {
+        "domains": [
+            {
+                "rank": 2,
+                "domain": "facebook",
+                "categories": ["Social Networks"],
+                "url": "https://www.facebook.com",
+                "title": "Facebook \u2013 log in or sign up",
+                "icon": "",
+            },
+        ]
+    }
+
+    update_top_picks_with_firefox_favicons(input_top_picks)
+    assert input_top_picks == updated_top_picks


### PR DESCRIPTION
…l suggestions

## References

JIRA: https://mozilla-hub.atlassian.net/browse/DENG-916,
          https://mozilla-hub.atlassian.net/browse/DENG-1037,
          https://mozilla-hub.atlassian.net/browse/DENG-1036
GitHub:

## Description
 - For 4 of the top ranked domains (google, bing, youtube, twitter), use the [favicons from firefox](https://searchfox.org/mozilla-central/source/browser/components/newtab/data/content/tippytop/images)




## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
