### PR TITLE
[DISCO-2472] Merino: Load Test Script Modifies Kubernetes Config On First Run Only

### DIFF
--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -203,7 +203,7 @@ will stop automatically.
 
 * Results should be recorded in the [Merino Load Test Spreadsheet][merino_spreadsheet]
 * Optionally, the Locust reports can be saved and linked in the spreadsheet:
-  * Download the results via command:
+  * Download the results via the Locust UI or via command:
       ```bash
       kubectl cp <master-pod-name>:/home/locust/merino_stats.csv merino_stats.csv
       kubectl cp <master-pod-name>:/home/locust/merino_exceptions.csv merino_exceptions.csv
@@ -213,7 +213,8 @@ will stop automatically.
       ```bash 
       kubectl get pods -o wide
       ```
-  * Upload the files to [gist][gist] and record the links
+  * Upload the files to the [ConServ][conserv] drive and record the links in the 
+    spreadsheet
 
 ### Clean-up Environment
 
@@ -225,8 +226,8 @@ Execute the `setup_k8s.sh` file and select the **delete** option
 ```
 
 [cloud]: https://console.cloud.google.com/home/dashboard?q=search&referrer=search&project=spheric-keel-331521&cloudshell=false
+[conserv]: https://drive.google.com/drive/folders/1rvCpmwGuLt4COH6Zw6vSyu_019_sB3Ux:
 [container_registry]: https://console.cloud.google.com/gcr/images/spheric-keel-331521/global/locust-merino?project=spheric-keel-331521
-[gist]: https://gist.github.com/new
 [grafana]: https://earthangel-b40313e5.influxcloud.net/d/rQAfYKIVk/merino-py-application-and-infrastructure?orgId=1&refresh=1m&var-environment=stagepy
 [merino_test_plan]: https://docs.google.com/document/d/1v7LDXENPZg37KXeNcznEZKNZ8rQlOhNbsHprFyMXHhs/edit?usp=sharing
 [merino_history_doc]: https://docs.google.com/document/d/1BGNhKuclUH40Bit9KxYWLiv_N_VnE66uxi9pBFbRWbg/edit

--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -136,7 +136,6 @@ a GKE cluster
   **setup** option.
     * This option will consider the local commit history, creating new containers and
       deploying them (see [Container Registry][container_registry])
-    * **Reset the files in the `kubernetes-config` directory between executions of the script**
 
 ### Run Test Session
 

--- a/tests/load/kubernetes-config/locust-master-controller.yml
+++ b/tests/load/kubernetes-config/locust-master-controller.yml
@@ -21,38 +21,38 @@ spec:
             - name: LOCUST_MODE_MASTER
               value: "true"
             - name: TARGET_HOST
-              value: [TARGET_HOST]
+              value:
             - name: LOCUST_CSV
-              value: [LOCUST_CSV]
+              value:
             - name: LOCUST_HOST
-              value: [LOCUST_HOST]
+              value:
             - name: LOCUST_USERS
-              value: "[LOCUST_USERS]"
+              value:
             - name: LOCUST_SPAWN_RATE
-              value: "[LOCUST_SPAWN_RATE]"
+              value:
             - name: LOCUST_RUN_TIME
-              value: "[LOCUST_RUN_TIME]"
+              value:
             - name: LOAD_TESTS__LOGGING_LEVEL
               # The logging level value 20 defines the 'info' level
               value: "20"
             - name: MERINO_REMOTE_SETTINGS__COLLECTION
-              value: [MERINO_REMOTE_SETTINGS__COLLECTION]
+              value:
             - name: MERINO_REMOTE_SETTINGS__BUCKET
-              value: [MERINO_REMOTE_SETTINGS__BUCKET]
+              value:
             - name: MERINO_REMOTE_SETTINGS__SERVER
-              value: [MERINO_REMOTE_SETTINGS__SERVER]
+              value:
             - name: MERINO_PROVIDERS__TOP_PICKS__TOP_PICKS_FILE_PATH
-              value: [MERINO_PROVIDERS__TOP_PICKS__TOP_PICKS_FILE_PATH]
+              value:
             - name: MERINO_PROVIDERS__TOP_PICKS__QUERY_CHAR_LIMIT
-              value: "[MERINO_PROVIDERS__TOP_PICKS__QUERY_CHAR_LIMIT]"
+              value:
             - name: MERINO_PROVIDERS__TOP_PICKS__FIREFOX_CHAR_LIMIT
-              value: "[MERINO_PROVIDERS__TOP_PICKS__FIREFOX_CHAR_LIMIT]"
+              value:
             - name: MERINO_PROVIDERS__WIKIPEDIA__ES_API_KEY
-              value: [MERINO_PROVIDERS__WIKIPEDIA__ES_API_KEY]
+              value:
             - name: MERINO_PROVIDERS__WIKIPEDIA__ES_URL
-              value: [MERINO_PROVIDERS__WIKIPEDIA__ES_URL]
+              value:
             - name: MERINO_PROVIDERS__WIKIPEDIA__ES_INDEX
-              value: [MERINO_PROVIDERS__WIKIPEDIA__ES_INDEX]
+              value:
           ports:
             - name: loc-master-web
               containerPort: 8089

--- a/tests/load/kubernetes-config/locust-worker-controller.yml
+++ b/tests/load/kubernetes-config/locust-worker-controller.yml
@@ -23,25 +23,25 @@ spec:
             - name: LOCUST_MASTER_NODE_HOST
               value: locust-master
             - name: TARGET_HOST
-              value: [TARGET_HOST]
+              value:
             - name: LOAD_TESTS__LOGGING_LEVEL
               # The logging level value 10 defines the 'debug' level
               value: "10"
             - name: MERINO_REMOTE_SETTINGS__COLLECTION
-              value: [MERINO_REMOTE_SETTINGS__COLLECTION]
+              value:
             - name: MERINO_REMOTE_SETTINGS__BUCKET
-              value: [MERINO_REMOTE_SETTINGS__BUCKET]
+              value:
             - name: MERINO_REMOTE_SETTINGS__SERVER
-              value: [MERINO_REMOTE_SETTINGS__SERVER]
+              value:
             - name: MERINO_PROVIDERS__TOP_PICKS__TOP_PICKS_FILE_PATH
-              value: [MERINO_PROVIDERS__TOP_PICKS__TOP_PICKS_FILE_PATH]
+              value:
             - name: MERINO_PROVIDERS__TOP_PICKS__QUERY_CHAR_LIMIT
-              value: "[MERINO_PROVIDERS__TOP_PICKS__QUERY_CHAR_LIMIT]"
+              value:
             - name: MERINO_PROVIDERS__TOP_PICKS__FIREFOX_CHAR_LIMIT
-              value: "[MERINO_PROVIDERS__TOP_PICKS__FIREFOX_CHAR_LIMIT]"
+              value:
             - name: MERINO_PROVIDERS__WIKIPEDIA__ES_API_KEY
-              value: [MERINO_PROVIDERS__WIKIPEDIA__ES_API_KEY]
+              value:
             - name: MERINO_PROVIDERS__WIKIPEDIA__ES_URL
-              value: [MERINO_PROVIDERS__WIKIPEDIA__ES_URL]
+              value:
             - name: MERINO_PROVIDERS__WIKIPEDIA__ES_INDEX
-              value: [MERINO_PROVIDERS__WIKIPEDIA__ES_INDEX]
+              value:


### PR DESCRIPTION
## References

JIRA: [DISCO-2472](https://mozilla-hub.atlassian.net/browse/DISCO-2472)
GitHub: #350 

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->
- Improve load test setup script by using patterns fixed on constants instead of placeholders
- Update load test README

**Related PR:** https://github.com/mozilla-services/contile/pull/609

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2472]: https://mozilla-hub.atlassian.net/browse/DISCO-2472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ