### PR TITLE
[DISCO-2626] Update merino_job to generate file with _latest prefix, update old file

### DIFF
--- a/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
+++ b/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
@@ -162,6 +162,9 @@ class DomainMetadataExtractor:
         "Please try again",
         "Access to this page",
         "We'll be right back",
+        "Bot or Not?",
+        "Too Many Requests",
+        "IP blocked",
     ]
 
     # List of blocked (second level) domains

--- a/merino/jobs/navigational_suggestions/domain_metadata_uploader.py
+++ b/merino/jobs/navigational_suggestions/domain_metadata_uploader.py
@@ -42,7 +42,7 @@ class DomainMetadataUploader:
         dst_top_pick_name = DomainMetadataUploader._destination_top_pick_name(
             suffix=DomainMetadataUploader.DESTINATION_TOP_PICK_FILE_NAME_SUFFIX
         )
-        self.update_latest_filename_suffix(
+        self.remove_latest_from_all_top_picks_files(
             bucket_name=self.bucket_name,
             file_suffix=DomainMetadataUploader.DESTINATION_TOP_PICK_FILE_NAME_SUFFIX,
             bucket=bucket,
@@ -56,9 +56,9 @@ class DomainMetadataUploader:
     def _destination_top_pick_name(suffix: str) -> str:
         """Return the name of the top pick file to be used for uploading to GCS"""
         current = datetime.datetime.now()
-        return f"{str(int(current.timestamp()))}_{suffix}"
+        return f"{int(current.timestamp())}_{suffix}"
 
-    def update_latest_filename_suffix(
+    def remove_latest_from_all_top_picks_files(
         self,
         bucket_name: str,
         file_suffix: str,

--- a/merino/jobs/navigational_suggestions/domain_metadata_uploader.py
+++ b/merino/jobs/navigational_suggestions/domain_metadata_uploader.py
@@ -42,6 +42,11 @@ class DomainMetadataUploader:
         """Upload the top pick contents to gcs."""
         bucket = self.storage_client.bucket(self.bucket_name)
         dst_top_pick_name = self._destination_top_pick_name()
+        self.update_latest_filename_suffix(
+            bucket_name=self.bucket_name,
+            bucket=bucket,
+            storage_client=self.storage_client,
+        )
         dst_blob = bucket.blob(dst_top_pick_name)
         dst_blob.upload_from_string(top_picks)
         return dst_blob
@@ -52,12 +57,13 @@ class DomainMetadataUploader:
         return f"{str(round(time.mktime(current.timetuple())))}_ \
             {self.DESTINATION_TOP_PICK_FILE_NAME_SUFFIX}"
 
-    def _update_latest_filename_suffix(self) -> None:
+    def update_latest_filename_suffix(
+        self, bucket_name, bucket, storage_client
+    ) -> None:
         """If an existing file with the `_latest` suffix exists, remove it so the
         most recent file has the suffix.
         """
-        bucket = self.storage_client.bucket(self.bucket_name)
-        blobs = self.storage_client.list_blobs(self.bucket_name)
+        blobs = storage_client.list_blobs(bucket_name)
         for blob in blobs:
             if blob.name.endswith(self.DESTINATION_TOP_PICK_FILE_NAME_SUFFIX):
                 bucket.copy_blob(

--- a/merino/jobs/navigational_suggestions/domain_metadata_uploader.py
+++ b/merino/jobs/navigational_suggestions/domain_metadata_uploader.py
@@ -2,7 +2,6 @@
 import datetime
 import hashlib
 import logging
-import time
 from typing import Optional
 from urllib.parse import urljoin
 
@@ -41,7 +40,9 @@ class DomainMetadataUploader:
     def upload_top_picks(self, top_picks: str) -> Blob:
         """Upload the top pick contents to gcs."""
         bucket = self.storage_client.bucket(self.bucket_name)
-        dst_top_pick_name = self._destination_top_pick_name()
+        dst_top_pick_name = DomainMetadataUploader._destination_top_pick_name(
+            suffix=DomainMetadataUploader.DESTINATION_TOP_PICK_FILE_NAME_SUFFIX
+        )
         self.update_latest_filename_suffix(
             bucket_name=self.bucket_name,
             bucket=bucket,
@@ -51,11 +52,11 @@ class DomainMetadataUploader:
         dst_blob.upload_from_string(top_picks)
         return dst_blob
 
-    def _destination_top_pick_name(self) -> str:
+    @staticmethod
+    def _destination_top_pick_name(suffix: str) -> str:
         """Return the name of the top pick file to be used for uploading to GCS"""
         current = datetime.datetime.now()
-        return f"{str(round(time.mktime(current.timetuple())))}_ \
-            {self.DESTINATION_TOP_PICK_FILE_NAME_SUFFIX}"
+        return f"{str(int(current.timestamp()))}_{suffix}"
 
     def update_latest_filename_suffix(
         self, bucket_name, bucket, storage_client

--- a/tests/unit/jobs/navigational_suggestions/test_domain_metadata_uploader.py
+++ b/tests/unit/jobs/navigational_suggestions/test_domain_metadata_uploader.py
@@ -62,7 +62,7 @@ def test_destination_top_pick_name() -> None:
     assert result == expected_result
 
 
-def test_update_latest_filename_suffix(
+def test_remove_latest_from_all_top_picks_files(
     mocker, mock_gcs_client, mock_gcs_bucket, mock_gcs_blob, mock_favicon_downloader
 ) -> None:
     """Test that updating the `_latest` suffix successfully alters the file name."""
@@ -80,7 +80,7 @@ def test_update_latest_filename_suffix(
     mocker.patch.object(mock_gcs_bucket, "copy_blob")
     mocker.patch.object(mock_gcs_bucket, "delete_blob")
 
-    domain_metadata_uploader.update_latest_filename_suffix(
+    domain_metadata_uploader.remove_latest_from_all_top_picks_files(
         bucket_name=mock_gcs_bucket.name,
         file_suffix=file_suffix,
         bucket=mock_gcs_bucket,


### PR DESCRIPTION
## References

JIRA: [DISCO-2626](https://mozilla-hub.atlassian.net/browse/DISCO-2626)

## Description
The merino_job currently generates a new file with the Unix Epoch timestamp prepending the file. We want to add _latest for easily grabbing the file and to also have functionality to update the existing _latest each time the job runs.

Some improvements were made to the `DomainMetadataUploader` like converting the `_destination_top_pick_name` method to a staticmethod with a parameter for suffix to make it more testable, as well as resolving the rounding issue where a needless trailing `.0` was generated after each epoch timestamp. Also, the timestamp is converted from microseconds to a standard timestamp with a simpler method, being `int(current.timestamp())`, given it is called in the UTC context anyways, avoiding a call to `time`. 

The `update_latest_filename_suffix` method takes in the parameters within the context of a `DomainMetadataUploader` instance, gets the blobs from the bucket, searches for the existing file with a `_latest` suffix and removes that suffix, all before the newest file is uploaded. This ensures that one and only one file contains the `_latest` suffix which makes it easy for the provider backend to ingest. 

Various type annotations added and code test coverage increased. 

Source docs from GCS for this patch:

Copy/Rename/Delete objects in GCS: https://cloud.google.com/storage/docs/copying-renaming-moving-objects#client-libraries 
List objects in GCS: https://cloud.google.com/storage/docs/listing-objects#storage-list-objects-python

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2626]: https://mozilla-hub.atlassian.net/browse/DISCO-2626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ