### PR TITLE
[DISCO-2620] Update `_latest` logic to write core domain file and timestamp file

### DIFF
--- a/merino/jobs/navigational_suggestions/__init__.py
+++ b/merino/jobs/navigational_suggestions/__init__.py
@@ -173,6 +173,4 @@ def prepare_domain_metadata(
         extra={"public_url": top_pick_blob.public_url},
     )
     if write_xcom is True:
-        _write_xcom_file(
-            {"top_pick_url": top_pick_blob.public_url, "diff": diff}
-        )
+        _write_xcom_file({"top_pick_url": top_pick_blob.public_url, "diff": diff})

--- a/merino/jobs/navigational_suggestions/__init__.py
+++ b/merino/jobs/navigational_suggestions/__init__.py
@@ -162,7 +162,7 @@ def prepare_domain_metadata(
     top_pick_blob = domain_metadata_uploader.upload_top_picks(
         json.dumps(top_picks, indent=4)
     )
-    diff: str = domain_diff.create_diff(
+    diff: dict = domain_diff.create_diff(
         file_name=top_pick_blob.name,
         unchanged=unchanged,
         domains=added_domains,
@@ -173,4 +173,6 @@ def prepare_domain_metadata(
         extra={"public_url": top_pick_blob.public_url},
     )
     if write_xcom is True:
-        _write_xcom_file({"top_pick_url": top_pick_blob.public_url, "diff": diff})
+        _write_xcom_file(
+            {"top_pick_url": top_pick_blob.public_url, "diff": diff}
+        )

--- a/merino/jobs/navigational_suggestions/domain_metadata_diff.py
+++ b/merino/jobs/navigational_suggestions/domain_metadata_diff.py
@@ -51,5 +51,5 @@ class DomainDiff:
             "total_domains_unchanged": len(unchanged),
             "newly_added_domains": len(domains),
             "newly_added_urls": len(urls),
-            "url_summary": sorted(urls),
+            "new_urls_summary": sorted(urls),
         }

--- a/merino/jobs/navigational_suggestions/domain_metadata_diff.py
+++ b/merino/jobs/navigational_suggestions/domain_metadata_diff.py
@@ -44,20 +44,12 @@ class DomainDiff:
         unchanged: set[str],
         domains: set[str],
         urls: set[str],
-    ) -> str:
-        """Create string representation of diff file comaring domain data."""
-        title = f"Top Picks Diff File {file_name}"
-        sep = "=" * 20
-
-        unchanged_summary = f"Total domain suggestions unchanged: {len(unchanged)}"
-        domain_summary = f"Newly added domains: {len(domains)}\n{sep}\n"
-        url_summary = f"Newly added urls: {len(urls)}\n{sep}\n"
-        url_summary += "\n".join(urls)
-
-        return f"""
-{title}
-
-{unchanged_summary}
-{domain_summary}
-{url_summary}
-""".strip()
+    ) -> dict:
+        """Create dict representation of diff file comaring domain data."""
+        return {
+            "title": f"Top Picks Diff File for: {file_name}",
+            "total_domains_unchanged": len(unchanged),
+            "newly_added_domains": len(domains),
+            "newly_added_urls": len(urls),
+            "url_summary": list(urls),
+        }

--- a/merino/jobs/navigational_suggestions/domain_metadata_diff.py
+++ b/merino/jobs/navigational_suggestions/domain_metadata_diff.py
@@ -51,5 +51,5 @@ class DomainDiff:
             "total_domains_unchanged": len(unchanged),
             "newly_added_domains": len(domains),
             "newly_added_urls": len(urls),
-            "url_summary": list(urls),
+            "url_summary": sorted(urls),
         }

--- a/merino/jobs/navigational_suggestions/domain_metadata_uploader.py
+++ b/merino/jobs/navigational_suggestions/domain_metadata_uploader.py
@@ -43,20 +43,13 @@ class DomainMetadataUploader:
         the other file is the latest entry from which data is loaded.
         """
         bucket = self.storage_client.bucket(self.bucket_name)
-        dst_top_pick_name = DomainMetadataUploader._destination_top_pick_name(
-            suffix="top_picks.json"
-        )
+        timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
+        timestamp_file_name = f"{timestamp}_top_picks.json"
         latest_blob = bucket.blob(self.DESTINATION_TOP_PICK_FILE_NAME)
         latest_blob.upload_from_string(top_picks)
-        dated_blob = bucket.blob(dst_top_pick_name)
+        dated_blob = bucket.blob(timestamp_file_name)
         dated_blob.upload_from_string(top_picks)
         return dated_blob
-
-    @staticmethod
-    def _destination_top_pick_name(suffix: str) -> str:
-        """Return the name of the top pick file to be used for uploading to GCS with timestamp."""
-        current = datetime.now().strftime("%Y%m%d%H%M%S")
-        return f"{current}_{suffix}"
 
     def get_latest_file_for_diff(
         self, client: Client

--- a/merino/providers/top_picks/backends/filemanager.py
+++ b/merino/providers/top_picks/backends/filemanager.py
@@ -92,7 +92,7 @@ class TopPicksRemoteFilemanager:
             bucket: Bucket = client.get_bucket(self.gcs_bucket_path)
             if (
                 blob := bucket.get_blob(
-                    "top_picks.json",
+                    "top_picks_latest.json",
                     if_generation_not_match=self.blob_generation,
                 )
             ) is not None:

--- a/merino/providers/top_picks/provider.py
+++ b/merino/providers/top_picks/provider.py
@@ -6,6 +6,7 @@
 import asyncio
 import logging
 import time
+from collections import defaultdict
 from typing import Any
 
 from merino import cron
@@ -52,6 +53,16 @@ class Provider(BaseProvider):
         self.resync_interval_sec = resync_interval_sec
         self.cron_interval_sec = cron_interval_sec
         self.last_fetch_at = 0
+        self.top_picks_data = TopPicksData(
+            primary_index=defaultdict(),
+            secondary_index=defaultdict(),
+            short_domain_index=defaultdict(),
+            results=[],
+            query_min=0,
+            query_max=0,
+            query_char_limit=0,
+            firefox_char_limit=0,
+        )
         super().__init__(**kwargs)
 
     async def initialize(self) -> None:

--- a/tests/unit/jobs/navigational_suggestions/test_domain_metadata_diff.py
+++ b/tests/unit/jobs/navigational_suggestions/test_domain_metadata_diff.py
@@ -241,7 +241,7 @@ def test_create_diff(json_domain_data_latest, json_domain_data_old) -> None:
         "total_domains_unchanged": 5,
         "newly_added_domains": 1,
         "newly_added_urls": 2,
-        "url_summary": ["https://test.firefox.com", "https://testexample.com"],
+        "url_summary": sorted(["https://test.firefox.com", "https://testexample.com"]),
     }
 
     assert diff_file == expected_diff

--- a/tests/unit/jobs/navigational_suggestions/test_domain_metadata_diff.py
+++ b/tests/unit/jobs/navigational_suggestions/test_domain_metadata_diff.py
@@ -236,6 +236,12 @@ def test_create_diff(json_domain_data_latest, json_domain_data_old) -> None:
         domains=added_domains,
         urls=added_urls,
     )
+    expected_diff = {
+        "title": "Top Picks Diff File for: test_blob.json",
+        "total_domains_unchanged": 5,
+        "newly_added_domains": 1,
+        "newly_added_urls": 2,
+        "url_summary": ["https://test.firefox.com", "https://testexample.com"],
+    }
 
-    assert diff_file.startswith("Top Picks Diff File")
-    assert "Newly added domains: 1" in diff_file
+    assert diff_file == expected_diff

--- a/tests/unit/jobs/navigational_suggestions/test_domain_metadata_diff.py
+++ b/tests/unit/jobs/navigational_suggestions/test_domain_metadata_diff.py
@@ -241,7 +241,8 @@ def test_create_diff(json_domain_data_latest, json_domain_data_old) -> None:
         "total_domains_unchanged": 5,
         "newly_added_domains": 1,
         "newly_added_urls": 2,
-        "url_summary": sorted(["https://test.firefox.com", "https://testexample.com"]),
+        "new_urls_summary": sorted(
+            ["https://test.firefox.com", "https://testexample.com"]
+        ),
     }
-
     assert diff_file == expected_diff

--- a/tests/unit/jobs/navigational_suggestions/test_domain_metadata_uploader.py
+++ b/tests/unit/jobs/navigational_suggestions/test_domain_metadata_uploader.py
@@ -3,13 +3,11 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """Unit tests for domain_metadata_uploader.py module."""
-import datetime
 import json
 from logging import INFO, LogRecord
 from typing import Any
 
 import pytest
-from freezegun import freeze_time
 from google.cloud.storage import Blob, Bucket, Client
 from pytest import LogCaptureFixture
 from pytest_mock import MockerFixture
@@ -239,16 +237,6 @@ def mock_favicon_downloader(mocker) -> Any:
         content=bytes(255), content_type="image/png"
     )
     return favicon_downloader_mock
-
-
-@freeze_time("2022-01-01 12:05:55")
-def test_destination_top_pick_name() -> None:
-    """Test the file name generation creates the expected file name for the blob."""
-    current = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
-    suffix = "top_picks.json"
-    result = DomainMetadataUploader._destination_top_pick_name(suffix=suffix)
-    expected_result = f"{current}_{suffix}"
-    assert result == expected_result
 
 
 def test_upload_top_picks(

--- a/tests/unit/jobs/navigational_suggestions/test_domain_metadata_uploader.py
+++ b/tests/unit/jobs/navigational_suggestions/test_domain_metadata_uploader.py
@@ -197,7 +197,7 @@ def mock_gcs_blob(mocker):
 def fixture_remote_blob(mocker: MockerFixture, json_domain_data) -> Any:
     """Create a remote blob mock object for testing."""
     remote_blob = mocker.MagicMock(spec=Blob)
-    remote_blob.name = "1681866452_top_picks.json"
+    remote_blob.name = "20220101120555_top_picks.json"
     remote_blob.download_as_text.return_value = json_domain_data
     return remote_blob
 
@@ -208,7 +208,7 @@ def fixture_remote_blob_newest(mocker: MockerFixture, json_domain_data) -> Any:
     Has higher timestamp, therefore newer.
     """
     remote_blob = mocker.MagicMock(spec=Blob)
-    remote_blob.name = "1681866864_top_picks.json"
+    remote_blob.name = "20220501120555_top_picks.json"
     remote_blob.download_as_text.return_value = json_domain_data
     return remote_blob
 
@@ -241,14 +241,13 @@ def mock_favicon_downloader(mocker) -> Any:
     return favicon_downloader_mock
 
 
-@freeze_time("2022-01-01 00:00:00")
+@freeze_time("2022-01-01 12:05:55")
 def test_destination_top_pick_name() -> None:
     """Test the file name generation creates the expected file name for the blob."""
-    current = datetime.datetime.now()
-    suffix = DomainMetadataUploader.DESTINATION_TOP_PICK_FILE_NAME
+    current = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
+    suffix = "top_picks.json"
     result = DomainMetadataUploader._destination_top_pick_name(suffix=suffix)
-    expected_result = f"{str(int(current.timestamp()))}_{suffix}"
-
+    expected_result = f"{current}_{suffix}"
     assert result == expected_result
 
 
@@ -260,7 +259,7 @@ def test_upload_top_picks(
     mock_gcs_bucket = mock_gcs_client.bucket.return_value
     mock_dst_blob = mock_gcs_bucket.blob.return_value
 
-    mock_gcs_blob.name = "0_top_picks.json"
+    mock_gcs_blob.name = "20220101120555_top_picks.json"
     mock_gcs_client.list_blobs.return_value = [mock_gcs_blob]
     mocker.patch.object(mock_gcs_bucket, "copy_blob")
     mocker.patch.object(mock_gcs_bucket, "delete_blob")

--- a/tests/unit/providers/top_picks/backends/test_filemanager.py
+++ b/tests/unit/providers/top_picks/backends/test_filemanager.py
@@ -99,7 +99,7 @@ def fixture_gcs_blob_mock(
 ) -> Any:
     """Create a GCS Blob mock object for testing."""
     mock_blob = mocker.MagicMock(spec=Blob)
-    mock_blob.name = "1681866452_top_picks.json"
+    mock_blob.name = "20220101120555_top_picks.json"
     mock_blob.generation = expected_timestamp
     mock_blob.download_as_text.return_value = blob_json
     return mock_blob

--- a/tests/unit/providers/top_picks/backends/test_filemanager.py
+++ b/tests/unit/providers/top_picks/backends/test_filemanager.py
@@ -99,7 +99,7 @@ def fixture_gcs_blob_mock(
 ) -> Any:
     """Create a GCS Blob mock object for testing."""
     mock_blob = mocker.MagicMock(spec=Blob)
-    mock_blob.name = "1681866452_top_picks_latest.json"
+    mock_blob.name = "1681866452_top_picks.json"
     mock_blob.generation = expected_timestamp
     mock_blob.download_as_text.return_value = blob_json
     return mock_blob

--- a/tests/unit/providers/top_picks/backends/test_top_picks.py
+++ b/tests/unit/providers/top_picks/backends/test_top_picks.py
@@ -119,7 +119,7 @@ def fixture_gcs_blob_mock(
 ) -> Any:
     """Create a GCS Blob mock object for testing."""
     mock_blob = mocker.MagicMock(spec=Blob)
-    mock_blob.name = "1681866452_top_picks_latest.json"
+    mock_blob.name = "1681866452_top_picks.json"
     mock_blob.generation = expected_timestamp
     mock_blob.download_as_text.return_value = blob_json
     return mock_blob

--- a/tests/unit/providers/top_picks/backends/test_top_picks.py
+++ b/tests/unit/providers/top_picks/backends/test_top_picks.py
@@ -119,7 +119,7 @@ def fixture_gcs_blob_mock(
 ) -> Any:
     """Create a GCS Blob mock object for testing."""
     mock_blob = mocker.MagicMock(spec=Blob)
-    mock_blob.name = "1681866452_top_picks.json"
+    mock_blob.name = "20220101120555_top_picks.json"
     mock_blob.generation = expected_timestamp
     mock_blob.download_as_text.return_value = blob_json
     return mock_blob


### PR DESCRIPTION
## References

JIRA: [DISCO-2620](https://mozilla-hub.atlassian.net/browse/DISCO-2620)

## Description
Like the spec for Shepherd storage.py [here](https://github.com/mozilla-services/consvc-shepherd/blob/main/consvc_shepherd/storage.py), we want merino jobs to similarly create a latest file which is always overridden (`top_picks_latest.json`) and used as the single domain source while also writing a second file for our records with the time stamp(`<0123>_top_picks_latest.json`).

This improves reliability and decreases possibility of bottlenecks when future data grows. 

Note: The process will now write a`top_picks_latest.json` file from which data will be read and overwritten as well as a timestamped file `<0123>_top_picks_latest.json` for our records. The timestamped files at each generation will have the `_latest` suffix which makes it simple to capture the value when making a comparison and passing the dated file to the diff email header and logs for auditing. This is preferable to doing any calculations based on the timestamp alone, which would be necessary given we may change the interval at which the job runs. The process then just removes `_latest` from the timestamped file and each time the job runs, the `top_picks_latest.json` file is overridden

Since the `_latest` will now only be removed from the timestamped files via regex and it runs on the job, there isn't a performance concern for merino. 



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2620]: https://mozilla-hub.atlassian.net/browse/DISCO-2620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ