### PR TITLE
Moved Rollback documentation into its own file

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -17,6 +17,8 @@
   - [Release Process](./dev/release-process.md)
   - [Profiling](./dev/profiling.md)
 - [Operations](./operations/index.md)
+  - [Rollback](./operations/rollback.md)
+  - [Test Failures in CI](./operations/testfailures.md)
   - [Configs](./operations/configs.md)
   - [Elasticsearch](./operations/elasticsearch.md)
   - [Jobs](./operations/jobs.md)

--- a/docs/dev/release-process.md
+++ b/docs/dev/release-process.md
@@ -26,12 +26,12 @@ down).
 [activity_circleci_main_workflow]: ./circleci_main_workflow.jpg
 [stage_version]: https://stage.merino.nonprod.cloudops.mozgcp.net/__version__
 
-## Development Guidelines
+## Release Best Practices
 
-Please see the [CONTRIBUTING.md][contributing] docs on commit guidelines and pull request best
-practices.
+The _expectation_ is that the author of the change will:
 
-[contributing]: https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md
+- merge pull requests during hours when the majority of contributors are online
+- monitor the [Merino Application & Infrastructure][merino_app_info] dashboard for any anomaly
 
 ## Versioning
 
@@ -54,92 +54,11 @@ Locust master kubernetes pod.
 
 [load_test_readme]: https://github.com/mozilla-services/merino-py/blob/main/tests/load/README.md
 
-## Releasing to production
-
-Developers with write access to the Merino repository will initiate a deployment to production when
-a Pull-Request on the Merino GitHub repository is merged to the `main` branch. It is recommended to
-merge pull requests during hours when the majority of Contile contributors are online.
-
-While any developer with write access can trigger the deployment to production, the _expectation_ is
-that the individual(s) who authored and merged the Pull-Request should do so, as they are the ones
-most familiar with their changes and who can tell, by looking at the data, if anything looks
-anomalous. Developers **must** monitor the [Merino Application & Infrastructure][merino_app_info]
-dashboard for any anomaly, for example significant changes in HTTP response codes, increase in
-latency, container/cpu/memory usage (most things under the 'Infrastructure' heading).
-
-### What to do if tests fail during deployment?
-
-1. Investigate the cause of the test failure
-    - For functional tests (unit, integration or contract), logs can be found on
-      [CircleCI][circleci]
-    - For performance tests (load), insights can be found on [Grafana][merino_app_info] and in the
-      Locust logs. To access the Locust logs:
-      1. Open a cloud shell in the [Merino stage environment][merino_gcp_stage]
-      2. Authenticate by executing the following command:
-      ```shell
-      gcloud container clusters get-credentials merino-nonprod-v1 \
-        --region us-west1 --project moz-fx-merino-nonprod-ee93
-      ```
-      3. Access the data in the Kubernetes pod by executing the following command:
-      ```shell
-        kubectl exec -it -n locust-merino locust-master-0 -- bash -c "cd /data && /bin/bash"
-      ```
-
-2. Fix or mitigate the failure
-    - If a fix can be identified in a relatively short time, then submit a fix
-    - If the failure is caused by a flaky or intermittent functional test and the risk to the
-      end-user experience is low, then the test can be "skipped", using the pytest`xfail`
-      [decorator][pytest_xfail] during continued investigation. Example:
-      ```python
-      @pytest.mark.xfail(reason="Test Flake Detected (ref: DISCO-####)")
-      ```
-3. Re-Deploy
-    - A fix or mitigation will most likely require a PR merge to the `main` branch that will
-      automatically trigger the deployment process. If this is not possible, a re-deployment can be
-      initiated manually by triggering the CI pipeline in [CircleCI][circleci].
-
-[circleci]: https://app.circleci.com/pipelines/github/mozilla-services/merino-py
-[merino_app_info]: https://earthangel-b40313e5.influxcloud.net/d/rQAfYKIVk/wip-merino-py-application-and-infrastructure?orgId=1&from=now-24h&to=now&var-environment=prodpy&refresh=1m
-[merino_gcp_stage]: https://console.cloud.google.com/kubernetes/list/overview?project=moz-fx-merino-nonprod-ee93
-[pytest_xfail]: https://docs.pytest.org/en/latest/how-to/skipping.html
-
 ### What to do if production breaks?
 
 If your latest release causes problems and needs to be rolled back:
-don't panic and follow the instructions below:
+don't panic and follow the instructions in the [Rollback Runbook](../operations/rollback.md).
 
-1. Depending on the severity of the problem, decide if this warrants
-   [kicking off an incident][incident_docs];
-2. Identify the problematic commit (see instructions below), as it may not necessarily be the latest one!
-3. Revert the problematic commit, merge that into GitHub,
-   then [deploy the revert commit to production](#releasing-to-production).
-    - If a fix can be identified in a relatively short time,
-      then you may submit a fix, rather than reverting the problematic commit.
+### What to do if tests fail during deployment?
 
-#### Locate problematic commit via "git bisect"
-If you are not sure about which commit broke production, you can use `git bisect` to locate the problematic commit as follows:
-
-```sh
-# Start the bisect session.
-$ git bisect start
-
-# Flag a bad commit, usually you can set it to the latest commit as it's broken
-# in production.
-$ git bisect bad <commit-hash-for-a-bad-commit>
-
-# Flag a good commit, this can be set to the last known good commit.
-# You can use an old commit if you're still unsure, bisect will perform binary
-# searches anyway.
-$ git bisect good <commit-hash-for-a-good-commit>
-
-# Git will check out a commit in the middle and then you can test it to see if
-# the issue is still reproducible. If yes, flag it "bad", otherwise flag it
-# "good". Git will use that as input to make the next move until it locates the
-# problematic commit.
-$ git bisect [bad|good]
-
-# End the bisect session when you're done.
-$ git bisect reset
-```
-
-[incident_docs]: https://mozilla-hub.atlassian.net/wiki/spaces/MIR/overview
+Please refer to [What to do with Test Failures in CI?](../operations/testfailures.md)

--- a/docs/operations/rollback.md
+++ b/docs/operations/rollback.md
@@ -1,0 +1,15 @@
+# How to Rollback Changes
+
+Note: We use "roll-forward" strategy for rolling back changes in production.
+
+1. Depending on the severity of the problem, decide if this warrants
+   [kicking off an incident][incident_docs];
+2. Identify the problematic commit (it may not be the latest commit)
+   and create a revert PR. 
+   If it is the latest commit, you can revert the change with:
+   ```
+   git revert HEAD~1
+   ```
+3. Create a revert PR and go through normal review process to merge PR.
+
+[incident_docs]: https://mozilla-hub.atlassian.net/wiki/spaces/MIR/overview

--- a/docs/operations/testfailures.md
+++ b/docs/operations/testfailures.md
@@ -1,0 +1,35 @@
+# What to do with test failures in CI?
+
+1. Investigate the cause of the test failure
+    - For functional tests (unit, integration or contract), logs can be found on
+      [CircleCI][circleci]
+    - For performance tests (load), insights can be found on [Grafana][merino_app_info] and in the
+      Locust logs. To access the Locust logs:
+      1. Open a cloud shell in the [Merino stage environment][merino_gcp_stage]
+      2. Authenticate by executing the following command:
+      ```shell
+      gcloud container clusters get-credentials merino-nonprod-v1 \
+        --region us-west1 --project moz-fx-merino-nonprod-ee93
+      ```
+      3. Access the data in the Kubernetes pod by executing the following command:
+      ```shell
+        kubectl exec -it -n locust-merino locust-master-0 -- bash -c "cd /data && /bin/bash"
+      ```
+
+2. Fix or mitigate the failure
+    - If a fix can be identified in a relatively short time, then submit a fix
+    - If the failure is caused by a flaky or intermittent functional test and the risk to the
+      end-user experience is low, then the test can be "skipped", using the pytest`xfail`
+      [decorator][pytest_xfail] during continued investigation. Example:
+      ```python
+      @pytest.mark.xfail(reason="Test Flake Detected (ref: DISCO-####)")
+      ```
+3. Re-Deploy
+    - A fix or mitigation will most likely require a PR merge to the `main` branch that will
+      automatically trigger the deployment process. If this is not possible, a re-deployment can be
+      initiated manually by triggering the CI pipeline in [CircleCI][circleci].
+
+[circleci]: https://app.circleci.com/pipelines/github/mozilla-services/merino-py
+[merino_app_info]: https://earthangel-b40313e5.influxcloud.net/d/rQAfYKIVk/wip-merino-py-application-and-infrastructure?orgId=1&from=now-24h&to=now&var-environment=prodpy&refresh=1m
+[merino_gcp_stage]: https://console.cloud.google.com/kubernetes/list/overview?project=moz-fx-merino-nonprod-ee93
+[pytest_xfail]: https://docs.pytest.org/en/latest/how-to/skipping.html


### PR DESCRIPTION
## References

JIRA: [DISCO-2513](https://mozilla-hub.atlassian.net/browse/DISCO-2513)
Fixes #400 

## Description
This makes the "rollback" documentation more searchable. 

I also moved out the test "debugging" documentation from the release docs. We want to keep stuff in the "Release Process" documentation at a conceptual level. However as procedural documentation, they're excellent (so they're unmodified).


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2513]: https://mozilla-hub.atlassian.net/browse/DISCO-2513?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ