### PR TITLE
[DISCO-2647] addons timeout errors

### DIFF
--- a/merino/providers/amo/backends/dynamic.py
+++ b/merino/providers/amo/backends/dynamic.py
@@ -11,7 +11,7 @@ from merino.providers.amo.addons_data import ADDON_DATA, SupportedAddon
 from merino.providers.amo.backends.protocol import Addon, AmoBackendError
 from merino.utils.http_client import create_http_client
 
-AMO_CONNECT_TIMEOUT: float = 5.0
+AMO_CONNECT_TIMEOUT: float = 10.0
 
 logger = logging.getLogger(__name__)
 

--- a/merino/providers/base.py
+++ b/merino/providers/base.py
@@ -150,11 +150,11 @@ class BaseProvider(ABC):
         """Boolean indicating whether or not provider is enabled."""
         return self._enabled_by_default
 
-    def hidden(self) -> bool:
+    def hidden(self) -> bool:  # pragma: no cover
         """Boolean indicating whether or not this provider is hidden."""
         return False
 
-    def availability(self) -> str:
+    def availability(self) -> str:  # pragma: no cover
         """Return the status of this provider."""
         if self.hidden():
             return "hidden"
@@ -169,6 +169,6 @@ class BaseProvider(ABC):
         return self._name
 
     @property
-    def query_timeout_sec(self) -> float:
+    def query_timeout_sec(self) -> float:  # pragma: no cover
         """Return the query timeout for this provider."""
         return self._query_timeout_sec


### PR DESCRIPTION
## References

JIRA: [DISCO-2647](https://mozilla-hub.atlassian.net/browse/DISCO-2647)

## Description
Increase addons provider timeout. The PR also added a few annotations for unit tests regarding `base.py` that were noticed when running a test, just to improve coverage where we can


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
