### PR TITLE
Turn on Dynamic AMO again with logging

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -132,7 +132,7 @@ enabled_by_default = false
 score = 0.25
 # Specifies which backend to use. Should default to dynamic backend.
 # Currently turned off so that we don't make repeated calls to Addon API if it doesn't work.
-backend = "static"
+backend = "dynamic"
 # The minimum number of characters to be considered for matching.
 min_chars = 4
 # The re-syncing frequency for the AMO data. Defaults to daily.

--- a/merino/providers/amo/backends/dynamic.py
+++ b/merino/providers/amo/backends/dynamic.py
@@ -54,8 +54,8 @@ class DynamicAmoBackend:
                 "rating": f"{(json_res['ratings']['average']):.1f}",
                 "number_of_ratings": json_res["ratings"]["count"],
             }
-        except httpx.HTTPError:
-            logger.error(f"Addons API could not find key: {addon_key}")
+        except httpx.HTTPError as e:
+            logger.error(f"Addons API could not find key: {addon_key}, {e}")
         except (KeyError, JSONDecodeError):
             logger.error(
                 "Problem with Addons API formatting. "


### PR DESCRIPTION
## Description
This was producing error last time. The API call seems OK from local environment and other environments. So, going to try to push this with extra error logging to see what is up with production environment.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
