### PR TITLE
feat: modify csv uploader job to remove dupe keywords

### DIFF
--- a/docs/operations/jobs/csv-remote-settings.md
+++ b/docs/operations/jobs/csv-remote-settings.md
@@ -72,8 +72,9 @@ Their return values will be used as the values in the output JSON.
   takes a comma-delimited string and splits it into individual keyword strings.
   Each keyword is converted to lowercase, some non-ASCII characters are replaced
   with ASCII equivalents that users are more likely to type, leading and
-  trailing whitespace is stripped, and all whitespace is replaced with spaces
-  and collapsed. Returns the list of keyword strings.
+  trailing whitespace is stripped, all whitespace is replaced with spaces and
+  collapsed, and duplicate keywords are removed. Returns the list of keyword
+  strings.
 
 #### 5. Implement the `csv_to_json()` class method
 

--- a/merino/jobs/csv_rs_uploader/__init__.py
+++ b/merino/jobs/csv_rs_uploader/__init__.py
@@ -230,4 +230,4 @@ async def _upload_file_object(
             uploader.delete_records()
 
         for suggestion in suggestions:
-            uploader.add_suggestion(vars(suggestion))
+            uploader.add_suggestion(suggestion.model_dump(mode="json"))

--- a/merino/jobs/csv_rs_uploader/base.py
+++ b/merino/jobs/csv_rs_uploader/base.py
@@ -35,9 +35,9 @@ class BaseSuggestion(BaseModel):
         validated list of keyword strings. Each keyword is converted to
         lowercase, some non-ASCII characters are replaced with ASCII
         equivalents that users are more likely to type, leading and trailing
-        whitespace is stripped, and all whitespace is replaced with spaces and
-        collapsed. Subclasses may call this method to validate keywords in their
-        models.
+        whitespace is stripped, all whitespace is replaced with spaces and
+        collapsed, and duplicate keywords are removed. Subclasses may call this
+        method to validate keywords in their models.
         """
         value = value.lower()
         value = re.sub(r"\s+", " ", value)
@@ -48,6 +48,8 @@ class BaseSuggestion(BaseModel):
                 map(str.strip, value.split(",")),
             )
         ]
+        # Sort the list so tests can rely on a consistent ordering.
+        keywords = sorted(list(set(keywords)))
         if not keywords or len(keywords) == 0:
             raise ValueError(f"{name} must not be empty")
         return keywords

--- a/merino/jobs/csv_rs_uploader/base.py
+++ b/merino/jobs/csv_rs_uploader/base.py
@@ -49,7 +49,7 @@ class BaseSuggestion(BaseModel):
             )
         ]
         # Sort the list so tests can rely on a consistent ordering.
-        keywords = sorted(list(set(keywords)))
+        keywords = sorted(set(keywords))
         if not keywords or len(keywords) == 0:
             raise ValueError(f"{name} must not be empty")
         return keywords

--- a/merino/jobs/utils/chunked_rs_uploader.py
+++ b/merino/jobs/utils/chunked_rs_uploader.py
@@ -5,8 +5,16 @@ import logging
 from typing import Any
 
 import kinto_http
+from pydantic_core import Url
 
 logger = logging.getLogger(__name__)
+
+
+class _JSONEncoder(json.JSONEncoder):
+    def default(self, value):
+        if isinstance(value, Url):
+            return str(value)
+        return super().default(value)
 
 
 class _Chunk:
@@ -167,7 +175,7 @@ class ChunkedRemoteSettingsUploader:
             "id": record_id,
             "type": self.record_type,
         }
-        attachment_json = json.dumps(chunk.suggestions)
+        attachment_json = json.dumps(chunk.suggestions, cls=_JSONEncoder)
 
         logger.info(f"Uploading record: {record}")
         if not self.dry_run:

--- a/tests/unit/jobs/csv_rs_uploader/test_csv_rs_uploader.py
+++ b/tests/unit/jobs/csv_rs_uploader/test_csv_rs_uploader.py
@@ -9,7 +9,7 @@ from typing import Any
 
 import pytest
 from click.exceptions import BadParameter
-from pydantic import HttpUrl, ValidationError
+from pydantic import ValidationError
 
 from merino.jobs.csv_rs_uploader import MissingFieldError, upload
 from tests.unit.jobs.csv_rs_uploader.model import (
@@ -44,7 +44,7 @@ TEST_CSV_ROW = {
 }
 
 TEST_EXPECTED_SUGGESTION = {
-    "url": HttpUrl(TEST_CSV_ROW[FIELD_URL]),
+    "url": TEST_CSV_ROW[FIELD_URL],
     "title": TEST_CSV_ROW[FIELD_TITLE],
     "description": TEST_CSV_ROW[FIELD_DESC],
     "lowConfidenceKeywords": TEST_CSV_ROW[FIELD_KEYWORDS_LOW].split(","),
@@ -60,7 +60,7 @@ def expected_primary_suggestions() -> list[dict[str, Any]]:
     for s in range(PRIMARY_SUGGESTION_COUNT):
         suggestions.append(
             {
-                "url": HttpUrl(f"http://example.com/pocket-{s}"),
+                "url": f"http://example.com/pocket-{s}",
                 "title": f"Title {s}",
                 "description": f"Description {s}",
                 "lowConfidenceKeywords": [

--- a/tests/unit/jobs/csv_rs_uploader/test_csv_rs_uploader.py
+++ b/tests/unit/jobs/csv_rs_uploader/test_csv_rs_uploader.py
@@ -163,7 +163,7 @@ def test_lowConfidenceKeywords_transform(mocker):
         csv_rows=[
             {
                 **TEST_CSV_ROW,
-                FIELD_KEYWORDS_LOW: "   AaA\n,b,\r\nCCC,  d  ,e’e",
+                FIELD_KEYWORDS_LOW: "   AaA\n,b,\r\nCCC,  d  ,aaa,e’e",
             },
         ],
         expected_suggestions=[
@@ -186,7 +186,7 @@ def test_highConfidenceKeywords_transform(mocker):
         csv_rows=[
             {
                 **TEST_CSV_ROW,
-                FIELD_KEYWORDS_HIGH: "   AaA\n,b,\r\nCCC,  d  ,e’e",
+                FIELD_KEYWORDS_HIGH: "   AaA\n,b,\r\nCCC,  d  ,aaa,e’e",
             },
         ],
         expected_suggestions=[

--- a/tests/unit/jobs/csv_rs_uploader/test_mdn.py
+++ b/tests/unit/jobs/csv_rs_uploader/test_mdn.py
@@ -4,7 +4,7 @@
 
 """Unit tests for the mdn.py model."""
 
-from pydantic import HttpUrl, ValidationError
+from pydantic import ValidationError
 
 from merino.jobs.csv_rs_uploader import MissingFieldError
 from merino.jobs.csv_rs_uploader.mdn import (
@@ -46,13 +46,13 @@ def test_upload(mocker):
         ],
         expected_suggestions=[
             {
-                "url": HttpUrl("http://example.com/mdn/0"),
+                "url": "http://example.com/mdn/0",
                 "title": "Title 0",
                 "description": "Description 0",
                 "keywords": ["aaa", "bbb", "ccc"],
             },
             {
-                "url": HttpUrl("http://example.com/mdn/1"),
+                "url": "http://example.com/mdn/1",
                 "title": "Title 1",
                 "description": "Description 1",
                 "keywords": ["xxx", "yyy", "zzz"],

--- a/tests/unit/jobs/csv_rs_uploader/test_pocket.py
+++ b/tests/unit/jobs/csv_rs_uploader/test_pocket.py
@@ -4,7 +4,7 @@
 
 """Unit tests for the pocket.py model."""
 
-from pydantic import HttpUrl, ValidationError
+from pydantic import ValidationError
 
 from merino.jobs.csv_rs_uploader import MissingFieldError
 from merino.jobs.csv_rs_uploader.pocket import (
@@ -50,14 +50,14 @@ def test_upload(mocker):
         ],
         expected_suggestions=[
             {
-                "url": HttpUrl("http://example.com/pocket/0"),
+                "url": "http://example.com/pocket/0",
                 "title": "Title 0",
                 "description": "Description 0",
                 "lowConfidenceKeywords": ["a", "b", "c"],
                 "highConfidenceKeywords": ["aaa", "bbb", "ccc"],
             },
             {
-                "url": HttpUrl("http://example.com/pocket/1"),
+                "url": "http://example.com/pocket/1",
                 "title": "Title 1",
                 "description": "Description 1",
                 "lowConfidenceKeywords": ["x", "y", "z"],


### PR DESCRIPTION
## References

[Dupe keyword discussion](https://github.com/mozilla/application-services/pull/5841)

## Description

There's some kind of unrelated new problem with the uploader where `json.dumps()` can't serialize the `Url` objects created by Pydantic. Nothing changed in the uploader so I don't know if this is due to upgrading Pydantic or what. This PR fixes that too.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
