### PR TITLE
[DISCO-2669] update all localhost instances to ipv4 127.0.0.1 [load test: abort]

### DIFF
--- a/dev/kinto.ini
+++ b/dev/kinto.ini
@@ -18,7 +18,7 @@ kinto.changes.resources = /buckets/main
 kinto.attachment.base_path = /app/attachments
 kinto.attachment.base_url =
 # See uwsgi static-map setting
-kinto.attachment.extra.base_url = http://localhost:8888/attachments
+kinto.attachment.extra.base_url = http://127.0.0.1:8888/attachments
 kinto.attachment.folder = {bucket_id}/{collection_id}
 
 [uwsgi]

--- a/docs/dev/dependencies.md
+++ b/docs/dev/dependencies.md
@@ -59,7 +59,7 @@ $ make docker-compose-up-daemon
 $ make docker-compose-down
 ```
 
-Redis is listening on port 6397 and can be connected via `redis://localhost:6397`.
+Redis is listening on port 6397 and can be connected via `redis://127.0.0.1:6397`.
 
 This Dockerized set up is optional. Feel free to run the dependent services by
 any other means as well.
@@ -69,7 +69,7 @@ any other means as well.
 The docker-compose setup also includes some services that can help during
 development.
 
-- Redis Commander, http://localhost:8081 - Explore the Redis database started
+- Redis Commander, http://127.0.0.1:8081 - Explore the Redis database started
   above.
 
 

--- a/docs/testing/contract-tests/client.md
+++ b/docs/testing/contract-tests/client.md
@@ -127,11 +127,11 @@ tests within a Python virtual environment to prevent dependency cross contaminat
     The following environment variables are set in `docker-compose.yml`, but will
     require local setup via command line, pytest.ini file or IDE configuration:
     * `MERINO_URL`: The URL of the Merino service
-      * Example: `MERINO_URL=http://localhost:8000`
+      * Example: `MERINO_URL=http://127.0.0.1:8000`
     * `KINTO_URL`: The URL of the Kinto service
-      * Example: `KINTO_URL=http://localhost:8888`
+      * Example: `KINTO_URL=http://127.0.0.1:8888`
     * `KINTO_ATTACHMENTS_URL`: The URL of the Kinto Attachments service
-      * Example: `KINTO_ATTACHMENTS_URL=http://localhost:80`
+      * Example: `KINTO_ATTACHMENTS_URL=http://127.0.0.1:80`
     * `KINTO_BUCKET`: The ID of the Kinto bucket to create
       * Example: `KINTO_BUCKET=main`
     * `KINTO_COLLECTION`: The ID of the Kinto collection to create

--- a/docs/testing/contract-tests/kinto-setup.md
+++ b/docs/testing/contract-tests/kinto-setup.md
@@ -25,7 +25,7 @@ within a Python virtual environment to prevent dependency cross contamination.
     The following environment variables are set in `docker-compose.yml`, but will
     require local setup via command line, pytest.ini file or IDE configuration:
     * `KINTO_URL`: The URL of the Kinto service
-      * Example: `KINTO_URL=http://localhost:8888`
+      * Example: `KINTO_URL=http://127.0.0.1:8888`
     * `KINTO_BUCKET`: The ID of the Kinto bucket to create
       * Example: `KINTO_BUCKET=main`
     * `KINTO_COLLECTION`: The ID of the Kinto collection to create

--- a/docs/testing/load-tests.md
+++ b/docs/testing/load-tests.md
@@ -88,7 +88,7 @@ repository root:
 
 #### 1. Start Load Test
 
-* In a browser navigate to `http://localhost:8089/`
+* In a browser navigate to `http://127.0.0.1:8089/`
 * Set up the load test parameters:
     * Option 1: Select the `MerinoLoadTestShape`
       * This option has pre-defined settings and will last 10 minutes

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -89,8 +89,8 @@ query_character_max = 500
 dev_logger = false
 
 # MERINO_METRICS__HOST
-# The IP or hostname to send metrics over UDP. Defaults to localhost.
-host = "localhost"
+# The IP or hostname to send metrics over UDP. Defaults to 127.0.0.1.
+host = "127.0.0.1"
 
 # MERINO_METRICS__PORT
 # The port to send metrics to over UDP. Defaults to 8092.
@@ -208,7 +208,7 @@ query_timeout_sec = 5.0
 
 # MERINO_REDIS__SERVER - redis.server (Currently not configured here)
 # Global Redis settings. The weather provider optionally uses Redis to cache weather suggestions.
-# In the form of `redis://localhost:6379`.
+# In the form of `redis://127.0.0.1:6379`.
 
 
 [default.providers.accuweather.cache_ttls]
@@ -381,7 +381,7 @@ backend = "elasticsearch"
 
 # MERINO_PROVIDERS__WIKIPEDIA__ES_URL
 # The URL of the Elasticsearch cluster that we want to connect to.
-es_url = "http://localhost:9200"
+es_url = "http://127.0.0.1:9200"
 
 # MERINO_PROVIDERS__WIKIPEDIA__ES_API_KEY
 # The base64 key used to authenticate on the Elasticsearch cluster specified by `es_cloud_id`.

--- a/tests/unit/jobs/utils/test_chunked_rs_uploader.py
+++ b/tests/unit/jobs/utils/test_chunked_rs_uploader.py
@@ -16,7 +16,7 @@ TEST_UPLOADER_KWARGS: dict[str, Any] = {
     "bucket": "test-bucket",
     "collection": "test-collection",
     "record_type": "test-record-type",
-    "server": "http://localhost",
+    "server": "http://127.0.0.1",
 }
 
 

--- a/tests/unit/jobs/wikipedia_indexer/test_utils.py
+++ b/tests/unit/jobs/wikipedia_indexer/test_utils.py
@@ -28,7 +28,7 @@ def test_create_blocklist(
     blocklist_csv_text: str,
 ):
     """Test that the blocklist is created from CSV file."""
-    url = "https://localhost"
+    url = "https://127.0.0.1"
     requests_mock.get(url, text=blocklist_csv_text)  # nosec
 
     categories = create_blocklist(blocklist_file_url=url)
@@ -86,7 +86,7 @@ def test_create_elasticsearch_client_url(mocker: MockerFixture):
     es_new_mock = mocker.patch.object(Elasticsearch, "__new__")
 
     api_key = "mMyY2E2ZDA0MjI0OWFmMGNjN2Q3YTllOTYyNTc0Mw=="
-    url = "http://localhost:9200"
+    url = "http://127.0.0.1:9200"
 
     create_elasticsearch_client(url, api_key)
 

--- a/tests/unit/providers/weather/backends/test_accuweather.py
+++ b/tests/unit/providers/weather/backends/test_accuweather.py
@@ -1328,16 +1328,16 @@ async def test_get_forecast_error(accuweather: AccuweatherBackend) -> None:
     [
         (
             {"q": "asdfg", "apikey": "filter_me_out"},
-            f"AccuweatherBackend:v3:localhost:"
+            f"AccuweatherBackend:v3:127.0.0.1:"
             f"{hashlib.blake2s('q'.encode('utf-8') + 'asdfg'.encode('utf-8')).hexdigest()}",
         ),
         (
             {},
-            "AccuweatherBackend:v3:localhost",
+            "AccuweatherBackend:v3:127.0.0.1",
         ),
         (
             {"q": "asdfg"},
-            f"AccuweatherBackend:v3:localhost:"
+            f"AccuweatherBackend:v3:127.0.0.1:"
             f"{hashlib.blake2s('q'.encode('utf-8') + 'asdfg'.encode('utf-8')).hexdigest()}",
         ),
     ],
@@ -1349,7 +1349,7 @@ def test_cache_key_for_accuweather_request(
     expected_cache_key: str,
 ):
     """Test that the cache key is created properly."""
-    url = "localhost"
+    url = "127.0.0.1"
     cache_key = accuweather.cache_key_for_accuweather_request(
         url, query_params=query_params
     )

--- a/tests/unit/providers/wikipedia/backends/test_elastic.py
+++ b/tests/unit/providers/wikipedia/backends/test_elastic.py
@@ -19,7 +19,7 @@ from merino.providers.wikipedia.backends.elastic import (
 def fixture_es_backend() -> ElasticBackend:
     """Return an ES backend instance."""
     return ElasticBackend(
-        url="https://localhost:9200",
+        url="https://127.0.0.1:9200",
         api_key=settings.providers.wikipedia.es_api_key,
     )
 
@@ -27,7 +27,7 @@ def fixture_es_backend() -> ElasticBackend:
 def test_es_backend_initialize_with_url():
     """Test that backend initializes when we pass a URL."""
     backend = ElasticBackend(
-        url="https://localhost:9200",
+        url="https://127.0.0.1:9200",
         api_key=settings.providers.wikipedia.es_api_key,
     )
     assert backend

--- a/tests/unit/test_config_sentry.py
+++ b/tests/unit/test_config_sentry.py
@@ -15,7 +15,7 @@ mock_sentry_hint: dict[str, list] = {"exc_info": [RuntimeError, RuntimeError(), 
 mock_sentry_event_data: dict = {
     "request": {
         "method": "GET",
-        "url": "http://localhost:8000/api/v1/suggest",
+        "url": "http://127.0.0.1:8000/api/v1/suggest",
         "query_string": "query_str_foo",
     },
     "exception": {


### PR DESCRIPTION
## References

JIRA: [DISCO-2669](https://mozilla-hub.atlassian.net/browse/DISCO-2669)

## Description
I came across an interesting recommendation from an [engineer at Sentry](https://www.youtube.com/watch?v=98SYTvNw1kw) that determined the lax use of localhost can have deleterious results on performance and can cause bugs. See [Sentry repo example here](https://github.com/getsentry/snuba/pull/3736/commits/6f4b041bc3949f16f3fc9f569fa388424b518373)

It turns out that if you default to localhost, there is not a guaranteed translation to the IPv4 127.0.0.1. More often than not, a IPv6 lookup is made first. For example:
```python
import socket
socket.getaddrinfo('localhost', 0)

# result from python 3.11 merino env
[(<AddressFamily.AF_INET6: 30>, <SocketKind.SOCK_DGRAM: 2>, 17, '', ('::1', 0, 0, 0)),
(<AddressFamily.AF_INET6: 30>, <SocketKind.SOCK_STREAM: 1>, 6, '', ('::1', 0, 0, 0)),
(<AddressFamily.AF_INET: 2>, <SocketKind.SOCK_DGRAM: 2>, 17, '', ('127.0.0.1', 0)),
(<AddressFamily.AF_INET: 2>, <SocketKind.SOCK_STREAM: 1>, 6, '', ('127.0.0.1', 0))]
```

In this example, you can see 2 IPv6 lookups were made first.

This ticket prevents this from being an issue on some operating systems, reduces confusion and may provide modest performance gains. Prevents needless system calls.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2669]: https://mozilla-hub.atlassian.net/browse/DISCO-2669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ