### PR TITLE
[DISCO-2634] Disable Provider Disaster Recovery

### DIFF
--- a/merino/config.py
+++ b/merino/config.py
@@ -3,6 +3,7 @@ from dynaconf import Dynaconf, Validator
 
 # Validators for Merino settings.
 _validators = [
+    Validator("providers.disabled", is_type_of=list),
     Validator("deployment.canary", is_type_of=bool),
     Validator("logging.format", is_in=["mozlog", "pretty"]),
     Validator("logging.level", is_in=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]),

--- a/merino/config.py
+++ b/merino/config.py
@@ -3,7 +3,11 @@ from dynaconf import Dynaconf, Validator
 
 # Validators for Merino settings.
 _validators = [
-    Validator("providers.disabled", is_type_of=list),
+    # Circuit-breaker to disable providers at startup
+    Validator(
+        "runtime.disabled_providers",
+        is_type_of=list,
+    ),
     Validator("deployment.canary", is_type_of=bool),
     Validator("logging.format", is_in=["mozlog", "pretty"]),
     Validator("logging.level", is_in=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]),

--- a/merino/config.py
+++ b/merino/config.py
@@ -3,7 +3,6 @@ from dynaconf import Dynaconf, Validator
 
 # Validators for Merino settings.
 _validators = [
-    # Circuit-breaker to disable providers at startup
     Validator(
         "runtime.disabled_providers",
         is_type_of=list,

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -173,6 +173,10 @@ env = "dev"
 # If set to `debug`, the DSN will be set to a testing value recommended by Sentry, 
 # and extra output will be included in the logs.
 
+[default.providers]
+# MERINO_PROVIDERS__DISABLED
+# List containing providers to disable at startup.
+disabled = []
 
 [default.providers.accuweather]
 # MERINO_PROVIDERS__ACCUWEATHER__TYPE

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -36,6 +36,7 @@ query_timeout_sec = 0.2
 
 # MERINO_RUNTIME__DISABLED_PROVIDERS
 # List containing providers to disable at startup.
+# Prevents a provider from being instantiated.
 disabled_providers = []
 
 

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -34,6 +34,10 @@ debug = false
 # The provider timeout takes precedence over this value.
 query_timeout_sec = 0.2
 
+# MERINO_RUNTIME__DISABLED_PROVIDERS
+# List containing providers to disable at startup.
+disabled_providers = []
+
 
 [default.logging]
 # MERINO_LOGGING__LEVEL
@@ -172,11 +176,6 @@ env = "dev"
 # If `sentry.mode` is set to `disabled`, no Sentry integration will be activated.
 # If set to `debug`, the DSN will be set to a testing value recommended by Sentry, 
 # and extra output will be included in the logs.
-
-[default.providers]
-# MERINO_PROVIDERS__DISABLED
-# List containing providers to disable at startup.
-disabled = []
 
 [default.providers.accuweather]
 # MERINO_PROVIDERS__ACCUWEATHER__TYPE

--- a/merino/configs/testing.toml
+++ b/merino/configs/testing.toml
@@ -10,6 +10,7 @@ dynaconf_merge = true
 [testing.runtime]
 # Use a larger timeout for testing
 query_timeout_sec = 0.5
+disabled_providers = ["disabled_provider"]
 
 
 [testing.metrics]

--- a/merino/providers/__init__.py
+++ b/merino/providers/__init__.py
@@ -2,8 +2,9 @@
 import asyncio
 import logging
 from timeit import default_timer as timer
-from merino.config import settings
+
 from merino import metrics
+from merino.config import settings
 from merino.providers.base import BaseProvider
 from merino.providers.manager import load_providers
 

--- a/merino/providers/__init__.py
+++ b/merino/providers/__init__.py
@@ -2,7 +2,7 @@
 import asyncio
 import logging
 from timeit import default_timer as timer
-
+from merino.config import settings
 from merino import metrics
 from merino.providers.base import BaseProvider
 from merino.providers.manager import load_providers
@@ -21,7 +21,9 @@ async def init_providers() -> None:
     start = timer()
 
     # register providers
-    providers.update(load_providers())
+    providers.update(
+        load_providers(disabled_providers_list=settings.runtime.disabled_providers)
+    )
 
     # initialize providers and record time
     init_metric = "providers.initialize"

--- a/merino/providers/manager.py
+++ b/merino/providers/manager.py
@@ -141,7 +141,7 @@ def _create_provider(provider_id: str, setting: Settings) -> BaseProvider:
             raise InvalidProviderError(f"Unknown provider type: {setting.type}")
 
 
-def load_providers() -> dict[str, BaseProvider]:
+def load_providers(disabled_providers_list: list[str]) -> dict[str, BaseProvider]:
     """Load providers from configurations.
 
     Exceptions:
@@ -150,10 +150,6 @@ def load_providers() -> dict[str, BaseProvider]:
     providers: dict[str, BaseProvider] = {}
     for provider_id, setting in settings.providers.items():
         # Do not initialize provider if disabled in config.
-        if (
-            provider_id.lower() in settings.runtime.disabled_providers
-            and provider_id.lower() in [pt.value for pt in ProviderType]
-        ):
-            continue
-        providers[provider_id] = _create_provider(provider_id, setting)
+        if provider_id.lower() not in disabled_providers_list:
+            providers[provider_id] = _create_provider(provider_id, setting)
     return providers

--- a/merino/providers/manager.py
+++ b/merino/providers/manager.py
@@ -148,8 +148,12 @@ def load_providers() -> dict[str, BaseProvider]:
       - `InvalidProviderError` if the provider type is unknown.
     """
     providers: dict[str, BaseProvider] = {}
-
     for provider_id, setting in settings.providers.items():
+        # Do not initialize provider if disabled in config.
+        if (
+            provider_id.lower() in settings.runtime.disabled_providers
+            and provider_id.lower() in [pt.value for pt in ProviderType]
+        ):
+            continue
         providers[provider_id] = _create_provider(provider_id, setting)
-
     return providers

--- a/tests/integration/api/v1/conftest.py
+++ b/tests/integration/api/v1/conftest.py
@@ -9,6 +9,7 @@ from typing import Any, Callable, Coroutine
 
 import pytest_asyncio
 
+from merino.config import settings
 from merino.main import app
 from merino.providers import get_providers
 from merino.providers.base import BaseProvider
@@ -63,6 +64,7 @@ async def fixture_inject_providers(
     setup_providers: SetupProvidersFixture,
     teardown_providers: TeardownProvidersFixture,
     providers: Providers,
+    disabled_providers=settings.runtime.disabled_providers,
 ):
     """Set up and teardown the given providers.
 
@@ -92,6 +94,10 @@ async def fixture_inject_providers(
         ],
     )
     """
-    setup_providers(providers)
+    # Ensures this test interface takes into account disabled providers.
+    enabled_providers = {
+        k: v for k, v in providers.items() if k not in disabled_providers
+    }
+    setup_providers(enabled_providers)
     yield
     await teardown_providers(providers)

--- a/tests/integration/api/v1/fake_providers.py
+++ b/tests/integration/api/v1/fake_providers.py
@@ -222,3 +222,14 @@ class FakeProviderFactory:
             ),
             query_timeout_sec=settings.runtime.query_timeout_sec * 4,
         )
+
+    @staticmethod
+    def disabled_provider(enabled_by_default: bool = True) -> FakeProvider:
+        """Return a new provider that is intended to be disabled."""
+        provider_name = "disabled_provider"
+        return FakeProvider(
+            name=provider_name,
+            enabled_by_default=enabled_by_default,
+            hidden=False,
+            query_callable=query_sponsored(provider_name),
+        )

--- a/tests/integration/api/v1/providers/test_providers.py
+++ b/tests/integration/api/v1/providers/test_providers.py
@@ -84,6 +84,39 @@ def test_providers(
     assert response.json() == expected_response
 
 
+@pytest.mark.parametrize(
+    [
+        "expected_response",
+        "providers",
+    ],
+    [
+        (
+            [],
+            {
+                "disabled_provider": FakeProviderFactory.disabled_provider(
+                    enabled_by_default=True
+                ),
+            },
+        ),
+    ],
+    ids=[
+        "disabled_provider",
+    ],
+)
+def test_disabled_providers_setting(
+    client: TestClient,
+    expected_response: list[dict[str, str]],
+    providers: dict[str, BaseProvider],
+) -> None:
+    """Test that the disabled_providers setting behaves as expected when
+    querying the providers endpoint.
+    """
+    response = client.get("/api/v1/providers")
+
+    assert response.status_code == 200
+    assert response.json() == expected_response
+
+
 @freeze_time("1998-03-31")
 @pytest.mark.parametrize("providers", [{}])
 def test_providers_request_log_data(

--- a/tests/unit/providers/test_init_providers.py
+++ b/tests/unit/providers/test_init_providers.py
@@ -37,28 +37,17 @@ async def test_init_providers() -> None:
 
 @pytest.mark.parametrize("provider", ["adm", "amo", "top_picks", "wikipedia"])
 @pytest.mark.asyncio
-async def test_init_providers_with_disabled_provider(
-    monkeypatch: pytest.MonkeyPatch, provider: str
-) -> None:
+async def test_init_providers_with_disabled_provider(provider: str) -> None:
     """Test for the `init_providers`and `load_providers` methods when a provider
     is disabled through the `merino.runtime.disabled_providers` config.
     """
     await init_providers()
 
-    providers = load_providers(
-        disabled_providers_list=settings.runtime.disabled_providers
-    )
+    providers = load_providers(disabled_providers_list=[])
     assert provider in providers.keys()
 
-    monkeypatch.setattr(
-        settings,
-        "runtime",
-        {"disabled_providers": [provider]},
-    )
-
-    providers = load_providers(
-        disabled_providers_list=settings.runtime.disabled_providers
-    )
+    # Add provider from parameters to block instantiation.
+    providers = load_providers(disabled_providers_list=[provider])
     assert provider not in providers.keys()
 
 

--- a/tests/unit/providers/test_init_providers.py
+++ b/tests/unit/providers/test_init_providers.py
@@ -45,7 +45,9 @@ async def test_init_providers_with_disabled_provider(
     """
     await init_providers()
 
-    providers = load_providers()
+    providers = load_providers(
+        disabled_providers_list=settings.runtime.disabled_providers
+    )
     assert provider in providers.keys()
 
     monkeypatch.setattr(
@@ -54,7 +56,9 @@ async def test_init_providers_with_disabled_provider(
         {"disabled_providers": [provider]},
     )
 
-    providers = load_providers()
+    providers = load_providers(
+        disabled_providers_list=settings.runtime.disabled_providers
+    )
     assert provider not in providers.keys()
 
 


### PR DESCRIPTION
## References

JIRA: [DISCO-2634](https://mozilla-hub.atlassian.net/browse/DISCO-2634)

## Description
Implementation of a circuit-breaker to disable certain providers from initializing that can't be bypassed using normal API request params like `enabled_by_default` and `hidden`

Documentation in disaster recovery runbook updated as well. 



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2634]: https://mozilla-hub.atlassian.net/browse/DISCO-2634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ