### PR TITLE
fix to resolve kinto key error for load tests [load test: abort]

### DIFF
--- a/merino/providers/adm/backends/remotesettings.py
+++ b/merino/providers/adm/backends/remotesettings.py
@@ -39,7 +39,9 @@ class RemoteSettingsBackend:
 
     kinto_http_client: kinto_http.AsyncClient
 
-    def __init__(self, server: str, collection: str, bucket: str) -> None:
+    def __init__(
+        self, server: str | None, collection: str | None, bucket: str | None
+    ) -> None:
         """Init the Remote Settings backend and create a new client.
 
         Args:

--- a/tests/load/locustfiles/locustfile.py
+++ b/tests/load/locustfiles/locustfile.py
@@ -82,14 +82,14 @@ MERINO_PROVIDERS__WIKIPEDIA__ES_API_KEY: str | None = os.getenv(
 MERINO_PROVIDERS__WIKIPEDIA__ES_INDEX: str | None = os.getenv(
     "MERINO_PROVIDERS__WIKIPEDIA__ES_INDEX"
 )
-MERINO_REMOTE_SETTINGS__SERVER: str = os.getenv(
-    "MERINO_REMOTE_SETTINGS__SERVER", default=os.environ["KINTO__SERVER_URL"]
+MERINO_REMOTE_SETTINGS__SERVER: str | None = os.getenv(
+    "MERINO_REMOTE_SETTINGS__SERVER", os.getenv("KINTO__SERVER_URL")
 )
-MERINO_REMOTE_SETTINGS__BUCKET: str = os.getenv(
-    "MERINO_REMOTE_SETTINGS__BUCKET", default=os.environ["KINTO__BUCKET"]
+MERINO_REMOTE_SETTINGS__BUCKET: str | None = os.getenv(
+    "MERINO_REMOTE_SETTINGS__BUCKET", os.getenv("KINTO__BUCKET")
 )
-MERINO_REMOTE_SETTINGS__COLLECTION: str = os.getenv(
-    "MERINO_REMOTE_SETTINGS__COLLECTION", default=os.environ["KINTO__COLLECTION"]
+MERINO_REMOTE_SETTINGS__COLLECTION: str | None = os.getenv(
+    "MERINO_REMOTE_SETTINGS__COLLECTION", os.getenv("KINTO__COLLECTION")
 )
 
 
@@ -162,7 +162,9 @@ def on_locust_test_start(environment, **kwargs) -> None:
         )
 
 
-def get_adm_queries(server: str, collection: str, bucket: str) -> QueriesList:
+def get_adm_queries(
+    server: str | None, collection: str | None, bucket: str | None
+) -> QueriesList:
     """Get query strings for use in testing the AdM Provider.
 
     Args:


### PR DESCRIPTION
## References
JIRA: [DISCO-2534](https://mozilla-hub.atlassian.net/browse/DISCO-2534)

## Description
Related to DISCO-2534.

Fix for production env of locust where change could not be verified locally. `KeyError` occurred from `KINTO__SERVER_URL` not being found. 

Due to a change to enforce stricter typing of imported enviornment variables, `os.environ["KEY"]` replaced a call to `os.getenv("KEY")`. This was done as `getenv` can return `None`, which did not match the class signatures which these variables are passed into. 

Upon further investigation, it became clear that in `remotesettings.py`, a check is done at the creation of `RemoteSettingsBackend` (see [HERE](https://github.com/mozilla-services/merino-py/blob/28b3775ed9a0dc9ba446d1627149255693afd1d4/merino/providers/adm/backends/remotesettings.py#L37-L57)) to see if either server, collection, bucket or bucket are falsy. 

Therefore, it made sense to update the `RemoteSettingsBackend` signature to allow `None`, which resolved the mypy typing issue, as this will dependably raise a `ValueError` in any environment. Then, updating `get_adm_queries` to accept the same env variables now with possible `None` will handle error cases without causing a `KeyError` during load tests.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2534]: https://mozilla-hub.atlassian.net/browse/DISCO-2534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ