### PR TITLE
[DISCO-2534] Update to mypy 1.4.1 & Handle regressions and deprecated types [load test: abort]

### DIFF
--- a/merino/config_sentry.py
+++ b/merino/config_sentry.py
@@ -42,7 +42,6 @@ def strip_sensitive_data(event: dict, hint: dict) -> dict:
 
     try:
         for entry in event["exception"]["values"][0]["stacktrace"]["frames"]:
-
             if entry["vars"].get("q"):
                 entry["vars"]["q"] = ""
             if entry["vars"].get("query"):

--- a/merino/jobs/wikipedia_indexer/filemanager.py
+++ b/merino/jobs/wikipedia_indexer/filemanager.py
@@ -112,14 +112,14 @@ class FileManager:
         name = "{}/{}".format(self.object_prefix, dump_url.split("/")[-1])
         blob = self.client.bucket(self.gcs_bucket).blob(name, chunk_size=chunk_size)
         with requests.get(dump_url, stream=True) as resp:  # nosec
-            content_len = int(resp.headers.get("Content-Length", 0))  # type: ignore[attr-defined]
-            resp.raise_for_status()  # type: ignore[attr-defined]
+            content_len = int(resp.headers.get("Content-Length", 0))
+            resp.raise_for_status()
             logger.info("Writing to GCS: gs://{}/{}".format(self.gcs_bucket, blob.name))
             logger.info("Total File Size: {}".format(content_len))
             reporter = ProgressReporter(logger, "Copy", dump_url, name, content_len)
             writer: BlobWriter
             with blob.open("wb") as writer:
-                for chunk in resp.iter_content(chunk_size=chunk_size):  # type: ignore
+                for chunk in resp.iter_content(chunk_size=chunk_size):
                     completed = writer.write(chunk)
                     reporter.report(completed)
 

--- a/merino/providers/adm/backends/fake_backends.py
+++ b/merino/providers/adm/backends/fake_backends.py
@@ -8,4 +8,4 @@ class FakeAdmBackend:  # pragma: no cover
 
     async def fetch(self) -> SuggestionContent:
         """Get fake Content from partner."""
-        return SuggestionContent()
+        return SuggestionContent()  # type: ignore [call-arg]

--- a/merino/providers/adm/provider.py
+++ b/merino/providers/adm/provider.py
@@ -137,7 +137,7 @@ class Provider(BaseProvider):
             res = self.suggestion_content.results[results_id]
             is_sponsored = res.get("iab_category") == IABCategory.SHOPPING
 
-            suggestion_dict = {
+            suggestion_dict: dict[str, Any] = {
                 "block_id": res.get("id"),
                 "full_keyword": self.suggestion_content.full_keywords[fkw_id],
                 "title": res.get("title"),

--- a/merino/providers/amo/backends/dynamic.py
+++ b/merino/providers/amo/backends/dynamic.py
@@ -107,6 +107,6 @@ class DynamicAmoBackend:
             url=static_info["url"],
             icon=icon_and_rating["icon"],
             rating=icon_and_rating["rating"],
-            number_of_ratings=icon_and_rating["number_of_ratings"],
+            number_of_ratings=int(icon_and_rating["number_of_ratings"]),
             guid=static_info["guid"],
         )

--- a/merino/providers/amo/provider.py
+++ b/merino/providers/amo/provider.py
@@ -4,6 +4,8 @@ import logging
 import time
 from typing import Any, Literal
 
+from pydantic import HttpUrl
+
 from merino import cron
 from merino.config import settings
 from merino.providers.amo.addons_data import SupportedAddon
@@ -133,7 +135,7 @@ class Provider(BaseProvider):
             AddonSuggestion(
                 title=addon.name,
                 description=addon.description,
-                url=addon.url,
+                url=HttpUrl(addon.url),
                 score=self.score,
                 provider=self.name,
                 icon=addon.icon,

--- a/merino/providers/top_picks/backends/top_picks.py
+++ b/merino/providers/top_picks/backends/top_picks.py
@@ -18,7 +18,7 @@ class TopPicksBackend:
 
     def __init__(
         self,
-        top_picks_file_path: str,
+        top_picks_file_path: str | None,
         query_char_limit: int,
         firefox_char_limit: int,
     ) -> None:

--- a/merino/utils/log_data_creators.py
+++ b/merino/utils/log_data_creators.py
@@ -1,4 +1,4 @@
-"""A utility module for lag data creation"""
+"""A utility module for log data creation"""
 from datetime import datetime
 from typing import Any, Optional
 

--- a/merino/utils/log_data_creators.py
+++ b/merino/utils/log_data_creators.py
@@ -1,6 +1,6 @@
 """A utility module for log data creation"""
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any
 
 from pydantic import BaseModel, field_serializer
 from starlette.datastructures import Headers
@@ -31,8 +31,8 @@ class LogDataModel(BaseModel):
 class RequestSummaryLogDataModel(LogDataModel):
     """Log metadata specific to Request Summary."""
 
-    agent: Optional[str] = None
-    lang: Optional[str] = None
+    agent: str | None = None
+    lang: str | None = None
     querystring: dict[str, Any]
     code: int
 
@@ -41,17 +41,17 @@ class SuggestLogDataModel(LogDataModel):
     """Log metadata specific to Suggest logs."""
 
     sensitive: bool
-    query: Optional[str] = None
+    query: str | None = None
     code: int
     rid: str  # Provided by the asgi-correlation-id middleware.
-    session_id: Optional[str] = None
-    sequence_no: Optional[int] = None
+    session_id: str | None = None
+    sequence_no: int | None = None
     client_variants: str
     requested_providers: str
-    country: Optional[str] = None
-    region: Optional[str] = None
-    city: Optional[str] = None
-    dma: Optional[int] = None
+    country: str | None = None
+    region: str | None = None
+    city: str | None = None
+    dma: int | None = None
     browser: str
     os_family: str
     form_factor: str

--- a/merino/web/models_v1.py
+++ b/merino/web/models_v1.py
@@ -19,6 +19,6 @@ class SuggestResponse(BaseModel):
     # to a dictionary.  See Pydantic docs for context:
     # https://docs.pydantic.dev/latest/usage/serialization/#serializing-subclasses
     suggestions: list[SerializeAsAny[BaseSuggestion]]
-    request_id: str
+    request_id: str | None = None
     client_variants: list[str] = []
     server_variants: list[str] = []

--- a/poetry.lock
+++ b/poetry.lock
@@ -279,29 +279,40 @@ lxml = ["lxml"]
 
 [[package]]
 name = "black"
-version = "22.12.0"
+version = "23.7.0"
 description = "The uncompromising code formatter."
 category = "dev"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "black-22.12.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9eedd20838bd5d75b80c9f5487dbcb06836a43833a37846cf1d8c1cc01cef59d"},
-    {file = "black-22.12.0-cp310-cp310-win_amd64.whl", hash = "sha256:159a46a4947f73387b4d83e87ea006dbb2337eab6c879620a3ba52699b1f4351"},
-    {file = "black-22.12.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d30b212bffeb1e252b31dd269dfae69dd17e06d92b87ad26e23890f3efea366f"},
-    {file = "black-22.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:7412e75863aa5c5411886804678b7d083c7c28421210180d67dfd8cf1221e1f4"},
-    {file = "black-22.12.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c116eed0efb9ff870ded8b62fe9f28dd61ef6e9ddd28d83d7d264a38417dcee2"},
-    {file = "black-22.12.0-cp37-cp37m-win_amd64.whl", hash = "sha256:1f58cbe16dfe8c12b7434e50ff889fa479072096d79f0a7f25e4ab8e94cd8350"},
-    {file = "black-22.12.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77d86c9f3db9b1bf6761244bc0b3572a546f5fe37917a044e02f3166d5aafa7d"},
-    {file = "black-22.12.0-cp38-cp38-win_amd64.whl", hash = "sha256:82d9fe8fee3401e02e79767016b4907820a7dc28d70d137eb397b92ef3cc5bfc"},
-    {file = "black-22.12.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:101c69b23df9b44247bd88e1d7e90154336ac4992502d4197bdac35dd7ee3320"},
-    {file = "black-22.12.0-cp39-cp39-win_amd64.whl", hash = "sha256:559c7a1ba9a006226f09e4916060982fd27334ae1998e7a38b3f33a37f7a2148"},
-    {file = "black-22.12.0-py3-none-any.whl", hash = "sha256:436cc9167dd28040ad90d3b404aec22cedf24a6e4d7de221bec2730ec0c97bcf"},
-    {file = "black-22.12.0.tar.gz", hash = "sha256:229351e5a18ca30f447bf724d007f890f97e13af070bb6ad4c0a441cd7596a2f"},
+    {file = "black-23.7.0-cp310-cp310-macosx_10_16_arm64.whl", hash = "sha256:5c4bc552ab52f6c1c506ccae05681fab58c3f72d59ae6e6639e8885e94fe2587"},
+    {file = "black-23.7.0-cp310-cp310-macosx_10_16_universal2.whl", hash = "sha256:552513d5cd5694590d7ef6f46e1767a4df9af168d449ff767b13b084c020e63f"},
+    {file = "black-23.7.0-cp310-cp310-macosx_10_16_x86_64.whl", hash = "sha256:86cee259349b4448adb4ef9b204bb4467aae74a386bce85d56ba4f5dc0da27be"},
+    {file = "black-23.7.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:501387a9edcb75d7ae8a4412bb8749900386eaef258f1aefab18adddea1936bc"},
+    {file = "black-23.7.0-cp310-cp310-win_amd64.whl", hash = "sha256:fb074d8b213749fa1d077d630db0d5f8cc3b2ae63587ad4116e8a436e9bbe995"},
+    {file = "black-23.7.0-cp311-cp311-macosx_10_16_arm64.whl", hash = "sha256:b5b0ee6d96b345a8b420100b7d71ebfdd19fab5e8301aff48ec270042cd40ac2"},
+    {file = "black-23.7.0-cp311-cp311-macosx_10_16_universal2.whl", hash = "sha256:893695a76b140881531062d48476ebe4a48f5d1e9388177e175d76234ca247cd"},
+    {file = "black-23.7.0-cp311-cp311-macosx_10_16_x86_64.whl", hash = "sha256:c333286dc3ddca6fdff74670b911cccedacb4ef0a60b34e491b8a67c833b343a"},
+    {file = "black-23.7.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:831d8f54c3a8c8cf55f64d0422ee875eecac26f5f649fb6c1df65316b67c8926"},
+    {file = "black-23.7.0-cp311-cp311-win_amd64.whl", hash = "sha256:7f3bf2dec7d541b4619b8ce526bda74a6b0bffc480a163fed32eb8b3c9aed8ad"},
+    {file = "black-23.7.0-cp38-cp38-macosx_10_16_arm64.whl", hash = "sha256:f9062af71c59c004cd519e2fb8f5d25d39e46d3af011b41ab43b9c74e27e236f"},
+    {file = "black-23.7.0-cp38-cp38-macosx_10_16_universal2.whl", hash = "sha256:01ede61aac8c154b55f35301fac3e730baf0c9cf8120f65a9cd61a81cfb4a0c3"},
+    {file = "black-23.7.0-cp38-cp38-macosx_10_16_x86_64.whl", hash = "sha256:327a8c2550ddc573b51e2c352adb88143464bb9d92c10416feb86b0f5aee5ff6"},
+    {file = "black-23.7.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6d1c6022b86f83b632d06f2b02774134def5d4d4f1dac8bef16d90cda18ba28a"},
+    {file = "black-23.7.0-cp38-cp38-win_amd64.whl", hash = "sha256:27eb7a0c71604d5de083757fbdb245b1a4fae60e9596514c6ec497eb63f95320"},
+    {file = "black-23.7.0-cp39-cp39-macosx_10_16_arm64.whl", hash = "sha256:8417dbd2f57b5701492cd46edcecc4f9208dc75529bcf76c514864e48da867d9"},
+    {file = "black-23.7.0-cp39-cp39-macosx_10_16_universal2.whl", hash = "sha256:47e56d83aad53ca140da0af87678fb38e44fd6bc0af71eebab2d1f59b1acf1d3"},
+    {file = "black-23.7.0-cp39-cp39-macosx_10_16_x86_64.whl", hash = "sha256:25cc308838fe71f7065df53aedd20327969d05671bac95b38fdf37ebe70ac087"},
+    {file = "black-23.7.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:642496b675095d423f9b8448243336f8ec71c9d4d57ec17bf795b67f08132a91"},
+    {file = "black-23.7.0-cp39-cp39-win_amd64.whl", hash = "sha256:ad0014efc7acf0bd745792bd0d8857413652979200ab924fbf239062adc12491"},
+    {file = "black-23.7.0-py3-none-any.whl", hash = "sha256:9fd59d418c60c0348505f2ddf9609c1e1de8e7493eab96198fc89d9f865e7a96"},
+    {file = "black-23.7.0.tar.gz", hash = "sha256:022a582720b0d9480ed82576c920a8c1dde97cc38ff11d8d8859b3bd6ca9eedb"},
 ]
 
 [package.dependencies]
 click = ">=8.0.0"
 mypy-extensions = ">=0.4.3"
+packaging = ">=22.0"
 pathspec = ">=0.9.0"
 platformdirs = ">=2"
 
@@ -810,20 +821,20 @@ testing = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "diff-cover (>=7.5)", "p
 
 [[package]]
 name = "flake8"
-version = "4.0.1"
+version = "6.1.0"
 description = "the modular source code checker: pep8 pyflakes and co"
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.8.1"
 files = [
-    {file = "flake8-4.0.1-py2.py3-none-any.whl", hash = "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d"},
-    {file = "flake8-4.0.1.tar.gz", hash = "sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d"},
+    {file = "flake8-6.1.0-py2.py3-none-any.whl", hash = "sha256:ffdfce58ea94c6580c77888a86506937f9a1a227dfcd15f245d694ae20a6b6e5"},
+    {file = "flake8-6.1.0.tar.gz", hash = "sha256:d5b3857f07c030bdb5bf41c7f53799571d75c4491748a3adcd47de929e34cd23"},
 ]
 
 [package.dependencies]
-mccabe = ">=0.6.0,<0.7.0"
-pycodestyle = ">=2.8.0,<2.9.0"
-pyflakes = ">=2.4.0,<2.5.0"
+mccabe = ">=0.7.0,<0.8.0"
+pycodestyle = ">=2.11.0,<2.12.0"
+pyflakes = ">=3.1.0,<3.2.0"
 
 [[package]]
 name = "freezegun"
@@ -1553,14 +1564,14 @@ files = [
 
 [[package]]
 name = "mccabe"
-version = "0.6.1"
+version = "0.7.0"
 description = "McCabe checker, plugin for flake8"
 category = "dev"
 optional = false
-python-versions = "*"
+python-versions = ">=3.6"
 files = [
-    {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
-    {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
+    {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
+    {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
 ]
 
 [[package]]
@@ -1649,44 +1660,48 @@ files = [
 
 [[package]]
 name = "mypy"
-version = "0.971"
+version = "1.5.1"
 description = "Optional static typing for Python"
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.8"
 files = [
-    {file = "mypy-0.971-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:f2899a3cbd394da157194f913a931edfd4be5f274a88041c9dc2d9cdcb1c315c"},
-    {file = "mypy-0.971-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:98e02d56ebe93981c41211c05adb630d1d26c14195d04d95e49cd97dbc046dc5"},
-    {file = "mypy-0.971-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:19830b7dba7d5356d3e26e2427a2ec91c994cd92d983142cbd025ebe81d69cf3"},
-    {file = "mypy-0.971-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:02ef476f6dcb86e6f502ae39a16b93285fef97e7f1ff22932b657d1ef1f28655"},
-    {file = "mypy-0.971-cp310-cp310-win_amd64.whl", hash = "sha256:25c5750ba5609a0c7550b73a33deb314ecfb559c350bb050b655505e8aed4103"},
-    {file = "mypy-0.971-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:d3348e7eb2eea2472db611486846742d5d52d1290576de99d59edeb7cd4a42ca"},
-    {file = "mypy-0.971-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3fa7a477b9900be9b7dd4bab30a12759e5abe9586574ceb944bc29cddf8f0417"},
-    {file = "mypy-0.971-cp36-cp36m-win_amd64.whl", hash = "sha256:2ad53cf9c3adc43cf3bea0a7d01a2f2e86db9fe7596dfecb4496a5dda63cbb09"},
-    {file = "mypy-0.971-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:855048b6feb6dfe09d3353466004490b1872887150c5bb5caad7838b57328cc8"},
-    {file = "mypy-0.971-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:23488a14a83bca6e54402c2e6435467a4138785df93ec85aeff64c6170077fb0"},
-    {file = "mypy-0.971-cp37-cp37m-win_amd64.whl", hash = "sha256:4b21e5b1a70dfb972490035128f305c39bc4bc253f34e96a4adf9127cf943eb2"},
-    {file = "mypy-0.971-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:9796a2ba7b4b538649caa5cecd398d873f4022ed2333ffde58eaf604c4d2cb27"},
-    {file = "mypy-0.971-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:5a361d92635ad4ada1b1b2d3630fc2f53f2127d51cf2def9db83cba32e47c856"},
-    {file = "mypy-0.971-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:b793b899f7cf563b1e7044a5c97361196b938e92f0a4343a5d27966a53d2ec71"},
-    {file = "mypy-0.971-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:d1ea5d12c8e2d266b5fb8c7a5d2e9c0219fedfeb493b7ed60cd350322384ac27"},
-    {file = "mypy-0.971-cp38-cp38-win_amd64.whl", hash = "sha256:23c7ff43fff4b0df93a186581885c8512bc50fc4d4910e0f838e35d6bb6b5e58"},
-    {file = "mypy-0.971-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:1f7656b69974a6933e987ee8ffb951d836272d6c0f81d727f1d0e2696074d9e6"},
-    {file = "mypy-0.971-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d2022bfadb7a5c2ef410d6a7c9763188afdb7f3533f22a0a32be10d571ee4bbe"},
-    {file = "mypy-0.971-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ef943c72a786b0f8d90fd76e9b39ce81fb7171172daf84bf43eaf937e9f220a9"},
-    {file = "mypy-0.971-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:d744f72eb39f69312bc6c2abf8ff6656973120e2eb3f3ec4f758ed47e414a4bf"},
-    {file = "mypy-0.971-cp39-cp39-win_amd64.whl", hash = "sha256:77a514ea15d3007d33a9e2157b0ba9c267496acf12a7f2b9b9f8446337aac5b0"},
-    {file = "mypy-0.971-py3-none-any.whl", hash = "sha256:0d054ef16b071149917085f51f89555a576e2618d5d9dd70bd6eea6410af3ac9"},
-    {file = "mypy-0.971.tar.gz", hash = "sha256:40b0f21484238269ae6a57200c807d80debc6459d444c0489a102d7c6a75fa56"},
+    {file = "mypy-1.5.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f33592ddf9655a4894aef22d134de7393e95fcbdc2d15c1ab65828eee5c66c70"},
+    {file = "mypy-1.5.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:258b22210a4a258ccd077426c7a181d789d1121aca6db73a83f79372f5569ae0"},
+    {file = "mypy-1.5.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a9ec1f695f0c25986e6f7f8778e5ce61659063268836a38c951200c57479cc12"},
+    {file = "mypy-1.5.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:abed92d9c8f08643c7d831300b739562b0a6c9fcb028d211134fc9ab20ccad5d"},
+    {file = "mypy-1.5.1-cp310-cp310-win_amd64.whl", hash = "sha256:a156e6390944c265eb56afa67c74c0636f10283429171018446b732f1a05af25"},
+    {file = "mypy-1.5.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6ac9c21bfe7bc9f7f1b6fae441746e6a106e48fc9de530dea29e8cd37a2c0cc4"},
+    {file = "mypy-1.5.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:51cb1323064b1099e177098cb939eab2da42fea5d818d40113957ec954fc85f4"},
+    {file = "mypy-1.5.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:596fae69f2bfcb7305808c75c00f81fe2829b6236eadda536f00610ac5ec2243"},
+    {file = "mypy-1.5.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:32cb59609b0534f0bd67faebb6e022fe534bdb0e2ecab4290d683d248be1b275"},
+    {file = "mypy-1.5.1-cp311-cp311-win_amd64.whl", hash = "sha256:159aa9acb16086b79bbb0016145034a1a05360626046a929f84579ce1666b315"},
+    {file = "mypy-1.5.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:f6b0e77db9ff4fda74de7df13f30016a0a663928d669c9f2c057048ba44f09bb"},
+    {file = "mypy-1.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:26f71b535dfc158a71264e6dc805a9f8d2e60b67215ca0bfa26e2e1aa4d4d373"},
+    {file = "mypy-1.5.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2fc3a600f749b1008cc75e02b6fb3d4db8dbcca2d733030fe7a3b3502902f161"},
+    {file = "mypy-1.5.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:26fb32e4d4afa205b24bf645eddfbb36a1e17e995c5c99d6d00edb24b693406a"},
+    {file = "mypy-1.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:82cb6193de9bbb3844bab4c7cf80e6227d5225cc7625b068a06d005d861ad5f1"},
+    {file = "mypy-1.5.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:4a465ea2ca12804d5b34bb056be3a29dc47aea5973b892d0417c6a10a40b2d65"},
+    {file = "mypy-1.5.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:9fece120dbb041771a63eb95e4896791386fe287fefb2837258925b8326d6160"},
+    {file = "mypy-1.5.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d28ddc3e3dfeab553e743e532fb95b4e6afad51d4706dd22f28e1e5e664828d2"},
+    {file = "mypy-1.5.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:57b10c56016adce71fba6bc6e9fd45d8083f74361f629390c556738565af8eeb"},
+    {file = "mypy-1.5.1-cp38-cp38-win_amd64.whl", hash = "sha256:ff0cedc84184115202475bbb46dd99f8dcb87fe24d5d0ddfc0fe6b8575c88d2f"},
+    {file = "mypy-1.5.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:8f772942d372c8cbac575be99f9cc9d9fb3bd95c8bc2de6c01411e2c84ebca8a"},
+    {file = "mypy-1.5.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:5d627124700b92b6bbaa99f27cbe615c8ea7b3402960f6372ea7d65faf376c14"},
+    {file = "mypy-1.5.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:361da43c4f5a96173220eb53340ace68cda81845cd88218f8862dfb0adc8cddb"},
+    {file = "mypy-1.5.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:330857f9507c24de5c5724235e66858f8364a0693894342485e543f5b07c8693"},
+    {file = "mypy-1.5.1-cp39-cp39-win_amd64.whl", hash = "sha256:c543214ffdd422623e9fedd0869166c2f16affe4ba37463975043ef7d2ea8770"},
+    {file = "mypy-1.5.1-py3-none-any.whl", hash = "sha256:f757063a83970d67c444f6e01d9550a7402322af3557ce7630d3c957386fa8f5"},
+    {file = "mypy-1.5.1.tar.gz", hash = "sha256:b031b9601f1060bf1281feab89697324726ba0c0bae9d7cd7ab4b690940f0b92"},
 ]
 
 [package.dependencies]
-mypy-extensions = ">=0.4.3"
-typing-extensions = ">=3.10"
+mypy-extensions = ">=1.0.0"
+typing-extensions = ">=4.1.0"
 
 [package.extras]
 dmypy = ["psutil (>=4.0)"]
-python2 = ["typed-ast (>=1.4.0,<2)"]
+install-types = ["pip"]
 reports = ["lxml"]
 
 [[package]]
@@ -1953,14 +1968,14 @@ pyasn1 = ">=0.4.6,<0.6.0"
 
 [[package]]
 name = "pycodestyle"
-version = "2.8.0"
+version = "2.11.0"
 description = "Python style guide checker"
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = ">=3.8"
 files = [
-    {file = "pycodestyle-2.8.0-py2.py3-none-any.whl", hash = "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20"},
-    {file = "pycodestyle-2.8.0.tar.gz", hash = "sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f"},
+    {file = "pycodestyle-2.11.0-py2.py3-none-any.whl", hash = "sha256:5d1013ba8dc7895b548be5afb05740ca82454fd899971563d2ef625d090326f8"},
+    {file = "pycodestyle-2.11.0.tar.gz", hash = "sha256:259bcc17857d8a8b3b4a2327324b79e5f020a13c16074670f9c8c8f872ea76d0"},
 ]
 
 [[package]]
@@ -2129,14 +2144,14 @@ toml = ["tomli (>=1.2.3)"]
 
 [[package]]
 name = "pyflakes"
-version = "2.4.0"
+version = "3.1.0"
 description = "passive checker of Python programs"
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=3.8"
 files = [
-    {file = "pyflakes-2.4.0-py2.py3-none-any.whl", hash = "sha256:3bb3a3f256f4b7968c9c788781e4ff07dce46bdf12339dcda61053375426ee2e"},
-    {file = "pyflakes-2.4.0.tar.gz", hash = "sha256:05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c"},
+    {file = "pyflakes-3.1.0-py2.py3-none-any.whl", hash = "sha256:4132f6d49cb4dae6819e5379898f2b8cce3c5f23994194c24b77d5da2e36f774"},
+    {file = "pyflakes-3.1.0.tar.gz", hash = "sha256:a0aae034c444db0071aa077972ba4768d40c830d9539fd45bf4cd3f8f6992efc"},
 ]
 
 [[package]]
@@ -3270,4 +3285,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "9457fff9d28f0e70594a1ae42ce5d76f249ca829ab51858dcf899beb1a171465"
+content-hash = "afba377a6cfcc80d1fd45b55ba20175cd6634b4c5ea52abc3484e133dea6f73a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,13 +86,13 @@ types-python-dateutil = "^2.8.19.13"
 pydantic = "^2.1.0"
 
 [tool.poetry.dev-dependencies]
-black = "^22.6.0"
-flake8 = "^4.0.1"
+black = "^23.7.0"
+flake8 = "^6.1.0"
 isort = "^5.10.1"
 pydocstyle = "^6.1.1"
-mypy = "^0.971"
+mypy = "^1.5"
 pre-commit = "^2.20.0"
-bandit = {extras = ["toml"], version = "^1.7.4"}
+bandit = {extras = ["toml"], version = "^1.7.5"}
 types-PyYAML = "^6.0.11"
 types-requests = "^2.28.10"
 types-geoip2 = "^3.0.0"

--- a/tests/contract/client/tests/test_merino.py
+++ b/tests/contract/client/tests/test_merino.py
@@ -121,7 +121,7 @@ def fixture_merino_step(
 
             if (
                 step.request.path == "/__version__"
-                and type(step.response.content) == VersionResponseContent
+                and type(step.response.content) is VersionResponseContent
             ):
                 assert_200_version_endpoint_response(
                     step_content=step.response.content,

--- a/tests/contract/client/tests/test_merino.py
+++ b/tests/contract/client/tests/test_merino.py
@@ -131,7 +131,7 @@ def fixture_merino_step(
             else:
                 assert_200_response(
                     # type ignored to appease mypy, does not infer 2 possible types.
-                    step_content=step.response.content,  # type: ignore
+                    step_content=step.response.content,
                     merino_content=ResponseContent(**response.json()),
                     fetch_kinto_icon_url=fetch_kinto_icon_url,
                 )

--- a/tests/integration/api/test_error.py
+++ b/tests/integration/api/test_error.py
@@ -3,8 +3,8 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """Integration tests for the Merino __error__ API endpoint."""
-
 import logging
+from datetime import datetime
 from logging import LogRecord
 
 import aiodogstatsd
@@ -55,7 +55,7 @@ def test_error_request_log_data(
         querystring={},
         errno=0,
         code=500,
-        time="1998-03-31T00:00:00",
+        time=datetime(1998, 3, 31),
     )
 
     client.get(

--- a/tests/integration/api/test_heartbeat.py
+++ b/tests/integration/api/test_heartbeat.py
@@ -3,8 +3,8 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """Integration tests for the Merino __heartbeat__ and __lbheartbeat__ API endpoints."""
-
 import logging
+from datetime import datetime
 from logging import LogRecord
 
 import pytest
@@ -50,7 +50,7 @@ def test_heartbeat_request_log_data(
         querystring={},
         errno=0,
         code=200,
-        time="1998-03-31T00:00:00",
+        time=datetime(1998, 3, 31),
     )
 
     client.get(

--- a/tests/integration/api/test_version.py
+++ b/tests/integration/api/test_version.py
@@ -3,9 +3,9 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """Integration tests for the Merino __version__ API endpoint."""
-
 import logging
 import pathlib
+from datetime import datetime
 from logging import LogRecord
 
 from fastapi.testclient import TestClient
@@ -65,7 +65,7 @@ def test_version_request_log_data(
         querystring={},
         errno=0,
         code=200,
-        time="1998-03-31T00:00:00",
+        time=datetime(1998, 3, 31),
     )
 
     client.get(

--- a/tests/integration/api/v1/fake_providers.py
+++ b/tests/integration/api/v1/fake_providers.py
@@ -7,6 +7,8 @@
 import asyncio
 from typing import Protocol
 
+from pydantic import HttpUrl
+
 from merino.config import settings
 from merino.providers import BaseProvider
 from merino.providers.base import BaseSuggestion, SuggestionRequest
@@ -34,8 +36,8 @@ class SponsoredSuggestion(BaseSuggestion):
     block_id: int
     full_keyword: str
     advertiser: str
-    impression_url: str
-    click_url: str
+    impression_url: HttpUrl | None = None
+    click_url: HttpUrl | None = None
 
 
 def query_nonsponsored(provider_name: str) -> QueryCallable:
@@ -49,7 +51,7 @@ def query_nonsponsored(provider_name: str) -> QueryCallable:
                     block_id=0,
                     full_keyword="nonsponsored",
                     title="nonsponsored title",
-                    url="https://www.nonsponsored.com",
+                    url=HttpUrl("https://www.nonsponsored.com"),
                     provider=provider_name,
                     advertiser="test nonadvertiser",
                     is_sponsored=False,
@@ -74,9 +76,9 @@ def query_sponsored(provider_name: str) -> QueryCallable:
                     block_id=0,
                     full_keyword="sponsored",
                     title="sponsored title",
-                    url="https://www.sponsored.com",
-                    impression_url="https://www.sponsoredimpression.com",
-                    click_url="https://www.sponsoredclick.com",
+                    url=HttpUrl("https://www.sponsored.com"),
+                    impression_url=HttpUrl("https://www.sponsoredimpression.com"),
+                    click_url=HttpUrl("https://www.sponsoredclick.com"),
                     provider=provider_name,
                     advertiser="test advertiser",
                     is_sponsored=True,

--- a/tests/integration/api/v1/providers/test_providers.py
+++ b/tests/integration/api/v1/providers/test_providers.py
@@ -3,8 +3,8 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """Integration tests for the Merino v1 providers API endpoint."""
-
 import logging
+from datetime import datetime
 from logging import LogRecord
 
 import pytest
@@ -108,7 +108,7 @@ def test_providers_request_log_data(
         querystring={},
         errno=0,
         code=200,
-        time="1998-03-31T00:00:00",
+        time=datetime(1998, 3, 31),
     )
 
     client.get(

--- a/tests/integration/api/v1/suggest/test_suggest.py
+++ b/tests/integration/api/v1/suggest/test_suggest.py
@@ -3,8 +3,8 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """Integration tests for the Merino v1 suggest API endpoint."""
-
 import logging
+from datetime import datetime
 
 import aiodogstatsd
 import pytest
@@ -250,7 +250,7 @@ def test_suggest_request_log_data(
     expected_log_data: SuggestLogDataModel = SuggestLogDataModel(
         sensitive=True,
         errno=0,
-        time="1998-03-31T00:00:00",
+        time=datetime(1998, 3, 31),
         path="/api/v1/suggest",
         method="GET",
         query="nope",

--- a/tests/integration/api/v1/suggest/test_suggest.py
+++ b/tests/integration/api/v1/suggest/test_suggest.py
@@ -142,8 +142,8 @@ def test_suggest_default_wildcard_providers(client: TestClient, query: str) -> N
 def test_suggest_default_wildcard_providers_and_additional_provider(
     client: TestClient, query: str
 ) -> None:
-    """Test that `default` wildcard provider parameter plus an added parameter for disabled provider
-    returns suggestions from all passed in providers.
+    """Test that `default` wildcard provider parameter plus an added parameter
+    for disabled provider returns suggestions from all passed in providers.
     """
     response = client.get(f"/api/v1/suggest?q={query}&providers=default,top_picks")
     assert response.status_code == 200

--- a/tests/integration/api/v1/suggest/test_suggest_top_picks.py
+++ b/tests/integration/api/v1/suggest/test_suggest_top_picks.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import pytest
 from fastapi.testclient import TestClient
+from pydantic import HttpUrl
 
 from merino.config import settings
 from merino.providers.top_picks.backends.top_picks import TopPicksBackend
@@ -62,7 +63,7 @@ def test_top_picks_query(client: TestClient, query: str) -> None:
         Suggestion(
             block_id=0,
             title="Example",
-            url="https://example.com",
+            url=HttpUrl("https://example.com"),
             provider="top_picks",
             is_top_pick=True,
             is_sponsored=False,
@@ -112,7 +113,7 @@ def test_top_picks_short_domains(
         Suggestion(
             block_id=0,
             title=title,
-            url=url,
+            url=HttpUrl(url),
             provider="top_picks",
             is_top_pick=True,
             is_sponsored=False,

--- a/tests/integration/api/v1/suggest/test_suggest_weather.py
+++ b/tests/integration/api/v1/suggest/test_suggest_weather.py
@@ -12,7 +12,7 @@ from typing import Any
 import pytest
 from fastapi.testclient import TestClient
 from freezegun import freeze_time
-from pydantic import TypeAdapter
+from pydantic import HttpUrl, TypeAdapter
 from pytest import LogCaptureFixture
 from pytest_mock import MockerFixture
 
@@ -60,7 +60,7 @@ def test_suggest_with_weather_report(client: TestClient, backend_mock: Any) -> N
     weather_report: WeatherReport = WeatherReport(
         city_name="Milton",
         current_conditions=CurrentConditions(
-            url=(
+            url=HttpUrl(
                 "http://www.accuweather.com/en/us/milton-wa/98354/current-weather/"
                 "41512_pc?lang=en-us"
             ),
@@ -69,7 +69,7 @@ def test_suggest_with_weather_report(client: TestClient, backend_mock: Any) -> N
             temperature=Temperature(c=-3.0, f=27.0),
         ),
         forecast=Forecast(
-            url=(
+            url=HttpUrl(
                 "http://www.accuweather.com/en/us/milton-wa/98354/"
                 "daily-weather-forecast/41512_pc?lang=en-us"
             ),
@@ -84,7 +84,7 @@ def test_suggest_with_weather_report(client: TestClient, backend_mock: Any) -> N
     expected_suggestion: list[Suggestion] = [
         Suggestion(
             title="Weather for Milton",
-            url=(
+            url=HttpUrl(
                 "http://www.accuweather.com/en/us/milton-wa/98354/current-weather/"
                 "41512_pc?lang=en-us"
             ),

--- a/tests/integration/api/v1/suggest/test_suggest_weather.py
+++ b/tests/integration/api/v1/suggest/test_suggest_weather.py
@@ -6,6 +6,7 @@
 provider.
 """
 import logging
+from datetime import datetime
 from logging import LogRecord
 from typing import Any
 
@@ -169,7 +170,7 @@ def test_providers_request_log_data_weather(
         querystring={"providers": "accuweather", "q": ""},
         errno=0,
         code=200,
-        time="1998-03-31T00:00:00",
+        time=datetime(1998, 3, 31),
     )
 
     client.get("/api/v1/suggest?providers=accuweather&q=")

--- a/tests/integration/api/v1/test_unsupported.py
+++ b/tests/integration/api/v1/test_unsupported.py
@@ -3,8 +3,8 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """Integration tests for unsupported Merino v1 API endpoints."""
-
 import logging
+from datetime import datetime
 from logging import LogRecord
 
 import aiodogstatsd
@@ -43,7 +43,7 @@ def test_unsupported_endpoint_request_log_data(
         querystring={},
         errno=0,
         code=404,
-        time="1998-03-31T00:00:00",
+        time=datetime(1998, 3, 31),
     )
 
     client.get(

--- a/tests/load/locustfiles/load.py
+++ b/tests/load/locustfiles/load.py
@@ -57,6 +57,6 @@ class MerinoLoadTestShape(LoadTestShape):
             None: Instruction to stop the load test
         """
         for stage in self.stages:
-            if self.get_run_time() < stage.run_time:
+            if self.get_run_time() < stage.run_time:  # type: ignore [no-untyped-call]
                 return stage.users, stage.spawn_rate, stage.user_classes
         return None

--- a/tests/load/locustfiles/load.py
+++ b/tests/load/locustfiles/load.py
@@ -30,7 +30,7 @@ class MerinoLoadTestShape(LoadTestShape):
 
     stages: list[ShapeStage]
 
-    def __init__(self):
+    def __init__(self) -> None:
         super(LoadTestShape, self).__init__()
 
         spawn_rate: float = round(self.USERS / 60, 2)
@@ -57,6 +57,6 @@ class MerinoLoadTestShape(LoadTestShape):
             None: Instruction to stop the load test
         """
         for stage in self.stages:
-            if self.get_run_time() < stage.run_time:  # type: ignore [no-untyped-call]
+            if self.get_run_time() < stage.run_time:
                 return stage.users, stage.spawn_rate, stage.user_classes
         return None

--- a/tests/load/locustfiles/locustfile.py
+++ b/tests/load/locustfiles/locustfile.py
@@ -454,7 +454,6 @@ class MerinoUser(HttpUser):
             # group all requests under the 'name' entry
             name=f"{SUGGEST_API}{(f'?providers={providers}' if providers else '')}",
         ) as response:
-
             if response.status_code == 0:
                 # Do not classify as failure
                 #

--- a/tests/load/locustfiles/locustfile.py
+++ b/tests/load/locustfiles/locustfile.py
@@ -102,7 +102,7 @@ WIKIPEDIA_QUERIES: list[str] = []
 
 
 @events.test_start.add_listener
-def on_locust_test_start(environment, **kwargs):
+def on_locust_test_start(environment, **kwargs) -> None:
     """Download suggestions from Kinto and store suggestions on workers."""
     if not isinstance(environment.runner, MasterRunner):
         return
@@ -162,7 +162,9 @@ def on_locust_test_start(environment, **kwargs):
         )
 
 
-def get_adm_queries(server: str, collection: str, bucket: str) -> QueriesList:
+def get_adm_queries(
+    server: str | None, collection: str | None, bucket: str | None
+) -> QueriesList:
     """Get query strings for use in testing the AdM Provider.
 
     Args:
@@ -198,7 +200,7 @@ def get_amo_queries() -> list[str]:
 
 
 def get_top_picks_queries(
-    top_picks_file_path: str, query_char_limit: int, firefox_char_limit: int
+    top_picks_file_path: str | None, query_char_limit: int, firefox_char_limit: int
 ) -> QueriesList:
     """Get query strings for use in testing the Top Picks Provider.
 
@@ -283,7 +285,7 @@ def get_ip_ranges(ip_range_files: list[str]) -> IpRangeList:
     return ip_ranges
 
 
-def store_suggestions(environment, msg, **kwargs):
+def store_suggestions(environment, msg, **kwargs) -> None:
     """Modify the module scoped list with suggestions in-place."""
     logger.info("store_suggestions: Storing %d suggestions", len(msg.data))
 
@@ -316,10 +318,10 @@ class QueryData(BaseModel):
 class MerinoUser(HttpUser):
     """User that sends requests to the Merino API."""
 
-    def on_start(self):
+    def on_start(self) -> Any:
         """Instructions to execute for each simulated user when they start."""
         # Check that the Merino 'Host' is available
-        version: Version = self._request_version()
+        version: Version | None = self._request_version()
         if not version:
             logger.error(
                 "The Merino version information was unavailable. Verify that "
@@ -341,7 +343,7 @@ class MerinoUser(HttpUser):
             f"wikipedia: {len(WIKIPEDIA_QUERIES)}"
         )
 
-        return super().on_start()
+        return super().on_start()  # type: ignore [no-untyped-call]
 
     @task(weight=2)
     def adm_suggestions(self) -> None:

--- a/tests/load/locustfiles/locustfile.py
+++ b/tests/load/locustfiles/locustfile.py
@@ -110,9 +110,9 @@ def on_locust_test_start(environment, **kwargs) -> None:
     query_data: QueryData = QueryData()
     try:
         query_data.adm = get_adm_queries(
-            server=MERINO_REMOTE_SETTINGS__SERVER,
-            collection=MERINO_REMOTE_SETTINGS__COLLECTION,
-            bucket=MERINO_REMOTE_SETTINGS__BUCKET,
+            server=MERINO_REMOTE_SETTINGS__SERVER,  # type: ignore [arg-type]
+            collection=MERINO_REMOTE_SETTINGS__COLLECTION,  # type: ignore [arg-type]
+            bucket=MERINO_REMOTE_SETTINGS__BUCKET,  # type: ignore [arg-type]
         )
 
         logger.info(f"Download {len(query_data.adm)} queries for AdM")
@@ -122,7 +122,7 @@ def on_locust_test_start(environment, **kwargs) -> None:
         logger.info(f"Download {len(query_data.amo)} queries for AMO")
 
         query_data.top_picks = get_top_picks_queries(
-            top_picks_file_path=MERINO_PROVIDERS__TOP_PICKS__TOP_PICKS_FILE_PATH,
+            top_picks_file_path=MERINO_PROVIDERS__TOP_PICKS__TOP_PICKS_FILE_PATH,  # type: ignore
             query_char_limit=MERINO_PROVIDERS__TOP_PICKS__QUERY_CHAR_LIMIT,
             firefox_char_limit=MERINO_PROVIDERS__TOP_PICKS__FIREFOX_CHAR_LIMIT,
         )
@@ -162,9 +162,7 @@ def on_locust_test_start(environment, **kwargs) -> None:
         )
 
 
-def get_adm_queries(
-    server: str | None, collection: str | None, bucket: str | None
-) -> QueriesList:
+def get_adm_queries(server: str, collection: str, bucket: str) -> QueriesList:
     """Get query strings for use in testing the AdM Provider.
 
     Args:
@@ -200,7 +198,7 @@ def get_amo_queries() -> list[str]:
 
 
 def get_top_picks_queries(
-    top_picks_file_path: str | None, query_char_limit: int, firefox_char_limit: int
+    top_picks_file_path: str, query_char_limit: int, firefox_char_limit: int
 ) -> QueriesList:
     """Get query strings for use in testing the Top Picks Provider.
 
@@ -343,7 +341,7 @@ class MerinoUser(HttpUser):
             f"wikipedia: {len(WIKIPEDIA_QUERIES)}"
         )
 
-        return super().on_start()  # type: ignore [no-untyped-call]
+        return super().on_start()
 
     @task(weight=2)
     def adm_suggestions(self) -> None:

--- a/tests/load/locustfiles/locustfile.py
+++ b/tests/load/locustfiles/locustfile.py
@@ -82,14 +82,14 @@ MERINO_PROVIDERS__WIKIPEDIA__ES_API_KEY: str | None = os.getenv(
 MERINO_PROVIDERS__WIKIPEDIA__ES_INDEX: str | None = os.getenv(
     "MERINO_PROVIDERS__WIKIPEDIA__ES_INDEX"
 )
-MERINO_REMOTE_SETTINGS__SERVER: str | None = os.getenv(
-    "MERINO_REMOTE_SETTINGS__SERVER", os.getenv("KINTO__SERVER_URL")
+MERINO_REMOTE_SETTINGS__SERVER: str = os.getenv(
+    "MERINO_REMOTE_SETTINGS__SERVER", default=os.environ["KINTO__SERVER_URL"]
 )
-MERINO_REMOTE_SETTINGS__BUCKET: str | None = os.getenv(
-    "MERINO_REMOTE_SETTINGS__BUCKET", os.getenv("KINTO__BUCKET")
+MERINO_REMOTE_SETTINGS__BUCKET: str = os.getenv(
+    "MERINO_REMOTE_SETTINGS__BUCKET", default=os.environ["KINTO__BUCKET"]
 )
-MERINO_REMOTE_SETTINGS__COLLECTION: str | None = os.getenv(
-    "MERINO_REMOTE_SETTINGS__COLLECTION", os.getenv("KINTO__COLLECTION")
+MERINO_REMOTE_SETTINGS__COLLECTION: str = os.getenv(
+    "MERINO_REMOTE_SETTINGS__COLLECTION", default=os.environ["KINTO__COLLECTION"]
 )
 
 
@@ -110,9 +110,9 @@ def on_locust_test_start(environment, **kwargs) -> None:
     query_data: QueryData = QueryData()
     try:
         query_data.adm = get_adm_queries(
-            server=MERINO_REMOTE_SETTINGS__SERVER,  # type: ignore [arg-type]
-            collection=MERINO_REMOTE_SETTINGS__COLLECTION,  # type: ignore [arg-type]
-            bucket=MERINO_REMOTE_SETTINGS__BUCKET,  # type: ignore [arg-type]
+            server=MERINO_REMOTE_SETTINGS__SERVER,
+            collection=MERINO_REMOTE_SETTINGS__COLLECTION,
+            bucket=MERINO_REMOTE_SETTINGS__BUCKET,
         )
 
         logger.info(f"Download {len(query_data.adm)} queries for AdM")
@@ -122,7 +122,7 @@ def on_locust_test_start(environment, **kwargs) -> None:
         logger.info(f"Download {len(query_data.amo)} queries for AMO")
 
         query_data.top_picks = get_top_picks_queries(
-            top_picks_file_path=MERINO_PROVIDERS__TOP_PICKS__TOP_PICKS_FILE_PATH,  # type: ignore
+            top_picks_file_path=MERINO_PROVIDERS__TOP_PICKS__TOP_PICKS_FILE_PATH,
             query_char_limit=MERINO_PROVIDERS__TOP_PICKS__QUERY_CHAR_LIMIT,
             firefox_char_limit=MERINO_PROVIDERS__TOP_PICKS__FIREFOX_CHAR_LIMIT,
         )
@@ -198,7 +198,7 @@ def get_amo_queries() -> list[str]:
 
 
 def get_top_picks_queries(
-    top_picks_file_path: str, query_char_limit: int, firefox_char_limit: int
+    top_picks_file_path: str | None, query_char_limit: int, firefox_char_limit: int
 ) -> QueriesList:
     """Get query strings for use in testing the Top Picks Provider.
 

--- a/tests/unit/jobs/navigational_suggestions/test_domain_metadata_uploader.py
+++ b/tests/unit/jobs/navigational_suggestions/test_domain_metadata_uploader.py
@@ -22,7 +22,7 @@ def mock_gcs_client(mocker):
 
 
 @pytest.fixture
-def mock_favicon_downloader(mocker):
+def mock_favicon_downloader(mocker) -> Any:
     """Return a mock FaviconDownloader instance"""
     favicon_downloader_mock: Any = mocker.Mock(spec=FaviconDownloader)
     favicon_downloader_mock.download_favicon.return_value = FaviconImage(
@@ -31,14 +31,18 @@ def mock_favicon_downloader(mocker):
     return favicon_downloader_mock
 
 
-def test_upload_top_picks(mock_gcs_client, mock_favicon_downloader):
+def test_upload_top_picks(mock_gcs_client, mock_favicon_downloader) -> None:
     """Test if upload top picks call relevant GCS api"""
     DUMMY_TOP_PICKS = "dummy top picks contents"
     mock_gcs_bucket = mock_gcs_client.bucket.return_value
     mock_dst_blob = mock_gcs_bucket.blob.return_value
 
     domain_metadata_uploader = DomainMetadataUploader(
-        "dummy_gcp_project", "dummy_gcs_bucket", None, False, mock_favicon_downloader
+        destination_gcp_project="dummy_gcp_project",
+        destination_bucket_name="dummy_gcs_bucket",
+        destination_cdn_hostname="",
+        force_upload=False,
+        favicon_downloader=mock_favicon_downloader,
     )
     domain_metadata_uploader.upload_top_picks(DUMMY_TOP_PICKS)
 
@@ -49,7 +53,7 @@ def test_upload_top_picks(mock_gcs_client, mock_favicon_downloader):
 
 def test_upload_favicons_upload_if_not_present(
     mock_gcs_client, mock_favicon_downloader
-):
+) -> None:
     """Test that favicons are uploaded only if not already present in GCS when
     force upload is not set
     """
@@ -61,11 +65,11 @@ def test_upload_favicons_upload_if_not_present(
     mock_dst_blob.public_url = UPLOADED_FAVICON_PUBLIC_URL
 
     domain_metadata_uploader = DomainMetadataUploader(
-        "dummy_gcp_project",
-        "dummy_gcs_bucket",
-        None,
-        FORCE_UPLOAD,
-        mock_favicon_downloader,
+        destination_gcp_project="dummy_gcp_project",
+        destination_bucket_name="dummy_gcs_bucket",
+        destination_cdn_hostname="",
+        force_upload=FORCE_UPLOAD,
+        favicon_downloader=mock_favicon_downloader,
     )
     uploaded_favicons = domain_metadata_uploader.upload_favicons(["favicon1.png"])
 
@@ -78,18 +82,18 @@ def test_upload_favicons_upload_if_not_present(
 
 def test_upload_favicons_upload_if_force_upload_set(
     mock_gcs_client, mock_favicon_downloader
-):
+) -> None:
     """Test that favicons are uploaded always when force upload is set"""
     FORCE_UPLOAD: bool = True
     mock_dst_blob = mock_gcs_client.bucket.return_value.blob.return_value
     mock_dst_blob.exists.return_value = True
 
     domain_metadata_uploader = DomainMetadataUploader(
-        "dummy_gcp_project",
-        "dummy_gcs_bucket",
-        None,
-        FORCE_UPLOAD,
-        mock_favicon_downloader,
+        destination_gcp_project="dummy_gcp_project",
+        destination_bucket_name="dummy_gcs_bucket",
+        destination_cdn_hostname="",
+        force_upload=FORCE_UPLOAD,
+        favicon_downloader=mock_favicon_downloader,
     )
     domain_metadata_uploader.upload_favicons(["favicon1.png"])
 
@@ -101,7 +105,7 @@ def test_upload_favicons_upload_if_force_upload_set(
 
 def test_upload_favicons_return_favicon_with_cdnhostname_when_provided(
     mock_gcs_client, mock_favicon_downloader
-):
+) -> None:
     """Test if uploaded favicon url has cdn hostname when provided"""
     CDN_HOSTNAME = "dummy.cdn.hostname"
 
@@ -109,11 +113,11 @@ def test_upload_favicons_return_favicon_with_cdnhostname_when_provided(
     mock_dst_blob.exists.return_value = True
 
     domain_metadata_uploader = DomainMetadataUploader(
-        "dummy_gcp_project",
-        "dummy_gcs_bucket",
-        CDN_HOSTNAME,
-        False,
-        mock_favicon_downloader,
+        destination_gcp_project="dummy_gcp_project",
+        destination_bucket_name="dummy_gcs_bucket",
+        destination_cdn_hostname=CDN_HOSTNAME,
+        force_upload=False,
+        favicon_downloader=mock_favicon_downloader,
     )
     uploaded_favicons = domain_metadata_uploader.upload_favicons(["favicon1.png"])
 
@@ -124,14 +128,18 @@ def test_upload_favicons_return_favicon_with_cdnhostname_when_provided(
 
 def test_upload_favicons_return_empty_url_for_failed_favicon_download(
     mock_gcs_client, mock_favicon_downloader
-):
+) -> None:
     """Test if a failure in downloading favicon from the scraped url returns an empty
     uploaded favicon url
     """
     mock_favicon_downloader.download_favicon.return_value = None
 
     domain_metadata_uploader = DomainMetadataUploader(
-        "dummy_gcp_project", "dummy_gcs_bucket", None, False, mock_favicon_downloader
+        destination_gcp_project="dummy_gcp_project",
+        destination_bucket_name="dummy_gcs_bucket",
+        destination_cdn_hostname="",
+        force_upload=False,
+        favicon_downloader=mock_favicon_downloader,
     )
     uploaded_favicons = domain_metadata_uploader.upload_favicons(["favicon1.png"])
 

--- a/tests/unit/providers/adm/test_provider.py
+++ b/tests/unit/providers/adm/test_provider.py
@@ -7,6 +7,7 @@
 from typing import Any
 
 import pytest
+from pydantic import HttpUrl
 from pytest import LogCaptureFixture
 
 from merino.providers.adm.backends.protocol import SuggestionContent
@@ -123,9 +124,9 @@ async def test_query_success(
             block_id=2,
             full_keyword="firefox accounts",
             title="Mozilla Firefox Accounts",
-            url="https://example.org/target/mozfirefoxaccounts",
-            impression_url="https://example.org/impression/mozilla",
-            click_url="https://example.org/click/mozilla",
+            url=HttpUrl("https://example.org/target/mozfirefoxaccounts"),
+            impression_url=HttpUrl("https://example.org/impression/mozilla"),
+            click_url=HttpUrl("https://example.org/click/mozilla"),
             provider="adm",
             advertiser="Example.org",
             is_sponsored=False,

--- a/tests/unit/providers/amo/backends/test_static.py
+++ b/tests/unit/providers/amo/backends/test_static.py
@@ -1,4 +1,6 @@
 """Test StaticAddonsBackend."""
+from typing import Any
+
 import pytest
 
 from merino.providers.amo.addons_data import ADDON_DATA, SupportedAddon
@@ -19,8 +21,10 @@ def fixture_static_backend() -> StaticAmoBackend:
 async def test_get_addon_success(static_backend: StaticAmoBackend):
     """Test that we can get Addon information statically."""
     addons = await static_backend.get_addon(SupportedAddon.VIDEO_DOWNLOADER)
-    video_downloader = ADDON_DATA[SupportedAddon.VIDEO_DOWNLOADER]
-    vd_icon_rating = STATIC_RATING_AND_ICONS[SupportedAddon.VIDEO_DOWNLOADER]
+    video_downloader: dict[str, str] = ADDON_DATA[SupportedAddon.VIDEO_DOWNLOADER]
+    vd_icon_rating: dict[str, Any] = STATIC_RATING_AND_ICONS[
+        SupportedAddon.VIDEO_DOWNLOADER
+    ]
     assert (
         Addon(
             name=video_downloader["name"],

--- a/tests/unit/providers/amo/test_provider.py
+++ b/tests/unit/providers/amo/test_provider.py
@@ -1,10 +1,12 @@
 """Test Addon Provider"""
 import datetime
 import time
+from typing import Any
 
 import freezegun
 import pytest
 from _pytest.logging import LogCaptureFixture
+from pydantic import HttpUrl
 
 from merino.middleware.geolocation import Location
 from merino.providers.amo.addons_data import ADDON_DATA, SupportedAddon
@@ -124,13 +126,15 @@ async def test_query_return_match(
     await addons_provider.initialize()
 
     req = SuggestionRequest(query="dictionary", geolocation=Location())
-    expected_info = ADDON_DATA[SupportedAddon.LANGAUGE_TOOL]
-    expected_icon_rating = STATIC_RATING_AND_ICONS[SupportedAddon.LANGAUGE_TOOL]
+    expected_info: dict[str, str] = ADDON_DATA[SupportedAddon.LANGAUGE_TOOL]
+    expected_icon_rating: dict[str, Any] = STATIC_RATING_AND_ICONS[
+        SupportedAddon.LANGAUGE_TOOL
+    ]
     assert [
         AddonSuggestion(
             title=expected_info["name"],
             description=expected_info["description"],
-            url=expected_info["url"],
+            url=HttpUrl(expected_info["url"]),
             score=0.3,
             provider="amo",
             icon=expected_icon_rating["icon"],

--- a/tests/unit/providers/top_picks/backends/test_top_picks.py
+++ b/tests/unit/providers/top_picks/backends/test_top_picks.py
@@ -31,7 +31,7 @@ def fixture_top_picks(top_picks_backend_parameters: dict[str, Any]) -> TopPicksB
 
 def test_init_failure_no_domain_file(
     top_picks_backend_parameters: dict[str, Any]
-) -> TopPicksBackend:
+) -> None:
     """Test exception handling for the __init__() method when no domain file provided."""
     top_picks_backend_parameters["top_picks_file_path"] = None
     with pytest.raises(ValueError):

--- a/tests/unit/providers/top_picks/test_provider.py
+++ b/tests/unit/providers/top_picks/test_provider.py
@@ -5,6 +5,7 @@
 """Unit tests for the top picks provider module."""
 
 import pytest
+from pydantic import HttpUrl
 from pytest import LogCaptureFixture
 
 from merino.config import settings
@@ -32,9 +33,9 @@ def test_hidden(top_picks: Provider) -> None:
 async def test_initialize(top_picks: Provider, backend: TopPicksBackend) -> None:
     """Test initialization of top pick provider"""
     await top_picks.initialize()
-    backend = await backend.fetch()
+    backend_data = await backend.fetch()
 
-    assert top_picks.top_picks_data == backend
+    assert top_picks.top_picks_data == backend_data
 
 
 @pytest.mark.parametrize(
@@ -113,7 +114,7 @@ async def test_query(
         Suggestion(
             block_id=0,
             title=title,
-            url=url,
+            url=HttpUrl(url),
             provider="top_picks",
             is_top_pick=True,
             is_sponsored=False,
@@ -165,7 +166,7 @@ async def test_short_domain_query(
         Suggestion(
             block_id=0,
             title=title,
-            url=url,
+            url=HttpUrl(url),
             provider="top_picks",
             is_top_pick=True,
             is_sponsored=False,
@@ -216,7 +217,7 @@ async def test_short_domain_query_similars_longer_than_domain(
         Suggestion(
             block_id=0,
             title=title,
-            url=url,
+            url=HttpUrl(url),
             provider="top_picks",
             is_top_pick=True,
             is_sponsored=False,

--- a/tests/unit/providers/weather/backends/test_accuweather.py
+++ b/tests/unit/providers/weather/backends/test_accuweather.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock
 import freezegun
 import pytest
 from httpx import AsyncClient, HTTPError, Request, Response
+from pydantic import HttpUrl
 from pytest import FixtureRequest, LogCaptureFixture
 from pytest_mock import MockerFixture
 from redis import RedisError
@@ -89,7 +90,7 @@ def fixture_expected_weather_report() -> WeatherReport:
     return WeatherReport(
         city_name="San Francisco",
         current_conditions=CurrentConditions(
-            url=(
+            url=HttpUrl(
                 "http://www.accuweather.com/en/us/san-francisco-ca/94103/"
                 "current-weather/39376_pc?lang=en-us"
             ),
@@ -98,7 +99,7 @@ def fixture_expected_weather_report() -> WeatherReport:
             temperature=Temperature(c=15.5, f=60.0),
         ),
         forecast=Forecast(
-            url=(
+            url=HttpUrl(
                 "http://www.accuweather.com/en/us/san-francisco-ca/94103/"
                 "daily-weather-forecast/39376_pc?lang=en-us"
             ),
@@ -1114,7 +1115,7 @@ async def test_get_current_conditions(
 ) -> None:
     """Test that the get_current_conditions method returns CurrentConditions."""
     expected_conditions: CurrentConditions = CurrentConditions(
-        url=expected_current_conditions_url,
+        url=HttpUrl(expected_current_conditions_url),
         summary="Mostly cloudy",
         icon_id=6,
         temperature=Temperature(c=15.5, f=60),
@@ -1235,7 +1236,7 @@ async def test_get_forecast(
 ) -> None:
     """Test that the get_forecast method returns a Forecast."""
     expected_forecast: Forecast = Forecast(
-        url=expected_forecast_url,
+        url=HttpUrl(expected_forecast_url),
         summary="Pleasant Saturday",
         high=Temperature(f=70),
         low=Temperature(f=57),

--- a/tests/unit/providers/weather/backends/test_accuweather.py
+++ b/tests/unit/providers/weather/backends/test_accuweather.py
@@ -488,9 +488,11 @@ def fixture_accuweather_cached_data_misses() -> list[Optional[bytes]]:
 
 
 @pytest.fixture(name="accuweather_parsed_data_misses")
-def fixture_accuweather_parsed_data_misses() -> tuple[
-    Optional[AccuweatherLocation], Optional[CurrentConditions], Optional[Forecast]
-]:
+def fixture_accuweather_parsed_data_misses() -> (
+    tuple[
+        Optional[AccuweatherLocation], Optional[CurrentConditions], Optional[Forecast]
+    ]
+):
     """Return the partial parsed AccuWeather triplet for a cache hit."""
     return (
         None,

--- a/tests/unit/providers/weather/test_provider.py
+++ b/tests/unit/providers/weather/test_provider.py
@@ -7,6 +7,7 @@
 from typing import Any
 
 import pytest
+from pydantic import HttpUrl
 from pytest import LogCaptureFixture
 from pytest_mock import MockerFixture
 
@@ -73,7 +74,7 @@ async def test_query_weather_report_returned(
     report: WeatherReport = WeatherReport(
         city_name="San Francisco",
         current_conditions=CurrentConditions(
-            url=(
+            url=HttpUrl(
                 "http://www.accuweather.com/en/us/san-francisco-ca/"
                 "94103/current-weather/39376_pc?lang=en-us"
             ),
@@ -82,7 +83,7 @@ async def test_query_weather_report_returned(
             temperature=Temperature(c=15.5, f=60.0),
         ),
         forecast=Forecast(
-            url=(
+            url=HttpUrl(
                 "http://www.accuweather.com/en/us/san-francisco-ca/"
                 "94103/daily-weather-forecast/39376_pc?lang=en-us"
             ),
@@ -94,7 +95,7 @@ async def test_query_weather_report_returned(
     expected_suggestions: list[Suggestion] = [
         Suggestion(
             title="Weather for San Francisco",
-            url=(
+            url=HttpUrl(
                 "http://www.accuweather.com/en/us/san-francisco-ca/"
                 "94103/current-weather/39376_pc?lang=en-us"
             ),

--- a/tests/unit/providers/wikipedia/test_provider.py
+++ b/tests/unit/providers/wikipedia/test_provider.py
@@ -1,5 +1,6 @@
 """Unit tests for the Merino v1 suggest API endpoint for the Wikipedia provider."""
 import pytest
+from pydantic import HttpUrl
 from pytest_mock import MockerFixture
 
 from merino.config import settings
@@ -102,7 +103,7 @@ async def test_query(
         WikipediaSuggestion(
             title=query,
             full_keyword=query,
-            url=f"https://en.wikipedia.org/wiki/{expected_title}",
+            url=HttpUrl(f"https://en.wikipedia.org/wiki/{expected_title}"),
             advertiser=ADVERTISER,
             is_sponsored=False,
             provider="wikipedia",

--- a/tests/unit/utils/test_log_data_creator.py
+++ b/tests/unit/utils/test_log_data_creator.py
@@ -45,7 +45,7 @@ def test_create_request_summary_log_data(
 
     expected_log_data: RequestSummaryLogDataModel = RequestSummaryLogDataModel(
         errno=0,
-        time=dt.isoformat(),
+        time=dt,
         agent=expected_agent,
         path="/__heartbeat__",
         method="GET",
@@ -125,7 +125,7 @@ def test_create_suggest_log_data(
     expected_log_data: SuggestLogDataModel = SuggestLogDataModel(
         sensitive=True,
         errno=0,
-        time="1998-03-31T00:00:00",
+        time=datetime(1998, 3, 31),
         path="/api/v1/suggest",
         method="GET",
         query=expected_query,
@@ -181,10 +181,10 @@ def test_create_log_object_fails_on_invalid_time(time_input: Any):
     """Test that `time` fails validation on invalid time input."""
     with pytest.raises(ValidationError):
         LogDataModel(
+            errno=0,
             time=time_input,
             path="/",
             method="GET",
-            errno=0,
         )
 
 
@@ -192,20 +192,20 @@ def test_create_log_object_fails_on_invalid_time(time_input: Any):
 @pytest.mark.parametrize(
     "datetime_rep",
     [
-        1671379121,
         datetime(2022, 12, 18, hour=15, minute=58, second=41, tzinfo=timezone.utc),
-        "2022-12-18T15:58:41Z",
     ],
-    ids=["epoch_time", "datetime_obj", "str"],
+    ids=["datetime_obj"],
 )
 def test_create_log_object_can_convert_time_to_isoformat(
-    datetime_rep: str | int | datetime, expected_time: str
+    datetime_rep: datetime, expected_time: str
 ):
-    """Ensure that `time` field correctly validates datetime inputs and outputs as string."""
+    """Ensure that `time` field correctly validates datetime inputs
+    and outputs ISO format string.
+    """
     log_data = LogDataModel(
+        errno=0,
         time=datetime_rep,
         path="/",
         method="GET",
-        errno=0,
     )
-    assert log_data.model_dump()["time"] == expected_time
+    assert log_data.model_dump().get("time") == expected_time


### PR DESCRIPTION
## References

JIRA: [DISCO-2534](https://mozilla-hub.atlassian.net/browse/DISCO-2534)

## Description
Update core outdated dependencies including mypy, black, flake8, and bandit.  Resolved all regressions, including 68 mypy changes.

New mypy features include faster parsing, more library support, better error messages, better recognition of library methods and improved inferred type checking. flake8 updates include faster parsing, and bandit supports more CVEs and CWEs.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2534]: https://mozilla-hub.atlassian.net/browse/DISCO-2534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ