### PR TITLE
[DISCO-2482] refactor: Use bulk fetch for accuweather backend [load test: abort]

### DIFF
--- a/merino/cache/none.py
+++ b/merino/cache/none.py
@@ -21,7 +21,7 @@ class NoCacheAdapter:  # pragma: no cover
     async def close(self) -> None:  # noqa: D102
         pass
 
-    def register_script(self, script: str) -> None:  # noqa: D102
+    def register_script(self, sid: str, script: str) -> None:  # noqa: D102
         pass
 
     async def run_script(self, sid: str, keys: list, args: list) -> Any:  # noqa: D102

--- a/merino/cache/none.py
+++ b/merino/cache/none.py
@@ -1,7 +1,7 @@
 """No-operation adapter that disables caching."""
 
 from datetime import timedelta
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 
 class NoCacheAdapter:  # pragma: no cover
@@ -19,4 +19,10 @@ class NoCacheAdapter:  # pragma: no cover
         pass
 
     async def close(self) -> None:  # noqa: D102
+        pass
+
+    def register_script(self, script: str) -> None:  # noqa: D102
+        pass
+
+    async def run_script(self, sid: str, keys: list, args: list) -> Any:  # noqa: D102
         pass

--- a/merino/cache/protocol.py
+++ b/merino/cache/protocol.py
@@ -32,7 +32,7 @@ class CacheAdapter(Protocol):
         """Close the adapter and release any underlying resources."""
         ...
 
-    def register_script(self, sid: str, script: str) -> None:
+    def register_script(self, sid: str, script: str) -> None:  # pragma: no cover
         """Register a Lua script in Redis. Regist multiple scripts using the same `sid`
         will overwrite the previous ones.
 
@@ -42,7 +42,9 @@ class CacheAdapter(Protocol):
         """
         ...
 
-    async def run_script(self, sid: str, keys: list, args: list) -> Any:
+    async def run_script(
+        self, sid: str, keys: list, args: list
+    ) -> Any:  # pragma: no cover
         """Run a given script with keys and arguments.
 
         Params:

--- a/merino/cache/protocol.py
+++ b/merino/cache/protocol.py
@@ -1,7 +1,7 @@
 """Protocol for cache adapters."""
 
 from datetime import timedelta
-from typing import Optional, Protocol
+from typing import Any, Optional, Protocol
 
 
 class CacheAdapter(Protocol):
@@ -30,4 +30,28 @@ class CacheAdapter(Protocol):
 
     async def close(self) -> None:  # pragma: no cover
         """Close the adapter and release any underlying resources."""
+        ...
+
+    def register_script(self, sid: str, script: str) -> None:
+        """Register a Lua script in Redis. Regist multiple scripts using the same `sid`
+        will overwrite the previous ones.
+
+        Params:
+            - `sid` {str}, a script identifier
+            - `script` {str}, a Redis supported Lua script
+        """
+        ...
+
+    async def run_script(self, sid: str, keys: list, args: list) -> Any:
+        """Run a given script with keys and arguments.
+
+        Params:
+            - `sid` {str}, a script identifier
+            - `keys` list[str], a list of keys used as the global `KEYS` in Redis scripting
+            - `args` list[str], a list of arguments used as the global `ARGV` in Redis scripting
+        Returns:
+            A Reids value based on the return value of the specified script
+        Raises:
+            - `CacheAdapterError` if Redis returns an error.
+        """
         ...

--- a/merino/cache/redis.py
+++ b/merino/cache/redis.py
@@ -1,9 +1,10 @@
 """Redis cache adapter."""
 
 from datetime import timedelta
-from typing import Optional
+from typing import Any, Optional
 
 from redis.asyncio import Redis, RedisError
+from redis.commands.core import AsyncScript
 
 from merino.exceptions import CacheAdapterError
 
@@ -12,6 +13,7 @@ class RedisAdapter:
     """A cache adapter that stores key-value pairs in Redis."""
 
     redis: Redis
+    scripts: dict[str, AsyncScript] = {}
 
     def __init__(self, redis: Redis):
         self.redis = redis
@@ -52,3 +54,37 @@ class RedisAdapter:
     async def close(self) -> None:
         """Close the Redis connection."""
         await self.redis.close()
+
+    def register_script(self, sid: str, script: str) -> None:
+        """Register a Lua script in Redis. Regist multiple scripts using the same `sid`
+        will overwrite the previous ones.
+
+        Note that script registration is lazy, no network call will be made for this.
+
+        Params:
+            - `sid` {str}, a script identifier
+            - `script` {str}, a Redis supported Lua script
+        """
+        self.scripts[sid] = self.redis.register_script(script)
+
+    async def run_script(self, sid: str, keys: list[str], args: list[str]) -> Any:
+        """Run a given script with keys and arguments.
+
+        Params:
+            - `sid` {str}, a script identifier
+            - `keys` list[str], a list of keys used as the global `KEYS` in Redis scripting
+            - `args` list[str], a list of arguments used as the global `ARGV` in Redis scripting
+        Returns:
+            A Reids value based on the return value of the specified script
+        Raises:
+            - `CacheAdapterError` if Redis returns an error
+            - `KeyError` if `sid` does not have a script associated
+        """
+        try:
+            res = await self.scripts[sid](keys, args)
+        except RedisError as exc:
+            raise CacheAdapterError(
+                f"Failed to run script {id} with error: `{exc}`"
+            ) from exc
+
+        return res

--- a/merino/cache/redis.py
+++ b/merino/cache/redis.py
@@ -75,7 +75,7 @@ class RedisAdapter:
             - `keys` list[str], a list of keys used as the global `KEYS` in Redis scripting
             - `args` list[str], a list of arguments used as the global `ARGV` in Redis scripting
         Returns:
-            A Reids value based on the return value of the specified script
+            A Redis value based on the return value of the specified script
         Raises:
             - `CacheAdapterError` if Redis returns an error
             - `KeyError` if `sid` does not have a script associated

--- a/merino/config.py
+++ b/merino/config.py
@@ -11,6 +11,9 @@ _validators = [
     Validator("metrics.host", is_type_of=str),
     Validator("metrics.port", gte=0, is_type_of=int),
     Validator(
+        "accuweather.url_location_key_placeholder", is_type_of=str, must_exist=True
+    ),
+    Validator(
         "accuweather.url_param_partner_code",
         is_type_of=str,
         must_exist=True,

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -104,6 +104,8 @@ url_base = "https://apidev.accuweather.com"
 url_param_api_key = "apikey"
 url_current_conditions_path = "/currentconditions/v1/{location_key}.json"
 url_forecasts_path = "/forecasts/v1/daily/1day/{location_key}.json"
+# The placeholder for the location key used by the above two configurations.
+url_location_key_placeholder = "{location_key}"
 url_postalcodes_path = "/locations/v1/postalcodes/{country_code}/search.json"
 url_postalcodes_param_query = "q"
 # The name of the partner code query param appended to the current conditions and forecast links in

--- a/merino/providers/manager.py
+++ b/merino/providers/manager.py
@@ -68,6 +68,7 @@ def _create_provider(provider_id: str, setting: Settings) -> BaseProvider:
                     url_postalcodes_param_query=settings.accuweather.url_postalcodes_param_query,
                     url_current_conditions_path=settings.accuweather.url_current_conditions_path,
                     url_forecasts_path=settings.accuweather.url_forecasts_path,
+                    url_location_key_placeholder=settings.accuweather.url_location_key_placeholder,
                 )
                 if setting.backend == "accuweather"
                 else FakeWeatherBackend(),

--- a/merino/providers/weather/backends/accuweather.py
+++ b/merino/providers/weather/backends/accuweather.py
@@ -1,26 +1,22 @@
 """A wrapper for AccuWeather API interactions."""
 import asyncio
 import datetime
+import functools
 import hashlib
 import json
 import logging
-from json import JSONDecodeError
-from typing import Any, Callable, Optional
+from enum import Enum
+from typing import Any, Callable, Optional, no_type_check
 
 import aiodogstatsd
 from dateutil import parser
 from httpx import URL, AsyncClient, HTTPError, InvalidURL, Response
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 from pydantic.datetime_parse import timedelta
 
 from merino.cache.protocol import CacheAdapter
 from merino.config import settings
-from merino.exceptions import (
-    BackendError,
-    CacheAdapterError,
-    CacheEntryError,
-    CacheMissError,
-)
+from merino.exceptions import BackendError, CacheAdapterError
 from merino.middleware.geolocation import Location
 from merino.providers.weather.backends.protocol import (
     CurrentConditions,
@@ -33,6 +29,36 @@ logger = logging.getLogger(__name__)
 
 PARTNER_PARAM_ID: Optional[str] = settings.accuweather.get("url_param_partner_code")
 PARTNER_CODE: Optional[str] = settings.accuweather.get("partner_code")
+
+# The Lua script to fetch the location key, current condition, and forecast for
+# a given country/postal code.
+#
+# Note:
+#   - The cache key for the country/postal code should be provided through `KEYS[1]`
+#   - The cache key templates for current conditions and forecast should be provided
+#     through `ARGV[1]` and `ARGV[2]`
+#   - If the location key is present in the cache, it uses the key to fetch the current
+#     conditions and forecast for that key in the cache. It returns a 3-element array
+#     `[location_key, current_condition, forecast]`. The last two element can be `nil`
+#     if they are not present in the cache
+#   - If the location key is missing, it will return an empty array
+LUA_SCRIPT_CACHE_BULK_FETCH: str = """
+    local location_key = redis.call("GET", KEYS[1])
+
+    if not location_key then
+        return {}
+    end
+
+    local key = cjson.decode(location_key)["key"]
+    local condition_key = string.gsub(ARGV[1], "{location_key}", key)
+    local forecast_key = string.gsub(ARGV[2], "{location_key}", key)
+
+    local current_conditions = redis.call("GET", condition_key)
+    local forecast = redis.call("GET", forecast_key)
+
+    return {location_key, current_conditions, forecast}
+"""
+SCRIPT_ID: str = "bulk_fetch"
 
 
 class AccuweatherLocation(BaseModel):
@@ -48,6 +74,13 @@ class AccuweatherLocation(BaseModel):
 
 class AccuweatherError(BackendError):
     """Error during interaction with the AccuWeather API."""
+
+
+class WeatherDataType(Enum):
+    """Enum to capture all types for weather data."""
+
+    CURRENT_CONDITIONS = 1
+    FORECAST = 2
 
 
 class AccuweatherBackend:
@@ -96,6 +129,8 @@ class AccuweatherBackend:
 
         self.api_key = api_key
         self.cache = cache
+        # This registration is lazy (i.e. no interaction with Redis) and infallible.
+        self.cache.register_script(SCRIPT_ID, LUA_SCRIPT_CACHE_BULK_FETCH)
         self.cached_report_ttl_sec = cached_report_ttl_sec
         self.metrics_client = metrics_client
         self.http_client = http_client
@@ -119,9 +154,24 @@ class AccuweatherBackend:
                     hasher.update(key.encode("utf-8") + value.encode("utf-8"))
             extra_identifiers = hasher.hexdigest()
 
-            return f"{self.__class__.__name__}:v2:{url}:{extra_identifiers}"
+            return f"{self.__class__.__name__}:v3:{url}:{extra_identifiers}"
 
-        return f"{self.__class__.__name__}:v2:{url}"
+        return f"{self.__class__.__name__}:v3:{url}"
+
+    @functools.cache
+    def cache_key_template(self, dt: WeatherDataType) -> str:
+        """Get the cache key template for weather data."""
+        match dt:
+            case WeatherDataType.CURRENT_CONDITIONS:
+                return self.cache_key_for_accuweather_request(
+                    self.url_current_conditions_path,
+                    query_params={self.url_param_api_key: self.api_key},
+                )
+            case WeatherDataType.FORECAST:
+                return self.cache_key_for_accuweather_request(
+                    self.url_forecasts_path,
+                    query_params={self.url_param_api_key: self.api_key},
+                )
 
     async def get_request(
         self,
@@ -138,41 +188,31 @@ class AccuweatherBackend:
         # The top level path in the URL gives us a good enough idea of what type of request
         # we are calling from here.
         request_type: str = url_path.strip("/").split("/", 1)[0]
-        try:
-            response_dict = await self.fetch_request_from_cache(cache_key)
-            self.metrics_client.increment(f"accuweather.cache.hit.{request_type}")
-        except (CacheMissError, CacheEntryError, CacheAdapterError) as exc:
-            error_type = "miss" if isinstance(exc, CacheMissError) else "error"
+
+        with self.metrics_client.timeit(f"accuweather.request.{request_type}.get"):
+            response: Response = await self.http_client.get(url_path, params=params)
+            response.raise_for_status()
+
+        if (response_dict := process_api_response(response.json())) is None:
             self.metrics_client.increment(
-                f"accuweather.cache.fetch.{error_type}.{request_type}"
+                f"accuweather.request.{request_type}.processor.error"
             )
+            return None
 
-            with self.metrics_client.timeit(f"accuweather.request.{request_type}.get"):
-                response: Response = await self.http_client.get(url_path, params=params)
-                response.raise_for_status()
-
-            if (response_dict := process_api_response(response.json())) is None:
-                self.metrics_client.increment(
-                    f"accuweather.request.{request_type}.processor.error"
-                )
-                return None
-
-            response_expiry: str = response.headers.get("Expires")
-            try:
-                await self.store_request_into_cache(
-                    cache_key, response_dict, response_expiry
-                )
-            except (CacheAdapterError, ValueError) as exc:
-                logger.error(f"Error with storing Accuweather to cache: {exc}")
-                error_type = (
-                    "set_error"
-                    if isinstance(exc, CacheAdapterError)
-                    else "ttl_date_error"
-                )
-                self.metrics_client.increment(f"accuweather.cache.store.{error_type}")
-                raise AccuweatherError(
-                    "Something went wrong with storing to cache. Did not update cache."
-                )
+        response_expiry: str = response.headers.get("Expires")
+        try:
+            await self.store_request_into_cache(
+                cache_key, response_dict, response_expiry
+            )
+        except (CacheAdapterError, ValueError) as exc:
+            logger.error(f"Error with storing Accuweather to cache: {exc}")
+            error_type = (
+                "set_error" if isinstance(exc, CacheAdapterError) else "ttl_date_error"
+            )
+            self.metrics_client.increment(f"accuweather.cache.store.{error_type}")
+            raise AccuweatherError(
+                "Something went wrong with storing to cache. Did not update cache."
+            )
 
         return response_dict
 
@@ -192,23 +232,99 @@ class AccuweatherBackend:
             cache_value = json.dumps(response_dict).encode("utf-8")
             await self.cache.set(cache_key, cache_value, ttl=cache_ttl)
 
-    async def fetch_request_from_cache(self, cache_key: str) -> dict[str, Any]:
-        """Get the request from the cache."""
-        with self.metrics_client.timeit("accuweather.cache.fetch"):
-            response: Optional[bytes] = await self.cache.get(cache_key)
-            if not response:
-                raise CacheMissError
+    def emit_cache_fetch_metrics(self, cached_data: list[bytes]) -> None:
+        """Emit cache fetch metrics.
 
-            try:
-                response_dict: dict[str, Any] = json.loads(response)
-                return response_dict
-            except JSONDecodeError as e:
-                raise CacheEntryError("Failed to parse cache entry") from e
+        Params:
+            - `cached_data` {list[bytes]} A list of bytes for location_key,
+              current_condition, forecast
+        """
+        location, current, forecast = False, False, False
+        match cached_data:
+            case []:
+                pass
+            case [_, current_cached, forecast_cached]:
+                location, current, forecast = (
+                    True,
+                    current_cached is not None,
+                    forecast_cached is not None,
+                )
+            case _:  # noqa: D102
+                pass
+
+        self.metrics_client.increment(
+            "accuweather.cache.hit.locations"
+            if location
+            else "accuweather.cache.fetch.miss.locations"
+        )
+        self.metrics_client.increment(
+            "accuweather.cache.hit.currentconditions"
+            if current
+            else "accuweather.cache.fetch.miss.currentconditions"
+        )
+        self.metrics_client.increment(
+            "accuweather.cache.hit.forecasts"
+            if forecast
+            else "accuweather.cache.fetch.miss.forecasts"
+        )
+
+    # Opt out the type check as mypy really struggles with the pattern match below.
+    # TODO(nanj): re-enable type checking once we upgrade mypy to the lastest.
+    @no_type_check
+    def parse_cached_data(
+        self, cached_data: list[bytes]
+    ) -> tuple[
+        Optional[AccuweatherLocation],
+        Optional[CurrentConditions],
+        Optional[Forecast],
+    ]:
+        """Parse the weather data from cache.
+
+        Upon parsing errors, it will return the successfully parsed data thus far.
+
+        Params:
+            - `cached_data` {list[bytes]} A list of bytes for location_key,
+              current_conditions, forecast
+        """
+        location: Optional[AccuweatherLocation] = None
+        current_conditions: Optional[CurrentConditions] = None
+        forecast: Optional[Forecast] = None
+        try:
+            match cached_data:
+                case [location_cached, None, _] | [location_cached, _, None]:
+                    # A partial hit and at least one of the latter two is missing, just return
+                    # the location_key.
+                    location = AccuweatherLocation.parse_raw(location_cached)
+                case [location_cached, current_cached, forecast_cached]:
+                    location = AccuweatherLocation.parse_raw(location_cached)
+                    current_conditions = CurrentConditions.parse_raw(current_cached)
+                    forecast = Forecast.parse_raw(forecast_cached)
+                case _:
+                    pass
+        except ValidationError as exc:
+            logger.error(f"Failed to load weather report data from Redis: {exc}")
+            self.metrics_client.increment("accuweather.cache.data.error")
+
+        return location, current_conditions, forecast
 
     async def get_weather_report(
         self, geolocation: Location
     ) -> Optional[WeatherReport]:
         """Get weather information from AccuWeather.
+
+        Firstly, it will look up the Redis cache for the location key, current condition,
+        and forecast. If all of them are found in the cache, then return them without
+        requesting those from AccuWeather. Otherwise, it will issue API requests to
+        AccuWeather for the missing data. Lastly, the API responses are stored in the
+        cache for future uses.
+
+        Note:
+            - To simplify the implementation, if either current conditions or the forecast
+              is missing in the cache, we will fetch both of them from AccuWeather as they
+              normally co-exist in the cache
+            - To avoid making excessive API requests to Accuweather in the event of
+              "Cache Avalanche", it will *not* call AccuWeather for weather reports upon any
+              cache errors such as timeouts or connection issues to Redis
 
         Raises:
             AccuweatherError: Failed request or 4xx and 5xx response from AccuWeather.
@@ -218,8 +334,48 @@ class AccuweatherBackend:
         if not country or not postal_code:
             raise AccuweatherError("Country and/or postal code unknown")
 
-        if not (location := await self.get_location(country, postal_code)):
+        cache_key: str = self.cache_key_for_accuweather_request(
+            self.url_postalcodes_path.format(country_code=country),
+            query_params={
+                self.url_param_api_key: self.api_key,
+                self.url_postalcodes_param_query: postal_code,
+            },
+        )
+        # Look up for all the weather data from the cache.
+        try:
+            cached_data: list[bytes] = await self.cache.run_script(
+                sid=SCRIPT_ID,
+                keys=[cache_key],
+                args=[
+                    self.cache_key_template(WeatherDataType.CURRENT_CONDITIONS),
+                    self.cache_key_template(WeatherDataType.FORECAST),
+                ],
+            )
+        except CacheAdapterError as exc:
+            logger.error(f"Failed to fetch weather report from Redis: {exc}")
+            self.metrics_client.increment("accuweather.cache.fetch.error")
             return None
+
+        self.emit_cache_fetch_metrics(cached_data)
+
+        location, current_conditions, forecast = self.parse_cached_data(cached_data)
+
+        # Everything is ready, just return them.
+        if location and current_conditions and forecast:
+            return WeatherReport(
+                city_name=location.localized_name,
+                current_conditions=current_conditions,
+                forecast=forecast,
+            )
+
+        # Fetch the location key from AccuWeather if it's missing in the cache.
+        if location is None:
+            if (location := await self.get_location(country, postal_code)) is None:
+                return None
+
+        # Fetch current conditions and forecast from AccuWeather.
+        # To simplify the implementation we always fetch both as they share the
+        # same cache TTL now.
         try:
             async with asyncio.TaskGroup() as tg:
                 task_current = tg.create_task(self.get_current_conditions(location.key))
@@ -289,7 +445,7 @@ class AccuweatherBackend:
                 url=response["url"],
                 summary=response["summary"],
                 icon_id=response["icon_id"],
-                temperature=Temperature(*response["temperature"]),
+                temperature=Temperature(**response["temperature"]),
             )
             if response
             else None
@@ -395,7 +551,7 @@ def process_current_condition_response(response: Any) -> Optional[dict[str, Any]
                 "url": url,
                 "summary": summary,
                 "icon_id": icon_id,
-                "temperature": [c, f],
+                "temperature": {"c": c, "f": f},
             }
         case _:
             return None


### PR DESCRIPTION
## References

JIRA: [DISCO-2482](https://mozilla-hub.atlassian.net/browse/DISCO-2482)
GitHub: N/A

## Description
This patch uses a Lua script to bulk fetch weather data from Redis. It cuts the Redis lookup calls from 3 to 1 per each request. Local benchmark suggests it has increased ~50% in throughput and ~30% in latency in a high cache-hit scenario (similar to production). It should perform better in other scenarios as well as it reduces the overall overhead for Redis cache lookups.

Main vs This branch
QPS: 1,150 vs 1,750 (52%)
Latency (p95): 110ms vs 77ms (30%)  

Need to add/fix tests

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2482]: https://mozilla-hub.atlassian.net/browse/DISCO-2482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ