### PR TITLE
Make geolocation provider return location name instead of iso code

### DIFF
--- a/merino/middleware/geolocation.py
+++ b/merino/middleware/geolocation.py
@@ -22,7 +22,9 @@ class Location(BaseModel):
     """Data model for geolocation."""
 
     country: Optional[str] = None
+    country_name: Optional[str] = None
     region: Optional[str] = None
+    region_name: Optional[str] = None
     city: Optional[str] = None
     dma: Optional[int] = None
     postal_code: Optional[str] = None
@@ -63,7 +65,11 @@ class GeolocationMiddleware:
         scope[ScopeKey.GEOLOCATION] = (
             Location(
                 country=record.country.iso_code,
+                country_name=record.country.names.get("en"),
                 region=record.subdivisions[0].iso_code if record.subdivisions else None,
+                region_name=record.subdivisions[0].names.get("en")
+                if record.subdivisions
+                else None,
                 city=record.city.names.get("en"),
                 dma=record.location.metro_code,
                 postal_code=record.postal.code if record.postal else None,

--- a/merino/providers/geolocation/provider.py
+++ b/merino/providers/geolocation/provider.py
@@ -56,8 +56,8 @@ class Provider(BaseProvider):
                 score=0,
                 custom_details=CustomDetails(
                     geolocation=GeolocationDetails(
-                        country=srequest.geolocation.country,
-                        region=srequest.geolocation.region,
+                        country=srequest.geolocation.country_name,
+                        region=srequest.geolocation.region_name,
                         city=srequest.geolocation.city,
                     )
                 ),

--- a/tests/unit/middleware/test_geolocation.py
+++ b/tests/unit/middleware/test_geolocation.py
@@ -26,12 +26,25 @@ def fixture_geolocation_middleware(mocker: MockerFixture) -> GeolocationMiddlewa
     [
         (
             Location(
-                country="US", region="WA", city="Milton", dma=819, postal_code="98354"
+                country="US",
+                country_name="United States",
+                region="WA",
+                region_name="Washington",
+                city="Milton",
+                dma=819,
+                postal_code="98354",
             ),
             ["216.160.83.56", 50000],
         ),
         (
-            Location(country="GB", region="ENG", city="Boxford", postal_code="OX1"),
+            Location(
+                country="GB",
+                country_name="United Kingdom",
+                region="ENG",
+                region_name="England",
+                city="Boxford",
+                postal_code="OX1",
+            ),
             ["2.125.160.216", 50000],
         ),
         (
@@ -92,7 +105,13 @@ async def test_geolocation_client_ip_override(
     request IP assignment.
     """
     expected_location: Location = Location(
-        country="US", region="WA", city="Milton", dma=819, postal_code="98354"
+        country="US",
+        country_name="United States",
+        region="WA",
+        region_name="Washington",
+        city="Milton",
+        dma=819,
+        postal_code="98354",
     )
     mocker.patch("merino.middleware.geolocation.CLIENT_IP_OVERRIDE", "216.160.83.56")
 

--- a/tests/unit/providers/geolocation/test_provider.py
+++ b/tests/unit/providers/geolocation/test_provider.py
@@ -21,7 +21,9 @@ def fixture_geolocation() -> Location:
     """Return a test Location."""
     return Location(
         country="US",
+        country_name="United States",
         region="CA",
+        region_name="California",
         city="San Francisco",
         dma=807,
         postal_code="94105",
@@ -33,7 +35,9 @@ def fixture_empty_region() -> Location:
     """Return a test Location."""
     return Location(
         country="US",
+        country_name="United States",
         region=None,
+        region_name=None,
         city="San Francisco",
         dma=807,
         postal_code="94105",
@@ -58,8 +62,8 @@ async def test_query_geolocation(provider: Provider, geolocation: Location) -> N
             score=0,
             custom_details=CustomDetails(
                 geolocation=GeolocationDetails(
-                    country="US",
-                    region="CA",
+                    country="United States",
+                    region="California",
                     city="San Francisco",
                 )
             ),
@@ -87,7 +91,7 @@ async def test_query_geolocation_empty_region(
             score=0,
             custom_details=CustomDetails(
                 geolocation=GeolocationDetails(
-                    country="US",
+                    country="United States",
                     city="San Francisco",
                 )
             ),


### PR DESCRIPTION
## References

JIRA: https://mozilla-hub.atlassian.net/browse/SNG-928

## Description
We implemented a provider that returns geolocation in https://github.com/mozilla-services/merino-py/pull/482.
The provider returns iso code as a city and region name, but cannot be used as a parameter for Yelp since it is represented by a number in Japan. (e.g. `14` which expresses `Kanagawa`)
https://en.wikipedia.org/wiki/ISO_3166-2:JP
Therefore, make the provider return the name of the country and the name of the region.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
