### PR TITLE
[DISCO-2575] refactor: Perform fine-grained cache refreshing for accuweather backend [load test: abort]

### DIFF
--- a/docs/operations/configs.md
+++ b/docs/operations/configs.md
@@ -212,7 +212,7 @@ Configuration for using AccuWeather as a weather backend
   - `partner_code` (`MERINO_ACCUWEATHER__PARTNER_CODE`) -
     The partner code to append to URLs in the current conditions and forecast responses.
 
-### AMO API 
+### AMO API
 
 - `api_url` (`MERINO_AMO__DYNAMIC__API_URL`) - the base URL of the Addons API.
 
@@ -260,10 +260,6 @@ These are production providers that generate suggestions.
   - `query_timeout_sec` (`MERINO_PROVIDERS__ACCUWEATHER__QUERY_TIMEOUT_SEC`) - A floating
     point (in seconds) indicating the maximum waiting period when Merino queries
     for weather forecasts. This will override the default query timeout.
-  - `cached_report_ttl_sec` (`MERINO_PROVIDERS__ACCUWEATHER__CACHED_REPORT_TTL_SEC`) - The
-    number of whole seconds (as an integer) indicating the time-to-live for a cached weather
-    report (current conditions and forecast) for a location. After the TTL expires, the provider
-    will fetch and cache the report again on the next suggestion request for that location.
 
 #### AMO Provider
 
@@ -276,10 +272,10 @@ These are production providers that generate suggestions.
   as a floating point number. Defaults to 0.3.
 - `min_chars` (`MERINO_PROVIDERS__AMO__MIN_CHARS`) - The minimum number of characters
   to process a querystring.
-- `resync_interval_sec` (`MERINO_PROVIDERS__AMO__RESYNC_INTERVAL_SEC`) - The re-syncing frequency 
+- `resync_interval_sec` (`MERINO_PROVIDERS__AMO__RESYNC_INTERVAL_SEC`) - The re-syncing frequency
   for the AMO data. Defaults to daily.
 - `cron_interval_sec` (`MERINO_PROVIDERS__AMO__CRON_INTERVAL_SEC`) - The frequency that the cron checks
-  to see if re-syncing is required. This should be more frequent than the `resync_interval_sec` to retry 
+  to see if re-syncing is required. This should be more frequent than the `resync_interval_sec` to retry
   on errors. Defaults to every minute.
 
 #### Top Picks Provider

--- a/merino/cache/redis.py
+++ b/merino/cache/redis.py
@@ -45,7 +45,9 @@ class RedisAdapter:
             - `CacheAdapterError` if Redis returns an error.
         """
         try:
-            await self.redis.set(key, value, ex=ttl.seconds if ttl else None)
+            await self.redis.set(
+                key, value, ex=ttl.days * 86400 + ttl.seconds if ttl else None
+            )
         except RedisError as exc:
             raise CacheAdapterError(
                 f"Failed to set `{repr(key)}` with error: `{exc}`"

--- a/merino/config.py
+++ b/merino/config.py
@@ -36,7 +36,13 @@ _validators = [
     ),
     Validator("providers.accuweather.type", is_type_of=str, must_exist=True),
     Validator("providers.accuweather.cache", is_in=["redis", "none"]),
-    Validator("providers.accuweather.cached_report_ttl_sec", is_type_of=int, gte=0),
+    Validator(
+        "providers.accuweather.cached_current_condition_ttl_sec", is_type_of=int, gte=0
+    ),
+    Validator("providers.accuweather.cached_forecast_ttl_sec", is_type_of=int, gte=0),
+    Validator(
+        "providers.accuweather.cached_location_key_ttl_sec", is_type_of=int, gte=0
+    ),
     Validator("providers.adm.backend", is_in=["remote-settings", "test"]),
     Validator("providers.adm.cron_interval_sec", gt=0),
     Validator("providers.adm.enabled_by_default", is_type_of=bool),

--- a/merino/config.py
+++ b/merino/config.py
@@ -37,11 +37,15 @@ _validators = [
     Validator("providers.accuweather.type", is_type_of=str, must_exist=True),
     Validator("providers.accuweather.cache", is_in=["redis", "none"]),
     Validator(
-        "providers.accuweather.cached_current_condition_ttl_sec", is_type_of=int, gte=0
+        "providers.accuweather.cache_ttls.current_condition_ttl_sec",
+        is_type_of=int,
+        gte=0,
     ),
-    Validator("providers.accuweather.cached_forecast_ttl_sec", is_type_of=int, gte=0),
     Validator(
-        "providers.accuweather.cached_location_key_ttl_sec", is_type_of=int, gte=0
+        "providers.accuweather.cache_ttls.forecast_ttl_sec", is_type_of=int, gte=0
+    ),
+    Validator(
+        "providers.accuweather.cached_ttls.location_key_ttl_sec", is_type_of=int, gte=0
     ),
     Validator("providers.adm.backend", is_in=["remote-settings", "test"]),
     Validator("providers.adm.cron_interval_sec", gt=0),

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -95,7 +95,9 @@ cache = "none"
 enabled_by_default = false
 score = 0.3
 query_timeout_sec = 5.0
-cached_report_ttl_sec = 2700 # 45 mins.
+cached_location_key_ttl_sec = 604800 # 7 days
+cached_current_condition_ttl_sec = 1800 # 1/2 hr
+cached_forecast_ttl_sec = 3600 # 1 hr
 
 [default.accuweather]
 # Our API key used to access the AccuWeather API.

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -95,9 +95,12 @@ cache = "none"
 enabled_by_default = false
 score = 0.3
 query_timeout_sec = 5.0
-cached_location_key_ttl_sec = 604800 # 7 days
-cached_current_condition_ttl_sec = 1800 # 1/2 hr
-cached_forecast_ttl_sec = 3600 # 1 hr
+
+[default.providers.accuweather.cache_ttls]
+# Cache TTLs for weather data
+location_key_ttl_sec = 604800 # 7 days
+current_condition_ttl_sec = 1800 # 1/2 hr
+forecast_ttl_sec = 3600 # 1 hr
 
 [default.accuweather]
 # Our API key used to access the AccuWeather API.

--- a/merino/providers/manager.py
+++ b/merino/providers/manager.py
@@ -58,7 +58,9 @@ def _create_provider(provider_id: str, setting: Settings) -> BaseProvider:
                 backend=AccuweatherBackend(
                     api_key=settings.accuweather.api_key,
                     cache=cache,  # type: ignore [arg-type]
-                    cached_report_ttl_sec=setting.cached_report_ttl_sec,
+                    cached_location_key_ttl_sec=setting.cached_location_key_ttl_sec,
+                    cached_current_condition_ttl_sec=setting.cached_current_condition_ttl_sec,
+                    cached_forecast_ttl_sec=setting.cached_forecast_ttl_sec,
                     metrics_client=get_metrics_client(),
                     http_client=create_http_client(
                         base_url=settings.accuweather.url_base

--- a/merino/providers/manager.py
+++ b/merino/providers/manager.py
@@ -58,9 +58,9 @@ def _create_provider(provider_id: str, setting: Settings) -> BaseProvider:
                 backend=AccuweatherBackend(
                     api_key=settings.accuweather.api_key,
                     cache=cache,  # type: ignore [arg-type]
-                    cached_location_key_ttl_sec=setting.cached_location_key_ttl_sec,
-                    cached_current_condition_ttl_sec=setting.cached_current_condition_ttl_sec,
-                    cached_forecast_ttl_sec=setting.cached_forecast_ttl_sec,
+                    cached_location_key_ttl_sec=setting.cache_ttls.location_key_ttl_sec,
+                    cached_current_condition_ttl_sec=setting.cache_ttls.current_condition_ttl_sec,
+                    cached_forecast_ttl_sec=setting.cache_ttls.forecast_ttl_sec,
                     metrics_client=get_metrics_client(),
                     http_client=create_http_client(
                         base_url=settings.accuweather.url_base


### PR DESCRIPTION
## References

JIRA: [DISCO-2575](https://mozilla-hub.atlassian.net/browse/DISCO-2575)

## Description
Merino currently refreshes "Current Conditions" and "Forecast" at the same time regardless of its cache validity, this patch implements fine-grained refreshing so that it only refreshes the cached data if they're expired. 



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2575]: https://mozilla-hub.atlassian.net/browse/DISCO-2575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ