### PR TITLE
[DISCO-2474] Merino: Titles in Wikipedia Suggestions Have Trailing Punctuation

### DIFF
--- a/merino/providers/wikipedia/backends/elastic.py
+++ b/merino/providers/wikipedia/backends/elastic.py
@@ -1,5 +1,6 @@
 """The Elasticsearch backend for Dynamic Wikipedia."""
 import logging
+import string
 from typing import Any, Final
 from urllib.parse import quote
 
@@ -23,7 +24,7 @@ def get_best_keyword(q: str, title: str):
     """Try to get the best autocomplete keyword match from the title. If there are no matches,
     then return the full title as a match. Lowercase everything.
     """
-    title = title.lower().replace(",", "")
+    title = title.lower().translate(str.maketrans("", "", string.punctuation))
     q = q.strip().lower()
     start_index = title.find(q)
     if start_index < 0:

--- a/merino/providers/wikipedia/backends/elastic.py
+++ b/merino/providers/wikipedia/backends/elastic.py
@@ -24,7 +24,7 @@ def get_best_keyword(q: str, title: str):
     """Try to get the best autocomplete keyword match from the title. If there are no matches,
     then return the full title as a match. Lowercase everything.
     """
-    title = title.lower().translate(str.maketrans("", "", string.punctuation))
+    title = title.lower()
     q = q.strip().lower()
     start_index = title.find(q)
     if start_index < 0:
@@ -34,7 +34,7 @@ def get_best_keyword(q: str, title: str):
     if end_index < start_index:
         return title[start_index:]
 
-    return title[start_index:end_index]
+    return title[start_index:end_index].rstrip(string.punctuation)
 
 
 class ElasticBackend:

--- a/merino/providers/wikipedia/backends/elastic.py
+++ b/merino/providers/wikipedia/backends/elastic.py
@@ -23,7 +23,7 @@ def get_best_keyword(q: str, title: str):
     """Try to get the best autocomplete keyword match from the title. If there are no matches,
     then return the full title as a match. Lowercase everything.
     """
-    title = title.lower()
+    title = title.lower().replace(",", "")
     q = q.strip().lower()
     start_index = title.find(q)
     if start_index < 0:

--- a/tests/unit/providers/wikipedia/backends/test_elastic.py
+++ b/tests/unit/providers/wikipedia/backends/test_elastic.py
@@ -1,4 +1,5 @@
 """Unit tests for the Elastic Backend."""
+import string
 from unittest.mock import AsyncMock
 
 import pytest
@@ -7,7 +8,11 @@ from pytest_mock import MockerFixture
 
 from merino.config import settings
 from merino.exceptions import BackendError
-from merino.providers.wikipedia.backends.elastic import SUGGEST_ID, ElasticBackend
+from merino.providers.wikipedia.backends.elastic import (
+    SUGGEST_ID,
+    ElasticBackend,
+    get_best_keyword,
+)
 
 
 @pytest.fixture(name="es_backend")
@@ -158,3 +163,44 @@ async def test_es_backend_shutdown(
 
     await es_backend.shutdown()
     spy.assert_called_once()
+
+
+def test_get_best_keyword_removes_trailing_punctuation() -> None:
+    """Test that the get_best_keyword method removes any trailing punctuation for
+    keywords.
+    """
+    keyword = get_best_keyword(q="mozi", title="Mozilla, Corporation")
+    assert string.punctuation not in keyword
+
+
+@pytest.mark.asyncio
+async def test_es_backend_search_keyword_strip(
+    mocker: MockerFixture, es_backend: ElasticBackend
+) -> None:
+    """Test that ensures the search keyword does not return dangling punctuation
+    and that ascii encoding for punctuation remains in url with replaced underscores.
+    """
+    async_mock = AsyncMock(
+        return_value={
+            "suggest": {
+                SUGGEST_ID: [
+                    {
+                        "options": [
+                            {"_source": {"title": "Mozilla, Corporation"}},
+                        ]
+                    }
+                ]
+            }
+        }
+    )
+    mocker.patch.object(AsyncElasticsearch, "search", side_effect=async_mock)
+
+    suggestions = await es_backend.search("mozi")
+
+    assert suggestions == [
+        {
+            "full_keyword": "mozilla",
+            "title": "Wikipedia - Mozilla, Corporation",
+            "url": "https://en.wikipedia.org/wiki/Mozilla%2C_Corporation",
+        },
+    ]


### PR DESCRIPTION
## References

JIRA: [DISCO-2474](https://mozilla-hub.atlassian.net/browse/DISCO-2474)
GitHub: [#366 ](https://github.com/mozilla-services/merino-py/issues/366)

## Description
Reported on the #contextual-services-tech Slack channel on June 28th 2023

Some titles on wikipedia seem to have a comma at the end (this one is likely because the title is “Split, Croatia”). It’s low priority but we should fix it at some point if we can if there are multiple occurrences.

Multiple occurrences found, mostly with geographic locations.
<img width="526" alt="Screen Shot 2023-07-11 at 6 52 27 PM" src="https://github.com/mozilla-services/merino-py/assets/35045299/48825263-1de7-4208-8ca9-7de2aefcfead">
<img width="533" alt="Screen Shot 2023-07-11 at 7 00 27 PM" src="https://github.com/mozilla-services/merino-py/assets/35045299/a2a1094e-dc2c-41ef-a151-9487233236ec">

As discussed in ticket, we could just again return the title, but upon investigation this method required the removal of the comma from passed in title, as `get_best_keyword` method splits on the space, which is inclusive of the comma.  Have added logic to remove any and all punctuation that could also cause this issue. Just returning the title and then the text to the immediate right being the same (just possibly lowercase) seems like it would be cluttered and redundant. 

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2474]: https://mozilla-hub.atlassian.net/browse/DISCO-2474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ