### PR TITLE
feat: add Pocket RS suggestions uploader

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -209,3 +209,10 @@ min_favicon_width = 48
 [default.jobs.amo_rs_uploader]
 # The "type" of each remote settings record
 record_type = "amo-suggestions"
+
+[default.jobs.pocket_rs_uploader]
+# Path to the CSV file that contains the source data
+csv_path = ""
+# The "type" of each remote settings record
+record_type = "pocket-suggestions"
+score = 0.25

--- a/merino/jobs/amo_rs_uploader/__init__.py
+++ b/merino/jobs/amo_rs_uploader/__init__.py
@@ -6,9 +6,7 @@ from typing import Any
 import typer
 
 from merino.config import settings as config
-from merino.jobs.amo_rs_uploader.chunked_rs_uploader import (
-    ChunkedRemoteSettingsUploader,
-)
+from merino.jobs.utils.chunked_rs_uploader import ChunkedRemoteSettingsUploader
 from merino.providers.amo.addons_data import ADDON_DATA, ADDON_KEYWORDS
 from merino.providers.amo.backends.dynamic import DynamicAmoBackend
 
@@ -131,6 +129,7 @@ async def _upload(
         record_type=record_type,
         server=server,
         suggestion_score_fallback=score,
+        total_suggestion_count=len(backend.dynamic_data),
     ) as uploader:
         if delete_existing_records:
             uploader.delete_records()

--- a/merino/jobs/cli.py
+++ b/merino/jobs/cli.py
@@ -4,6 +4,7 @@ import typer
 from merino.config_logging import configure_logging
 from merino.jobs.amo_rs_uploader import amo_rs_uploader_cmd
 from merino.jobs.navigational_suggestions import navigational_suggestions_cmd
+from merino.jobs.pocket_rs_uploader import pocket_rs_uploader_cmd
 from merino.jobs.wikipedia_indexer import indexer_cmd
 
 cli = typer.Typer(no_args_is_help=True, add_completion=False)
@@ -15,6 +16,9 @@ cli.add_typer(navigational_suggestions_cmd, no_args_is_help=True)
 
 # Add the AMO suggestions subcommands
 cli.add_typer(amo_rs_uploader_cmd, no_args_is_help=True)
+
+# Add the Pocket suggestions subcommands
+cli.add_typer(pocket_rs_uploader_cmd, no_args_is_help=True)
 
 
 @cli.callback("setup")

--- a/merino/jobs/pocket_rs_uploader/__init__.py
+++ b/merino/jobs/pocket_rs_uploader/__init__.py
@@ -1,22 +1,37 @@
 """CLI commands for the pocket_rs_uploader module"""
 import asyncio
 import csv
+import io
 from typing import Any
 
 import typer
+from pydantic import BaseModel, HttpUrl, validator
 
 from merino.config import settings as config
 from merino.jobs.utils.chunked_rs_uploader import ChunkedRemoteSettingsUploader
 
-# Maps from CSV field name in the input data to the corresponding suggestion
-# property in the output.
-SUGGESTION_PROPERTIES_BY_CSV_FIELD = {
-    "Collection Title": "title",
-    "Collection Description": "description",
-    "Collection URL": "url",
-    "High-Confidence Keywords": "highConfidenceKeywords",
-    "Low-Confidence Keywords": "lowConfidenceKeywords",
-}
+# The names of expected fields (columns) in the CSV input data.
+FIELD_DESC = "Collection Description"
+FIELD_KEYWORDS_LOW = "Low-Confidence Keywords"
+FIELD_KEYWORDS_HIGH = "High-Confidence Keywords"
+FIELD_TITLE = "Collection Title"
+FIELD_URL = "Collection URL"
+
+ALL_FIELDS = [
+    FIELD_DESC,
+    FIELD_KEYWORDS_LOW,
+    FIELD_KEYWORDS_HIGH,
+    FIELD_TITLE,
+    FIELD_URL,
+]
+
+# The names of fields whose values are suggestion keywords. In the input data,
+# the values of these fields are expected to be comma-delimited strings. The
+# uploader converts them to arrays in the output JSON.
+KEYWORDS_FIELDS = [
+    FIELD_KEYWORDS_LOW,
+    FIELD_KEYWORDS_HIGH,
+]
 
 job_settings = config.jobs.pocket_rs_uploader
 rs_settings = config.remote_settings
@@ -88,6 +103,58 @@ pocket_rs_uploader_cmd = typer.Typer(
 )
 
 
+class Suggestion(BaseModel):
+    """Model for Pocket suggestions as encoded in the output JSON."""
+
+    url: HttpUrl
+    title: str
+    description: str
+    lowConfidenceKeywords: list[str]
+    highConfidenceKeywords: list[str]
+
+    def _validate_str(cls, value: str, name: str) -> str:
+        if not value:
+            raise ValueError(f"{name} must not be empty")
+        return value
+
+    def _validate_keywords(cls, value: list[str], name: str) -> list[str]:
+        if not value or len(value) == 0:
+            raise ValueError(f"{name} must not be empty")
+        if any(map(lambda kw: not kw, value)):
+            raise ValueError(f"{name} must not contain any empty strings")
+        if any(map(lambda kw: kw.strip() != kw, value)):
+            raise ValueError(f"{name} must not contain leading or trailing spaces")
+        if any(map(lambda kw: kw.lower() != kw, value)):
+            raise ValueError(f"{name} must not contain uppercase chars")
+        return value
+
+    @validator("title", pre=True, always=True)
+    def validate_title(cls, value):
+        """Validate title"""
+        return cls._validate_str(cls, value, "title")
+
+    @validator("description", pre=True, always=True)
+    def validate_description(cls, value):
+        """Validate description"""
+        return cls._validate_str(cls, value, "description")
+
+    @validator("lowConfidenceKeywords", pre=True, always=True)
+    def validate_lowConfidenceKeywords(cls, value):
+        """Validate lowConfidenceKeywords"""
+        return cls._validate_keywords(cls, value, "lowConfidenceKeywords")
+
+    @validator("highConfidenceKeywords", pre=True, always=True)
+    def validate_highConfidenceKeywords(cls, value):
+        """Validate highConfidenceKeywords"""
+        return cls._validate_keywords(cls, value, "highConfidenceKeywords")
+
+
+class MissingFieldError(Exception):
+    """An error that means the input CSV did not contain an expected field."""
+
+    pass
+
+
 @pocket_rs_uploader_cmd.command()
 def upload(
     auth: str = auth_option,
@@ -131,41 +198,71 @@ async def _upload(
     server: str,
 ):
     with open(csv_path, newline="", encoding="utf-8-sig") as csv_file:
-        csv_reader = csv.DictReader(csv_file)
-
-        # Generate the full list of suggestions before creating the chunked
-        # uploader so we can detect errors in the source data before deleting
-        # existing records and starting the upload.
-        suggestions: list[dict[str, Any]] = []
-        for row in csv_reader:
-            suggestion: dict[str, Any] = {}
-            for field, prop in SUGGESTION_PROPERTIES_BY_CSV_FIELD.items():
-                if not row[field]:
-                    raise Exception(f"Empty value for '{field}' in row: {row}")
-                suggestion[prop] = row[field]
-
-            # The two keywords fields are comma-delimited strings. Split them
-            # into arrays.
-            for prop in ["highConfidenceKeywords", "lowConfidenceKeywords"]:
-                suggestion[prop] = [
-                    *map(str.strip, suggestion[prop].lower().split(","))
-                ]
-
-            suggestions.append(suggestion)
-
-        with ChunkedRemoteSettingsUploader(
+        await _upload_file_object(
             auth=auth,
             bucket=bucket,
             chunk_size=chunk_size,
             collection=collection,
+            delete_existing_records=delete_existing_records,
             dry_run=dry_run,
+            file_object=csv_file,
             record_type=record_type,
+            score=score,
             server=server,
-            suggestion_score_fallback=score,
-            total_suggestion_count=len(suggestions),
-        ) as uploader:
-            if delete_existing_records:
-                uploader.delete_records()
+        )
 
-            for suggestion in suggestions:
-                uploader.add_suggestion(suggestion)
+
+async def _upload_file_object(
+    auth: str,
+    bucket: str,
+    chunk_size: int,
+    collection: str,
+    file_object: io.TextIOWrapper,
+    delete_existing_records: bool,
+    dry_run: bool,
+    record_type: str,
+    score: float,
+    server: str,
+):
+    csv_reader = csv.DictReader(file_object)
+
+    # Generate the full list of suggestions before creating the chunked uploader
+    # so we can validate the source data before deleting existing records and
+    # starting the upload.
+    suggestions: list[Suggestion] = []
+    for row in csv_reader:
+        for field in ALL_FIELDS:
+            if field not in row:
+                raise MissingFieldError(f"Missing field {field}")
+
+        # The keywords fields are comma-delimited strings. Split them into lists.
+        keywords = {}
+        for field in KEYWORDS_FIELDS:
+            keywords[field] = [*map(str.strip, row[field].lower().split(","))]
+
+        suggestions.append(
+            Suggestion(
+                url=row[FIELD_URL],
+                title=row[FIELD_TITLE],
+                description=row[FIELD_DESC],
+                lowConfidenceKeywords=keywords[FIELD_KEYWORDS_LOW],
+                highConfidenceKeywords=keywords[FIELD_KEYWORDS_HIGH],
+            )
+        )
+
+    with ChunkedRemoteSettingsUploader(
+        auth=auth,
+        bucket=bucket,
+        chunk_size=chunk_size,
+        collection=collection,
+        dry_run=dry_run,
+        record_type=record_type,
+        server=server,
+        suggestion_score_fallback=score,
+        total_suggestion_count=len(suggestions),
+    ) as uploader:
+        if delete_existing_records:
+            uploader.delete_records()
+
+        for suggestion in suggestions:
+            uploader.add_suggestion(suggestion)

--- a/merino/jobs/pocket_rs_uploader/__init__.py
+++ b/merino/jobs/pocket_rs_uploader/__init__.py
@@ -1,0 +1,171 @@
+"""CLI commands for the pocket_rs_uploader module"""
+import asyncio
+import csv
+from typing import Any
+
+import typer
+
+from merino.config import settings as config
+from merino.jobs.utils.chunked_rs_uploader import ChunkedRemoteSettingsUploader
+
+# Maps from CSV field name in the input data to the corresponding suggestion
+# property in the output.
+SUGGESTION_PROPERTIES_BY_CSV_FIELD = {
+    "Collection Title": "title",
+    "Collection Description": "description",
+    "Collection URL": "url",
+    "High-Confidence Keywords": "highConfidenceKeywords",
+    "Low-Confidence Keywords": "lowConfidenceKeywords",
+}
+
+job_settings = config.jobs.pocket_rs_uploader
+rs_settings = config.remote_settings
+
+# Options
+auth_option = typer.Option(
+    rs_settings.auth,
+    "--auth",
+    help="Remote settings authorization token",
+)
+
+bucket_option = typer.Option(
+    rs_settings.bucket,
+    "--bucket",
+    help="Remote settings bucket",
+)
+
+chunk_size_option = typer.Option(
+    rs_settings.chunk_size,
+    "--chunk-size",
+    help="The number of suggestions to store in each attachment",
+)
+
+collection_option = typer.Option(
+    rs_settings.collection,
+    "--collection",
+    help="Remote settings collection ID",
+)
+
+delete_existing_records_option = typer.Option(
+    rs_settings.delete_existing_records,
+    "--delete-existing-records",
+    help="Delete existing records before uploading new records",
+)
+
+dry_run_option = typer.Option(
+    rs_settings.dry_run,
+    "--dry-run",
+    help="Log the records that would be uploaded but don't upload them",
+)
+
+server_option = typer.Option(
+    rs_settings.server,
+    "--server",
+    help="Remote settings server",
+)
+
+csv_path_option = typer.Option(
+    job_settings.csv_path,
+    "--csv-path",
+    help="Path to CSV file containing the source data",
+)
+
+record_type_option = typer.Option(
+    job_settings.record_type,
+    "--record-type",
+    help="The `type` of each remote settings record",
+)
+
+score_option = typer.Option(
+    job_settings.score,
+    "--score",
+    help="The score of each suggestion",
+)
+
+pocket_rs_uploader_cmd = typer.Typer(
+    name="pocket-rs-uploader",
+    help="Command for uploading Pocket suggestions to remote settings",
+)
+
+
+@pocket_rs_uploader_cmd.command()
+def upload(
+    auth: str = auth_option,
+    bucket: str = bucket_option,
+    chunk_size: int = chunk_size_option,
+    collection: str = collection_option,
+    csv_path: str = csv_path_option,
+    delete_existing_records: bool = delete_existing_records_option,
+    dry_run: bool = dry_run_option,
+    record_type: str = record_type_option,
+    score: float = score_option,
+    server: str = server_option,
+):
+    """Upload Pocket suggestions to remote settings."""
+    asyncio.run(
+        _upload(
+            auth=auth,
+            bucket=bucket,
+            chunk_size=chunk_size,
+            collection=collection,
+            csv_path=csv_path,
+            delete_existing_records=delete_existing_records,
+            dry_run=dry_run,
+            record_type=record_type,
+            score=score,
+            server=server,
+        )
+    )
+
+
+async def _upload(
+    auth: str,
+    bucket: str,
+    chunk_size: int,
+    collection: str,
+    csv_path: str,
+    delete_existing_records: bool,
+    dry_run: bool,
+    record_type: str,
+    score: float,
+    server: str,
+):
+    with open(csv_path, newline="", encoding="utf-8-sig") as csv_file:
+        csv_reader = csv.DictReader(csv_file)
+
+        # Generate the full list of suggestions before creating the chunked
+        # uploader so we can detect errors in the source data before deleting
+        # existing records and starting the upload.
+        suggestions: list[dict[str, Any]] = []
+        for row in csv_reader:
+            suggestion: dict[str, Any] = {}
+            for field, prop in SUGGESTION_PROPERTIES_BY_CSV_FIELD.items():
+                if not row[field]:
+                    raise Exception(f"Empty value for '{field}' in row: {row}")
+                suggestion[prop] = row[field]
+
+            # The two keywords fields are comma-delimited strings. Split them
+            # into arrays.
+            for prop in ["highConfidenceKeywords", "lowConfidenceKeywords"]:
+                suggestion[prop] = [
+                    *map(str.strip, suggestion[prop].lower().split(","))
+                ]
+
+            suggestions.append(suggestion)
+
+        with ChunkedRemoteSettingsUploader(
+            auth=auth,
+            bucket=bucket,
+            chunk_size=chunk_size,
+            collection=collection,
+            dry_run=dry_run,
+            record_type=record_type,
+            server=server,
+            suggestion_score_fallback=score,
+            total_suggestion_count=len(suggestions),
+        ) as uploader:
+            if delete_existing_records:
+                uploader.delete_records()
+
+            for suggestion in suggestions:
+                uploader.add_suggestion(suggestion)

--- a/merino/jobs/pocket_rs_uploader/__init__.py
+++ b/merino/jobs/pocket_rs_uploader/__init__.py
@@ -235,10 +235,19 @@ async def _upload_file_object(
             if field not in row:
                 raise MissingFieldError(f"Missing field {field}")
 
-        # The keywords fields are comma-delimited strings. Split them into lists.
+        # The keywords fields are comma-delimited strings. Split them into lists
+        # and transform each individual keyword string as follows:
+        # - Lowercase
+        # - Remove leading and trailing space
+        # - Filter out empty keywords
         keywords = {}
         for field in KEYWORDS_FIELDS:
-            keywords[field] = [*map(str.strip, row[field].lower().split(","))]
+            keywords[field] = [
+                *filter(
+                    lambda kw: len(kw) > 0,
+                    map(str.strip, row[field].lower().split(",")),
+                )
+            ]
 
         suggestions.append(
             Suggestion(
@@ -265,4 +274,4 @@ async def _upload_file_object(
             uploader.delete_records()
 
         for suggestion in suggestions:
-            uploader.add_suggestion(suggestion)
+            uploader.add_suggestion(vars(suggestion))

--- a/tests/unit/jobs/amo_rs_uploader/test_amo_rs_uploader.py
+++ b/tests/unit/jobs/amo_rs_uploader/test_amo_rs_uploader.py
@@ -124,6 +124,7 @@ def do_upload_test(
     mock_chunked_uploader_ctor.assert_called_once_with(
         **common_kwargs,
         suggestion_score_fallback=score,
+        total_suggestion_count=TEST_ADDON_COUNT,
     )
 
     if delete_existing_records:

--- a/tests/unit/jobs/pocket_rs_uploader/test.csv
+++ b/tests/unit/jobs/pocket_rs_uploader/test.csv
@@ -1,0 +1,4 @@
+Collection Title,Collection Description,Collection URL,High-Confidence Keywords,Low-Confidence Keywords
+Title 0,Description 0,http://example.com/pocket-0,"high-0-0,high-0-1,high-0-2","low-0-0,low-0-1,low-0-2"
+Title 1,Description 1,http://example.com/pocket-1,"high-1-0,high-1-1,high-1-2","low-1-0,low-1-1,low-1-2"
+Title 2,Description 2,http://example.com/pocket-2,"high-2-0,high-2-1,high-2-2","low-2-0,low-2-1,low-2-2"

--- a/tests/unit/jobs/pocket_rs_uploader/test_pocket_rs_uploader.py
+++ b/tests/unit/jobs/pocket_rs_uploader/test_pocket_rs_uploader.py
@@ -4,29 +4,46 @@
 
 """Unit tests for __init__.py module."""
 
+import asyncio
+import csv
+import io
 import pathlib
 from typing import Any
 
-from merino.jobs.pocket_rs_uploader import upload
+import pytest
+from pydantic import ValidationError
 
-# The CSV file containing the test suggestions data. If you modify the data in
-# this file, be sure to keep the following in sync:
-# * TEST_SUGGESTION_COUNT
-# * TEST_KEYWORD_COUNT
-# * expected_add_suggestion_calls()
-TEST_CSV_BASENAME = "test.csv"
-TEST_CSV_PATH = str(pathlib.Path(__file__).parent / TEST_CSV_BASENAME)
+from merino.jobs.pocket_rs_uploader import (
+    FIELD_DESC,
+    FIELD_KEYWORDS_HIGH,
+    FIELD_KEYWORDS_LOW,
+    FIELD_TITLE,
+    FIELD_URL,
+    MissingFieldError,
+    _upload_file_object,
+    upload,
+)
 
-TEST_SUGGESTION_COUNT = 3
-TEST_KEYWORD_COUNT = 3
+# The CSV file containing the primary test suggestions data. If you modify this
+# file, be sure to keep the following in sync:
+# - PRIMARY_SUGGESTION_COUNT
+# - PRIMARY_KEYWORD_COUNT
+# - expected_primary_add_suggestion_calls()
+PRIMARY_CSV_BASENAME = "test.csv"
+PRIMARY_CSV_PATH = str(pathlib.Path(__file__).parent / PRIMARY_CSV_BASENAME)
+
+PRIMARY_SUGGESTION_COUNT = 3
+PRIMARY_KEYWORD_COUNT = 3
 
 
-def expected_add_suggestion_calls(
+def expected_primary_add_suggestion_calls(
     mocker,
-    suggestion_count: int = TEST_SUGGESTION_COUNT,
-    keyword_count: int = TEST_KEYWORD_COUNT,
+    suggestion_count: int = PRIMARY_SUGGESTION_COUNT,
+    keyword_count: int = PRIMARY_KEYWORD_COUNT,
 ):
-    """Return a list of expected `add_suggestion()` calls."""
+    """Return a list of expected `add_suggestion()` calls for the primary CSV
+    test data in `PRIMARY_CSV_PATH`.
+    """
     calls = []
     for s in range(suggestion_count):
         call: dict[str, Any] = {
@@ -40,12 +57,14 @@ def expected_add_suggestion_calls(
     return calls
 
 
-def do_upload_test(
+def do_primary_upload_test(
     mocker,
     delete_existing_records: bool = False,
     score: float = 0.99,
 ) -> None:
-    """Perform an upload test."""
+    """Perform an upload test using the primary CSV test data in
+    `PRIMARY_CSV_PATH`.
+    """
     # Mock the chunked uploader.
     mock_chunked_uploader_ctor = mocker.patch(
         "merino.jobs.pocket_rs_uploader.ChunkedRemoteSettingsUploader"
@@ -68,14 +87,14 @@ def do_upload_test(
         **common_kwargs,
         delete_existing_records=delete_existing_records,
         score=score,
-        csv_path=TEST_CSV_PATH,
+        csv_path=PRIMARY_CSV_PATH,
     )
 
     # Check calls.
     mock_chunked_uploader_ctor.assert_called_once_with(
         **common_kwargs,
         suggestion_score_fallback=score,
-        total_suggestion_count=TEST_SUGGESTION_COUNT,
+        total_suggestion_count=PRIMARY_SUGGESTION_COUNT,
     )
 
     if delete_existing_records:
@@ -84,20 +103,266 @@ def do_upload_test(
         mock_chunked_uploader.delete_records.assert_not_called()
 
     mock_chunked_uploader.add_suggestion.assert_has_calls(
-        expected_add_suggestion_calls(mocker)
+        expected_primary_add_suggestion_calls(mocker)
     )
 
 
 def test_upload_without_deleting(mocker):
-    """Tests `upload(delete_existing_records=False)`"""
-    do_upload_test(mocker, delete_existing_records=False)
+    """upload(delete_existing_records=False) with the primary CSV test data"""
+    do_primary_upload_test(mocker, delete_existing_records=False)
 
 
 def test_delete_and_upload(mocker):
-    """Tests `upload(delete_existing_records=True)`"""
-    do_upload_test(mocker, delete_existing_records=True)
+    """upload(delete_existing_records=True) with the primary CSV test data"""
+    do_primary_upload_test(mocker, delete_existing_records=True)
 
 
 def test_upload_with_score(mocker):
-    """Tests `upload(score=float)`"""
-    do_upload_test(mocker, score=0.12)
+    """upload(score=float) with the primary CSV test data"""
+    do_primary_upload_test(mocker, score=0.12)
+
+
+def make_csv_file_object(csv_rows: list[dict[str, str]]) -> io.TextIOWrapper:
+    """Return a StringIO that encodes the given CSV rows."""
+    f = io.StringIO()
+    csv_writer = csv.DictWriter(f, fieldnames=[*csv_rows[0].keys()])
+    csv_writer.writeheader()
+    for row in csv_rows:
+        csv_writer.writerow(row)
+    f.seek(0)
+    return f
+
+
+def do_upload_file_object_test(
+    mocker,
+    file_object: io.TextIOWrapper,
+    expected_add_suggestion_calls,
+    delete_existing_records: bool = False,
+    score: float = 0.99,
+) -> None:
+    """Perform an upload test using sync_upload_file_object()."""
+    # Mock the chunked uploader.
+    mock_chunked_uploader_ctor = mocker.patch(
+        "merino.jobs.pocket_rs_uploader.ChunkedRemoteSettingsUploader"
+    )
+    mock_chunked_uploader = (
+        mock_chunked_uploader_ctor.return_value.__enter__.return_value
+    )
+
+    # Do the upload.
+    common_kwargs: dict[str, Any] = {
+        "auth": "auth",
+        "bucket": "bucket",
+        "chunk_size": 99,
+        "collection": "collection",
+        "dry_run": False,
+        "record_type": "record_type",
+        "server": "server",
+    }
+    asyncio.run(
+        _upload_file_object(
+            **common_kwargs,
+            delete_existing_records=delete_existing_records,
+            score=score,
+            file_object=file_object,
+        )
+    )
+
+    # Check calls.
+    mock_chunked_uploader_ctor.assert_called_once_with(
+        **common_kwargs,
+        suggestion_score_fallback=score,
+        total_suggestion_count=len(expected_add_suggestion_calls),
+    )
+
+    if delete_existing_records:
+        mock_chunked_uploader.delete_records.assert_called_once()
+    else:
+        mock_chunked_uploader.delete_records.assert_not_called()
+
+    mock_chunked_uploader.add_suggestion.assert_has_calls(expected_add_suggestion_calls)
+
+
+def do_transformed_keyword_test(
+    mocker,
+    fields: dict[str, str],
+    expected_call: dict[str, Any],
+):
+    """Perform a test where the input data contains keywords with uppercase
+    chars, leading or trailing space, etc. The uploader should transform these
+    keywords so that all chars are lowercased, trailing and leading space is
+    removed, etc.
+    """
+    row = {
+        FIELD_URL: "http://example.com/",
+        FIELD_TITLE: "title",
+        FIELD_DESC: "desc",
+        FIELD_KEYWORDS_LOW: "low",
+        FIELD_KEYWORDS_HIGH: "high",
+        **fields,
+    }
+    f = make_csv_file_object([row])
+    call: dict[str, Any] = {
+        "url": row[FIELD_URL],
+        "title": row[FIELD_TITLE],
+        "description": row[FIELD_DESC],
+        "lowConfidenceKeywords": ["low"],
+        "highConfidenceKeywords": ["high"],
+        **expected_call,
+    }
+    calls = [mocker.call(call)]
+    do_upload_file_object_test(
+        mocker,
+        file_object=f,
+        expected_add_suggestion_calls=calls,
+    )
+    f.close()
+
+
+def test_lowConfidenceKeywords_leading_space(mocker):
+    """Leading spaces in lowConfidenceKeywords should be removed"""
+    do_transformed_keyword_test(
+        mocker,
+        fields={FIELD_KEYWORDS_LOW: "a,   b,c"},
+        expected_call={"lowConfidenceKeywords": ["a", "b", "c"]},
+    )
+
+
+def test_lowConfidenceKeywords_trailing_space(mocker):
+    """Trailing spaces in lowConfidenceKeywords should be removed"""
+    do_transformed_keyword_test(
+        mocker,
+        fields={FIELD_KEYWORDS_LOW: "a,b   ,c"},
+        expected_call={"lowConfidenceKeywords": ["a", "b", "c"]},
+    )
+
+
+def test_lowConfidenceKeywords_uppercase(mocker):
+    """Uppercase chars in lowConfidenceKeywords should be lowercased"""
+    do_transformed_keyword_test(
+        mocker,
+        fields={FIELD_KEYWORDS_LOW: "a,BBB,c"},
+        expected_call={"lowConfidenceKeywords": ["a", "bbb", "c"]},
+    )
+
+
+def test_highConfidenceKeywords_leading_space(mocker):
+    """Leading spaces in highConfidenceKeywords should be removed"""
+    do_transformed_keyword_test(
+        mocker,
+        fields={FIELD_KEYWORDS_HIGH: "a,   b,c"},
+        expected_call={"highConfidenceKeywords": ["a", "b", "c"]},
+    )
+
+
+def test_highConfidenceKeywords_trailing_space(mocker):
+    """Trailing spaces in highConfidenceKeywords should be removed"""
+    do_transformed_keyword_test(
+        mocker,
+        fields={FIELD_KEYWORDS_HIGH: "a,b   ,c"},
+        expected_call={"highConfidenceKeywords": ["a", "b", "c"]},
+    )
+
+
+def test_highConfidenceKeywords_uppercase(mocker):
+    """Uppercase chars in highConfidenceKeywords should be highercased"""
+    do_transformed_keyword_test(
+        mocker,
+        fields={FIELD_KEYWORDS_HIGH: "a,BBB,c"},
+        expected_call={"highConfidenceKeywords": ["a", "bbb", "c"]},
+    )
+
+
+def do_validation_error_test(mocker, fields: dict[str, str]):
+    """Perform a test that should raise a ValidationError."""
+    row = {
+        FIELD_URL: "http://example.com/",
+        FIELD_TITLE: "title",
+        FIELD_DESC: "desc",
+        FIELD_KEYWORDS_LOW: "low",
+        FIELD_KEYWORDS_HIGH: "high",
+        **fields,
+    }
+    f = make_csv_file_object([row])
+    with pytest.raises(ValidationError):
+        do_upload_file_object_test(
+            mocker,
+            file_object=f,
+            expected_add_suggestion_calls=[],
+        )
+    f.close()
+
+
+def test_url_empty(mocker):
+    """An empty URL should raise a ValidationError"""
+    do_validation_error_test(mocker, {FIELD_URL: ""})
+
+
+def test_url_invalid(mocker):
+    """An invalid URL should raise a ValidationError"""
+    do_validation_error_test(mocker, {FIELD_URL: "not a valid URL"})
+
+
+def test_title_empty(mocker):
+    """An empty title should raise a ValidationError"""
+    do_validation_error_test(mocker, {FIELD_TITLE: ""})
+
+
+def test_description_empty(mocker):
+    """An empty description should raise a ValidationError"""
+    do_validation_error_test(mocker, {FIELD_DESC: ""})
+
+
+def test_lowConfidenceKeywords_empty(mocker):
+    """An empty lowConfidenceKeywords should raise a ValidationError"""
+    do_validation_error_test(mocker, {FIELD_KEYWORDS_LOW: ""})
+
+
+def test_highConfidenceKeywords_empty(mocker):
+    """An empty highConfidenceKeywords should raise a ValidationError"""
+    do_validation_error_test(mocker, {FIELD_KEYWORDS_HIGH: ""})
+
+
+def do_missing_field_test(mocker, missing_field: str):
+    """Perform a test that should raise a MissingFieldError."""
+    row = {
+        FIELD_URL: "http://example.com/",
+        FIELD_TITLE: "title",
+        FIELD_DESC: "desc",
+        FIELD_KEYWORDS_LOW: "low",
+        FIELD_KEYWORDS_HIGH: "high",
+    }
+    del row[missing_field]
+    f = make_csv_file_object([row])
+    with pytest.raises(MissingFieldError):
+        do_upload_file_object_test(
+            mocker,
+            file_object=f,
+            expected_add_suggestion_calls=[],
+        )
+    f.close()
+
+
+def test_missing_url(mocker):
+    """A missing URL field should raise a MissingFieldError"""
+    do_missing_field_test(mocker, FIELD_URL)
+
+
+def test_missing_title(mocker):
+    """A missing title field should raise a MissingFieldError"""
+    do_missing_field_test(mocker, FIELD_TITLE)
+
+
+def test_missing_description(mocker):
+    """A missing description field should raise a MissingFieldError"""
+    do_missing_field_test(mocker, FIELD_DESC)
+
+
+def test_missing_low_keywords(mocker):
+    """A missing low confidence keywords field should raise a MissingFieldError"""
+    do_missing_field_test(mocker, FIELD_KEYWORDS_LOW)
+
+
+def test_missing_high_keywords(mocker):
+    """A missing high confidence keywords field should raise a MissingFieldError"""
+    do_missing_field_test(mocker, FIELD_KEYWORDS_HIGH)

--- a/tests/unit/jobs/pocket_rs_uploader/test_pocket_rs_uploader.py
+++ b/tests/unit/jobs/pocket_rs_uploader/test_pocket_rs_uploader.py
@@ -1,0 +1,103 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Unit tests for __init__.py module."""
+
+import pathlib
+from typing import Any
+
+from merino.jobs.pocket_rs_uploader import upload
+
+# The CSV file containing the test suggestions data. If you modify the data in
+# this file, be sure to keep the following in sync:
+# * TEST_SUGGESTION_COUNT
+# * TEST_KEYWORD_COUNT
+# * expected_add_suggestion_calls()
+TEST_CSV_BASENAME = "test.csv"
+TEST_CSV_PATH = str(pathlib.Path(__file__).parent / TEST_CSV_BASENAME)
+
+TEST_SUGGESTION_COUNT = 3
+TEST_KEYWORD_COUNT = 3
+
+
+def expected_add_suggestion_calls(
+    mocker,
+    suggestion_count: int = TEST_SUGGESTION_COUNT,
+    keyword_count: int = TEST_KEYWORD_COUNT,
+):
+    """Return a list of expected `add_suggestion()` calls."""
+    calls = []
+    for s in range(suggestion_count):
+        call: dict[str, Any] = {
+            "url": f"http://example.com/pocket-{s}",
+            "title": f"Title {s}",
+            "description": f"Description {s}",
+            "lowConfidenceKeywords": [f"low-{s}-{k}" for k in range(keyword_count)],
+            "highConfidenceKeywords": [f"high-{s}-{k}" for k in range(keyword_count)],
+        }
+        calls.append(mocker.call(call))
+    return calls
+
+
+def do_upload_test(
+    mocker,
+    delete_existing_records: bool = False,
+    score: float = 0.99,
+) -> None:
+    """Perform an upload test."""
+    # Mock the chunked uploader.
+    mock_chunked_uploader_ctor = mocker.patch(
+        "merino.jobs.pocket_rs_uploader.ChunkedRemoteSettingsUploader"
+    )
+    mock_chunked_uploader = (
+        mock_chunked_uploader_ctor.return_value.__enter__.return_value
+    )
+
+    # Do the upload.
+    common_kwargs: dict[str, Any] = {
+        "auth": "auth",
+        "bucket": "bucket",
+        "chunk_size": 99,
+        "collection": "collection",
+        "dry_run": False,
+        "record_type": "record_type",
+        "server": "server",
+    }
+    upload(
+        **common_kwargs,
+        delete_existing_records=delete_existing_records,
+        score=score,
+        csv_path=TEST_CSV_PATH,
+    )
+
+    # Check calls.
+    mock_chunked_uploader_ctor.assert_called_once_with(
+        **common_kwargs,
+        suggestion_score_fallback=score,
+        total_suggestion_count=TEST_SUGGESTION_COUNT,
+    )
+
+    if delete_existing_records:
+        mock_chunked_uploader.delete_records.assert_called_once()
+    else:
+        mock_chunked_uploader.delete_records.assert_not_called()
+
+    mock_chunked_uploader.add_suggestion.assert_has_calls(
+        expected_add_suggestion_calls(mocker)
+    )
+
+
+def test_upload_without_deleting(mocker):
+    """Tests `upload(delete_existing_records=False)`"""
+    do_upload_test(mocker, delete_existing_records=False)
+
+
+def test_delete_and_upload(mocker):
+    """Tests `upload(delete_existing_records=True)`"""
+    do_upload_test(mocker, delete_existing_records=True)
+
+
+def test_upload_with_score(mocker):
+    """Tests `upload(score=float)`"""
+    do_upload_test(mocker, score=0.12)


### PR DESCRIPTION
## Description

Add a job that uploads Pocket suggestions to remote settings. The source data is expected to be in a CSV file because we're collaborating with the Pocket team to build a list of suggestions and keywords using [this Google sheet](https://docs.google.com/spreadsheets/d/14mjaEYWnHD3VuTT5vq1HCzCz9e98cm8Z5a9fwjtKzGw/edit?usp=sharing). Running this job requires an initial manual step of exporting the sheet as CSV. I didn't add the CSV to this commit because I don't think we want to keep it in the repo.

Move chunked_rs_uploader.py to a new jobs/utils directory so it can be shared between the AMO and Pocket uploader and any future uploader jobs. Modify it to zero-pad the chunk start and end indexes in record IDs similar to how indexes are zero-padded in adm records.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
