### PR TITLE
Temporarily turn off Dynamic AMO

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -130,8 +130,9 @@ api_url = "https://addons.mozilla.org/api/v5/addons/addon/"
 type = "amo"
 enabled_by_default = false
 score = 0.25
-# Specifies which backend to use. Currently defaulting to dynamic backend.
-backend = "dynamic"
+# Specifies which backend to use. Should default to dynamic backend.
+# Currently turned off so that we don't make repeated calls to Addon API if it doesn't work.
+backend = "static"
 # The minimum number of characters to be considered for matching.
 min_chars = 4
 # The re-syncing frequency for the AMO data. Defaults to daily.


### PR DESCRIPTION
## Description
Currently we're running into quite a lot of API failures. While we investigate this, let's switch over to the static AMO suggestions to stop unnecessarily calling the live Addons endpoint.

Errors can be seen in Sentry: https://mozilla.sentry.io/issues/?project=6622434


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
