### PR TITLE
[DISCO-2598] Add some extra logging to AMO request errors

### DIFF
--- a/merino/providers/amo/backends/dynamic.py
+++ b/merino/providers/amo/backends/dynamic.py
@@ -46,6 +46,13 @@ class DynamicAmoBackend:
         """Fetch addon metadata via AMO. Return `None` on errors."""
         try:
             res = await client.get(f"{self.api_url}/{addon_key}", follow_redirects=True)
+        except httpx.HTTPError as e:
+            logger.error(
+                f"Addons API failed request to fetch addon: {addon_key}, {e}, {e.__class__}"
+            )
+            return None
+
+        try:
             res.raise_for_status()
 
             json_res = res.json()
@@ -55,7 +62,9 @@ class DynamicAmoBackend:
                 "number_of_ratings": json_res["ratings"]["count"],
             }
         except httpx.HTTPError as e:
-            logger.error(f"Addons API could not find key: {addon_key}, {e}")
+            logger.error(
+                f"Addons API could not find key: {addon_key}, {e}, {e.__class__}"
+            )
         except (KeyError, JSONDecodeError):
             logger.error(
                 "Problem with Addons API formatting. "


### PR DESCRIPTION
## References

JIRA: [DISCO-2598](https://mozilla-hub.atlassian.net/browse/DISCO-2598)

## Description
This is to help us hopefully get more information on what is causing the errors for AMO requests.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2598]: https://mozilla-hub.atlassian.net/browse/DISCO-2598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ