### PR TITLE
[DISCO-2623] Top Picks Content Moderation - Ad-hoc Blocking: Exclude Blocklist Domains at Provider Backend

### DIFF
--- a/docs/dev/content-moderation.md
+++ b/docs/dev/content-moderation.md
@@ -32,10 +32,10 @@ At job runtime, the indexer reads the remote blocklist and creates a set of arti
 The article categories in the blocklist are chosen based off of analysis and best guesses of what could be considered _objectionable_ content, based off of Mozilla's values and brand image.
 Any modifications to the file should be done with careful consideration.
 
-The indexer also blocks titles that are defined in the `title_blocklist` in the application, which is referenced below.  Any title that matches this blocklist is excluded from indexing. 
+The indexer also blocks titles that are defined in the `WIKIPEDIA_TITLE_BLOCKLIST` in the application, which is referenced below.  Any title that matches this blocklist is excluded from indexing. 
 
 ### Provider
-When queried, the Wikipedia provider reads the `title_blocklist` when creating a `WikipediaSuggestion` and if the query matches a blocked title, the suggestion is not shown to the client. 
+When queried, the Wikipedia provider reads the `WIKIPEDIA_TITLE_BLOCKLIST` when creating a `WikipediaSuggestion` and if the query matches a blocked title, the suggestion is not shown to the client. 
 
 We have this feature because the indexing job is not run daily. Therefore, we desire having an option to rapidly add to this list should we need to block a specific article. 
 

--- a/docs/operations/blocklist-wikipedia.md
+++ b/docs/operations/blocklist-wikipedia.md
@@ -18,4 +18,4 @@ The next time the Wikipedia indexer job runs, this title will be excluded during
 
 *NOTE:* There are two blocklists referenced by the Wikipedia Indexer Job:
 1. `blocklist_file_url`: a key contained in the `merino/configs/default.toml` file that points to a remote block list which encapsulates blocked categories.
-2. `title_blocklist`: an application-level list of titles found at `/merino/utils/blocklist.py` as explained above.
+2. `WIKIPEDIA_TITLE_BLOCKLIST`: an application-level list of titles found at `/merino/utils/blocklist.py` as explained above.

--- a/docs/operations/blocklist-wikipedia.md
+++ b/docs/operations/blocklist-wikipedia.md
@@ -3,7 +3,7 @@
 ## Provider - Rapid Blocklist Addition
 These steps define how to rapidly add and therefore block a Wikipedia article by its title.
 
-1. In `/merino/utils/blocklist.py`, add the matching title to `TITLE_BLOCK_LIST`.
+1. In `/merino/utils/blocklists.py`, add the matching title to `TITLE_BLOCK_LIST`.
 
 *NOTE:* Ensure the title field is added as it appears with correct spacing between the words.
 In adding to the list, enter the title as it appears in Wikipedia.
@@ -18,4 +18,4 @@ The next time the Wikipedia indexer job runs, this title will be excluded during
 
 *NOTE:* There are two blocklists referenced by the Wikipedia Indexer Job:
 1. `blocklist_file_url`: a key contained in the `merino/configs/default.toml` file that points to a remote block list which encapsulates blocked categories.
-2. `WIKIPEDIA_TITLE_BLOCKLIST`: an application-level list of titles found at `/merino/utils/blocklist.py` as explained above.
+2. `WIKIPEDIA_TITLE_BLOCKLIST`: an application-level list of titles found at `/merino/utils/blocklists.py` as explained above.

--- a/merino/jobs/wikipedia_indexer/__init__.py
+++ b/merino/jobs/wikipedia_indexer/__init__.py
@@ -10,7 +10,7 @@ from merino.jobs.wikipedia_indexer.utils import (
     create_blocklist,
     create_elasticsearch_client,
 )
-from merino.utils.blocklist import WIKIPEDIA_TITLE_BLOCKLIST
+from merino.utils.blocklists import WIKIPEDIA_TITLE_BLOCKLIST
 
 logger = logging.getLogger(__name__)
 

--- a/merino/jobs/wikipedia_indexer/__init__.py
+++ b/merino/jobs/wikipedia_indexer/__init__.py
@@ -10,7 +10,7 @@ from merino.jobs.wikipedia_indexer.utils import (
     create_blocklist,
     create_elasticsearch_client,
 )
-from merino.utils.blocklist import TITLE_BLOCKLIST
+from merino.utils.blocklist import WIKIPEDIA_TITLE_BLOCKLIST
 
 logger = logging.getLogger(__name__)
 
@@ -63,7 +63,7 @@ def index(
     indexer = Indexer(
         index_version,
         blocklist,
-        TITLE_BLOCKLIST,
+        WIKIPEDIA_TITLE_BLOCKLIST,
         file_manager,
         es_client,
     )

--- a/merino/providers/manager.py
+++ b/merino/providers/manager.py
@@ -26,7 +26,7 @@ from merino.providers.weather.provider import Provider as WeatherProvider
 from merino.providers.wikipedia.backends.elastic import ElasticBackend
 from merino.providers.wikipedia.backends.fake_backends import FakeWikipediaBackend
 from merino.providers.wikipedia.provider import Provider as WikipediaProvider
-from merino.utils.blocklist import TITLE_BLOCKLIST
+from merino.utils.blocklist import WIKIPEDIA_TITLE_BLOCKLIST
 from merino.utils.http_client import create_http_client
 
 
@@ -131,7 +131,7 @@ def _create_provider(provider_id: str, setting: Settings) -> BaseProvider:
                 )  # type: ignore [arg-type]
                 if setting.backend == "elasticsearch"
                 else FakeWikipediaBackend(),
-                title_block_list=TITLE_BLOCKLIST,
+                title_block_list=WIKIPEDIA_TITLE_BLOCKLIST,
                 name=provider_id,
                 query_timeout_sec=setting.query_timeout_sec,
                 enabled_by_default=setting.enabled_by_default,

--- a/merino/providers/manager.py
+++ b/merino/providers/manager.py
@@ -26,7 +26,7 @@ from merino.providers.weather.provider import Provider as WeatherProvider
 from merino.providers.wikipedia.backends.elastic import ElasticBackend
 from merino.providers.wikipedia.backends.fake_backends import FakeWikipediaBackend
 from merino.providers.wikipedia.provider import Provider as WikipediaProvider
-from merino.utils.blocklist import WIKIPEDIA_TITLE_BLOCKLIST
+from merino.utils.blocklists import TOP_PICKS_BLOCKLIST, WIKIPEDIA_TITLE_BLOCKLIST
 from merino.utils.http_client import create_http_client
 
 
@@ -116,6 +116,7 @@ def _create_provider(provider_id: str, setting: Settings) -> BaseProvider:
                     top_picks_file_path=setting.top_picks_file_path,
                     query_char_limit=setting.query_char_limit,
                     firefox_char_limit=setting.firefox_char_limit,
+                    domain_blocklist=TOP_PICKS_BLOCKLIST,
                 ),
                 score=setting.score,
                 name=provider_id,

--- a/merino/providers/top_picks/backends/top_picks.py
+++ b/merino/providers/top_picks/backends/top_picks.py
@@ -21,6 +21,7 @@ class TopPicksBackend:
         top_picks_file_path: str | None,
         query_char_limit: int,
         firefox_char_limit: int,
+        domain_blocklist: set[str],
     ) -> None:
         """Initialize Top Picks backend.
 
@@ -33,6 +34,7 @@ class TopPicksBackend:
         self.top_picks_file_path = top_picks_file_path
         self.query_char_limit = query_char_limit
         self.firefox_char_limit = firefox_char_limit
+        self.domain_blocklist = {entry.lower() for entry in domain_blocklist}
 
     async def fetch(self) -> TopPicksData:
         """Fetch Top Picks suggestions from domain list.
@@ -77,7 +79,10 @@ class TopPicksBackend:
 
         for record in domain_list["domains"]:
             index_key: int = len(results)
-            domain = record["domain"].strip().lower()
+            domain: str = record["domain"].strip().lower()
+
+            if domain in self.domain_blocklist:
+                continue
 
             if len(domain) > query_max:
                 query_max = len(domain)

--- a/merino/utils/blocklist.py
+++ b/merino/utils/blocklist.py
@@ -1,4 +1,0 @@
-"""Util module containing blocklists for Dynamic Wikipedia and Top Picks providers."""
-
-WIKIPEDIA_TITLE_BLOCKLIST: set[str] = set()
-TOP_PICKS_BLOCKLIST: set[str] = set()

--- a/merino/utils/blocklist.py
+++ b/merino/utils/blocklist.py
@@ -1,3 +1,4 @@
-"""Util module containing block list for Dynamic Wikipedia provider."""
+"""Util module containing blocklists for Dynamic Wikipedia and Top Picks providers."""
 
-TITLE_BLOCKLIST: set[str] = set()
+WIKIPEDIA_TITLE_BLOCKLIST: set[str] = set()
+TOP_PICKS_BLOCKLIST: set[str] = set()

--- a/merino/utils/blocklists.py
+++ b/merino/utils/blocklists.py
@@ -1,0 +1,12 @@
+"""Util module containing blocklists for Dynamic Wikipedia and Top Picks providers."""
+
+WIKIPEDIA_TITLE_BLOCKLIST: set[str] = set()
+TOP_PICKS_BLOCKLIST: set[str] = {
+    "furaffinity",
+    "worldstarhiphop",
+    "myvidster",
+    "urbandictionary",
+    "megapersonals",
+    "4channel",
+    "thegatewaypundit",
+}

--- a/merino/utils/blocklists.py
+++ b/merino/utils/blocklists.py
@@ -9,4 +9,6 @@ TOP_PICKS_BLOCKLIST: set[str] = {
     "megapersonals",
     "4channel",
     "thegatewaypundit",
+    "winloot",
+    "sniffies",
 }

--- a/tests/data/top_picks.json
+++ b/tests/data/top_picks.json
@@ -62,6 +62,20 @@
                 "acbc",
                 "aecbc"
             ]
+        },
+        {
+            "rank": 5,
+            "title": "BadDomain",
+            "domain": "baddomain",
+            "url": "https://baddomain.test",
+            "icon": "",
+            "categories": [
+                "web-browser"
+            ],
+            "similars": [
+                "bad",
+                "badd"
+            ]
         }
     ]
 }

--- a/tests/integration/api/v1/suggest/test_suggest_top_picks.py
+++ b/tests/integration/api/v1/suggest/test_suggest_top_picks.py
@@ -17,13 +17,20 @@ from merino.providers.top_picks.provider import Provider, Suggestion
 from tests.integration.api.v1.types import Providers
 
 
+@pytest.fixture(name="domain_blocklist")
+def fixture_top_picks_domain_blocklist() -> set[str]:
+    """Create domain_blocklist."""
+    return {"baddomain"}
+
+
 @pytest.fixture(name="top_picks_backend_parameters")
-def fixture_top_picks_backend_parameters() -> dict[str, Any]:
+def fixture_top_picks_backend_parameters(domain_blocklist: set[str]) -> dict[str, Any]:
     """Define Top Pick backed parameters for test."""
     return {
         "top_picks_file_path": settings.providers.top_picks.top_picks_file_path,
         "query_char_limit": settings.providers.top_picks.query_char_limit,
         "firefox_char_limit": settings.providers.top_picks.firefox_char_limit,
+        "domain_blocklist": domain_blocklist,
     }
 
 

--- a/tests/load/locustfiles/locustfile.py
+++ b/tests/load/locustfiles/locustfile.py
@@ -30,6 +30,7 @@ from merino.providers.adm.backends.remotesettings import (
 from merino.providers.amo.addons_data import ADDON_KEYWORDS
 from merino.providers.top_picks.backends.protocol import TopPicksData
 from merino.providers.top_picks.backends.top_picks import TopPicksBackend, TopPicksError
+from merino.utils.blocklists import TOP_PICKS_BLOCKLIST
 from merino.utils.version import Version
 from merino.web.models_v1 import SuggestResponse
 from tests.load.common.client_info import DESKTOP_FIREFOX, LOCALES
@@ -125,6 +126,7 @@ def on_locust_test_start(environment, **kwargs) -> None:
             top_picks_file_path=MERINO_PROVIDERS__TOP_PICKS__TOP_PICKS_FILE_PATH,
             query_char_limit=MERINO_PROVIDERS__TOP_PICKS__QUERY_CHAR_LIMIT,
             firefox_char_limit=MERINO_PROVIDERS__TOP_PICKS__FIREFOX_CHAR_LIMIT,
+            domain_blocklist=TOP_PICKS_BLOCKLIST,
         )
 
         logger.info(f"Download {len(query_data.top_picks)} queries for Top Picks")
@@ -200,7 +202,10 @@ def get_amo_queries() -> list[str]:
 
 
 def get_top_picks_queries(
-    top_picks_file_path: str | None, query_char_limit: int, firefox_char_limit: int
+    top_picks_file_path: str | None,
+    query_char_limit: int,
+    firefox_char_limit: int,
+    domain_blocklist: set[str],
 ) -> QueriesList:
     """Get query strings for use in testing the Top Picks Provider.
 
@@ -217,7 +222,7 @@ def get_top_picks_queries(
         TopPicksError: If the top picks file path cannot be opened or decoded
     """
     backend: TopPicksBackend = TopPicksBackend(
-        top_picks_file_path, query_char_limit, firefox_char_limit
+        top_picks_file_path, query_char_limit, firefox_char_limit, domain_blocklist
     )
     data: TopPicksData = asyncio.run(backend.fetch())
 

--- a/tests/unit/providers/top_picks/backends/test_top_picks.py
+++ b/tests/unit/providers/top_picks/backends/test_top_picks.py
@@ -13,13 +13,20 @@ from merino.config import settings
 from merino.providers.top_picks.backends.top_picks import TopPicksBackend, TopPicksError
 
 
+@pytest.fixture(name="domain_blocklist")
+def fixture_top_picks_domain_blocklist() -> set[str]:
+    """Create domain_blocklist."""
+    return {"baddomain"}
+
+
 @pytest.fixture(name="top_picks_backend_parameters")
-def fixture_top_picks_parameters() -> dict[str, Any]:
-    """Create a Top Picks backend object for test."""
+def fixture_top_picks_backend_parameters(domain_blocklist: set[str]) -> dict[str, Any]:
+    """Define Top Picks backed parameters for test."""
     return {
         "top_picks_file_path": settings.providers.top_picks.top_picks_file_path,
         "query_char_limit": settings.providers.top_picks.query_char_limit,
         "firefox_char_limit": settings.providers.top_picks.firefox_char_limit,
+        "domain_blocklist": domain_blocklist,
     }
 
 
@@ -88,3 +95,10 @@ async def test_fetch(top_picks_backend: TopPicksBackend, attr: str) -> None:
     """Test the fetch method returns TopPickData."""
     result = await top_picks_backend.fetch()
     assert hasattr(result, attr)
+
+
+def test_domain_blocklist(
+    top_picks_backend: TopPicksBackend, domain_blocklist: set[str]
+) -> None:
+    """Test that the domain_blocklist has expected value."""
+    assert top_picks_backend.domain_blocklist == domain_blocklist

--- a/tests/unit/providers/top_picks/conftest.py
+++ b/tests/unit/providers/top_picks/conftest.py
@@ -12,13 +12,20 @@ from merino.providers.top_picks.backends.top_picks import TopPicksBackend
 from merino.providers.top_picks.provider import Provider
 
 
+@pytest.fixture(name="domain_blocklist")
+def fixture_top_picks_domain_blocklist() -> set[str]:
+    """Create domain_blocklist."""
+    return {"baddomain"}
+
+
 @pytest.fixture(name="top_picks_backend_parameters")
-def fixture_top_picks_backend_parameters() -> dict[str, Any]:
+def fixture_top_picks_backend_parameters(domain_blocklist: set[str]) -> dict[str, Any]:
     """Define Top Picks backed parameters for test."""
     return {
         "top_picks_file_path": settings.providers.top_picks.top_picks_file_path,
         "query_char_limit": settings.providers.top_picks.query_char_limit,
         "firefox_char_limit": settings.providers.top_picks.firefox_char_limit,
+        "domain_blocklist": domain_blocklist,
     }
 
 


### PR DESCRIPTION
## References

JIRA: [DISCO-2623](https://mozilla-hub.atlassian.net/browse/DISCO-2623)

## Description
Currently, we have a feature in the Wikipedia provider that checks against categories in a block list. This allows for ad-hoc blocking which requires just a PR and merge to immediately remove terms from being presented to clients. 

This is implemented for the Top Picks Provider, though with some differences:

- Block 2nd-level domain, not term. Contained in a set of strings. This is the `"domain"` key in the JSON data.
- This filtering takes place at the creation of the backend and therefore a blocked suggestion is not indexed.
- Uniform `blocklists.py` utility module that contains the in-memory blocklists for Wikipedia and Top Picks.

Note: Subsequent PR will decouple the `navigational_suggestions` job block list JSON file and implement this same in-memory list. The job only implements the block list operations locally and add strings to a JSON file, which is then read again during the job run on Airflow in prod/stage. This is less simple than adding to a set blocklist in Merino that can be used in multiple places. It doesn't make sense to add the additional overhead of reading another JSON file to create the blocklist or reading from 2 separate sources. This emulates the in-memory blocklist in the Wikipedia provider. 

Testing and documentation is updated.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2623]: https://mozilla-hub.atlassian.net/browse/DISCO-2623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ