### PR TITLE
[DISCO-2478] Merino: Load Test Config Changes & Document Updates

### DIFF
--- a/docs/dev/release-process.md
+++ b/docs/dev/release-process.md
@@ -65,7 +65,7 @@ that the individual(s) who authored and merged the Pull-Request should do so, as
 most familiar with their changes and who can tell, by looking at the data, if anything looks
 anomalous. Developers **must** monitor the [Merino Application & Infrastructure][merino_app_info]
 dashboard for any anomaly, for example significant changes in HTTP response codes, increase in
-latency, increased container/cpu/memory usage (most things under the 'Infrastructure' heading).
+latency, container/cpu/memory usage (most things under the 'Infrastructure' heading).
 
 ### What to do if tests fail during deployment?
 

--- a/docs/dev/release-process.md
+++ b/docs/dev/release-process.md
@@ -65,15 +65,26 @@ that the individual(s) who authored and merged the Pull-Request should do so, as
 most familiar with their changes and who can tell, by looking at the data, if anything looks
 anomalous. Developers **must** monitor the [Merino Application & Infrastructure][merino_app_info]
 dashboard for any anomaly, for example significant changes in HTTP response codes, increase in
-latency, cpu/memory usage (most things under the 'Infrastructure' heading).
+latency, increased container/cpu/memory usage (most things under the 'Infrastructure' heading).
 
 ### What to do if tests fail during deployment?
 
 1. Investigate the cause of the test failure
     - For functional tests (unit, integration or contract), logs can be found on
       [CircleCI][circleci]
-    - For performance tests (load), insights can be found in the Locust logs or
-      [Grafana][merino_app_info]
+    - For performance tests (load), insights can be found on [Grafana][merino_app_info] and in the
+      Locust logs or. To access the Locust logs:
+      1. Open a cloud shell in the [Merino stage environment][merino_gcp_stage]
+      2. Authenticate by executing the following command:
+      ```shell
+      gcloud container clusters get-credentials merino-nonprod-v1 \
+        --region us-west1 --project moz-fx-merino-nonprod-ee93
+      ```
+      3. Access the data in the Kubernetes pod by executing the following command:
+      ```shell
+        kubectl exec -it -n locust-merino locust-master-0 -- bash -c "cd /data && /bin/bash"
+      ```
+
 2. Fix or mitigate the failure
     - If a fix can be identified in a relatively short time, then submit a fix
     - If the failure is caused by a flaky or intermittent functional test and the risk to the
@@ -89,6 +100,7 @@ latency, cpu/memory usage (most things under the 'Infrastructure' heading).
 
 [circleci]: https://app.circleci.com/pipelines/github/mozilla-services/merino-py
 [merino_app_info]: https://earthangel-b40313e5.influxcloud.net/d/rQAfYKIVk/wip-merino-py-application-and-infrastructure?orgId=1&from=now-24h&to=now&var-environment=prodpy&refresh=1m
+[merino_gcp_stage]: https://console.cloud.google.com/kubernetes/list/overview?project=moz-fx-merino-nonprod-ee93
 [pytest_xfail]: https://docs.pytest.org/en/latest/how-to/skipping.html
 
 ### What to do if production breaks?

--- a/docs/dev/release-process.md
+++ b/docs/dev/release-process.md
@@ -73,7 +73,7 @@ latency, container/cpu/memory usage (most things under the 'Infrastructure' head
     - For functional tests (unit, integration or contract), logs can be found on
       [CircleCI][circleci]
     - For performance tests (load), insights can be found on [Grafana][merino_app_info] and in the
-      Locust logs or. To access the Locust logs:
+      Locust logs. To access the Locust logs:
       1. Open a cloud shell in the [Merino stage environment][merino_gcp_stage]
       2. Authenticate by executing the following command:
       ```shell

--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -166,31 +166,38 @@ will stop automatically.
 
 **RPS**
 * The request-per-second load target for Merino is `1500`
-* Locust reports client-side RPS via the "merino_stats.csv" file and the UI 
+* Locust reports client-side RPS via the "merino_stats.csv" file and the UI
   (under the "Statistics" tab or the "Charts" tab)
-* [Grafana][grafana] reports the server-side RPS via the 
+* [Grafana][grafana] reports the server-side RPS via the
   "HTTP requests per second per country" chart
 
-**HTTP Request Failures** 
+**HTTP Request Failures**
 * The number of responses with errors (5xx response codes) should be `0`
-* Locust reports Failures via the "merino_failures.csv" file and the UI 
+* Locust reports Failures via the "merino_failures.csv" file and the UI
   (under the "Failures" tab or the "Charts" tab)
 * [Grafana][grafana] reports Failures via the "HTTP Response codes" chart and the
   "HTTP 5xx error rate" chart
 
 **Exceptions**
 * The number of exceptions raised by the test framework should be `0`
-* Locust reports Exceptions via the "merino_exceptions.csv" file and the UI 
+* Locust reports Exceptions via the "merino_exceptions.csv" file and the UI
   (under the "Exceptions" tab)
 
 **Latency**
-* The HTTP client-side response time (aka request duration) for 95 percent of users 
-  is required to be 200ms or less (`p95 <= 200ms`)
-* Locust reports client-side latency via the "merino_stats.csv" file and the UI 
+* The HTTP client-side response time (aka request duration) for 95 percent of users
+  is required to be 200ms or less (`p95 <= 200ms`), excluding weather requests
+* Locust reports client-side latency via the "merino_stats.csv" file and the UI
   (under the "Statistics" tab or the "Charts" tab)
-  * _Warning!_ A Locust worker with too many users will bottleneck RPS and inflate 
-    client-side latency measures
-* [Grafana][grafana] reports server-side latency via the "p95 latency" chart 
+  * _Warning!_ A Locust worker with too many users will bottleneck RPS and inflate
+    client-side latency measures. Locust reports worker CPU and memory usage metrics via
+    the UI (under the "Workers" tab)
+* [Grafana][grafana] reports server-side latency via the "p95 latency" chart
+
+**Resource Consumption**
+* To conserve costs, resource allocation must be kept to a minimum. It is expected that
+  container, CPU and memory usage should trend consistently between load test runs.
+* [Grafana][grafana] reports metrics on resources via the "Container Count",
+  "CPU usage time sum" and "Memory usage sum" charts
 
 #### 4. Report Results
 

--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -65,7 +65,8 @@ make load-tests
 * Setup parameters:
   * Number of users: 75
   * Spawn rate: 2
-  * Host: http://merino:8000 
+  * Host: 'https://stagepy.merino.nonprod.cloudops.mozgcp.net' (Alternatively, such as when
+    profiling, point the host to a local instance of merino)
   * Run time (optional): 10m
 * Select "Start Swarming"
 
@@ -78,7 +79,8 @@ will stop automatically.
 #### 3. Analyse Results
 
 * See [Distributed GCP Execution - Analyse Results](#3-analyse-results-1)
-* Only client-side measures, provided by Locust, are available for local execution
+* Only client-side measures, provided by Locust, are available when executing against a
+  local instance of Merino.
 
 ### Clean-up Environment
 

--- a/tests/load/docker-compose.yml
+++ b/tests/load/docker-compose.yml
@@ -1,26 +1,16 @@
 version: "3"
 services:
-  merino:
-    image: app:build
-    container_name: merino
-    environment:
-      MERINO__ENV: "ci"
-    volumes:
-      - ../../dev:/tmp/dev
-
   locust_master:
     image: locust
     build:
       context: ../../
       dockerfile: ./tests/load/Dockerfile
     container_name: locust_master
-    depends_on:
-      - merino
     ports:
       - "8089:8089"
     environment:
       # Set environment variables, see https://docs.locust.io/en/stable/configuration.html#environment-variables
-      LOCUST_HOST: http://merino:8000
+      LOCUST_HOST: http://localhost:8000
       LOAD_TESTS__LOGGING_LEVEL: 10
       MERINO_REMOTE_SETTINGS__SERVER: "https://firefox.settings.services.mozilla.com"
       MERINO_REMOTE_SETTINGS__BUCKET: "main"

--- a/tests/load/docker-compose.yml
+++ b/tests/load/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - "8089:8089"
     environment:
       # Set environment variables, see https://docs.locust.io/en/stable/configuration.html#environment-variables
-      LOCUST_HOST: http://localhost:8000
+      LOCUST_HOST: https://stagepy.merino.nonprod.cloudops.mozgcp.net
       LOAD_TESTS__LOGGING_LEVEL: 10
       MERINO_REMOTE_SETTINGS__SERVER: "https://firefox.settings.services.mozilla.com"
       MERINO_REMOTE_SETTINGS__BUCKET: "main"
@@ -29,8 +29,6 @@ services:
     build:
       context: ../../
       dockerfile: ./tests/load/Dockerfile
-    depends_on:
-      - merino
     environment:
       # Set environment variables, see https://docs.locust.io/en/stable/configuration.html#environment-variables
       LOCUST_MASTER_NODE_HOST: locust_master


### PR DESCRIPTION
## References

JIRA: [DISCO-2478](https://mozilla-hub.atlassian.net/browse/DISCO-2478)
GitHub: N/A

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->
- Remove merino from the load test docker-compose definition
    - It is not the common use case that a team member would execute the load tests against a local instance of Merino. Furthermore, local execution would most likely be for the profiling use case, which necessitates executing Merino with different configurations. 
- Add instructions for accessing load test logs in release procedure
- Add resource consumption to load test result analysis documentation

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2478]: https://mozilla-hub.atlassian.net/browse/DISCO-2478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ