### PR TITLE
[DISCO-2480] refactor: cache processed content for accuweather

### DIFF
--- a/merino/providers/manager.py
+++ b/merino/providers/manager.py
@@ -66,10 +66,6 @@ def _create_provider(provider_id: str, setting: Settings) -> BaseProvider:
                     url_postalcodes_param_query=settings.accuweather.url_postalcodes_param_query,
                     url_current_conditions_path=settings.accuweather.url_current_conditions_path,
                     url_forecasts_path=settings.accuweather.url_forecasts_path,
-                    url_param_partner_code=settings.accuweather.get(
-                        "url_param_partner_code"
-                    ),
-                    partner_code=settings.accuweather.get("partner_code"),
                 )
                 if setting.backend == "accuweather"
                 else FakeWeatherBackend(),


### PR DESCRIPTION
## References

JIRA: [DISCO-2480](https://mozilla-hub.atlassian.net/browse/DISCO-2480)
GitHub: N/A

## Description
We currently cache the raw API responses from AccuWeather in Redis which contain lots of unused data. To reduce the bandwidth and cache fetch/store time, we should only cache the processed data instead.

Raw vs. Processed for one record:
- Location key: 1.2 KB / 0.03 KB
- Current conditions: 0.5 KB / 0.05 KB
- Forecasts: 1 KB / 0.05 KB

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2480]: https://mozilla-hub.atlassian.net/browse/DISCO-2480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ