### PR TITLE
[DISCO-2450] Remove caching from Weather Provider [load test: warn]

### DIFF
--- a/merino/providers/manager.py
+++ b/merino/providers/manager.py
@@ -74,12 +74,10 @@ def _create_provider(provider_id: str, setting: Settings) -> BaseProvider:
                 )
                 if setting.backend == "accuweather"
                 else FakeWeatherBackend(),
-                cache=cache,  # type: ignore [arg-type]
                 metrics_client=get_metrics_client(),
                 score=setting.score,
                 name=provider_id,
                 query_timeout_sec=setting.query_timeout_sec,
-                cached_report_ttl_sec=setting.cached_report_ttl_sec,
                 enabled_by_default=setting.enabled_by_default,
             )
         case ProviderType.AMO:

--- a/merino/providers/weather/backends/accuweather.py
+++ b/merino/providers/weather/backends/accuweather.py
@@ -108,15 +108,6 @@ class AccuweatherBackend:
         self.url_param_partner_code = url_param_partner_code
         self.partner_code = partner_code
 
-    def cache_inputs_for_weather_report(self, geolocation: Location) -> Optional[bytes]:
-        """Return the inputs used to form the cache key for looking up and storing the current
-        conditions and forecast for a location.
-        """
-        if geolocation.country is None or geolocation.postal_code is None:
-            return None
-
-        return (geolocation.country + geolocation.postal_code).encode("utf-8")
-
     def cache_key_for_accuweather_request(
         self, url: str, query_params: dict[str, str] = {}
     ) -> str:
@@ -416,3 +407,7 @@ class AccuweatherBackend:
         return str(
             parsed_url.copy_add_param(self.url_param_partner_code, self.partner_code)
         )
+
+    async def shutdown(self) -> None:
+        """Close out the cache during shutdown."""
+        await self.cache.close()

--- a/merino/providers/weather/backends/fake_backends.py
+++ b/merino/providers/weather/backends/fake_backends.py
@@ -8,12 +8,14 @@ from merino.providers.weather.backends.protocol import WeatherReport
 class FakeWeatherBackend:  # pragma: no cover
     """A fake backend that always returns empty results."""
 
-    def cache_inputs_for_weather_report(self, geolocation: Location) -> Optional[bytes]:
-        """Doesn't return any cache key inputs."""
-        return None
-
     async def get_weather_report(
         self, geolocation: Location
     ) -> Optional[WeatherReport]:
         """Fake Backend return nothing"""
         return None
+
+    async def shutdown(self) -> None:
+        """Fake Backend does not need to clean up
+        any open connections.
+        """
+        pass

--- a/merino/providers/weather/backends/protocol.py
+++ b/merino/providers/weather/backends/protocol.py
@@ -58,14 +58,6 @@ class WeatherBackend(Protocol):
     directly depend on.
     """
 
-    def cache_inputs_for_weather_report(
-        self, geolocation: Location
-    ) -> Optional[bytes]:  # pragma: no cover
-        """Return the inputs used to form the cache key for looking up and storing weather
-        information for a location.
-        """
-        ...
-
     async def get_weather_report(
         self, geolocation: Location
     ) -> Optional[WeatherReport]:  # pragma: no cover
@@ -74,4 +66,8 @@ class WeatherBackend(Protocol):
         Raises:
             BackendError: Category of error specific to provider backends.
         """
+        ...
+
+    async def shutdown(self) -> None:  # pragma: no cover
+        """Close down any open connections."""
         ...

--- a/merino/providers/weather/provider.py
+++ b/merino/providers/weather/provider.py
@@ -1,19 +1,11 @@
 """Weather integration."""
-import hashlib
-import json
+
 import logging
-from datetime import timedelta
 from typing import Any, Optional
 
 import aiodogstatsd
 
-from merino.cache.protocol import CacheAdapter
-from merino.exceptions import (
-    BackendError,
-    CacheAdapterError,
-    CacheEntryError,
-    CacheMissError,
-)
+from merino.exceptions import BackendError
 from merino.middleware.geolocation import Location
 from merino.providers.base import BaseProvider, BaseSuggestion, SuggestionRequest
 from merino.providers.weather.backends.protocol import (
@@ -38,30 +30,24 @@ class Provider(BaseProvider):
     """Suggestion provider for weather."""
 
     backend: WeatherBackend
-    cache: CacheAdapter
     metrics_client: aiodogstatsd.Client
     score: float
-    cached_report_ttl_sec: int
 
     def __init__(
         self,
         backend: WeatherBackend,
-        cache: CacheAdapter,
         metrics_client: aiodogstatsd.Client,
         score: float,
         name: str,
         query_timeout_sec: float,
-        cached_report_ttl_sec: int,
         enabled_by_default: bool = False,
         **kwargs: Any,
     ) -> None:
         self.backend = backend
-        self.cache = cache
         self.metrics_client = metrics_client
         self.score = score
         self._name = name
         self._query_timeout_sec = query_timeout_sec
-        self.cached_report_ttl_sec = cached_report_ttl_sec
         self._enabled_by_default = enabled_by_default
         super().__init__(**kwargs)
 
@@ -72,96 +58,17 @@ class Provider(BaseProvider):
     def hidden(self) -> bool:  # noqa: D102
         return False
 
-    def cache_key_for_weather_report(self, geolocation: Location) -> Optional[str]:
-        """Compute a Redis key used to look up and store cached weather reports for a location."""
-        cache_inputs: Optional[bytes] = self.backend.cache_inputs_for_weather_report(
-            geolocation
-        )
-        if not cache_inputs:
-            return None
-
-        return f"{self.name}:v1:report:{hashlib.blake2s(cache_inputs).hexdigest()}"
-
-    async def fetch_cached_weather_report(
-        self, geolocation: Location
-    ) -> Optional[WeatherReport]:
-        """Fetch a cached weather report, if available, for a location.
-
-        Raises:
-            - `CacheMissError` if there's no entry in the cache for this location.
-            - `CacheEntryError` if the cached weather report can't be deserialized.
-        """
-        with self.metrics_client.timeit(f"providers.{self.name}.query.cache.fetch"):
-            cache_key: Optional[str] = self.cache_key_for_weather_report(geolocation)
-            if not cache_key:
-                raise CacheMissError
-
-            cache_value: Optional[bytes] = await self.cache.get(cache_key)
-            if not cache_value:
-                raise CacheMissError
-
-            try:
-                weather_report_dict = json.loads(cache_value)
-                if not weather_report_dict:
-                    return None
-                return WeatherReport.parse_obj(weather_report_dict)
-            except ValueError as exc:
-                # `ValueError` is the common superclass of `json.JSONDecodeError` and
-                # `pydantic.ValidationError`.
-                raise CacheEntryError("Failed to parse cache entry") from exc
-
-    async def store_cached_weather_report(
-        self, geolocation: Location, weather_report: Optional[WeatherReport]
-    ):
-        """Store a cached weather report, or the absence of one, for a location."""
-        with self.metrics_client.timeit(f"providers.{self.name}.query.cache.store"):
-            cache_key: Optional[str] = self.cache_key_for_weather_report(geolocation)
-            if not cache_key:
-                return
-
-            # If the request to the backend succeeded, but didn't return a report, we want to
-            # negatively cache an empty value, so that subsequent requests for that location won't
-            # make additional backend calls every time. This case is separate from a transient
-            # backend error, which isn't negatively cached.
-            cache_value = (
-                weather_report.json().encode("utf-8") if weather_report else b"{}"
-            )
-            await self.cache.set(
-                cache_key,
-                cache_value,
-                ttl=timedelta(seconds=self.cached_report_ttl_sec),
-            )
-
     async def query(self, srequest: SuggestionRequest) -> list[BaseSuggestion]:
         """Provide weather suggestions."""
         geolocation: Location = srequest.geolocation
         weather_report: Optional[WeatherReport] = None
 
         try:
-            weather_report = await self.fetch_cached_weather_report(geolocation)
-            self.metrics_client.increment(f"providers.{self.name}.query.cache.hit")
-        except (CacheAdapterError, CacheEntryError, CacheMissError) as exc:
-            if isinstance(exc, CacheMissError):
-                self.metrics_client.increment(f"providers.{self.name}.query.cache.miss")
-            else:
-                self.metrics_client.increment(
-                    f"providers.{self.name}.query.cache.error"
-                )
-                logger.warning(f"Failed to load cached weather report: {exc}")
-            try:
-                with self.metrics_client.timeit(
-                    f"providers.{self.name}.query.backend.get"
-                ):
-                    weather_report = await self.backend.get_weather_report(geolocation)
-                try:
-                    await self.store_cached_weather_report(geolocation, weather_report)
-                except CacheAdapterError as exc:
-                    self.metrics_client.increment(
-                        f"providers.{self.name}.query.cache.error"
-                    )
-                    logger.warning(f"Failed to store cached weather report: {exc}")
-            except BackendError as backend_error:
-                logger.warning(backend_error)
+            with self.metrics_client.timeit(f"providers.{self.name}.query.backend.get"):
+                weather_report = await self.backend.get_weather_report(geolocation)
+
+        except BackendError as backend_error:
+            logger.warning(backend_error)
 
         if weather_report is None:
             return []
@@ -181,4 +88,4 @@ class Provider(BaseProvider):
 
     async def shutdown(self) -> None:
         """Shut down the provider."""
-        await self.cache.close()
+        await self.backend.shutdown()

--- a/tests/integration/api/v1/suggest/test_suggest_weather.py
+++ b/tests/integration/api/v1/suggest/test_suggest_weather.py
@@ -14,7 +14,6 @@ from pydantic import parse_obj_as
 from pytest import LogCaptureFixture
 from pytest_mock import MockerFixture
 
-from merino.cache.none import NoCacheAdapter
 from merino.exceptions import BackendError
 from merino.providers.weather.backends.protocol import (
     CurrentConditions,
@@ -32,7 +31,6 @@ from tests.types import FilterCaplogFixture
 def fixture_backend_mock(mocker: MockerFixture) -> Any:
     """Create a WeatherBackend mock object for test."""
     backend_mock = mocker.AsyncMock(spec=WeatherBackend)
-    backend_mock.cache_inputs_for_weather_report.return_value = None
     yield backend_mock
 
 
@@ -42,12 +40,10 @@ def fixture_providers(backend_mock: Any, statsd_mock: Any) -> Providers:
     return {
         "weather": Provider(
             backend=backend_mock,
-            cache=NoCacheAdapter(),
             metrics_client=statsd_mock,
             score=0.3,
             name="weather",
             query_timeout_sec=0.2,
-            cached_report_ttl_sec=10,
             enabled_by_default=True,
         )
     }

--- a/tests/unit/providers/weather/backends/test_accuweather.py
+++ b/tests/unit/providers/weather/backends/test_accuweather.py
@@ -1037,40 +1037,6 @@ async def test_get_forecast_error(
 
 
 @pytest.mark.parametrize(
-    "cache_inputs_by_location",
-    [
-        (Location(country="US", region="CA", city="San Francisco", dma=807), None),
-        (
-            Location(region="CA", city="San Francisco", dma=807, postal_code="94105"),
-            None,
-        ),
-        (
-            Location(
-                country="US",
-                region="CA",
-                city="San Francisco",
-                dma=807,
-                postal_code="94105",
-            ),
-            b"US94105",
-        ),
-    ],
-)
-@pytest.mark.asyncio
-async def test_cache_inputs_for_weather_report(
-    accuweather: AccuweatherBackend,
-    cache_inputs_by_location: tuple[Location, Optional[bytes]],
-) -> None:
-    """Test that `cache_inputs_for_weather_report` computes the correct cache inputs when
-    given locations with various missing fields.
-    """
-    cache_inputs: Optional[bytes] = accuweather.cache_inputs_for_weather_report(
-        cache_inputs_by_location[0]
-    )
-    assert cache_inputs == cache_inputs_by_location[1]
-
-
-@pytest.mark.parametrize(
     ("query_params", "expected_cache_key"),
     [
         (

--- a/tests/unit/providers/weather/test_provider.py
+++ b/tests/unit/providers/weather/test_provider.py
@@ -4,14 +4,12 @@
 
 """Unit tests for the weather provider module."""
 
-from typing import Any, cast
+from typing import Any
 
 import pytest
 from pytest import LogCaptureFixture
 from pytest_mock import MockerFixture
-from redis.asyncio import Redis, RedisError
 
-from merino.cache.redis import RedisAdapter
 from merino.config import settings
 from merino.exceptions import BackendError
 from merino.middleware.geolocation import Location
@@ -45,23 +43,15 @@ def fixture_backend_mock(mocker: MockerFixture) -> Any:
     return mocker.AsyncMock(spec=WeatherBackend)
 
 
-@pytest.fixture(name="redis_mock")
-def fixture_redis_mock(mocker: MockerFixture) -> Any:
-    """Create a Redis client mock object for testing."""
-    return mocker.AsyncMock(spec=Redis)
-
-
 @pytest.fixture(name="provider")
-def fixture_provider(backend_mock: Any, redis_mock: Any, statsd_mock: Any) -> Provider:
+def fixture_provider(backend_mock: Any, statsd_mock: Any) -> Provider:
     """Create a weather Provider for test."""
     return Provider(
         backend=backend_mock,
-        cache=RedisAdapter(redis_mock),
         metrics_client=statsd_mock,
         name="weather",
         score=0.3,
         query_timeout_sec=0.2,
-        cached_report_ttl_sec=10,
     )
 
 
@@ -117,7 +107,6 @@ async def test_query_weather_report_returned(
             forecast=report.forecast,
         )
     ]
-    backend_mock.cache_inputs_for_weather_report.return_value = None
     backend_mock.get_weather_report.return_value = report
 
     suggestions: list[BaseSuggestion] = await provider.query(
@@ -135,7 +124,6 @@ async def test_query_no_weather_report_returned(
     report.
     """
     expected_suggestions: list[Suggestion] = []
-    backend_mock.cache_inputs_for_weather_report.return_value = None
     backend_mock.get_weather_report.return_value = None
 
     suggestions: list[BaseSuggestion] = await provider.query(
@@ -160,7 +148,6 @@ async def test_query_error(
     expected_log_messages: list[dict[str, str]] = [
         {"levelname": "WARNING", "message": "Could not generate a weather report"}
     ]
-    backend_mock.cache_inputs_for_weather_report.return_value = None
     backend_mock.get_weather_report.side_effect = BackendError(
         expected_log_messages[0]["message"]
     )
@@ -175,310 +162,3 @@ async def test_query_error(
         for record in filter_caplog(caplog.records, "merino.providers.weather.provider")
     ]
     assert actual_log_messages == expected_log_messages
-
-
-@pytest.mark.asyncio
-async def test_query_cached_weather_report(
-    mocker: MockerFixture,
-    redis_mock: Any,
-    statsd_mock: Any,
-    backend_mock: Any,
-    provider: Provider,
-    geolocation: Location,
-) -> None:
-    """Test that weather reports are cached in Redis after the first request to the backend."""
-    cache_keys: dict[str, bytes] = {}
-
-    async def mock_redis_get(key) -> Any:
-        return cache_keys.get(key, None)
-
-    redis_mock.get.side_effect = mock_redis_get
-
-    async def mock_redis_set(key, value, **kwargs):
-        cache_keys[key] = value
-
-    redis_mock.set.side_effect = mock_redis_set
-
-    report: WeatherReport = WeatherReport(
-        city_name="San Francisco",
-        current_conditions=CurrentConditions(
-            url=(
-                "http://www.accuweather.com/en/us/san-francisco-ca/"
-                "94103/current-weather/39376_pc?lang=en-us"
-            ),
-            summary="Mostly cloudy",
-            icon_id=6,
-            temperature=Temperature(c=15.5, f=60.0),
-        ),
-        forecast=Forecast(
-            url=(
-                "http://www.accuweather.com/en/us/san-francisco-ca/"
-                "94103/daily-weather-forecast/39376_pc?lang=en-us"
-            ),
-            summary="Pleasant Saturday",
-            high=Temperature(c=21.1, f=70.0),
-            low=Temperature(c=13.9, f=57.0),
-        ),
-    )
-    backend_mock.cache_inputs_for_weather_report.return_value = cast(
-        str, geolocation.city
-    ).encode("utf-8") + cast(str, geolocation.postal_code).encode("utf-8")
-    backend_mock.get_weather_report.return_value = report
-
-    expected_suggestions: list[Suggestion] = [
-        Suggestion(
-            title="Weather for San Francisco",
-            url=(
-                "http://www.accuweather.com/en/us/san-francisco-ca/"
-                "94103/current-weather/39376_pc?lang=en-us"
-            ),
-            provider="weather",
-            is_sponsored=False,
-            score=settings.providers.accuweather.score,
-            icon=None,
-            city_name=report.city_name,
-            current_conditions=report.current_conditions,
-            forecast=report.forecast,
-        )
-    ]
-
-    uncached_suggestions: list[BaseSuggestion] = await provider.query(
-        SuggestionRequest(query="", geolocation=geolocation)
-    )
-    assert uncached_suggestions == expected_suggestions
-
-    cache_key = provider.cache_key_for_weather_report(geolocation)
-    assert cache_key is not None
-    redis_mock.get.assert_called_once_with(cache_key)
-    statsd_mock.increment.assert_called_once_with("providers.weather.query.cache.miss")
-    backend_mock.get_weather_report.assert_called_once()
-    redis_mock.set.assert_called_once_with(
-        cache_key, report.json().encode("utf-8"), ex=10
-    )
-    assert cache_keys[cache_key] is not None
-
-    redis_mock.reset_mock()
-    statsd_mock.reset_mock()
-    backend_mock.reset_mock()
-
-    cached_suggestions: list[BaseSuggestion] = await provider.query(
-        SuggestionRequest(query="", geolocation=geolocation)
-    )
-    assert cached_suggestions == expected_suggestions
-
-    redis_mock.get.assert_called_once_with(cache_key)
-    statsd_mock.increment.assert_called_once_with("providers.weather.query.cache.hit")
-    backend_mock.get_weather_report.assert_not_called()
-    redis_mock.set.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_query_cached_no_weather_report(
-    mocker: MockerFixture,
-    redis_mock: Any,
-    statsd_mock: Any,
-    backend_mock: Any,
-    provider: Provider,
-    geolocation: Location,
-) -> None:
-    """Test that the absence of a weather report for a location is cached in Redis, avoiding
-    multiple requests to the backend.
-    """
-    cache_keys: dict[str, bytes] = {}
-
-    async def mock_redis_get(key) -> Any:
-        return cache_keys.get(key, None)
-
-    redis_mock.get.side_effect = mock_redis_get
-
-    async def mock_redis_set(key, value, **kwargs):
-        cache_keys[key] = value
-
-    redis_mock.set.side_effect = mock_redis_set
-
-    backend_mock.cache_inputs_for_weather_report.return_value = cast(
-        str, geolocation.city
-    ).encode("utf-8") + cast(str, geolocation.postal_code).encode("utf-8")
-    backend_mock.get_weather_report.return_value = None
-
-    uncached_suggestions: list[BaseSuggestion] = await provider.query(
-        SuggestionRequest(query="", geolocation=geolocation)
-    )
-    assert uncached_suggestions == []
-
-    cache_key = provider.cache_key_for_weather_report(geolocation)
-    assert cache_key is not None
-    redis_mock.get.assert_called_once_with(cache_key)
-    statsd_mock.increment.assert_called_once_with("providers.weather.query.cache.miss")
-    backend_mock.get_weather_report.assert_called_once()
-    redis_mock.set.assert_called_once_with(cache_key, b"{}", ex=10)
-    assert cache_keys[cache_key] is not None
-
-    redis_mock.reset_mock()
-    statsd_mock.reset_mock()
-    backend_mock.reset_mock()
-
-    cached_suggestions: list[BaseSuggestion] = await provider.query(
-        SuggestionRequest(query="", geolocation=geolocation)
-    )
-    assert cached_suggestions == []
-
-    redis_mock.get.assert_called_once_with(cache_key)
-    statsd_mock.increment.assert_called_once_with("providers.weather.query.cache.hit")
-    backend_mock.get_weather_report.assert_not_called()
-    redis_mock.set.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_query_with_bad_cache_entry(
-    mocker: MockerFixture,
-    redis_mock: Any,
-    statsd_mock: Any,
-    backend_mock: Any,
-    provider: Provider,
-    geolocation: Location,
-) -> None:
-    """Test that a bad cache entry causes the provider to make a request to the backend."""
-    backend_mock.cache_inputs_for_weather_report.return_value = cast(
-        str, geolocation.city
-    ).encode("utf-8") + cast(str, geolocation.postal_code).encode("utf-8")
-    cache_key = provider.cache_key_for_weather_report(geolocation)
-    assert cache_key is not None
-
-    cache_keys: dict[str, bytes] = {
-        cache_key: b"badjson!",
-    }
-
-    async def mock_redis_get(key) -> Any:
-        return cache_keys.get(key, None)
-
-    redis_mock.get.side_effect = mock_redis_get
-
-    async def mock_redis_set(key, value, **kwargs):
-        cache_keys[key] = value
-
-    redis_mock.set.side_effect = mock_redis_set
-
-    report: WeatherReport = WeatherReport(
-        city_name="San Francisco",
-        current_conditions=CurrentConditions(
-            url=(
-                "http://www.accuweather.com/en/us/san-francisco-ca/"
-                "94103/current-weather/39376_pc?lang=en-us"
-            ),
-            summary="Mostly cloudy",
-            icon_id=6,
-            temperature=Temperature(c=15.5, f=60.0),
-        ),
-        forecast=Forecast(
-            url=(
-                "http://www.accuweather.com/en/us/san-francisco-ca/"
-                "94103/daily-weather-forecast/39376_pc?lang=en-us"
-            ),
-            summary="Pleasant Saturday",
-            high=Temperature(c=21.1, f=70.0),
-            low=Temperature(c=13.9, f=57.0),
-        ),
-    )
-    backend_mock.get_weather_report.return_value = report
-
-    expected_suggestions: list[Suggestion] = [
-        Suggestion(
-            title="Weather for San Francisco",
-            url=(
-                "http://www.accuweather.com/en/us/san-francisco-ca/"
-                "94103/current-weather/39376_pc?lang=en-us"
-            ),
-            provider="weather",
-            is_sponsored=False,
-            score=settings.providers.accuweather.score,
-            icon=None,
-            city_name=report.city_name,
-            current_conditions=report.current_conditions,
-            forecast=report.forecast,
-        )
-    ]
-
-    suggestions: list[BaseSuggestion] = await provider.query(
-        SuggestionRequest(query="", geolocation=geolocation)
-    )
-    assert suggestions == expected_suggestions
-
-    redis_mock.get.assert_called_once_with(cache_key)
-    statsd_mock.increment.assert_called_once_with("providers.weather.query.cache.error")
-    backend_mock.get_weather_report.assert_called_once()
-    redis_mock.set.assert_called_once_with(
-        cache_key, report.json().encode("utf-8"), ex=10
-    )
-
-
-@pytest.mark.asyncio
-async def test_query_redis_unavailable(
-    mocker: MockerFixture,
-    redis_mock: Any,
-    statsd_mock: Any,
-    backend_mock: Any,
-    provider: Provider,
-    geolocation: Location,
-) -> None:
-    """Test that Redis errors don't prevent requests to the backend."""
-    redis_mock.get.side_effect = RedisError("mercury in retrograde")
-    redis_mock.set.side_effect = RedisError("synergies not aligned")
-
-    report: WeatherReport = WeatherReport(
-        city_name="San Francisco",
-        current_conditions=CurrentConditions(
-            url=(
-                "http://www.accuweather.com/en/us/san-francisco-ca/"
-                "94103/current-weather/39376_pc?lang=en-us"
-            ),
-            summary="Mostly cloudy",
-            icon_id=6,
-            temperature=Temperature(c=15.5, f=60.0),
-        ),
-        forecast=Forecast(
-            url=(
-                "http://www.accuweather.com/en/us/san-francisco-ca/"
-                "94103/daily-weather-forecast/39376_pc?lang=en-us"
-            ),
-            summary="Pleasant Saturday",
-            high=Temperature(c=21.1, f=70.0),
-            low=Temperature(c=13.9, f=57.0),
-        ),
-    )
-    backend_mock.cache_inputs_for_weather_report.return_value = cast(
-        str, geolocation.city
-    ).encode("utf-8") + cast(str, geolocation.postal_code).encode("utf-8")
-    backend_mock.get_weather_report.return_value = report
-
-    expected_suggestions: list[Suggestion] = [
-        Suggestion(
-            title="Weather for San Francisco",
-            url=(
-                "http://www.accuweather.com/en/us/san-francisco-ca/"
-                "94103/current-weather/39376_pc?lang=en-us"
-            ),
-            provider="weather",
-            is_sponsored=False,
-            score=settings.providers.accuweather.score,
-            icon=None,
-            city_name=report.city_name,
-            current_conditions=report.current_conditions,
-            forecast=report.forecast,
-        )
-    ]
-
-    suggestions: list[BaseSuggestion] = await provider.query(
-        SuggestionRequest(query="", geolocation=geolocation)
-    )
-    assert suggestions == expected_suggestions
-
-    redis_mock.get.assert_called_once()
-    backend_mock.get_weather_report.assert_called_once()
-    redis_mock.set.assert_called_once()
-    statsd_mock.increment.assert_has_calls(
-        [
-            mocker.call("providers.weather.query.cache.error"),
-            mocker.call("providers.weather.query.cache.error"),
-        ]
-    )


### PR DESCRIPTION
## References

JIRA: [DISCO-2450](https://mozilla-hub.atlassian.net/browse/DISCO-2450)


## Description
Removing the caching from the weather provider because we are caching the full Accuweather response in the backend. 



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2450]: https://mozilla-hub.atlassian.net/browse/DISCO-2450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ