### PR TITLE
Update method to exclude favicons and match only json files

### DIFF
--- a/merino/jobs/navigational_suggestions/domain_metadata_uploader.py
+++ b/merino/jobs/navigational_suggestions/domain_metadata_uploader.py
@@ -60,7 +60,7 @@ class DomainMetadataUploader:
         bucket: Bucket = client.get_bucket(self.bucket_name)
         blobs = [
             blob
-            for blob in bucket.list_blobs()
+            for blob in bucket.list_blobs(delimiter="/", match_glob="*.json")
             if blob.name != self.DESTINATION_TOP_PICK_FILE_NAME
         ]
 


### PR DESCRIPTION
add delimiter to just get files in root and match_glob to only capture json files




## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
