### PR TITLE
[DISCO-2472] Load Test Script Modifies Kubernetes Config On First Run Only [load test: abort]

### DIFF
--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -131,8 +131,10 @@ a GKE cluster
   kubectl scale deployment/locust-worker --replicas=10
   ```
 * To apply new changes to an existing GCP Cluster, execute the `setup_k8s.sh` file and select the
-  **setup** option. This option will consider the local commit history, creating new containers and
-  deploying them (see [Container Registry][container_registry])
+  **setup** option.
+    * This option will consider the local commit history, creating new containers and
+      deploying them (see [Container Registry][16])
+    * **Reset the files in the `kubernetes-config` directory between executions of the script**
 
 ### Run Test Session
 

--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -133,7 +133,7 @@ a GKE cluster
 * To apply new changes to an existing GCP Cluster, execute the `setup_k8s.sh` file and select the
   **setup** option.
     * This option will consider the local commit history, creating new containers and
-      deploying them (see [Container Registry][16])
+      deploying them (see [Container Registry][container_registry])
     * **Reset the files in the `kubernetes-config` directory between executions of the script**
 
 ### Run Test Session


### PR DESCRIPTION
## References

JIRA: [DISCO-2472](https://mozilla-hub.atlassian.net/browse/DISCO-2472)
GitHub: N/A

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->
- Add workaround instruction to the load test Distributed GCP Execution procedure

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2472]: https://mozilla-hub.atlassian.net/browse/DISCO-2472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ