### PR TITLE
Disable propagate logs

### DIFF
--- a/merino/config.py
+++ b/merino/config.py
@@ -6,6 +6,7 @@ _validators = [
     Validator("deployment.canary", is_type_of=bool),
     Validator("logging.format", is_in=["mozlog", "pretty"]),
     Validator("logging.level", is_in=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]),
+    Validator("logging.can_propagate", is_type_of=bool),
     Validator("metrics.dev_logger", is_type_of=bool),
     Validator("metrics.host", is_type_of=str),
     Validator("metrics.port", gte=0, is_type_of=int),

--- a/merino/config_logging.py
+++ b/merino/config_logging.py
@@ -59,14 +59,17 @@ def configure_logging() -> None:
                 "merino": {
                     "handlers": handler,
                     "level": settings.logging.level,
+                    "propagate": settings.logging.can_propagate,
                 },
                 "request.summary": {
                     "handlers": handler,
                     "level": settings.logging.level,
+                    "propagate": settings.logging.can_propagate,
                 },
                 "web.suggest.request": {
                     "handlers": handler,
                     "level": settings.logging.level,
+                    "propagate": settings.logging.can_propagate,
                 },
                 "uvicorn.error": {
                     "handlers": ["uvicorn-error-handler"],

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -35,6 +35,7 @@ query_timeout_sec = 0.2
 level = "INFO"
 # Any of "mozlog" (i.e. JSON) or "pretty"
 format = "mozlog"
+can_propagate = false
 
 [default.web.api.v1]
 # Setting to contol the limit of optional client variants passed

--- a/merino/configs/testing.toml
+++ b/merino/configs/testing.toml
@@ -19,6 +19,7 @@ dev_logger = true
 # Any of "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"
 level = "DEBUG"
 format = "pretty"
+can_propagate = true
 
 [testing.web.api.v1]
 # Setting to contol the limit on optional client variants passed


### PR DESCRIPTION
## References

JIRA: [DISCO-2475](https://mozilla-hub.atlassian.net/browse/DISCO-2475)


## Description
This sets the Merino logger `propagate=False`. This is to hopefully prevent the ancestor loggers from logging unnecessarily to the stdout/stderr. I _think_ that this will fix the issue with GCP logging a random `text` formatted message, but not entirely certain. If anything, this change will clean up the logging locally (prevent the double entries when you run server).

Some documentation on `propagate`: https://docs.python.org/3/library/logging.html?highlight=propagate#logging.Logger.propagate



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2475]: https://mozilla-hub.atlassian.net/browse/DISCO-2475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ