### PR TITLE
[DISCO-2473] Inject AsyncClient into AccuweatherBackend

### DIFF
--- a/merino/providers/manager.py
+++ b/merino/providers/manager.py
@@ -3,6 +3,7 @@
 from enum import Enum, unique
 
 from dynaconf.base import Settings
+from httpx import AsyncClient
 from redis.asyncio import Redis
 
 from merino.cache.none import NoCacheAdapter
@@ -61,7 +62,7 @@ def _create_provider(provider_id: str, setting: Settings) -> BaseProvider:
                     cache=cache,  # type: ignore [arg-type]
                     cached_report_ttl_sec=setting.cached_report_ttl_sec,
                     metrics_client=get_metrics_client(),
-                    url_base=settings.accuweather.url_base,
+                    http_client=AsyncClient(base_url=settings.accuweather.url_base),
                     url_param_api_key=settings.accuweather.url_param_api_key,
                     url_postalcodes_path=settings.accuweather.url_postalcodes_path,
                     url_postalcodes_param_query=settings.accuweather.url_postalcodes_param_query,

--- a/merino/providers/weather/backends/accuweather.py
+++ b/merino/providers/weather/backends/accuweather.py
@@ -77,6 +77,7 @@ class AccuweatherBackend:
         url_forecasts_path: str,
         url_param_partner_code: Optional[str] = None,
         partner_code: Optional[str] = None,
+        http_client: AsyncClient = None,
     ) -> None:
         """Initialize the AccuWeather backend.
 
@@ -108,7 +109,9 @@ class AccuweatherBackend:
         self.url_forecasts_path = url_forecasts_path
         self.url_param_partner_code = url_param_partner_code
         self.partner_code = partner_code
-        self.http_client = AsyncClient(base_url=self.url_base)
+        self.http_client = (
+            AsyncClient(base_url=self.url_base) if http_client is None else http_client
+        )
 
     def cache_key_for_accuweather_request(
         self, url: str, query_params: dict[str, str] = {}

--- a/merino/providers/weather/backends/accuweather.py
+++ b/merino/providers/weather/backends/accuweather.py
@@ -53,7 +53,6 @@ class AccuweatherBackend:
     cache: CacheAdapter
     cached_report_ttl_sec: int
     metrics_client: aiodogstatsd.Client
-    url_base: str
     url_param_api_key: str
     url_postalcodes_path: str
     url_postalcodes_param_query: str
@@ -69,7 +68,7 @@ class AccuweatherBackend:
         cache: CacheAdapter,
         cached_report_ttl_sec: int,
         metrics_client: aiodogstatsd.Client,
-        url_base: str,
+        http_client: AsyncClient,
         url_param_api_key: str,
         url_postalcodes_path: str,
         url_postalcodes_param_query: str,
@@ -77,7 +76,6 @@ class AccuweatherBackend:
         url_forecasts_path: str,
         url_param_partner_code: Optional[str] = None,
         partner_code: Optional[str] = None,
-        http_client: AsyncClient = None,
     ) -> None:
         """Initialize the AccuWeather backend.
 
@@ -88,8 +86,7 @@ class AccuweatherBackend:
             raise ValueError("AccuWeather API key not specified")
 
         if (
-            not url_base
-            or not url_param_api_key
+            not url_param_api_key
             or not url_postalcodes_path
             or not url_postalcodes_param_query
             or not url_current_conditions_path
@@ -101,7 +98,7 @@ class AccuweatherBackend:
         self.cache = cache
         self.cached_report_ttl_sec = cached_report_ttl_sec
         self.metrics_client = metrics_client
-        self.url_base = url_base
+        self.http_client = http_client
         self.url_param_api_key = url_param_api_key
         self.url_postalcodes_path = url_postalcodes_path
         self.url_postalcodes_param_query = url_postalcodes_param_query
@@ -109,9 +106,6 @@ class AccuweatherBackend:
         self.url_forecasts_path = url_forecasts_path
         self.url_param_partner_code = url_param_partner_code
         self.partner_code = partner_code
-        self.http_client = (
-            AsyncClient(base_url=self.url_base) if http_client is None else http_client
-        )
 
     def cache_key_for_accuweather_request(
         self, url: str, query_params: dict[str, str] = {}

--- a/tests/unit/providers/weather/backends/test_accuweather.py
+++ b/tests/unit/providers/weather/backends/test_accuweather.py
@@ -377,7 +377,7 @@ async def test_get_weather_report(
             content=accuweather_location_response,
             request=Request(
                 method="GET",
-                url="test://test/locations/v1/postalcodes/US/search.json?apikey=test&q=94105",
+                url="[url_base]/locations/v1/postalcodes/US/search.json?apikey=test&q=94105",
             ),
         ),
         Response(
@@ -386,7 +386,7 @@ async def test_get_weather_report(
             content=accuweather_current_conditions_response,
             request=Request(
                 method="GET",
-                url="test://test/currentconditions/v1/39376_PC.json?apikey=test",
+                url="[url_base]/currentconditions/v1/39376_PC.json?apikey=test",
             ),
         ),
         Response(
@@ -395,7 +395,7 @@ async def test_get_weather_report(
             content=accuweather_forecast_response_fahrenheit,
             request=Request(
                 method="GET",
-                url="test://test/forecasts/v1/daily/1day/39376_PC.json?apikey=test",
+                url="[url_base]/forecasts/v1/daily/1day/39376_PC.json?apikey=test",
             ),
         ),
     ]
@@ -421,7 +421,7 @@ async def test_get_weather_report_failed_location_query(
         content=b"[]",
         request=Request(
             method="GET",
-            url="test://test/locations/v1/postalcodes/US/search.json?apikey=test&q=94105",
+            url="[url_base]/locations/v1/postalcodes/US/search.json?apikey=test&q=94105",
         ),
     )
 
@@ -449,7 +449,7 @@ async def test_get_weather_report_failed_current_conditions_query(
             content=accuweather_location_response,
             request=Request(
                 method="GET",
-                url="test://test/locations/v1/postalcodes/US/search.json?apikey=test&q=94105",
+                url="[url_base]/locations/v1/postalcodes/US/search.json?apikey=test&q=94105",
             ),
         ),
         Response(
@@ -458,7 +458,7 @@ async def test_get_weather_report_failed_current_conditions_query(
             content=b"[]",
             request=Request(
                 method="GET",
-                url="test://test/currentconditions/v1/39376_PC.json?apikey=test",
+                url="[url_base]/currentconditions/v1/39376_PC.json?apikey=test",
             ),
         ),
         Response(
@@ -467,7 +467,7 @@ async def test_get_weather_report_failed_current_conditions_query(
             content=accuweather_forecast_response_fahrenheit,
             request=Request(
                 method="GET",
-                url="test://test/forecasts/v1/daily/1day/39376_PC.json?apikey=test",
+                url="[url_base]/forecasts/v1/daily/1day/39376_PC.json?apikey=test",
             ),
         ),
     ]
@@ -496,7 +496,7 @@ async def test_get_weather_report_handles_exception_group_properly(
             content=accuweather_location_response,
             request=Request(
                 method="GET",
-                url="test://test/locations/v1/postalcodes/US/search.json?apikey=test&q=94105",
+                url="[url_base]/locations/v1/postalcodes/US/search.json?apikey=test&q=94105",
             ),
         ),
         HTTPError("Invalid Request - Current Conditions"),
@@ -534,7 +534,7 @@ async def test_get_weather_report_failed_forecast_query(
             content=accuweather_location_response,
             request=Request(
                 method="GET",
-                url="test://test/locations/v1/postalcodes/US/search.json?apikey=test&q=94105",
+                url="[url_base]/locations/v1/postalcodes/US/search.json?apikey=test&q=94105",
             ),
         ),
         Response(
@@ -543,7 +543,7 @@ async def test_get_weather_report_failed_forecast_query(
             content=accuweather_current_conditions_response,
             request=Request(
                 method="GET",
-                url="test://test/currentconditions/v1/39376_PC.json?apikey=test",
+                url="[url_base]/currentconditions/v1/39376_PC.json?apikey=test",
             ),
         ),
         Response(
@@ -552,7 +552,7 @@ async def test_get_weather_report_failed_forecast_query(
             content=b"{}",
             request=Request(
                 method="GET",
-                url="test://test/forecasts/v1/daily/1day/39376_PC.json?apikey=test",
+                url="[url_base]/forecasts/v1/daily/1day/39376_PC.json?apikey=test",
             ),
         ),
     ]
@@ -604,7 +604,7 @@ async def test_get_location(
         content=accuweather_location_response,
         request=Request(
             method="GET",
-            url="test://test/locations/v1/postalcodes/US/search.json?apikey=test&q=94105",
+            url="[url_base]/locations/v1/postalcodes/US/search.json?apikey=test&q=94105",
         ),
     )
 
@@ -669,7 +669,7 @@ async def test_get_location_no_location_returned(
         content=b"[]",
         request=Request(
             method="GET",
-            url="test://test/locations/v1/postalcodes/US/search.json?apikey=test&q=94105",
+            url="[url_base]/locations/v1/postalcodes/US/search.json?apikey=test&q=94105",
         ),
     )
 
@@ -702,7 +702,7 @@ async def test_get_location_error(
         ),
         request=Request(
             method="GET",
-            url="test://test/locations/v1/postalcodes/US/search.json?apikey=test&q=94105",
+            url="[url_base]/locations/v1/postalcodes/US/search.json?apikey=test&q=94105",
         ),
     )
 
@@ -752,7 +752,7 @@ async def test_get_current_conditions(
         content=accuweather_current_conditions_response,
         request=Request(
             method="GET",
-            url="test://test/currentconditions/v1/39376_PC.json?apikey=test",
+            url="[url_base]/currentconditions/v1/39376_PC.json?apikey=test",
         ),
     )
 
@@ -820,7 +820,7 @@ async def test_get_current_conditions_no_current_conditions_returned(
         content=b"[]",
         request=Request(
             method="GET",
-            url="test://test/currentconditions/v1/39376_PC.json?apikey=test",
+            url="[url_base]/currentconditions/v1/39376_PC.json?apikey=test",
         ),
     )
 
@@ -853,7 +853,7 @@ async def test_get_current_conditions_error(
         ),
         request=Request(
             method="GET",
-            url="test://test/currentconditions/v1/INVALID.json?apikey=test",
+            url="[url_base]/currentconditions/v1/INVALID.json?apikey=test",
         ),
     )
 
@@ -912,7 +912,7 @@ async def test_get_forecast(
         content=content,
         request=Request(
             method="GET",
-            url="test://test/forecasts/v1/daily/1day/39376_PC.json?apikey=test",
+            url="[url_base]/forecasts/v1/daily/1day/39376_PC.json?apikey=test",
         ),
     )
 
@@ -979,7 +979,7 @@ async def test_get_forecast_no_forecast_returned(
         content=b"{}",
         request=Request(
             method="GET",
-            url="test://test/forecasts/v1/daily/1day/39376_PC.json?apikey=test",
+            url="[url_base]/forecasts/v1/daily/1day/39376_PC.json?apikey=test",
         ),
     )
 
@@ -1007,7 +1007,7 @@ async def test_get_forecast_error(accuweather: AccuweatherBackend) -> None:
         ),
         request=Request(
             method="GET",
-            url="test://test/forecasts/v1/daily/1day/INVALID.json?apikey=test",
+            url="[url_base]/forecasts/v1/daily/1day/INVALID.json?apikey=test",
         ),
     )
 
@@ -1135,7 +1135,7 @@ async def test_get_request_cache_get_errors(
         content=json.dumps(expected_client_response).encode("utf-8"),
         request=Request(
             method="GET",
-            url=f"test://test/{url}?apikey=test",
+            url=f"[url_base]/{url}?apikey=test",
         ),
     )
 
@@ -1197,7 +1197,7 @@ async def test_get_request_cache_store_errors(
         content=json.dumps(expected_client_response).encode("utf-8"),
         request=Request(
             method="GET",
-            url=f"test://test/{url}?apikey=test",
+            url=f"[url_base]/{url}?apikey=test",
         ),
     )
 

--- a/tests/unit/providers/weather/backends/test_accuweather.py
+++ b/tests/unit/providers/weather/backends/test_accuweather.py
@@ -377,7 +377,10 @@ async def test_get_weather_report(
             content=accuweather_location_response,
             request=Request(
                 method="GET",
-                url="[url_base]/locations/v1/postalcodes/US/search.json?apikey=test&q=94105",
+                url=(
+                    "http://www.accuweather.com/locations/v1/postalcodes/US/search.json?"
+                    "apikey=test&q=94105"
+                ),
             ),
         ),
         Response(
@@ -386,7 +389,10 @@ async def test_get_weather_report(
             content=accuweather_current_conditions_response,
             request=Request(
                 method="GET",
-                url="[url_base]/currentconditions/v1/39376_PC.json?apikey=test",
+                url=(
+                    "http://www.accuweather.com/currentconditions/v1/39376_PC.json?"
+                    "apikey=test"
+                ),
             ),
         ),
         Response(
@@ -395,7 +401,10 @@ async def test_get_weather_report(
             content=accuweather_forecast_response_fahrenheit,
             request=Request(
                 method="GET",
-                url="[url_base]/forecasts/v1/daily/1day/39376_PC.json?apikey=test",
+                url=(
+                    "http://www.accuweather.com/forecasts/v1/daily/1day/39376_PC.json?"
+                    "apikey=test"
+                ),
             ),
         ),
     ]
@@ -421,7 +430,10 @@ async def test_get_weather_report_failed_location_query(
         content=b"[]",
         request=Request(
             method="GET",
-            url="[url_base]/locations/v1/postalcodes/US/search.json?apikey=test&q=94105",
+            url=(
+                "http://www.accuweather.com/locations/v1/postalcodes/US/search.json?"
+                "apikey=test&q=94105"
+            ),
         ),
     )
 
@@ -449,7 +461,10 @@ async def test_get_weather_report_failed_current_conditions_query(
             content=accuweather_location_response,
             request=Request(
                 method="GET",
-                url="[url_base]/locations/v1/postalcodes/US/search.json?apikey=test&q=94105",
+                url=(
+                    "http://www.accuweather.com/locations/v1/postalcodes/US/search.json?"
+                    "apikey=test&q=94105"
+                ),
             ),
         ),
         Response(
@@ -458,7 +473,10 @@ async def test_get_weather_report_failed_current_conditions_query(
             content=b"[]",
             request=Request(
                 method="GET",
-                url="[url_base]/currentconditions/v1/39376_PC.json?apikey=test",
+                url=(
+                    "http://www.accuweather.com/currentconditions/v1/39376_PC.json?"
+                    "apikey=test"
+                ),
             ),
         ),
         Response(
@@ -467,7 +485,10 @@ async def test_get_weather_report_failed_current_conditions_query(
             content=accuweather_forecast_response_fahrenheit,
             request=Request(
                 method="GET",
-                url="[url_base]/forecasts/v1/daily/1day/39376_PC.json?apikey=test",
+                url=(
+                    "http://www.accuweather.com/forecasts/v1/daily/1day/39376_PC.json?"
+                    "apikey=test"
+                ),
             ),
         ),
     ]
@@ -496,7 +517,10 @@ async def test_get_weather_report_handles_exception_group_properly(
             content=accuweather_location_response,
             request=Request(
                 method="GET",
-                url="[url_base]/locations/v1/postalcodes/US/search.json?apikey=test&q=94105",
+                url=(
+                    "http://www.accuweather.com/locations/v1/postalcodes/US/search.json?"
+                    "apikey=test&q=94105"
+                ),
             ),
         ),
         HTTPError("Invalid Request - Current Conditions"),
@@ -534,7 +558,10 @@ async def test_get_weather_report_failed_forecast_query(
             content=accuweather_location_response,
             request=Request(
                 method="GET",
-                url="[url_base]/locations/v1/postalcodes/US/search.json?apikey=test&q=94105",
+                url=(
+                    "http://www.accuweather.com/locations/v1/postalcodes/US/search.json?"
+                    "apikey=test&q=94105"
+                ),
             ),
         ),
         Response(
@@ -543,7 +570,10 @@ async def test_get_weather_report_failed_forecast_query(
             content=accuweather_current_conditions_response,
             request=Request(
                 method="GET",
-                url="[url_base]/currentconditions/v1/39376_PC.json?apikey=test",
+                url=(
+                    "http://www.accuweather.com/currentconditions/v1/39376_PC.json?"
+                    "apikey=test"
+                ),
             ),
         ),
         Response(
@@ -552,7 +582,10 @@ async def test_get_weather_report_failed_forecast_query(
             content=b"{}",
             request=Request(
                 method="GET",
-                url="[url_base]/forecasts/v1/daily/1day/39376_PC.json?apikey=test",
+                url=(
+                    "http://www.accuweather.com/forecasts/v1/daily/1day/39376_PC.json?"
+                    "apikey=test"
+                ),
             ),
         ),
     ]
@@ -604,7 +637,10 @@ async def test_get_location(
         content=accuweather_location_response,
         request=Request(
             method="GET",
-            url="[url_base]/locations/v1/postalcodes/US/search.json?apikey=test&q=94105",
+            url=(
+                "http://www.accuweather.com/locations/v1/postalcodes/US/search.json?"
+                "apikey=test&q=94105"
+            ),
         ),
     )
 
@@ -669,7 +705,10 @@ async def test_get_location_no_location_returned(
         content=b"[]",
         request=Request(
             method="GET",
-            url="[url_base]/locations/v1/postalcodes/US/search.json?apikey=test&q=94105",
+            url=(
+                "http://www.accuweather.com/locations/v1/postalcodes/US/search.json?"
+                "apikey=test&q=94105"
+            ),
         ),
     )
 
@@ -681,9 +720,7 @@ async def test_get_location_no_location_returned(
 
 
 @pytest.mark.asyncio
-async def test_get_location_error(
-    mocker: MockerFixture, accuweather: AccuweatherBackend
-) -> None:
+async def test_get_location_error(accuweather: AccuweatherBackend) -> None:
     """Test that the get_location method raises an appropriate exception in the event
     of an AccuWeather API error.
     """
@@ -702,7 +739,10 @@ async def test_get_location_error(
         ),
         request=Request(
             method="GET",
-            url="[url_base]/locations/v1/postalcodes/US/search.json?apikey=test&q=94105",
+            url=(
+                "http://www.accuweather.com/locations/v1/postalcodes/US/search.json?"
+                "apikey=test&q=94105"
+            ),
         ),
     )
 
@@ -752,7 +792,10 @@ async def test_get_current_conditions(
         content=accuweather_current_conditions_response,
         request=Request(
             method="GET",
-            url="[url_base]/currentconditions/v1/39376_PC.json?apikey=test",
+            url=(
+                "http://www.accuweather.com/currentconditions/v1/39376_PC.json?"
+                "apikey=test"
+            ),
         ),
     )
 
@@ -820,7 +863,10 @@ async def test_get_current_conditions_no_current_conditions_returned(
         content=b"[]",
         request=Request(
             method="GET",
-            url="[url_base]/currentconditions/v1/39376_PC.json?apikey=test",
+            url=(
+                "http://www.accuweather.com/currentconditions/v1/39376_PC.json?"
+                "apikey=test"
+            ),
         ),
     )
 
@@ -853,7 +899,10 @@ async def test_get_current_conditions_error(
         ),
         request=Request(
             method="GET",
-            url="[url_base]/currentconditions/v1/INVALID.json?apikey=test",
+            url=(
+                "http://www.accuweather.com/currentconditions/v1/INVALID.json?"
+                "apikey=test"
+            ),
         ),
     )
 
@@ -912,7 +961,10 @@ async def test_get_forecast(
         content=content,
         request=Request(
             method="GET",
-            url="[url_base]/forecasts/v1/daily/1day/39376_PC.json?apikey=test",
+            url=(
+                "http://www.accuweather.com/forecasts/v1/daily/1day/39376_PC.json?"
+                "apikey=test"
+            ),
         ),
     )
 
@@ -979,7 +1031,10 @@ async def test_get_forecast_no_forecast_returned(
         content=b"{}",
         request=Request(
             method="GET",
-            url="[url_base]/forecasts/v1/daily/1day/39376_PC.json?apikey=test",
+            url=(
+                "http://www.accuweather.com/forecasts/v1/daily/1day/39376_PC.json?"
+                "apikey=test"
+            ),
         ),
     )
 
@@ -1007,7 +1062,10 @@ async def test_get_forecast_error(accuweather: AccuweatherBackend) -> None:
         ),
         request=Request(
             method="GET",
-            url="[url_base]/forecasts/v1/daily/1day/INVALID.json?apikey=test",
+            url=(
+                "http://www.accuweather.com/forecasts/v1/daily/1day/INVALID.json?"
+                "apikey=test"
+            ),
         ),
     )
 
@@ -1135,7 +1193,7 @@ async def test_get_request_cache_get_errors(
         content=json.dumps(expected_client_response).encode("utf-8"),
         request=Request(
             method="GET",
-            url=f"[url_base]/{url}?apikey=test",
+            url=f"http://www.accuweather.com/{url}?apikey=test",
         ),
     )
 
@@ -1197,7 +1255,7 @@ async def test_get_request_cache_store_errors(
         content=json.dumps(expected_client_response).encode("utf-8"),
         request=Request(
             method="GET",
-            url=f"[url_base]/{url}?apikey=test",
+            url=f"http://www.accuweather.com/{url}?apikey=test",
         ),
     )
 

--- a/tests/unit/providers/weather/backends/test_accuweather.py
+++ b/tests/unit/providers/weather/backends/test_accuweather.py
@@ -60,13 +60,12 @@ def fixture_accuweather_parameters(
         "api_key": "test",
         "cached_report_ttl_sec": 1800,
         "metrics_client": statsd_mock,
-        "url_base": "test://test",
+        "http_client": mocker.AsyncMock(spec=AsyncClient),
         "url_param_api_key": "apikey",
         "url_postalcodes_path": "/locations/v1/postalcodes/{country_code}/search.json",
         "url_postalcodes_param_query": "q",
         "url_current_conditions_path": "/currentconditions/v1/{location_key}.json",
         "url_forecasts_path": "/forecasts/v1/daily/1day/{location_key}.json",
-        "http_client": mocker.AsyncMock(spec=AsyncClient),
     }
 
 
@@ -315,7 +314,6 @@ def test_init_api_key_value_error(
 @pytest.mark.parametrize(
     "url_value",
     [
-        "url_base",
         "url_param_api_key",
         "url_postalcodes_path",
         "url_postalcodes_param_query",


### PR DESCRIPTION
## References

JIRA: [DISCO-2473](https://mozilla-hub.atlassian.net/browse/DISCO-2473)
GitHub: N/A

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->
- follow-up to https://github.com/mozilla-services/merino-py/pull/354, enable injection of the AsyncClient to maintain test-ability ([ref](https://github.com/mozilla-services/merino-py/pull/354#discussion_r1253210392))

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2473]: https://mozilla-hub.atlassian.net/browse/DISCO-2473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ