### PR TITLE
[DISCO-2581] update load test docker command and documentation for local tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,7 @@ load-tests-clean:  ##  Stop and remove containers and networks for load tests
       -f $(LOAD_TEST_DIR)/docker-compose.yml \
       -p merino-py-load-tests \
       down
+	docker rmi locust
 
 .PHONY: doc-install-deps
 doc-install-deps:  ## Install the dependencies for doc generation

--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -72,10 +72,7 @@ make load-tests
     * Option 2: Select the `Default` load test shape with the following recommended settings:
       * Number of users: 35
       * Spawn rate: 1
-      * Host: 'https://stagepy.merino.nonprod.cloudops.mozgcp.net' (Alternatively, such as when
-        profiling, point the host to a local instance of merino. To access your host machine's instance
-        of merino from the load tests, you must use the functioning alias for `localhost`: `host.docker.internal:[service_port]`.
-        If running on port 8000, this would be: `http://host.docker.internal:8000`)
+      * Host: 'https://stagepy.merino.nonprod.cloudops.mozgcp.net'
       * Duration (Optional): 10m
 * Select "Start Swarming"
 

--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -27,6 +27,9 @@ The commit tag signals load test instructions to Jenkins by modifying the Docker
 
 ## Local Execution
 
+Note that if you make changes to the load test code, you must stop and remove the Docker containers and networks for changes to reflect.
+Do this by running `make load-tests-clean`.
+
 Follow the steps bellow to execute the load tests locally:
 
 ### Setup Environment
@@ -35,7 +38,8 @@ Follow the steps bellow to execute the load tests locally:
 
 The following environment variables as well as 
 [Locust environment variables][locust_environment_variables] can be set in 
-`tests\load\docker-compose.yml`:
+`tests\load\docker-compose.yml`.
+Make sure any required API key is added but then not checked into source control (i.e. `WIKIPEDIA__ES_API_KEY`).
 
 | Environment Variable                             | Node(s)         | Description                                                                               |
 |--------------------------------------------------|-----------------|-------------------------------------------------------------------------------------------|
@@ -69,7 +73,9 @@ make load-tests
       * Number of users: 35
       * Spawn rate: 1
       * Host: 'https://stagepy.merino.nonprod.cloudops.mozgcp.net' (Alternatively, such as when
-        profiling, point the host to a local instance of merino)
+        profiling, point the host to a local instance of merino. To access your host machine's instance
+        of merino from the load tests, you must use the functioning alias for `localhost`: `host.docker.internal:[service_port]`.
+        If running on port 8000, this would be: `http://host.docker.internal:8000`)
       * Duration (Optional): 10m
 * Select "Start Swarming"
 


### PR DESCRIPTION
## References

JIRA: [DISCO-2581](https://mozilla-hub.atlassian.net/browse/DISCO-2581)

## Description
Updates the following for load tests:
- Update the load-tests-clean command to match the contract tests, adding `docker rmi locust` to remove containers and networks when changes made to load test code
- Added local dev note to run `make load-tests-clean` between code changes.
- Added documentation on how to access host mach ine's merino instance through `host.docker.internal`
- Added context to requirement to add API key


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2581]: https://mozilla-hub.atlassian.net/browse/DISCO-2581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ