### PR TITLE
[DISCO-2580] Locust Load Tests Report False Results With Invalid Host [load test: abort]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,15 +120,12 @@ contract-tests-clean:  ##  Stop and remove containers and networks for contract 
       down
 	  docker rmi client kinto-setup
 
-.PHONY: run-load-tests
-run-load-tests:  ##  Run local execution of (Locust) load tests using existing merino-py docker image
+.PHONY: load-tests
+load-tests:  ##  Run local execution of (Locust) load tests
 	docker-compose \
       -f $(LOAD_TEST_DIR)/docker-compose.yml \
       -p merino-py-load-tests \
-      up --scale locust_worker=4
-
-.PHONY: load-tests
-load-tests: docker-build run-load-tests  ## Run local execution of (Locust) load tests, with merino-py docker build step
+      up --scale locust_worker=1
 
 .PHONY: load-tests-clean
 load-tests-clean:  ##  Stop and remove containers and networks for load tests
@@ -136,6 +133,7 @@ load-tests-clean:  ##  Stop and remove containers and networks for load tests
       -f $(LOAD_TEST_DIR)/docker-compose.yml \
       -p merino-py-load-tests \
       down
+	docker rmi locust
 
 .PHONY: doc-install-deps
 doc-install-deps:  ## Install the dependencies for doc generation

--- a/docs/dev/index.md
+++ b/docs/dev/index.md
@@ -92,10 +92,7 @@ $ make contract-tests
 # Run contract tests cleanup
 $ make contract-tests-clean
 
-# Run local execution of (Locust) load tests using existing merino-py docker image
-$ make run-load-tests
-
-# Run local execution of (Locust) load tests, with merino-py docker build step
+# Run local execution of (Locust) load tests
 $ make load-tests
 
 # Stop and remove containers and networks for load tests

--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -57,6 +57,24 @@ Execute the following from the repository root:
 make load-tests
 ```
 
+#### 3. (Optional) Host Merino Locally 
+
+Use one of the following commands to host Merino locally. Execute the following from the
+repository root:
+
+- Option 1: Use the local development instance
+  ```shell
+  make dev
+  ```
+- Option 2: Use the profiler instance
+  ```shell
+  make profile
+  ```
+- Option 3: Use the Docker instance
+  ```shell
+  make docker-build && docker run -p 8000:8000 app:build 
+  ```
+
 ### Run Test Session
 
 #### 1. Start Load Test
@@ -68,8 +86,8 @@ make load-tests
     * Option 2: Select the `Default` load test shape with the following recommended settings:
       * Number of users: 35
       * Spawn rate: 1
-      * Host: 'https://stagepy.merino.nonprod.cloudops.mozgcp.net' (Alternatively, such as when
-        profiling, point the host to a local instance of merino)
+      * Host: 'https://stagepy.merino.nonprod.cloudops.mozgcp.net' 
+        * Set host to 'http://host.docker.internal:8000' to test against a local instance of Merino
       * Duration (Optional): 10m
 * Select "Start Swarming"
 

--- a/tests/load/docker-compose.yml
+++ b/tests/load/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     environment:
       # Set environment variables, see https://docs.locust.io/en/stable/configuration.html#environment-variables
       LOCUST_HOST: https://stagepy.merino.nonprod.cloudops.mozgcp.net
+      LOCUST_USERCLASS_PICKER: true
       LOAD_TESTS__LOGGING_LEVEL: 10
       MERINO_REMOTE_SETTINGS__SERVER: "https://firefox.settings.services.mozilla.com"
       MERINO_REMOTE_SETTINGS__BUCKET: "main"
@@ -22,7 +23,7 @@ services:
       MERINO_PROVIDERS__WIKIPEDIA__ES_URL: "https://merino-nonprod.es.us-west1.gcp.cloud.es.io:9243"
       MERINO_PROVIDERS__WIKIPEDIA__ES_INDEX: "enwiki-v1"
     command: >
-      --master --class-picker
+      --master
 
   locust_worker:
     image: locust


### PR DESCRIPTION
## References

JIRA: [DISCO-2580](https://mozilla-hub.atlassian.net/browse/DISCO-2580)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->
- update locustfile:
  - refactor the `request_suggestions` method in locustfile.py to be part of the MerinoUser class
  - stop users if Merino is unreachable
  - log version information
  - log a warning when status codes of 0 are returned
- update Makefile:
  - Simplify `load-tests` make command to not build `Merino` and scale with 1 worker
  - Update `load-tests-clean` make command  to remove locust image
- update README to include instructions for running a local instance of Merino and setting it as the target host for the load tests

**Fix Details:**
In the case where the Locust target host doesn't resolve, a response with a status code of '0' is returned. This status code is returned very occasionally in CD and it is preferable not to abort a deployment should it occur ([ref](https://github.com/mozilla-services/merino-py/blob/main/tests/load/locustfiles/locustfile.py#L342-L350)). In the case where the target host is invalid, this leads to misleading messaging. This PR adds logging and stops a user early should the target host be invalid. Example log:

<img width="1340" alt="image" src="https://github.com/mozilla-services/merino-py/assets/3422688/9fa4a543-382b-414a-a238-58edd845e11c">

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
