### PR TITLE
Redact the Elasticsearch query in Sentry

### DIFF
--- a/merino/config_sentry.py
+++ b/merino/config_sentry.py
@@ -1,4 +1,5 @@
 """Sentry Configuration"""
+import json
 import logging
 
 import sentry_sdk
@@ -9,6 +10,8 @@ from merino.config import settings
 from merino.utils.version import fetch_app_version_from_file
 
 logger = logging.getLogger(__name__)
+
+REDACTED_TEXT = "[REDACTED]"
 
 
 def configure_sentry() -> None:  # pragma: no cover
@@ -38,24 +41,31 @@ def strip_sensitive_data(event: dict, hint: dict) -> dict:
     """Filter out sensitive data from Sentry events."""
     #  See: https://docs.sentry.io/platforms/python/configuration/filtering/
     if event.get("request", {}).get("query_string", {}):
-        event["request"]["query_string"] = ""
+        event["request"]["query_string"] = REDACTED_TEXT
 
     try:
         for entry in event["exception"]["values"][0]["stacktrace"]["frames"]:
             if entry["vars"].get("q"):
-                entry["vars"]["q"] = ""
+                entry["vars"]["q"] = REDACTED_TEXT
             if entry["vars"].get("query"):
-                entry["vars"]["query"] = ""
+                entry["vars"]["query"] = REDACTED_TEXT
             if entry["vars"].get("srequest"):
-                entry["vars"]["srequest"] = ""
+                entry["vars"]["srequest"] = REDACTED_TEXT
             if entry["vars"].get("values", {}).get("q"):
-                entry["vars"]["values"]["q"] = ""
+                entry["vars"]["values"]["q"] = REDACTED_TEXT
             if (
                 entry["vars"].get("solved_result", [])
                 and len(entry["vars"].get("solved_result", [])) > 0
             ):
                 if entry["vars"]["solved_result"][0].get("q"):
-                    entry["vars"]["solved_result"][0]["q"] = ""
+                    entry["vars"]["solved_result"][0]["q"] = REDACTED_TEXT
+
+            # Redact the query sent to Elasticsearch.
+            # This just redacts all the variables that contains a part of the
+            # Elasticsearch query.
+            for key, value in entry["vars"].items():
+                if "suggest-on-title" in json.dumps(value):
+                    entry["vars"][key] = REDACTED_TEXT
 
     except (KeyError, IndexError) as e:
         logger.warning(


### PR DESCRIPTION
## References

JIRA: [DISCO-2731](https://mozilla-hub.atlassian.net/browse/DISCO-2731)

## Description
We want to redact the Elasticsearch queries that are sent to Sentry because they might contain keywords. So, this will just redact the whole Elasticsearch query object. 


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2731]: https://mozilla-hub.atlassian.net/browse/DISCO-2731?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ