### PR TITLE
Increase the timeout for AMO suggestions

### DIFF
--- a/merino/providers/amo/backends/dynamic.py
+++ b/merino/providers/amo/backends/dynamic.py
@@ -11,6 +11,8 @@ from merino.providers.amo.addons_data import ADDON_DATA, SupportedAddon
 from merino.providers.amo.backends.protocol import Addon, AmoBackendError
 from merino.utils.http_client import create_http_client
 
+AMO_CONNECT_TIMEOUT = 5.0
+
 logger = logging.getLogger(__name__)
 
 
@@ -82,7 +84,10 @@ class DynamicAmoBackend:
         tasks: list[Task] = []
 
         try:
-            async with (create_http_client() as client, TaskGroup() as group):
+            async with (
+                create_http_client(connect_timeout=AMO_CONNECT_TIMEOUT) as client,
+                TaskGroup() as group,
+            ):
                 for addon_key in SupportedAddon:
                     tasks.append(
                         group.create_task(


### PR DESCRIPTION
## References

JIRA: [DISCO-2598](https://mozilla-hub.atlassian.net/browse/DISCO-2598)

## Description
Currently we're seeing a lot of `ConnectTimeout` for AMO requests. We're overriding the default timeout of 1s and increasing it to see if this will fix our timeout issues. Since this is a background job, the side effects of this is that start up might be a bit slower.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
