### PR TITLE
Remove techdocs reference in Service Catalog

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -6,7 +6,6 @@ metadata:
     github.com/project-slug: mozilla-services/merino-py
     github.com/team-slug: mozilla-services/teams/context-services
     circleci.com/project-slug: github/mozilla-services/merino-py
-    backstage.io/techdocs-ref: url:https://mozilla-services.github.io/merino-py/
     sentry.io/project-slug: mozilla/merino-py
   description: Service to provide address bar suggestions to Firefox.
   tags:


### PR DESCRIPTION
This is because this link is supposed to point to internal backstage documentation, not to external docs. So removing it from the catalog.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
