### PR TITLE
[DISCO-2681] fake default backend top picks

### DIFF
--- a/merino/config.py
+++ b/merino/config.py
@@ -62,6 +62,7 @@ _validators = [
     Validator("providers.amo.type", is_type_of=str, must_exist=True),
     Validator("providers.amo.min_chars", is_type_of=int, gte=1, lte=10),
     Validator("providers.top_picks.enabled_by_default", is_type_of=bool),
+    Validator("providers.top_picks.backend", is_type_of=str, is_in=["top-picks", "test"]),
     Validator("providers.top_picks.score", is_type_of=float, gte=0, lte=1),
     Validator("providers.top_picks.query_char_limit", is_type_of=int, gte=1),
     Validator("providers.top_picks.firefox_char_limit", is_type_of=int, gte=1),

--- a/merino/config.py
+++ b/merino/config.py
@@ -62,7 +62,9 @@ _validators = [
     Validator("providers.amo.type", is_type_of=str, must_exist=True),
     Validator("providers.amo.min_chars", is_type_of=int, gte=1, lte=10),
     Validator("providers.top_picks.enabled_by_default", is_type_of=bool),
-    Validator("providers.top_picks.backend", is_type_of=str, is_in=["top-picks", "test"]),
+    Validator(
+        "providers.top_picks.backend", is_type_of=str, is_in=["top-picks", "test"]
+    ),
     Validator("providers.top_picks.score", is_type_of=float, gte=0, lte=1),
     Validator("providers.top_picks.query_char_limit", is_type_of=int, gte=1),
     Validator("providers.top_picks.firefox_char_limit", is_type_of=int, gte=1),

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -346,6 +346,11 @@ type = "top_picks"
 # Whether this provider is enabled by default. Defaults to true.
 enabled_by_default = true
 
+# MERINO_PROVIDERS__TOP_PICKS__BACKEND
+# Specifies which backend to use. Either `test` or `top-picks`.
+# Otherwise a FakeTopPicksBackend that returns nothing is used for testing.
+backend = "top-picks"
+
 # MERINO_PROVIDERS__TOP_PICKS__SCORE
 # Ranking score for this provider as a floating point number with a default of 0.25.
 score = 0.25

--- a/merino/providers/manager.py
+++ b/merino/providers/manager.py
@@ -118,7 +118,7 @@ def _create_provider(provider_id: str, setting: Settings) -> BaseProvider:
                     query_char_limit=setting.query_char_limit,
                     firefox_char_limit=setting.firefox_char_limit,
                     domain_blocklist=TOP_PICKS_BLOCKLIST,
-                )
+                )  # type: ignore [arg-type]
                 if setting.backend == "top-picks"
                 else FakeTopPicksBackend(),
                 score=setting.score,

--- a/merino/providers/manager.py
+++ b/merino/providers/manager.py
@@ -18,6 +18,7 @@ from merino.providers.amo.backends.dynamic import DynamicAmoBackend
 from merino.providers.amo.backends.static import StaticAmoBackend
 from merino.providers.amo.provider import Provider as AmoProvider
 from merino.providers.base import BaseProvider
+from merino.providers.top_picks.backends.fake_backends import FakeTopPicksBackend
 from merino.providers.top_picks.backends.top_picks import TopPicksBackend
 from merino.providers.top_picks.provider import Provider as TopPicksProvider
 from merino.providers.weather.backends.accuweather import AccuweatherBackend
@@ -117,7 +118,9 @@ def _create_provider(provider_id: str, setting: Settings) -> BaseProvider:
                     query_char_limit=setting.query_char_limit,
                     firefox_char_limit=setting.firefox_char_limit,
                     domain_blocklist=TOP_PICKS_BLOCKLIST,
-                ),
+                )
+                if setting.backend == "top-picks"
+                else FakeTopPicksBackend(),
                 score=setting.score,
                 name=provider_id,
                 enabled_by_default=setting.enabled_by_default,

--- a/merino/providers/top_picks/backends/fake_backends.py
+++ b/merino/providers/top_picks/backends/fake_backends.py
@@ -1,0 +1,11 @@
+"""Test backend for the Top Picks provider."""
+
+from merino.providers.top_picks.backends.protocol import TopPicksData
+
+
+class FakeTopPicksBackend:  # pragma: no cover
+    """A fake test backend that always returns empty results."""
+
+    async def fetch(self) -> TopPicksData:
+        """Get fake Top Picks data."""
+        return TopPicksData()  # type: ignore [call-arg]

--- a/merino/providers/top_picks/provider.py
+++ b/merino/providers/top_picks/provider.py
@@ -7,8 +7,8 @@ import logging
 
 from merino.exceptions import BackendError
 from merino.providers.base import BaseProvider, BaseSuggestion, SuggestionRequest
-from merino.providers.top_picks.backends.protocol import TopPicksBackend, TopPicksData
 from merino.providers.top_picks.backends.fake_backends import FakeTopPicksBackend
+from merino.providers.top_picks.backends.protocol import TopPicksBackend, TopPicksData
 
 logger = logging.getLogger(__name__)
 

--- a/merino/providers/top_picks/provider.py
+++ b/merino/providers/top_picks/provider.py
@@ -7,7 +7,6 @@ import logging
 
 from merino.exceptions import BackendError
 from merino.providers.base import BaseProvider, BaseSuggestion, SuggestionRequest
-from merino.providers.top_picks.backends.fake_backends import FakeTopPicksBackend
 from merino.providers.top_picks.backends.protocol import TopPicksBackend, TopPicksData
 
 logger = logging.getLogger(__name__)
@@ -27,7 +26,7 @@ class Provider(BaseProvider):
 
     def __init__(
         self,
-        backend: TopPicksBackend | FakeTopPicksBackend,
+        backend: TopPicksBackend,
         score: float,
         name: str,
         enabled_by_default: bool = False,

--- a/merino/providers/top_picks/provider.py
+++ b/merino/providers/top_picks/provider.py
@@ -8,6 +8,7 @@ import logging
 from merino.exceptions import BackendError
 from merino.providers.base import BaseProvider, BaseSuggestion, SuggestionRequest
 from merino.providers.top_picks.backends.protocol import TopPicksBackend, TopPicksData
+from merino.providers.top_picks.backends.fake_backends import FakeTopPicksBackend
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +27,7 @@ class Provider(BaseProvider):
 
     def __init__(
         self,
-        backend: TopPicksBackend,
+        backend: TopPicksBackend | FakeTopPicksBackend,
         score: float,
         name: str,
         enabled_by_default: bool = False,


### PR DESCRIPTION
## References

JIRA: [DISCO-2681](https://mozilla-hub.atlassian.net/browse/DISCO-2681)

## Description
All other providers that present dynamic data have a Fake Provider for testing and in the case of initialization failure.

Now that the Top Picks provider will access data from a remote source, it requires a Fake Backend just like Adm, Wikipedia, and AMO. Want this patch in place so the remote GCS patch can make use of this logic. 



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2681]: https://mozilla-hub.atlassian.net/browse/DISCO-2681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ