### PR TITLE
[DISCO-2475] Overwrite the log severity codes to GCP logging

### DIFF
--- a/merino/config_logging.py
+++ b/merino/config_logging.py
@@ -1,6 +1,9 @@
 """Logging configuration"""
+import logging
 import sys
 from logging.config import dictConfig
+
+from dockerflow import logging as dockerflow_logging
 
 from merino.config import settings
 
@@ -29,7 +32,7 @@ def configure_logging() -> None:
                     "format": "%(message)s",
                 },
                 "json": {
-                    "()": "dockerflow.logging.JsonLogFormatter",
+                    "()": GCPCompatibleJSONFormatter,
                     "logger_name": "merino",
                 },
             },
@@ -73,3 +76,17 @@ def configure_logging() -> None:
             },
         }
     )
+
+
+class GCPCompatibleJSONFormatter(dockerflow_logging.JsonLogFormatter):
+    """Override the dockerflow log formatter with GCP compatible levels."""
+
+    SYSLOG_LEVEL_MAP = {
+        logging.CRITICAL: 600,
+        logging.ERROR: 500,
+        logging.WARNING: 400,
+        logging.INFO: 200,
+        logging.DEBUG: 100,
+    }
+
+    DEFAULT_SYSLOG_LEVEL = 200


### PR DESCRIPTION
## References

JIRA: [DISCO-2475](https://mozilla-hub.atlassian.net/browse/DISCO-2475)
GitHub: #369 

## Description
Check to see if this will fix the log categorization in GCP. 

This should switch _severity_ to using the GCP compatible severity codes, rather than the syslog codes that is outputted by `mozlog`. If this fixes the issue, consider patching [dockerflow](https://github.com/mozilla-services/python-dockerflow/blob/main/src/dockerflow/logging.py#L35).


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2475]: https://mozilla-hub.atlassian.net/browse/DISCO-2475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ