### PR TITLE
[DISCO-2585] Merino: Intermittent Failure Gathering AdM Queries From Remote Settings In Local Dev & Load Tests [load test: abort]

### DIFF
--- a/merino/providers/adm/backends/remotesettings.py
+++ b/merino/providers/adm/backends/remotesettings.py
@@ -12,6 +12,8 @@ from merino.exceptions import BackendError
 from merino.providers.adm.backends.protocol import SuggestionContent
 from merino.utils.http_client import create_http_client
 
+RS_CONNECT_TIMEOUT: float = 5.0
+
 RecordType = Literal["data", "icon", "offline-expansion-data"]
 
 
@@ -189,7 +191,9 @@ class RemoteSettingsBackend:
         Raises:
             RemoteSettingsError: Failed request to Remote Settings.
         """
-        async with create_http_client() as httpx_client:
+        async with create_http_client(
+            connect_timeout=RS_CONNECT_TIMEOUT
+        ) as httpx_client:
             try:
                 response: httpx.Response = await httpx_client.get(url)
                 response.raise_for_status()


### PR DESCRIPTION
## References

JIRA: [DISCO-2585](https://mozilla-hub.atlassian.net/browse/DISCO-2585)

## Description
During on_locust_test_start, the Merino load tests query Remote Settings in order to gather query strings for performance evaluation of the AdM provider. Occasionally this query fails at which time the load tests are programmed to exit with a failure status. There are also times when this fails when merino is running locally without load tests. This behavior is geared towards the CD use case, where we want to fail fast and a proper exit code is required. The behavior is not ideal for local execution as it requires re-starting the locust_master Docker container to try again.

Ideally, we will increase the timeout duration and hopefully this will be similar to the issues we had with the AMO provider timeouts.

Note: this has not been an issue in production, only in local development.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2585]: https://mozilla-hub.atlassian.net/browse/DISCO-2585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ