### PR TITLE
[DISCO-2583] configs from config.md to default.toml

### DIFF
--- a/docs/operations/configs.md
+++ b/docs/operations/configs.md
@@ -1,4 +1,6 @@
 # Configuring Merino (Operations)
+To manage configurations and view all documentation for individual config values,
+please view the [default.toml][default.toml] file.
 
 ## Settings
 
@@ -6,9 +8,10 @@ Merino's settings are managed via [Dynaconf][dynaconf] and can be specified in t
 1. a [TOML file][toml] in the `merino/configs/` [directory][configs_dir].
 2. via environment variables.
 Environment variables take precedence over the values set in the TOML files.
+Production environment variables are managed by SRE and defined in the relevant merino-py repo.
 TOML files set with the same environment name that is currently activated also automatically override defaults.
 Any config file that is pointed to will override the `merino/configs/default.toml` file.
-Read below for more specific details.
+
 
 ## File organization
 
@@ -70,6 +73,7 @@ lookups once or twice, it comes a surprisingly high overhead if accessing them
 repeatedly in the hot paths. You can cache those settings somewhere to mitigate
 this issue.
 
+[default.toml]: https://github.com/mozilla-services/merino-py/tree/main/merino/configs/default.toml
 [dynaconf]: https://www.dynaconf.com/
 [toml]: https://toml.io/en/
 [config.py]: https://github.com/mozilla-services/merino-py/blob/main/merino/config.py

--- a/docs/operations/configs.md
+++ b/docs/operations/configs.md
@@ -2,46 +2,45 @@
 
 ## Settings
 
-Merino's settings are managed via Dynaconf and can be specified in two ways: by a
-TOML file in the `merino/configs/` directory, or via environment variables. Environment
-variables take precedence over the values set in the TOML files. TOML files set with the
-same environment name that is currently activated also automatically override defaults.
+Merino's settings are managed via [Dynaconf][dynaconf] and can be specified in two ways: 
+1. a [TOML file][toml] in the `merino/configs/` [directory][configs_dir].
+2. via environment variables.
+Environment variables take precedence over the values set in the TOML files.
+TOML files set with the same environment name that is currently activated also automatically override defaults.
 Any config file that is pointed to will override the `merino/configs/default.toml` file.
 Read below for more specific details.
 
-### [File organization](#file-organization)
+## File organization
 
 These are the settings sources, with later sources overriding earlier ones.
 
-- A `config.py` file establishes a Dynaconf instance and environment-specific values
-are pulled in from the corresponding TOML files and environment variables. Other
-configurations are established by files that are prefixed with `config_*.py`,
-such as `config_sentry.py` or `config_logging.py`.
+- A [`config.py`][config.py] file establishes a Dynaconf instance and environment-specific values
+  are pulled in from the corresponding TOML files and environment variables.
+  Other configurations are established by files that are prefixed with `config_*.py`,
+  such as `config_sentry.py` or `config_logging.py`.
 
-- Per-environment configuration files are in the `configs` directory. The environment
-  is selected using the environment variable `MERINO_ENV`. The settings for
-  that environment are then loaded from `configs/${env}.toml`, if the file/env exists. The
-  default environment is "development". A "production" environment is also
-  provided.
+- Per-environment configuration files are in the [`configs` directory][configs_dir].
+  The environment is selected using the environment variable `MERINO_ENV`.
+  The settings for that environment are then loaded from `configs/${env}.toml`, if the file/env exists. The default environment is "development". A "production" environment is also provided.
 
-- Local configuration files are not checked into the repository, but if created should be named
-  `configs/development.local.toml`, following the format of `<environment>.local.toml`.
+- Local configuration files are not checked into the repository,
+  but if created should be named `configs/development.local.toml`,
+  following the format of `<environment>.local.toml`.
   This file is listed in the `.gitignore` file and is safe to use for local configuration.
   One may add secrets here if desired, though it is advised to exercise great caution.
 
-### General
+## General
 
-- All environments are prefixed with `MERINO_`. This is established in the
-  `config.py` file by setting the `envvar_prefix="MERINO"` for the Dynaconf
-  instance. The first level following `MERINO_` is accessed with a single underscore `_`
-  and any subsequent levels require two underscores `__`. For example,
-  the logging format can be controlled from the environment variable
-  `MERINO_LOGGING__FORMAT`.
+- All environments are prefixed with `MERINO_`. 
+  This is established in the `config.py` file by setting the `envvar_prefix="MERINO"` 
+  for the Dynaconf instance.
+  The first level following `MERINO_` is accessed with a single underscore `_` and any subsequent levels require two underscores `__`. 
+  For example, the logging format can be controlled from the environment variable `MERINO_LOGGING__FORMAT`.
 
 - Production environment variables are set by SRE and stored in the
-  cloudops project in the `configmap.yml` file. Contact SRE if you require
-  information or access on this file, or request access to the cloudops infra
-  repo.
+  cloudops project in the `configmap.yml` file. 
+  Contact SRE if you require information or access on this file,
+  or request access to the cloudops infra repo.
 
 - You can set these environment variables in your setup by modifying the `.toml` files.
   Conversely, when using `make`, you can prefix `make run` with overrides to the
@@ -50,17 +49,18 @@ such as `config_sentry.py` or `config_logging.py`.
   Example:
   `MERINO_ENV=production MERINO_LOGGING__FORMAT=pretty make dev`
 
-- `env` (`MERINO_ENV`) - Only settable from environment variables. Controls
-  which environment configuration is loaded, as described above.
+- `env` (`MERINO_ENV`) - Only settable from environment variables. 
+  Controls which environment configuration is loaded, as described above.
 
 - `debug` (`MERINO_DEBUG`) - Boolean that enables additional features to debug
-  the application. This should not be set to true in public environments, as it
-  reveals all configuration, including any configured secrets.
+  the application.
+  This should not be set to true in public environments, as it reveals all configuration,
+  including any configured secrets.
 
 - `format` (`MERINO_LOGGING__FORMAT`) - Controls the format of outputted logs in
-  either `pretty` or `mozlog` format. See [../config_logging.py][log].
+  either `pretty` or `mozlog` format. See [config_logging.py][log].
 
-### Caveat
+## Caveat
 
 Be extra careful whenever you need to reference those deeply nested settings
 (e.g. `settings.foo.bar.baz`) in the hot paths of the code base, such as middlewares
@@ -70,249 +70,8 @@ lookups once or twice, it comes a surprisingly high overhead if accessing them
 repeatedly in the hot paths. You can cache those settings somewhere to mitigate
 this issue.
 
-### Deployment
-
-This group currently features a single setting:
-
-- `deployment.canary` (`MERINO_DEPLOYMENT__CANARY`) - a boolean that represents
-whether the pod running this application is deployed as a canary. The value is
-added as a constant tag `deployment.canary` with type `int` to emitted metrics.
-Note that this setting is supposed to be controlled exclusively by deployment
-tooling.
-
-### Runtime Configurations
-
-- `runtime.query_timeout_sec` (`MERINO_RUNTIME__QUERY_TIMEOUT_SEC`) - A floating
-  point (in seconds) indicating the maximum waiting period for queries issued within
-  the handler of the `suggest` endpoint. All the unfinished query tasks will be
-  cancelled once the timeout gets triggered. Note that this timeout can also be
-  configured by specific providers. The provider timeout takes precedence over this
-  value.
-
-### API Configurations
-
-- `default.web.api.v1.client_variant_max` (`MERINO_WEB__API__V1__CLIENT_VARIANT_MAX`)
-- A non-negative integer to contol the limit of optional client variants passed
-  to suggest endpoint as part of experiments or rollouts.  Additional validators
-  can/will be implemented to ensure a limitation on the number of variants passed
-  to the request. See: https://mozilla-services.github.io/merino/api.html#suggest.
-
-- `default.web.api.v1.query_character_max` (`MERINO_WEB__API__V1__QUERY_CHARACTER_MAX`)
-- A non-negative integer value that is passed into the `max_length` parameter
-  of the FastAPI Query object constructor.  This limits the string character length
-  of a given query string, in this case the total string length count for the suggestion query.
-
-- `default.web.api.v1.client_variant_character_max` (`MERINO_WEB__API__V1__CLIENT_VARIANT_CHARACTER_MAX`)
-- A non-negative integer value that is passed into the `max_length` parameter
-  of the FastAPI Query object constructor.  This limits the string character length
-  of a given query string, in this case the total string length count for client variants.
-
-
-### Logging
-
-Settings to control the format and amount of logs generated.
-
-- `logging.format` (`MERINO_LOGGING__FORMAT`) - The format to emit logs in. One of
-
-  - `pretty` (default in development) - Multiple lines per event, human-oriented
-    formatting and color.
-  - `mozlog` (default in production) - A single line per event, formatted as
-    JSON in [MozLog](https://wiki.mozilla.org/Firefox/Services/Logging) format.
-
-- `logging.level` (`MERINO_LOGGING__LEVEL`) - Minimum level of logs that should
-  be reported. This should be a number of _entries_ separated by commas (for
-  environment variables) or specified as list (TOML).
-
-  Each entry can be one of `CRITICAL`, `ERROR`, `WARN`, `INFO`,  or `DEBUG` (in
-  increasing verbosity).
-
-### Metrics
-
-Settings for Statsd/Datadog style metrics reporting.
-
-- `metrics.host` (`MERINO_METRICS__HOST`) - The IP or hostname to send metrics
-  to over UDP. Defaults to localhost.
-
-- `metrics.port` (`MERINO_METRICS__PORT`) - The port to send metrics to over
-  UDP. Defaults to 8092.
-
-- `metrics.dev_logger` (`MERINO_METRICS__DEV_LOGGER`) - Whether or not to send
-  metrics over to the logger. Should only be used for non-production environments.
-
-### Sentry
-
-Error reporting via Sentry.
-
-- `sentry.mode` (`MERINO_SENTRY__MODE`) - The type of Sentry integration to
-  enable. One of `release`, `debug`, or `disabled`. The `debug` setting
-  should only be used for local development.
-
-If `sentry.mode` is set to `release`, then the following two settings are
-required:
-
-- `sentry.dsn` (`MERINO_SENTRY__DSN`) - Configuration to connect to the Sentry project.
-- `sentry.env` (`MERINO_SENTRY__ENV`) - The environment to report to Sentry.
-  Probably "prod", "stage", or "dev".
-
-If `sentry.mode` is set to `disabled`, no Sentry integration will be activated.
-If it is set to `debug`, the DSN will be set to a testing value
-recommended by Sentry, and extra output will be included in the logs.
-
-### Remote_settings
-
-Connection to Remote Settings. This is used by the Remote Settings suggestion
-provider below.
-
-- `remote_settings.server` (`MERINO_REMOTE_SETTINGS__SERVER`) - The server to
-  sync from. Example: `https://firefox.settings.services.mozilla.com`.
-
-- `remote_settings.bucket` (`MERINO_REMOTE_SETTINGS__BUCKET`) -
-  The bucket to use for Remote Settings providers if not specified in the
-  provider config. Example: "main".
-
-- `remote_settings.collection`
-  (`MERINO_REMOTE_SETTINGS__COLLECTION`) - The collection to use for
-  Remote Settings providers if not specified in the provider config. Example:
-  "quicksuggest".
-
-### Location
-
-Configuration for determining the location of users.
-
-- `location.maxmind_database` (`MERINO_LOCATION__MAXMIND_DATABASE`) - Path to a
-  MaxMind GeoIP database file.
-
-### [Redis](#redis)
-
-Global Redis settings. The weather provider optionally uses Redis to cache weather suggestions.
-
-- `redis.server` (`MERINO_REDIS__SERVER`) - The Redis server URL, in the form of
-  `redis://localhost:6379`.
-
-### AccuWeather
-
-Configuration for using AccuWeather as a weather backend
-  - `api_key` (`MERINO_ACCUWEATHER__API_KEY`) - The API key to AccuWeather's API
-    endpoint. In production, this should be set via environment variable as a secret.
-  - `url_base` (`MERINO_ACCUWEATHER__URL_BASE`) - The base URL of AccuWeather's
-    API endpoint.
-  - `url_param_api_key` (`MERINO_ACCUWEATHER__URL_PARAM_API_KEY`) - The parameter
-    of the API key for AccuWeather's API endpoint.
-  - `url_current_conditions_path` (`MERINO_ACCUWEATHER__URL_CURRENT_CONDITIONS_PATH`) -
-    The URL path for current conditions.
-  - `url_forecasts_path` (`MERINO_ACCUWEATHER__URL_FORECASTS_PATH`) - The URL path
-    for forecasts.
-  - `url_postalcodes_path` (`MERINO_ACCUWEATHER__URL_POSTALCODES_PATH`) - The URL path
-    for postal codes.
-  - `url_postalcodes_param_query` (`MERINO_ACCUWEATHER__URL_POSTALCODES_PARAM_QUERY`) -
-    The query parameter for postal codes.
-  - `url_param_partner_code` (`MERINO_ACCUWEATHER__URL_PARAM_PARTNER_CODE`) -
-    The query parameter for the [partner code](https://apidev.accuweather.com/developers/partner-code)
-    to append to URLs in the current conditions and forecast responses.
-  - `partner_code` (`MERINO_ACCUWEATHER__PARTNER_CODE`) -
-    The partner code to append to URLs in the current conditions and forecast responses.
-
-### AMO API
-
-- `api_url` (`MERINO_AMO__DYNAMIC__API_URL`) - the base URL of the Addons API.
-
-### Provider Configuration
-
-The configuration for suggestion providers.
-
-#### Adm Provider
-
-These are production providers that generate suggestions.
-
-- Remote Settings - Provides suggestions from a RS collection, such as the
-  suggestions provided by adM. See also the top level configuration for Remote
-  Settings above.
-  - `type` (`MERINO_PROVIDERS__ADM__TYPE`) - The type of this provider, should be `adm`.
-  - `enabled_by_default` (`MERINO_PROVIDERS__ADM__ENABLED_BY_DEFAULT`) - Whether
-    this provider is enabled by default.
-  - `backend` (`MERINO_PROVIDERS__ADM__BACKEND`) - The backend of the provider.
-    Either `remote-settings` or `test`.
-  - `resync_interval_sec` (`MERINO_PROVIDERS__ADM__RESYNC_INTERVAL_SEC`) - The time
-    between re-syncs of Remote Settings data, in seconds. Defaults to 3 hours.
-  - `cron_interval_sec`
-    (`MERINO_PROVIDERS__ADM__CRON_INTERVAL_SEC`) - The interval of the Remote
-    Settings cron job (in seconds). Following tasks are done in this cron job:
-    - Resync with Remote Settings if needed. The resync interval is configured
-      separately by the provider. Note that this interval should be set smaller
-      than `resync_interval_sec` of the Remote Settings leaf provider.
-    - Retry if the regular resync fails.
-  - `score` (`MERINO_PROVIDERS__ADM__SCORE`) - The ranking score for this provider
-    as a floating point number. Defaults to 0.3.
-
-#### AccuWeather Provider
-- AccuWeather - Provides weather suggestions & forecasts.
-  - `type` (`MERINO_PROVIDERS__ACCUWEATHER__TYPE`) - The type of this provider, should be
-    `accuweather`.
-  - `backend` (`MERINO_PROVIDERS__ACCUWEATHER__backend`) - The backend of the provider.
-    Either `accuweather` or `test`.
-  - `cache` (`MERINO_PROVIDERS__ACCUWEATHER__CACHE`) - The store used to cache weather reports.
-    Either `redis` or `none`. If `redis`, the [global Redis settings](#redis) must be set.
-    Defaults to `none`.
-  - `enabled_by_default` (`MERINO_PROVIDERS__ACCUWEATHER__ENABLED_BY_DEFAULT`) - Whether
-    this provider is enabled by default.
-  - `score` (`MERINO_PROVIDERS__ACCUWEATHER__SCORE`) - The ranking score for this provider
-    as a floating point number. Defaults to 0.3.
-  - `query_timeout_sec` (`MERINO_PROVIDERS__ACCUWEATHER__QUERY_TIMEOUT_SEC`) - A floating
-    point (in seconds) indicating the maximum waiting period when Merino queries
-    for weather forecasts. This will override the default query timeout.
-
-#### AMO Provider
-
-- `type` (`MERINO_PROVIDERS__AMO__TYPE`) - The type of this provider, should be `amo`.
-- `enabled_by_default` (`MERINO_PROVIDERS__AMO__ENABLED_BY_DEFAULT`) - Whether
-  this provider is enabled by default. Defaults to false.
-- `backend` (`MERINO_PROVIDERS__AMO__BACKEND`) - The backend of the provider.
-  Either `static` or `dynamic`.
-- `score` (`MERINO_PROVIDERS__AMO__SCORE`) - The ranking score for this provider
-  as a floating point number. Defaults to 0.3.
-- `min_chars` (`MERINO_PROVIDERS__AMO__MIN_CHARS`) - The minimum number of characters
-  to process a querystring.
-- `resync_interval_sec` (`MERINO_PROVIDERS__AMO__RESYNC_INTERVAL_SEC`) - The re-syncing frequency
-  for the AMO data. Defaults to daily.
-- `cron_interval_sec` (`MERINO_PROVIDERS__AMO__CRON_INTERVAL_SEC`) - The frequency that the cron checks
-  to see if re-syncing is required. This should be more frequent than the `resync_interval_sec` to retry
-  on errors. Defaults to every minute.
-
-#### Top Picks Provider
-- Top Picks - Provides suggestions from a static domain list of the 1000 most visited websites.
-  - `enabled_by_default` (`MERINO_PROVIDERS__TOP_PICKS__ENABLED_BY_DEFAULT`) - Boolean that defines
-  whether this provider is enabled by default.
-  - `score` (`MERINO_PROVIDERS__TOP_PICKS__SCORE`) - The ranking score for this provider as a floating
-  point number with a default set to 0.25.
-  - `query_char_limit` (`MERINO_PROVIDERS__TOP_PICKS__QUERY_CHAR_LIMIT`) - The minimum character limit
-  for a Top Picks suggestion to be indexed and query to be processed. Represented as an integer with a
-  default set to 4.
-  - `firefox_char_limit` (`MERINO_PROVIDERS__TOP_PICKS__FIREFOX_CHAR_LIMIT`) - The minimum character
-  limit set for short suggestion indexing and for Firefox to process a query on Merino. Represented
-  as an integer. Default is set to 2.
-  - `top_picks_file_path` (`MERINO_PROVIDERS__TOP_PICKS__TOP_PICKS_FILE_PATH`) - File path to the json
-  file of domains, represented as a string. Either `dev/top_picks.json` in production
-  or `tests/data/top_picks.json` for testing.
-
-#### Wikipedia Dynamic Match Provider
-- Wikipedia - Provider backed by the locally indexed Wikipedia through Elasticsearch.
-  - `type` (`MERINO_PROVIDERS__WIKIPEDIA__TYPE`) - The type of this provider, should be
-    `wikipedia`.
-  - `enabled_by_default` (`MERINO_PROVIDERS__WIKIPEDIA__ENABLED_BY_DEFAULT`) - Whether
-    this provider is enabled by default.
-  - `backend` (`MERINO_PROVIDERS__WIKIPEDIA__backend`) - The backend of the provider.
-    Either `elasticsearch` or `test`.
-  - `es_url` (`MERINO_PROVIDERS__WIKIPEDIA__ES_URL`) - The URL of the cluster that we
-    want to connect to.
-  - `es_api_key` (`MERINO_PROVIDERS__WIKIPEDIA__ES_API_KEY`) - The base64 key used to
-    authenticate on the Elasticsearch cluster specified by `es_cloud_id`.
-  - `es_index` (`MERINO_PROVIDERS__WIKIPEDIA__ES_INDEX`) - The index identifier
-    of Wikipedia in Elasticsearch.
-  - `es_max_suggestions` (`MERINO_PROVIDERS__WIKIPEDIA__ES_MAX_SUGGESTIONS`) - The
-    maximum suggestions for each search request to Elasticsearch.
-  - `es_request_timeout_ms` (`MERINO_PROVIDERS__WIKIPEDIA__ES_REQUEST_TIMEOUT_MS`) - The
-    timeout in milliseconds for each search request to Elasticsearch.
-  - `score` (`MERINO_PROVIDERS__WIKIPEDIA__SCORE`) - The ranking score for this provider
-    as a floating point number. Defaults to 0.23.
-
-[log]:../../merino/config_logging.py
+[dynaconf]: https://www.dynaconf.com/
+[toml]: https://toml.io/en/
+[config.py]: https://github.com/mozilla-services/merino-py/blob/main/merino/config.py
+[configs_dir]: https://github.com/mozilla-services/merino-py/tree/main/merino/configs
+[log]: https://github.com/mozilla-services/merino-py/blob/main/merino/config_logging.py

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -107,7 +107,7 @@ canary = false
 # Path to the MaxMindDB file. This should be overridden in production.
 maxmind_database = "./dev/GeoLite2-City-Test.mmdb"
 
-# # MERINO_LOCATION__CLIENT_IP_OVERRIDE
+# MERINO_LOCATION__CLIENT_IP_OVERRIDE
 # This can be set to facilitate manual testing during development.
 client_ip_override = ""
 
@@ -193,7 +193,7 @@ cache = "none"
 enabled_by_default = false
 
 # MERINO_PROVIDERS__ACCUWEATHER__SCORE
-#  The ranking score for this provider as a floating point number.
+# The ranking score for this provider as a floating point number.
 score = 0.3
 
 # MERINO_PROVIDERS__ACCUWEATHER__QUERY_TIMEOUT_SEC
@@ -208,9 +208,15 @@ query_timeout_sec = 5.0
 
 
 [default.providers.accuweather.cache_ttls]
-# Cache TTLs for weather data
+# Cache TTLs for weather data.
+
+# MERINO_PROVIDERS__ACCUWEATHER__CACHE_TTLS__LOCATION_KEY_TTL_SEC
 location_key_ttl_sec = 604800 # 7 days
+
+# MERINO_PROVIDERS__ACCUWEATHER__CACHE_TTLS__CURRENT_CONDITION_TTL_SEC
 current_condition_ttl_sec = 1800 # 1/2 hr
+
+# MERINO_PROVIDERS__ACCUWEATHER__CACHE_TTLS__FORECAST_TTL_SEC
 forecast_ttl_sec = 3600 # 1 hr
 
 
@@ -399,42 +405,71 @@ score = 0.23
 
 
 [default.jobs.wikipedia_indexer]
+# MERINO_JOBS__WIKIPEDIA_INDEXER__ES_URL
 # The URL of the Elasticsearch cluster for indexing job.
 # This takes precedent over the Cloud ID (i.e. if you pass both,
 # we will choose the URL over the Cloud ID).
 es_url = ""
-# Elasticsearch API key for indexing job
+
+# MERINO_JOBS__WIKIPEDIA_INDEXER__ES_API_KEY
+# Elasticsearch API key for indexing job.
 es_api_key = ""
-# Elasticsearch API key for indexing job
+
+# MERINO_JOBS__WIKIPEDIA_INDEXER__ES_ALIAS
+# Elasticsearch alias value for indexing job.
 es_alias = "enwiki-{version}"
+
+# MERINO_JOBS__WIKIPEDIA_INDEXER__INDEX_VERSION
 # Index version that will be written.
 index_version = "v1"
+
+# MERINO_JOBS__WIKIPEDIA_INDEXER__TOTAL_DOCS
 # Estimate of the total documents in the elasticsearch index.
 total_docs = 6_400_000
+
+# MERINO_JOBS__WIKIPEDIA_INDEXER__GCS_PATH
 # GCS path. Combined bucket and object prefix (folders).
 gcs_path = ""
+
+# MERINO_JOBS__WIKIPEDIA_INDEXER__GCP_PROJECT
 # GCP project name where the GCS bucket lives.
 gcp_project = ""
-# Wikipedia export base URL
+
+# MERINO_JOBS__WIKIPEDIA_INDEXER__EXPORT_BASE_URL
+# Wikipedia export base URL.
 export_base_url = "https://dumps.wikimedia.org/other/cirrussearch/current/"
+
+# MERINO_JOBS__WIKIPEDIA_INDEXER__BLOCKLIST_FILE_URL
 # Blocklist file as CSV. Contains a list of the categories for articles that we want to block.
 blocklist_file_url = "https://raw.githubusercontent.com/mozilla/search-terms-sanitization/7ab819c7515c526e6a407b08ba8e78d3bdb7f4e9/non_sensitive/wikipedia-content-moderation/blocklist_cats.csv"
 
 [default.jobs.navigational_suggestions]
+# MERINO_JOBS__NAVIGATIONAL_SUGGESTIONS__SOURCE_GCP_PROJECT
 # GCP project name that contains domain data tables
 source_gcp_project = ""
+
+# MERINO_JOBS__NAVIGATIONAL_SUGGESTIONS__DESTINATION_GCP_PROJECT
 # GCP project name where the GCS bucket lives
 destination_gcp_project = ""
+
+# MERINO_JOBS__NAVIGATIONAL_SUGGESTIONS__DESTINATION_GCS_BUCKET
 # GCS bucket name where domain metadata will be uploaded
 destination_gcs_bucket = ""
+
+# MERINO_JOBS__NAVIGATIONAL_SUGGESTIONS__DESTINATION_CDN_HOSTNAME
 # CDN hostname of the GCS bucket where domain metadata will be uploaded
 destination_cdn_hostname = ""
+
+# MERINO_JOBS__NAVIGATIONAL_SUGGESTIONS__FORCE_UPLOAD
 # Flag to enable uploading the domain metadata to GCS bucket even if it aleady exists there
 force_upload = false
+
+# MERINO_JOBS__NAVIGATIONAL_SUGGESTIONS__MIN_FAVICON_WIDTH
 # Minimum width of the domain favicon required for it to be a part of domain metadata
 min_favicon_width = 48
 
 
 [default.jobs.amo_rs_uploader]
+# MERINO_JOBS__AMO_RS_UPLOADER__RECORD_TYPE
 # The "type" of each remote settings record
 record_type = "amo-suggestions"

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -1,5 +1,6 @@
-# Default configurations that may be overridden by the counterparts defined in
-# `development.toml` or `production.toml` or environment variables.
+# Default configurations that may be overridden by the counterparts defined in:
+# `development.toml`, `default.local.toml`, `production.toml`, `testing.toml`,
+# `ci.toml` or environment variables.
 
 # Configurations can be defined by:
 #
@@ -23,70 +24,157 @@
 [default]
 debug = false
 
+
 [default.runtime]
+# MERINO_RUNTIME__QUERY_TIMEOUT_SEC
 # A float timeout (in seconds) for all queries issued in "web/api_v1.py".
+# Indicates the maximum waiting period for queries issued within handler of the `suggest` endpoint.
+# See `accuweather` as an example.
+# All the unfinished query tasks will be cancelled once the timeout gets triggered.
+# The provider timeout takes precedence over this value.
 # Each provider can override this timeout by specifying a provider-level
-# timeout with the same name `query_timeout_sec`. See `accuweather` as an
-# example.
+# timeout with the same name `query_timeout_sec`.
 query_timeout_sec = 0.2
 
+
 [default.logging]
-# Any of "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"
+# MERINO_LOGGING__LEVEL
+# Minimum level of logs that should be reported.
+# "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL" (in increasing verbosity).
+# This should be a number of entries separated by commas (environment variables) 
+# or specified as list (TOML).
 level = "INFO"
-# Any of "mozlog" (i.e. JSON) or "pretty"
+
+# MERINO_LOGGING__FORMAT
+# pretty - default in development - Multiple lines per event, human-oriented formatting and color.
+# mozlog - default in production - A single line per event, formatted as JSON in 
+# MozLog format. See https://wiki.mozilla.org/Firefox/Services/Logging
 format = "mozlog"
+
+# MERINO_LOGGING__CAN_PROPAGATE
+# Boolean to allow log propagation.
 can_propagate = false
 
+
 [default.web.api.v1]
+# MERINO_WEB__API__V1__CLIENT_VARIANT_MAX
 # Setting to contol the limit of optional client variants passed
 # to suggest endpoint as part of experiments or rollouts.
+# See: https://mozilla-services.github.io/merino/api.html#suggest.
 client_variant_max = 10
-# Values passed into Query object for FastAPI query parameter validator.
+
+# The following values are passed into Query object (`max_length` parameter) for FastAPI query parameter validator.
 # Sets limitation on the maximum string length of a query.
+
+# MERINO_WEB__API__V1__CLIENT_VARIANT_CHARACTER_MAX
+# A non-negative integer that limits the string character length of a given query string,
+# in this case the total string length count for client variants.
 client_variant_character_max = 100
+
+# MERINO_WEB__API__V1__QUERY_CHARACTER_MAX
+# A non-negative integer that limits the string character length of a given query string,
+# in this case the total string length count for the suggestion query.
 query_character_max = 500
 
+
 [default.metrics]
+# Settings for Statsd/Datadog style metrics reporting.
+
+# MERINO_METRICS__DEV_LOGGER
+# Whether or not to send metrics over to the logger. 
+# Should only be used for non-production environments.
 dev_logger = false
+
+# MERINO_METRICS__HOST
+# The IP or hostname to send metrics over UDP. Defaults to localhost.
 host = "localhost"
+
+# MERINO_METRICS__PORT
+# The port to send metrics to over UDP. Defaults to 8092.
 port = 8092
 
+
 [default.deployment]
-# The deployment workflow is expected to set this to true for canary pods
+# MERINO_DEPLOYMENT__CANARY
+# The value is added as a constant tag `deployment.canary` with type `int` to emitted metrics.
+# The deployment workflow is expected to set this to true for canary pods.
+# Note that this setting is supposed to be controlled exclusively by deployment tooling.
 canary = false
 
+
 [default.location]
+# Configuration for determining the location of users.
+
+# MERINO_LOCATION__MAXMIND_DATABASE
 # Path to the MaxMindDB file. This should be overridden in production.
 maxmind_database = "./dev/GeoLite2-City-Test.mmdb"
+
+# # MERINO_LOCATION__CLIENT_IP_OVERRIDE
 # This can be set to facilitate manual testing during development.
 client_ip_override = ""
 
+
 [default.remote_settings]
+# MERINO_REMOTE_SETTINGS__SERVER
+# The server to sync from. Ex: `https://firefox.settings.services.mozilla.com`
 server = "https://firefox.settings.services.mozilla.com"
+
+# MERINO_REMOTE_SETTINGS__BUCKET
+# The bucket to use for Remote Settings providers if not specified in provider config. 
+# Ex: "main".
 bucket = "main"
+
+# MERINO_REMOTE_SETTINGS__COLLECTION
+# The collection to use for Remote Settings providers if not specified in provider config. 
+# Ex: "quicksuggest".
 collection = "quicksuggest"
+
+# MERINO_REMOTE_SETTINGS__AUTH
 # Authorization token when uploading suggestions
 auth = ""
-# The maximum number of suggestions to store in each attachment when uploading
-# suggestions
+
+# MERINO_REMOTE_SETTINGS__CHUNK_SIZE
+# The maximum number of suggestions to store in each attachment when uploading suggestions
 chunk_size = 200
+
+# MERINO_REMOTE_SETTINGS__DELETE_EXISTING_RECORDS
 # Delete existing records before uploading new records
 delete_existing_records = true
+
+# MERINO_REMOTE_SETTINGS__DRY_RUN
 # Log changes but don't actually make them when uploading suggestions
 dry_run = false
+
+# MERINO_REMOTE_SETTINGS__SCORE
 # Default score to set in suggestions uploaded to remote settings
 score = 0.25
 
+
 [default.sentry]
+# MERINO_SENTRY__MODE
 # Any of "release", "debug", or "disabled".
-# Using "debug" will enable logging for Sentry.
+# Using "debug" will enable logging for Sentry, only use for local development.
 mode = "disabled"
-# Sentry will not send events out when given an empty string `dsn`.
-dsn = ""
-# Any of "prod", "stage", or "dev".
-env = "dev"
+
+# MERINO_SENTRY__TRACES_SAMPLE_RATE
 # A setting for the tracing sample rate. Should be a float in range [0, 1.0].
 traces_sample_rate = 0
+
+# If mode is set to "release", then the following settings are required:
+
+# MERINO_SENTRY__DSN
+# Configuration string to connect to Sentry project.
+# Sentry will not send events out when given an empty string `dsn`.
+dsn = ""
+
+# MERINO_SENTRY__ENV
+# Environment to report, either "prod", "stage", or "dev".
+env = "dev"
+
+# If `sentry.mode` is set to `disabled`, no Sentry integration will be activated.
+# If set to `debug`, the DSN will be set to a testing value recommended by Sentry, 
+# and extra output will be included in the logs.
+
 
 [default.providers.accuweather]
 type = "accuweather"
@@ -96,11 +184,13 @@ enabled_by_default = false
 score = 0.3
 query_timeout_sec = 5.0
 
+
 [default.providers.accuweather.cache_ttls]
 # Cache TTLs for weather data
 location_key_ttl_sec = 604800 # 7 days
 current_condition_ttl_sec = 1800 # 1/2 hr
 forecast_ttl_sec = 3600 # 1 hr
+
 
 [default.accuweather]
 # Our API key used to access the AccuWeather API.
@@ -120,6 +210,11 @@ url_postalcodes_param_query = "q"
 # Note that this is the name of the partner code parameter, not the partner code itself.
 url_param_partner_code = "partner"
 
+# MERINO_REDIS__SERVER - redis.server (Currently not configured here)
+# Global Redis settings. The weather provider optionally uses Redis to cache weather suggestions.
+# In the form of `redis://localhost:6379`.
+
+
 [default.providers.adm]
 type = "adm"
 # Whether or not this provider is enabled by default.
@@ -132,9 +227,12 @@ cron_interval_sec = 60
 resync_interval_sec = 10800
 score = 0.3
 
+
 [default.amo.dynamic]
-# This is the URL for the Addons API to get more information for particular addons
+# MERINO_AMO__DYNAMIC__API_URL
+# This is the URL for the Addons API to get more information for particular addons.
 api_url = "https://addons.mozilla.org/api/v5/addons/addon/"
+
 
 [default.providers.amo]
 type = "amo"
@@ -160,6 +258,7 @@ score = 0.25
 query_char_limit = 4
 firefox_char_limit = 2
 top_picks_file_path = "dev/top_picks.json"
+
 
 [default.providers.wikipedia]
 type = "wikipedia"
@@ -216,6 +315,7 @@ destination_cdn_hostname = ""
 force_upload = false
 # Minimum width of the domain favicon required for it to be a part of domain metadata
 min_favicon_width = 48
+
 
 [default.jobs.amo_rs_uploader]
 # The "type" of each remote settings record

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -29,11 +29,9 @@ debug = false
 # MERINO_RUNTIME__QUERY_TIMEOUT_SEC
 # A float timeout (in seconds) for all queries issued in "web/api_v1.py".
 # Indicates the maximum waiting period for queries issued within handler of the `suggest` endpoint.
-# See `accuweather` as an example.
 # All the unfinished query tasks will be cancelled once the timeout gets triggered.
+# Each provider can override this timeout by specifying a provider-level `query_timeout_sec`.
 # The provider timeout takes precedence over this value.
-# Each provider can override this timeout by specifying a provider-level
-# timeout with the same name `query_timeout_sec`.
 query_timeout_sec = 0.2
 
 
@@ -130,23 +128,23 @@ bucket = "main"
 collection = "quicksuggest"
 
 # MERINO_REMOTE_SETTINGS__AUTH
-# Authorization token when uploading suggestions
+# Authorization token when uploading suggestions.
 auth = ""
 
 # MERINO_REMOTE_SETTINGS__CHUNK_SIZE
-# The maximum number of suggestions to store in each attachment when uploading suggestions
+# The maximum number of suggestions to store in each attachment when uploading suggestions.
 chunk_size = 200
 
 # MERINO_REMOTE_SETTINGS__DELETE_EXISTING_RECORDS
-# Delete existing records before uploading new records
+# Delete existing records before uploading new records.
 delete_existing_records = true
 
 # MERINO_REMOTE_SETTINGS__DRY_RUN
-# Log changes but don't actually make them when uploading suggestions
+# Log changes but don't actually make them when uploading suggestions.
 dry_run = false
 
 # MERINO_REMOTE_SETTINGS__SCORE
-# Default score to set in suggestions uploaded to remote settings
+# Default score to set in suggestions uploaded to remote settings.
 score = 0.25
 
 
@@ -177,12 +175,36 @@ env = "dev"
 
 
 [default.providers.accuweather]
+# MERINO_PROVIDERS__ACCUWEATHER__TYPE
+# The type of this provider, should be `accuweather`.
 type = "accuweather"
+
+# MERINO_PROVIDERS__ACCUWEATHER__BACKEND
+#  The backend of the provider. Either `accuweather` or `test`.
 backend = "accuweather"
+
+# MERINO_PROVIDERS__ACCUWEATHER__CACHE
+# The store used to cache weather reports. Either `redis` or `none`.
+# If `redis`, the global Redis settings must be set. See redis.server.
 cache = "none"
+
+# MERINO_PROVIDERS__ACCUWEATHER__ENABLED_BY_DEFAULT
+# Whether this provider is enabled by default.
 enabled_by_default = false
+
+# MERINO_PROVIDERS__ACCUWEATHER__SCORE
+#  The ranking score for this provider as a floating point number.
 score = 0.3
+
+# MERINO_PROVIDERS__ACCUWEATHER__QUERY_TIMEOUT_SEC
+# A floating  point (in seconds) indicating the maximum waiting period when Merino queries
+# for weather forecasts. This will override the default global query timeout.
 query_timeout_sec = 5.0
+
+
+# MERINO_REDIS__SERVER - redis.server (Currently not configured here)
+# Global Redis settings. The weather provider optionally uses Redis to cache weather suggestions.
+# In the form of `redis://localhost:6379`.
 
 
 [default.providers.accuweather.cache_ttls]
@@ -193,38 +215,76 @@ forecast_ttl_sec = 3600 # 1 hr
 
 
 [default.accuweather]
-# Our API key used to access the AccuWeather API.
+# MERINO_ACCUWEATHER__API_KEY
+# The API key to AccuWeather's API endpoint.
+# In production, this should be set via environment variable as a secret.
 api_key = ""
+
 # The remainder of these variables are related to endpoint URLs.
+
+# MERINO_ACCUWEATHER__URL_BASE
+# The base URL of AccuWeather's API endpoint.
 url_base = "https://apidev.accuweather.com"
+
+# MERINO_ACCUWEATHER__URL_PARAM_API_KEY
 # The name of the query param whose value is the API key, not the key itself.
 url_param_api_key = "apikey"
-url_current_conditions_path = "/currentconditions/v1/{location_key}.json"
-url_forecasts_path = "/forecasts/v1/daily/1day/{location_key}.json"
-# The placeholder for the location key used by the above two configurations.
+
+# MERINO_ACCUWEATHER__URL_LOCATION_KEY_PLACEHOLDER
+# The placeholder for the location key used by the below two configurations.
 url_location_key_placeholder = "{location_key}"
+
+# MERINO_ACCUWEATHER__URL_CURRENT_CONDITIONS_PATH
+# The URL path for current conditions.
+url_current_conditions_path = "/currentconditions/v1/{location_key}.json"
+
+# MERINO_ACCUWEATHER__URL_FORECASTS_PATH
+# The URL path for forecasts.
+url_forecasts_path = "/forecasts/v1/daily/1day/{location_key}.json"
+
+# MERINO_ACCUWEATHER__URL_POSTALCODES_PATH
+# The URL path for postal codes.
 url_postalcodes_path = "/locations/v1/postalcodes/{country_code}/search.json"
+
+# MERINO_ACCUWEATHER__URL_POSTALCODES_PARAM_QUERY 
+# The query parameter for postal codes.
 url_postalcodes_param_query = "q"
+
+# MERINO_ACCUWEATHER__URL_PARAM_PARTNER_CODE
 # The name of the partner code query param appended to the current conditions and forecast links in
 # AccuWeather responses, as described in https://apidev.accuweather.com/developers/partner-code.
 # Note that this is the name of the partner code parameter, not the partner code itself.
 url_param_partner_code = "partner"
 
-# MERINO_REDIS__SERVER - redis.server (Currently not configured here)
-# Global Redis settings. The weather provider optionally uses Redis to cache weather suggestions.
-# In the form of `redis://localhost:6379`.
+# MERINO_ACCUWEATHER__PARTNER_CODE - partner_code (Not currently defined)
+# The partner code to append to URLs in the current conditions and forecast responses.
 
 
 [default.providers.adm]
+# MERINO_PROVIDERS__ADM__TYPE
+# The type of this provider, should be `adm`.
 type = "adm"
+
+# MERINO_PROVIDERS__ADM__ENABLED_BY_DEFAULT
 # Whether or not this provider is enabled by default.
 enabled_by_default = true
+
+# MERINO_PROVIDERS__ADM__BACKEND
 # The backend of the provider. Either "remote-settings" or "test".
 backend = "remote-settings"
+
+# MERINO_PROVIDERS__ADM__CRON_INTERVAL_SEC
+# The interval of the RemoteSettings cron job (in seconds)
 # The cron job should tick more frequently than `resync_interval_sec` so that
 # the resync failure can be retried soon.
 cron_interval_sec = 60
+
+# MERINO_PROVIDERS__ADM__RESYNC_INTERVAL_SEC
+# Time between re-syncs of Remote Settings data, in seconds. Defaults to 3 hours.
 resync_interval_sec = 10800
+
+# MERINO_PROVIDERS__ADM__SCORE
+# Ranking score for this provider as a floating point number. Defaults to 0.3.
 score = 0.3
 
 
@@ -235,16 +295,32 @@ api_url = "https://addons.mozilla.org/api/v5/addons/addon/"
 
 
 [default.providers.amo]
+# MERINO_PROVIDERS__AMO__TYPE
+# The type of this provider, should be `amo`.
 type = "amo"
+
+# MERINO_PROVIDERS__AMO__ENABLED_BY_DEFAULT
+# Whether this provider is enabled by default. Defaults to false.
 enabled_by_default = false
+
+# MERINO_PROVIDERS__AMO__SCORE
+# The ranking score for this provider as a floating point number. Defaults to 0.25.
 score = 0.25
+
+# MERINO_PROVIDERS__AMO__BACKEND
 # Specifies which backend to use. Should default to dynamic backend.
 # Currently turned off so that we don't make repeated calls to Addon API if it doesn't work.
 backend = "dynamic"
+
+# MERINO_PROVIDERS__AMO__MIN_CHARS
 # The minimum number of characters to be considered for matching.
 min_chars = 4
+
+# MERINO_PROVIDERS__AMO__RESYNC_INTERVAL_SEC
 # The re-syncing frequency for the AMO data. Defaults to daily.
 resync_interval_sec = 86400
+
+# MERINO_PROVIDERS__AMO__CRON_INTERVAL_SEC
 # The frequency that the cron checks to see if re-syncing is required.
 # This should be more frequent than the `resync_interval_sec` to retry
 # on errors. Defaults to every minute.
@@ -252,31 +328,73 @@ cron_interval_sec = 60
 
 
 [default.providers.top_picks]
+# MERINO_PROVIDERS__TOP_PICKS__TYPE
+# The type of this provider, should be `top_picks`.
 type = "top_picks"
+
+# MERINO_PROVIDERS__TOP_PICKS__ENABLED_BY_DEFAULT
+# Whether this provider is enabled by default. Defaults to true.
 enabled_by_default = true
+
+# MERINO_PROVIDERS__TOP_PICKS__SCORE
+# Ranking score for this provider as a floating point number with a default of 0.25.
 score = 0.25
+
+# MERINO_PROVIDERS__TOP_PICKS__QUERY_CHAR_LIMIT
+# Min character limit for a suggestion to be indexed and query to be processed.
+# Represented as an integer with a default set to 4.
 query_char_limit = 4
+
+# MERINO_PROVIDERS__TOP_PICKS__FIREFOX_CHAR_LIMIT
+# Min character limit set for short suggestion indexing and for Firefox to process a query.
+# Represented as an integer with a default set to 2.
 firefox_char_limit = 2
+
+# MERINO_PROVIDERS__TOP_PICKS__TOP_PICKS_FILE_PATH
+# File path to the json file of domains, represented as a string.
+# Either `dev/top_picks.json` in production or `tests/data/top_picks.json` for testing.
 top_picks_file_path = "dev/top_picks.json"
 
 
 [default.providers.wikipedia]
+# MERINO_PROVIDERS__WIKIPEDIA__TYPE
+# The type of this provider, should be `wikipedia`.
 type = "wikipedia"
+
+# MERINO_PROVIDERS__WIKIPEDIA__ENABLED_BY_DEFAULT
+# Whether this provider is enabled by default. Defaults to true.
 enabled_by_default = true
+
+# MERINO_PROVIDERS__WIKIPEDIA__BACKEND
 # The backend of the provider. Either "elasticsearch" or "test".
 backend = "elasticsearch"
-# The URL of the cluster that we want to connect to.
+
+# MERINO_PROVIDERS__WIKIPEDIA__ES_URL
+# The URL of the Elasticsearch cluster that we want to connect to.
 es_url = "http://localhost:9200"
-# The base64 key used to authenticate on the Elasticsearch cluster
+
+# MERINO_PROVIDERS__WIKIPEDIA__ES_API_KEY
+# The base64 key used to authenticate on the Elasticsearch cluster specified by `es_cloud_id`.
 es_api_key = ""
-# Elasticsearch index
+
+# MERINO_PROVIDERS__WIKIPEDIA__ES_INDEX
+#  The index identifier of Wikipedia in Elasticsearch.
 es_index = "enwiki-v1"
-# The maximum suggestions for each search request.
+
+# MERINO_PROVIDERS__WIKIPEDIA__ES_MAX_SUGGESTIONS
+# The maximum suggestions for each search request to Elasticsearch.
 es_max_suggestions = 3
-# The timeout (in millisecond) for each request to ES
+
+# MERINO_PROVIDERS__WIKIPEDIA__ES_REQUEST_TIMEOUT_MS
+# The timeout in milliseconds for each search request to Elasticsearch.
 es_request_timeout_ms = 5000
+
+# MERINO_PROVIDERS__WIKIPEDIA__QUERY_TIMEOUT_SEC
+# The timeout in seconds for each query request to the provider.
 query_timeout_sec = 5.0
-# Suggestion score
+
+# MERINO_PROVIDERS__WIKIPEDIA__SCORE
+# The ranking score for this provider as a floating point number. Defaults to 0.23.
 score = 0.23
 
 


### PR DESCRIPTION
## References

JIRA: [DISCO-2583](https://mozilla-hub.atlassian.net/browse/DISCO-2583)

## Description
Merino currently keeps configuration documents, we’ve found it inconvenient to keep two sources of documents - this and the one within the configuration TOML files. Let’s move the relevant docs from the Markdown file to `default.toml` to ease the config documentation for Merino.  

Notes for review:
Updated readability of toml file so more space delineates configs, all env vars like in original documentation define start of new value.

The `configs.md` remains with important contextual documentation that also points to external links. Hence this is why it wasn't moved into the `toml` file. Optionally, this could be moved, but since it's more broad generalized documentation that isn't specifically related to the configs in the `toml` file, it's present in markdown instead. 

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2583]: https://mozilla-hub.atlassian.net/browse/DISCO-2583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ