### PR TITLE
feat: modify csv uploader job to remove low keywords that dupe high keywords

### DIFF
--- a/tests/unit/jobs/csv_rs_uploader/test_pocket.py
+++ b/tests/unit/jobs/csv_rs_uploader/test_pocket.py
@@ -37,14 +37,14 @@ def test_upload(mocker):
                 FIELD_URL: "http://example.com/pocket/0",
                 FIELD_TITLE: "Title 0",
                 FIELD_DESC: "Description 0",
-                FIELD_KEYWORDS_LOW: "a,b,c",
+                FIELD_KEYWORDS_LOW: "a,b,c, AaA ,BBB, ccC ",
                 FIELD_KEYWORDS_HIGH: "aaa,bbb,ccc",
             },
             {
                 FIELD_URL: "http://example.com/pocket/1",
                 FIELD_TITLE: "      Title\n\r 1 \n",
                 FIELD_DESC: "      Description\n\t 1\r\n ",
-                FIELD_KEYWORDS_LOW: "  X  , Y , Z",
+                FIELD_KEYWORDS_LOW: "  X  , Y , Z,xxx,yyy,zzz",
                 FIELD_KEYWORDS_HIGH: "  XxX  , yYy , ZZZ   ",
             },
         ],
@@ -121,6 +121,23 @@ def test_lowConfidenceKeywords_empty(mocker):
             {
                 **TEST_CSV_ROW,
                 FIELD_KEYWORDS_LOW: "",
+            },
+        ],
+        expected_error=ValidationError,
+    )
+
+
+def test_lowConfidenceKeywords_empty_high_dupes(mocker):
+    """A lowConfidenceKeywords that becomes empty after removing keywords that
+    are present in highConfidenceKeywords should raise a ValidationError
+    """
+    do_error_test(
+        mocker,
+        model_name=MODEL_NAME,
+        csv_rows=[
+            {
+                **TEST_CSV_ROW,
+                FIELD_KEYWORDS_LOW: TEST_CSV_ROW[FIELD_KEYWORDS_HIGH],
             },
         ],
         expected_error=ValidationError,


### PR DESCRIPTION
## References

See discussion in https://github.com/mozilla/application-services/pull/5841

## Description

When validating Pocket suggestions, remove low-confidence keywords that dupe high-confidence keywords.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
