### PR TITLE
[DISCO-2489] - Do not log suggest request for accuweather provider

### DIFF
--- a/merino/middleware/logging.py
+++ b/merino/middleware/logging.py
@@ -41,7 +41,9 @@ class LoggingMiddleware:
             if message["type"] == "http.response.start":
                 request = Request(scope=scope)
                 dt: datetime = datetime.fromtimestamp(time.time())
-                if PATTERN.match(request.url.path):
+                if PATTERN.match(request.url.path) and [
+                    "accuweather"
+                ] != request.query_params.get("providers", "").split(","):
                     suggest_log_data: SuggestLogDataModel = create_suggest_log_data(
                         request, message, dt
                     )

--- a/tests/integration/api/v1/suggest/test_suggest_weather.py
+++ b/tests/integration/api/v1/suggest/test_suggest_weather.py
@@ -5,11 +5,13 @@
 """Integration tests for the Merino v1 suggest API endpoint configured with a weather
 provider.
 """
-
+import logging
+from logging import LogRecord
 from typing import Any
 
 import pytest
 from fastapi.testclient import TestClient
+from freezegun import freeze_time
 from pydantic import parse_obj_as
 from pytest import LogCaptureFixture
 from pytest_mock import MockerFixture
@@ -23,6 +25,8 @@ from merino.providers.weather.backends.protocol import (
     WeatherReport,
 )
 from merino.providers.weather.provider import Provider, Suggestion
+from merino.utils.log_data_creators import RequestSummaryLogDataModel
+from tests.integration.api.types import RequestSummaryLogDataFixture
 from tests.integration.api.v1.types import Providers
 from tests.types import FilterCaplogFixture
 
@@ -144,3 +148,38 @@ def test_suggest_weather_backend_error(
         for record in filter_caplog(caplog.records, "merino.providers.weather.provider")
     ]
     assert actual_log_messages == expected_log_messages
+
+
+@freeze_time("1998-03-31")
+def test_providers_request_log_data_weather(
+    caplog: LogCaptureFixture,
+    filter_caplog: FilterCaplogFixture,
+    extract_request_summary_log_data: RequestSummaryLogDataFixture,
+    client: TestClient,
+) -> None:
+    """Test that the request log for the 'accuweather' endpoint logs using request.summary"""
+    caplog.set_level(logging.INFO)
+
+    expected_log_data: RequestSummaryLogDataModel = RequestSummaryLogDataModel(
+        agent="testclient",
+        path="/api/v1/suggest",
+        method="GET",
+        querystring={"providers": "accuweather", "q": ""},
+        errno=0,
+        code=200,
+        time="1998-03-31T00:00:00",
+    )
+
+    client.get("/api/v1/suggest?providers=accuweather&q=")
+
+    records: list[LogRecord] = filter_caplog(caplog.records, "request.summary")
+    assert len(records) == 1
+
+    suggest_records: list[LogRecord] = filter_caplog(
+        caplog.records, "web.suggest.request"
+    )
+    assert len(suggest_records) == 0
+
+    record: LogRecord = records[0]
+    log_data: RequestSummaryLogDataModel = extract_request_summary_log_data(record)
+    assert log_data == expected_log_data


### PR DESCRIPTION
## References

JIRA: [DISCO-2489](https://mozilla-hub.atlassian.net/browse/DISCO-2489)
GitHub: [#364](https://github.com/mozilla-services/merino-py/issues/364)

## Description
Since the query field is empty for all the Accuweather requests, Merino has logged lots of records which have affected/broken the downstream query sanitization jobs. 

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [X] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [X] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [X] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
