### PR TITLE
[DISCO-2453] Add a wildcard provider ID to the suggest endpoint

### DIFF
--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -29,6 +29,9 @@ SUGGEST_RESPONSE = {
     "request_id": "",
 }
 
+# Param to capture all enabled_by_default=True providers.
+DEFAULT_PROVIDERS_PARAM_NAME: str = "default"
+
 # Timeout for query tasks.
 QUERY_TIMEOUT_SEC = settings.runtime.query_timeout_sec
 
@@ -76,12 +79,14 @@ async def suggest(
 
     active_providers, default_providers = sources
     if providers is not None:
-        search_from = [
-            active_providers[p]
-            # Set used to filter out possible duplicate providers passed in.
-            for p in set(providers.split(","))
-            if p in active_providers
+        # Set used to filter out possible duplicate providers passed in.
+        provider_names: set[str] = set(providers.split(","))
+        search_from: list[BaseProvider] = [
+            active_providers[p] for p in provider_names if p in active_providers
         ]
+        if DEFAULT_PROVIDERS_PARAM_NAME in provider_names:
+            # Search the default providers if `default` wildcard parameter passed in `providers`.
+            search_from.extend(p for p in default_providers if p not in search_from)
     else:
         search_from = default_providers
 


### PR DESCRIPTION
## References

JIRA: [DISCO-2453](https://mozilla-hub.atlassian.net/browse/DISCO-2453)
GitHub: [#342](https://github.com/mozilla-services/merino-py/issues/342)

## Description
As we enable more providers by default in Merino, it’s getting hard to keep the exact provider lists up to date in the experiment recipes. We can add a wildcard provider ID (i.e. 'default') to the suggest endpoint so that Merino can return suggestions from all the default providers without requiring API consumers explicitly to list all the default providers in the query parameter providers.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
