### PR TITLE
fix: score AMO suggestions below adM suggestions

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -129,7 +129,7 @@ api_url = "https://addons.mozilla.org/api/v5/addons/addon/"
 [default.providers.amo]
 type = "amo"
 enabled_by_default = false
-score = 0.3
+score = 0.25
 # Specifies which backend to use. Currently defaulting to dynamic backend.
 backend = "dynamic"
 # The minimum number of characters to be considered for matching.
@@ -209,6 +209,3 @@ min_favicon_width = 48
 [default.jobs.amo_rs_uploader]
 # The "type" of each remote settings record
 record_type = "amo-suggestions"
-# While the addon experiment is active, addon suggestions should be preferred
-# over all other types.
-score = 1.0

--- a/merino/jobs/amo_rs_uploader/__init__.py
+++ b/merino/jobs/amo_rs_uploader/__init__.py
@@ -14,6 +14,7 @@ from merino.providers.amo.backends.dynamic import DynamicAmoBackend
 
 logger = logging.getLogger(__name__)
 
+amo_settings = config.providers.amo
 job_settings = config.jobs.amo_rs_uploader
 rs_settings = config.remote_settings
 
@@ -67,7 +68,7 @@ record_type_option = typer.Option(
 )
 
 score_option = typer.Option(
-    job_settings.score,
+    amo_settings.score,
     "--score",
     help="The score of each suggestion",
 )


### PR DESCRIPTION
## Description

Change the score of AMO suggestions so it's less than the score of adM suggestions. Use the new score for both Merino and remote settings AMO suggestions. This ensures the client will show sponsored suggestions instead of AMO suggestions when keyword collisions occur, which according to Product is the desired behavior for both the addons-suggestion experiment and general release.


## PR Review Checklist

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
