### PR TITLE
chore: Increase cache TTL for accuweather

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -92,7 +92,7 @@ cache = "none"
 enabled_by_default = false
 score = 0.3
 query_timeout_sec = 5.0
-cached_report_ttl_sec = 1800 # 30 mins.
+cached_report_ttl_sec = 2700 # 45 mins.
 
 [default.accuweather]
 # Our API key used to access the AccuWeather API.

--- a/merino/providers/weather/backends/accuweather.py
+++ b/merino/providers/weather/backends/accuweather.py
@@ -148,6 +148,7 @@ class AccuweatherBackend:
             )
 
             with self.metrics_client.timeit(f"accuweather.request.{request_type}.get"):
+                logger.info(f"===Request: {url_path}, {params}")
                 response: Response = await self.http_client.get(url_path, params=params)
                 response.raise_for_status()
 

--- a/merino/providers/weather/backends/accuweather.py
+++ b/merino/providers/weather/backends/accuweather.py
@@ -148,7 +148,6 @@ class AccuweatherBackend:
             )
 
             with self.metrics_client.timeit(f"accuweather.request.{request_type}.get"):
-                logger.info(f"===Request: {url_path}, {params}")
                 response: Response = await self.http_client.get(url_path, params=params)
                 response.raise_for_status()
 


### PR DESCRIPTION
## References

JIRA: [DISCO-TODO](https://mozilla-hub.atlassian.net/browse/DISCO-TODO)
GitHub: [#TODO](https://github.com/mozilla-services/merino-py/issues/TODO)

## Description
Temporarily increase the cache TTL (from 30 mins to 45 mins) due to high request latency to AccuWeather.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
