### PR TITLE
[DISCO-2706] stage configs

### DIFF
--- a/merino/config.py
+++ b/merino/config.py
@@ -138,6 +138,7 @@ settings = Dynaconf(
         "configs/default.toml",
         "configs/development.toml",
         "configs/production.toml",
+        "configs/stage.toml",
         "configs/ci.toml",
         "configs/testing.toml",
     ],

--- a/merino/configs/stage.toml
+++ b/merino/configs/stage.toml
@@ -1,0 +1,21 @@
+# Configurations for stage. Configurations defined here will override the
+# counterparts in `default.toml`.
+
+# You can manually switch to this environment via:
+#
+# MERINO_ENV=stage /path/to/your/command
+
+[stage]
+# For `list` or `table` settings, `dynaconf_merge` allows you to merge settings with the default
+# settings. This enables merge for the entire `stage` environment.
+dynaconf_merge = true
+
+[stage.providers.top_picks]
+# MERINO_PROVIDERS__TOP_PICKS__GCS_PROJECT
+gcs_project = "moz-fx-merino-nonprod-ee93"
+
+# MERINO_PROVIDERS__TOP_PICKS__GCS_BUCKET
+gcs_bucket = "merino-images-stagepy"
+
+# MERINO_PROVIDERS__TOP_PICKS__DOMAIN_DATA_SOURCE
+domain_data_source = "remote"

--- a/merino/configs/stage.toml
+++ b/merino/configs/stage.toml
@@ -10,6 +10,9 @@
 # settings. This enables merge for the entire `stage` environment.
 dynaconf_merge = true
 
+[stage.accuweather]
+url_base = "https://api.accuweather.com"
+
 [stage.providers.top_picks]
 # MERINO_PROVIDERS__TOP_PICKS__GCS_PROJECT
 gcs_project = "moz-fx-merino-nonprod-ee93"


### PR DESCRIPTION
## References

JIRA: [DISCO-2706](https://mozilla-hub.atlassian.net/browse/DISCO-2706)

## Description
Add stage configs to scope values for stage deployment
Matching SRE cloudops-infra ticket [here](https://github.com/mozilla-services/cloudops-infra/pull/5313/files)



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2706]: https://mozilla-hub.atlassian.net/browse/DISCO-2706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ