### PR TITLE
refactor: Extract gcp upload logic into a separate module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,6 @@ workspace/
 
 # Emacs autosave files
 *~
+
+# IntelliJ IDE local settings
+.idea

--- a/merino/content_handler/__init__.py
+++ b/merino/content_handler/__init__.py
@@ -1,0 +1,1 @@
+"""Module designed to handle file (image) uploads to google cloud storage"""

--- a/merino/content_handler/gcp_uploader.py
+++ b/merino/content_handler/gcp_uploader.py
@@ -66,6 +66,7 @@ class GcsUploader:
         return destination_blob
 
     def get_most_recent_file(self, exclusion: str, sort_key: Callable) -> Blob | None:
+        """Get the most recent file from the bucket"""
         bucket: Bucket = self.storage_client.get_bucket(self.bucket_name)
         blobs = [
             blob

--- a/merino/content_handler/gcp_uploader.py
+++ b/merino/content_handler/gcp_uploader.py
@@ -1,0 +1,73 @@
+"""Uploads Content to GCS"""
+import logging
+from urllib.parse import urljoin
+
+from google.cloud.storage import Blob, Bucket, Client
+
+from merino.content_handler.models import Image
+
+logger = logging.getLogger(__name__)
+
+
+class GcsUploader:
+    """Class that includes shared logic to upload an image to GCP."""
+
+    def __init__(
+        self,
+        destination_gcp_project: str,
+        destination_bucket_name: str,
+        destination_cdn_hostname: str,
+    ) -> None:
+        self.storage_client = Client(destination_gcp_project)
+        self.bucket_name = destination_bucket_name
+        self.cdn_hostname = destination_cdn_hostname
+
+    def upload_image(
+        self, image: Image, destination_name: str, forced_upload: bool = False
+    ) -> str:
+        """Upload an Image to our GCS Bucket and return the public URL where it is hosted."""
+        image_blob: Blob = self.upload_content(
+            image.content, destination_name, image.content_type, forced_upload
+        )
+        image_public_url = self._get_public_url(image_blob, destination_name)
+
+        logger.info(f"Content public url: {image_public_url}")
+
+        return image_public_url
+
+    def upload_content(
+        self,
+        content: str,
+        destination_name: str,
+        content_type: str,
+        forced_upload: bool = False,
+    ) -> str:
+        """Upload the content then return the public URL where it is hosted."""
+        bucket: Bucket = self.storage_client.bucket(self.bucket_name)
+        destination_blob = bucket.blob(destination_name)
+
+        try:
+            if forced_upload or not destination_blob.exists():
+                logger.info(f"Uploading blob: {destination_blob}")
+                destination_blob.upload_from_string(
+                    content,
+                    content_type=content_type,
+                )
+                destination_blob.make_public()
+
+        except Exception as e:
+            logger.error(f"Exception {e} occured while uploading {destination_name}")
+
+        return destination_blob
+
+    def _get_public_url(self, blob: Blob, favicon_name: str) -> str:
+        """Get public url for some content"""
+        if self.cdn_hostname:
+            base_url = (
+                f"https://{self.cdn_hostname}"
+                if "https" not in self.cdn_hostname
+                else self.cdn_hostname
+            )
+            return urljoin(base_url, favicon_name)
+        else:
+            return str(blob.public_url)

--- a/merino/content_handler/gcp_uploader.py
+++ b/merino/content_handler/gcp_uploader.py
@@ -5,12 +5,12 @@ from urllib.parse import urljoin
 
 from google.cloud.storage import Blob, Bucket, Client
 
-from merino.content_handler.models import Image
+from merino.content_handler.models import BaseContentUploader, Image
 
 logger = logging.getLogger(__name__)
 
 
-class GcsUploader:
+class GcsUploader(BaseContentUploader):
     """Class that includes shared logic to upload an image to GCP."""
 
     storage_client: Client
@@ -42,7 +42,7 @@ class GcsUploader:
 
     def upload_content(
         self,
-        content: bytes,
+        content: bytes | str,
         destination_name: str,
         content_type: str = "text/plain",
         forced_upload: bool = False,

--- a/merino/content_handler/gcp_uploader.py
+++ b/merino/content_handler/gcp_uploader.py
@@ -75,7 +75,7 @@ class GcsUploader:
 
         if not blobs:
             return None
-        # return the most recent file. this sorts in ascending order, we are getting the last file.
+        # return the most recent file. This sorts in ascending order, we are getting the last file.
         most_recent = sorted(blobs, key=sort_key)[-1]
         return most_recent
 

--- a/merino/content_handler/gcp_uploader.py
+++ b/merino/content_handler/gcp_uploader.py
@@ -47,7 +47,7 @@ class GcsUploader:
         content_type: str = "text/plain",
         forced_upload: bool = False,
     ) -> Blob:
-        """Upload the content then return the public URL where it is hosted."""
+        """Upload the content then return the blob."""
         bucket: Bucket = self.storage_client.bucket(self.bucket_name)
         destination_blob = bucket.blob(destination_name)
 

--- a/merino/content_handler/models.py
+++ b/merino/content_handler/models.py
@@ -1,0 +1,30 @@
+from abc import ABC, abstractmethod
+
+from pydantic import BaseModel
+
+
+class Image(BaseModel):
+    """Data model for Image contents and associated metadata."""
+
+    content: bytes
+    content_type: str
+
+
+class BaseContentUploader(ABC):
+    """Abstract class for uploading content to GCS."""
+
+    @abstractmethod
+    def upload_content(
+        self, content: str, destination_name: str, content_type: str
+    ) -> str:
+        """Abstract method for uploading content to our GCS Bucket."""
+        ...
+
+    @abstractmethod
+    def upload_image(
+        self,
+        image: Image,
+        destination_name: str,
+    ) -> str:
+        """Abstract method for uploading an image to our GCS Bucket."""
+        ...

--- a/merino/content_handler/models.py
+++ b/merino/content_handler/models.py
@@ -10,7 +10,7 @@ class Image(BaseModel):
 
     content: bytes
     content_type: str = Field(
-        description="Content type of the Image. Can be 'image/png', 'image/jpeg', 'image"
+        description="Content type of the Image. Can be 'image/png', 'image/jpeg', 'image'"
     )
 
 

--- a/merino/content_handler/models.py
+++ b/merino/content_handler/models.py
@@ -1,8 +1,10 @@
 """Base Image and Content Uploader models"""
 from abc import ABC, abstractmethod
+from io import BytesIO
 from typing import Callable
 
 from google.cloud.storage import Blob
+from PIL import Image as PILImage
 from pydantic import BaseModel, Field
 
 
@@ -13,6 +15,10 @@ class Image(BaseModel):
     content_type: str = Field(
         description="Content type of the Image. Can be 'image/png', 'image/jpeg', 'image'"
     )
+
+    def open(self) -> PILImage:
+        """Open and return an PIL Image object"""
+        return PILImage.open(BytesIO(self.content))
 
 
 class BaseContentUploader(ABC):

--- a/merino/content_handler/models.py
+++ b/merino/content_handler/models.py
@@ -1,13 +1,17 @@
 from abc import ABC, abstractmethod
+from typing import Callable
 
-from pydantic import BaseModel
+from google.cloud.storage import Blob
+from pydantic import BaseModel, Field
 
 
 class Image(BaseModel):
     """Data model for Image contents and associated metadata."""
 
     content: bytes
-    content_type: str
+    content_type: str = Field(
+        description="Content type of the Image. Can be 'image/png', 'image/jpeg', 'image"
+    )
 
 
 class BaseContentUploader(ABC):
@@ -15,8 +19,8 @@ class BaseContentUploader(ABC):
 
     @abstractmethod
     def upload_content(
-        self, content: str, destination_name: str, content_type: str
-    ) -> str:
+        self, content: str, destination_name: str, content_type: str = "text/plain"
+    ) -> Blob:
         """Abstract method for uploading content to our GCS Bucket."""
         ...
 
@@ -25,6 +29,12 @@ class BaseContentUploader(ABC):
         self,
         image: Image,
         destination_name: str,
+        forced_upload=None,
     ) -> str:
         """Abstract method for uploading an image to our GCS Bucket."""
+        ...
+
+    @abstractmethod
+    def get_most_recent_file(self, exclusion: str, sort_key: Callable) -> Blob | None:
+        """Abstract method for getting the most recent file from the GCS bucket."""
         ...

--- a/merino/content_handler/models.py
+++ b/merino/content_handler/models.py
@@ -18,7 +18,8 @@ class Image(BaseModel):
 
     def open(self) -> PILImage:
         """Open and return an PIL Image object"""
-        return PILImage.open(BytesIO(self.content))
+        with PILImage.open(BytesIO(self.content)) as image:
+            return image
 
 
 class BaseContentUploader(ABC):

--- a/merino/content_handler/models.py
+++ b/merino/content_handler/models.py
@@ -1,10 +1,8 @@
 """Base Image and Content Uploader models"""
 from abc import ABC, abstractmethod
-from io import BytesIO
 from typing import Callable
 
 from google.cloud.storage import Blob
-from PIL import Image as PILImage
 from pydantic import BaseModel, Field
 
 
@@ -15,11 +13,6 @@ class Image(BaseModel):
     content_type: str = Field(
         description="Content type of the Image. Can be 'image/png', 'image/jpeg', 'image'"
     )
-
-    @staticmethod
-    def open(bytes_io: BytesIO) -> PILImage:
-        """Open and return an PIL Image object"""
-        return PILImage.open(bytes_io)
 
 
 class BaseContentUploader(ABC):

--- a/merino/content_handler/models.py
+++ b/merino/content_handler/models.py
@@ -1,3 +1,4 @@
+"""Base Image and Content Uploader models"""
 from abc import ABC, abstractmethod
 from typing import Callable
 

--- a/merino/content_handler/models.py
+++ b/merino/content_handler/models.py
@@ -18,6 +18,7 @@ class Image(BaseModel):
 
     @staticmethod
     def open(bytes_io: BytesIO) -> PILImage:
+        """Open and return an PIL Image object"""
         return PILImage.open(bytes_io)
 
 

--- a/merino/content_handler/models.py
+++ b/merino/content_handler/models.py
@@ -1,8 +1,10 @@
 """Base Image and Content Uploader models"""
 from abc import ABC, abstractmethod
+from io import BytesIO
 from typing import Callable
 
 from google.cloud.storage import Blob
+from PIL import Image as PILImage
 from pydantic import BaseModel, Field
 
 
@@ -14,13 +16,21 @@ class Image(BaseModel):
         description="Content type of the Image. Can be 'image/png', 'image/jpeg', 'image'"
     )
 
+    @staticmethod
+    def open(bytes_io: BytesIO) -> PILImage:
+        return PILImage.open(bytes_io)
+
 
 class BaseContentUploader(ABC):
     """Abstract class for uploading content to GCS."""
 
     @abstractmethod
     def upload_content(
-        self, content: str, destination_name: str, content_type: str = "text/plain"
+        self,
+        content: bytes | str,
+        destination_name: str,
+        content_type: str = "text/plain",
+        forced_upload: bool = False,
     ) -> Blob:
         """Abstract method for uploading content to our GCS Bucket."""
         ...

--- a/merino/jobs/navigational_suggestions/__init__.py
+++ b/merino/jobs/navigational_suggestions/__init__.py
@@ -6,6 +6,7 @@ from typing import Optional
 import typer
 
 from merino.config import settings as config
+from merino.content_handler.gcp_uploader import GcsUploader
 from merino.jobs.navigational_suggestions.domain_data_downloader import (
     DomainDataDownloader,
 )
@@ -127,9 +128,11 @@ def prepare_domain_metadata(
 
     # upload favicons and get their public urls
     domain_metadata_uploader = DomainMetadataUploader(
-        destination_gcp_project,
-        destination_gcs_bucket,
-        destination_cdn_hostname,
+        GcsUploader(
+            destination_gcp_project,
+            destination_gcs_bucket,
+            destination_cdn_hostname,
+        ),
         force_upload,
     )
     favicons = [str(metadata["icon"]) for metadata in domain_metadata]
@@ -149,11 +152,7 @@ def prepare_domain_metadata(
     domain_diff = DomainDiff(
         latest_domain_data=top_picks, old_domain_data=old_top_picks
     )
-    (
-        unchanged,
-        added_domains,
-        added_urls,
-    ) = domain_diff.compare_top_picks(
+    (unchanged, added_domains, added_urls,) = domain_diff.compare_top_picks(
         new_top_picks=top_picks,
         old_top_picks=old_top_picks,
     )

--- a/merino/jobs/navigational_suggestions/__init__.py
+++ b/merino/jobs/navigational_suggestions/__init__.py
@@ -128,12 +128,12 @@ def prepare_domain_metadata(
 
     # upload favicons and get their public urls
     domain_metadata_uploader = DomainMetadataUploader(
+        force_upload,
         GcsUploader(
             destination_gcp_project,
             destination_gcs_bucket,
             destination_cdn_hostname,
         ),
-        force_upload,
     )
     favicons = [str(metadata["icon"]) for metadata in domain_metadata]
     uploaded_favicons = domain_metadata_uploader.upload_favicons(favicons)
@@ -146,9 +146,11 @@ def prepare_domain_metadata(
     # Create diff class for comparison of Top Picks Files
     old_top_picks: dict[
         str, list[dict[str, str]]
-    ] = domain_metadata_uploader.get_latest_file_for_diff(
-        client=domain_metadata_uploader.storage_client
-    )
+    ] | None = domain_metadata_uploader.get_latest_file_for_diff()
+
+    if old_top_picks is None:
+        old_top_picks = {}
+
     domain_diff = DomainDiff(
         latest_domain_data=top_picks, old_domain_data=old_top_picks
     )

--- a/merino/jobs/navigational_suggestions/__init__.py
+++ b/merino/jobs/navigational_suggestions/__init__.py
@@ -152,7 +152,11 @@ def prepare_domain_metadata(
     domain_diff = DomainDiff(
         latest_domain_data=top_picks, old_domain_data=old_top_picks
     )
-    (unchanged, added_domains, added_urls,) = domain_diff.compare_top_picks(
+    (
+        unchanged,
+        added_domains,
+        added_urls,
+    ) = domain_diff.compare_top_picks(
         new_top_picks=top_picks,
         old_top_picks=old_top_picks,
     )

--- a/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
+++ b/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
@@ -5,7 +5,6 @@ from typing import Any, Optional
 from urllib.parse import urljoin, urlparse
 
 import requests
-from PIL import Image
 from pydantic import BaseModel
 from robobrowser import RoboBrowser
 

--- a/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
+++ b/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
@@ -261,7 +261,7 @@ class DomainMetadataExtractor:
         for favicon in favicons:
             url = self._fix_url(favicon["href"])
             width = None
-            favicon_image: Optional[Image] = self.favicon_downloader.download_favicon(
+            favicon_image: Image | None = self.favicon_downloader.download_favicon(
                 url
             )
             if favicon_image is None:

--- a/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
+++ b/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
@@ -9,13 +9,13 @@ from PIL import Image
 from pydantic import BaseModel
 from robobrowser import RoboBrowser
 
+from merino.content_handler.models import Image
 from merino.jobs.navigational_suggestions.utils import (
     REQUEST_HEADERS,
     TIMEOUT,
     FaviconDownloader,
     requests_get,
 )
-from merino.content_handler.models import Image
 
 logger = logging.getLogger(__name__)
 

--- a/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
+++ b/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
@@ -13,9 +13,9 @@ from merino.jobs.navigational_suggestions.utils import (
     REQUEST_HEADERS,
     TIMEOUT,
     FaviconDownloader,
-    FaviconImage,
     requests_get,
 )
+from merino.content_handler.models import Image
 
 logger = logging.getLogger(__name__)
 
@@ -261,9 +261,9 @@ class DomainMetadataExtractor:
         for favicon in favicons:
             url = self._fix_url(favicon["href"])
             width = None
-            favicon_image: Optional[
-                FaviconImage
-            ] = self.favicon_downloader.download_favicon(url)
+            favicon_image: Optional[Image] = self.favicon_downloader.download_favicon(
+                url
+            )
             if favicon_image is None:
                 continue
 

--- a/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
+++ b/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
@@ -5,6 +5,7 @@ from typing import Any, Optional
 from urllib.parse import urljoin, urlparse
 
 import requests
+from PIL import Image as PILImage
 from pydantic import BaseModel
 from robobrowser import RoboBrowser
 
@@ -193,9 +194,9 @@ class DomainMetadataExtractor:
             return f"https:{url}"
         return url
 
-    def _get_favicon_smallest_dimension(self, content: bytes) -> int:
+    def _get_favicon_smallest_dimension(self, image: Image) -> int:
         """Return the smallest of the favicon image width and height"""
-        with Image.open(BytesIO(content)) as img:
+        with PILImage.open(BytesIO(image.content)) as img:
             width, height = img.size
             return int(min(width, height))
 
@@ -279,7 +280,7 @@ class DomainMetadataExtractor:
                     logger.info(f"Masked SVG favicon {favicon} found; skipping it")
                     continue
             try:
-                width = self._get_favicon_smallest_dimension(favicon_image.content)
+                width = self._get_favicon_smallest_dimension(favicon_image)
             except Exception as e:
                 logger.info(f"Exception {e} for favicon {favicon}")
 

--- a/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
+++ b/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
@@ -1,11 +1,9 @@
 """Extract domain metadata from domain data"""
 import logging
-from io import BytesIO
 from typing import Any, Optional
 from urllib.parse import urljoin, urlparse
 
 import requests
-from PIL import Image as PILImage
 from pydantic import BaseModel
 from robobrowser import RoboBrowser
 
@@ -196,9 +194,8 @@ class DomainMetadataExtractor:
 
     def _get_favicon_smallest_dimension(self, image: Image) -> int:
         """Return the smallest of the favicon image width and height"""
-        with PILImage.open(BytesIO(image.content)) as img:
-            width, height = img.size
-            return int(min(width, height))
+        width, height = image.open()
+        return int(min(width, height))
 
     def _extract_favicons(self, scraped_url: str) -> list[dict[str, Any]]:
         """Extract all favicons for an already opened url"""

--- a/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
+++ b/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
@@ -194,7 +194,7 @@ class DomainMetadataExtractor:
 
     def _get_favicon_smallest_dimension(self, image: Image) -> int:
         """Return the smallest of the favicon image width and height"""
-        width, height = image.open()
+        width, height = image.open().size
         return int(min(width, height))
 
     def _extract_favicons(self, scraped_url: str) -> list[dict[str, Any]]:

--- a/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
+++ b/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
@@ -261,9 +261,7 @@ class DomainMetadataExtractor:
         for favicon in favicons:
             url = self._fix_url(favicon["href"])
             width = None
-            favicon_image: Image | None = self.favicon_downloader.download_favicon(
-                url
-            )
+            favicon_image: Image | None = self.favicon_downloader.download_favicon(url)
             if favicon_image is None:
                 continue
 

--- a/merino/jobs/navigational_suggestions/domain_metadata_uploader.py
+++ b/merino/jobs/navigational_suggestions/domain_metadata_uploader.py
@@ -72,7 +72,7 @@ class DomainMetadataUploader:
             )
             if favicon_image:
                 try:
-                    dst_favicon_name = self._destination_favicon_name(favicon_image)
+                    dst_favicon_name = self.destination_favicon_name(favicon_image)
                     dst_favicon_public_url = self.uploader.upload_image(
                         favicon_image, dst_favicon_name, forced_upload=self.force_upload
                     )
@@ -84,7 +84,7 @@ class DomainMetadataUploader:
 
         return dst_favicons
 
-    def _destination_favicon_name(self, favicon_image: Image) -> str:
+    def destination_favicon_name(self, favicon_image: Image) -> str:
         """Return the name of the favicon to be used for uploading to GCS"""
         content_hex_digest: str = hashlib.sha256(favicon_image.content).hexdigest()
         content_len: str = str(len(favicon_image.content))

--- a/merino/jobs/navigational_suggestions/domain_metadata_uploader.py
+++ b/merino/jobs/navigational_suggestions/domain_metadata_uploader.py
@@ -7,7 +7,8 @@ from urllib.parse import urljoin
 
 from google.cloud.storage import Blob, Bucket, Client
 
-from merino.jobs.navigational_suggestions.utils import FaviconDownloader, FaviconImage
+from merino.jobs.navigational_suggestions.utils import FaviconDownloader
+from merino.content_handler.models import Image, BaseContentUploader
 
 logger = logging.getLogger(__name__)
 
@@ -18,22 +19,15 @@ class DomainMetadataUploader:
     DESTINATION_FAVICONS_ROOT: str = "favicons"
     DESTINATION_TOP_PICK_FILE_NAME: str = "top_picks_latest.json"
 
-    bucket_name: str
-    storage_client: Client
-    cdn_hostname: str
     favicon_downloader: FaviconDownloader
 
     def __init__(
         self,
-        destination_gcp_project: str,
-        destination_bucket_name: str,
-        destination_cdn_hostname: str,
         force_upload: bool,
+        uploader: BaseContentUploader,
         favicon_downloader: FaviconDownloader = FaviconDownloader(),
     ) -> None:
-        self.storage_client = Client(destination_gcp_project)
-        self.bucket_name = destination_bucket_name
-        self.cdn_hostname = destination_cdn_hostname
+        self.uploader = uploader
         self.force_upload = force_upload
         self.favicon_downloader = favicon_downloader
 
@@ -42,13 +36,14 @@ class DomainMetadataUploader:
         One file is prepended by a timestamp for record keeping,
         the other file is the latest entry from which data is loaded.
         """
-        bucket = self.storage_client.bucket(self.bucket_name)
         timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
         timestamp_file_name = f"{timestamp}_top_picks.json"
-        latest_blob = bucket.blob(self.DESTINATION_TOP_PICK_FILE_NAME)
-        latest_blob.upload_from_string(top_picks)
-        dated_blob = bucket.blob(timestamp_file_name)
-        dated_blob.upload_from_string(top_picks)
+
+        _: Blob = self.uploader.upload_content(
+            top_picks, self.DESTINATION_TOP_PICK_FILE_NAME
+        )
+        dated_blob: Blob = self.uploader.upload_content(top_picks, timestamp_file_name)
+
         return dated_blob
 
     def get_latest_file_for_diff(
@@ -77,31 +72,16 @@ class DomainMetadataUploader:
         return the public urls of the uploaded ones.
         """
         dst_favicons: list = []
-        bucket: Bucket = self.storage_client.bucket(self.bucket_name)
         for src_favicon in src_favicons:
             dst_favicon_public_url: str = ""
-            favicon_image: FaviconImage | None = (
-                self.favicon_downloader.download_favicon(src_favicon)
+            favicon_image: Image | None = self.favicon_downloader.download_favicon(
+                src_favicon
             )
             if favicon_image:
                 try:
                     dst_favicon_name = self._destination_favicon_name(favicon_image)
-                    dst_blob = bucket.blob(dst_favicon_name)
-
-                    # upload favicon to gcs if force upload is set or if it doesn't exist there and
-                    # make it publicly accessible
-                    if self.force_upload or not dst_blob.exists():
-                        logger.info(
-                            f"Uploading favicon {src_favicon} to blob {dst_favicon_name}"
-                        )
-                        dst_blob.upload_from_string(
-                            favicon_image.content,
-                            content_type=favicon_image.content_type,
-                        )
-                        dst_blob.make_public()
-
-                    dst_favicon_public_url = self._get_favicon_public_url(
-                        dst_blob, dst_favicon_name
+                    dst_favicon_public_url = self.uploader.upload_image(
+                        favicon_image, dst_favicon_name, forced_upload=self.force_upload
                     )
                     logger.info(f"favicon public url: {dst_favicon_public_url}")
                 except Exception as e:
@@ -111,19 +91,7 @@ class DomainMetadataUploader:
 
         return dst_favicons
 
-    def _get_favicon_public_url(self, blob: Blob, favicon_name: str) -> str:
-        """Get public url for the uploaded favicon"""
-        if self.cdn_hostname:
-            base_url = (
-                f"https://{self.cdn_hostname}"
-                if "https" not in self.cdn_hostname
-                else self.cdn_hostname
-            )
-            return urljoin(base_url, favicon_name)
-        else:
-            return str(blob.public_url)
-
-    def _destination_favicon_name(self, favicon_image: FaviconImage) -> str:
+    def _destination_favicon_name(self, favicon_image: Image) -> str:
         """Return the name of the favicon to be used for uploading to GCS"""
         content_hex_digest: str = hashlib.sha256(favicon_image.content).hexdigest()
         content_len: str = str(len(favicon_image.content))

--- a/merino/jobs/navigational_suggestions/domain_metadata_uploader.py
+++ b/merino/jobs/navigational_suggestions/domain_metadata_uploader.py
@@ -38,9 +38,7 @@ class DomainMetadataUploader:
         timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
         timestamp_file_name = f"{timestamp}_top_picks.json"
 
-        self.uploader.upload_content(
-            top_picks, self.DESTINATION_TOP_PICK_FILE_NAME
-        )
+        self.uploader.upload_content(top_picks, self.DESTINATION_TOP_PICK_FILE_NAME)
         dated_blob: Blob = self.uploader.upload_content(top_picks, timestamp_file_name)
 
         return dated_blob

--- a/merino/jobs/navigational_suggestions/domain_metadata_uploader.py
+++ b/merino/jobs/navigational_suggestions/domain_metadata_uploader.py
@@ -38,7 +38,7 @@ class DomainMetadataUploader:
         timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
         timestamp_file_name = f"{timestamp}_top_picks.json"
 
-        _: Blob = self.uploader.upload_content(
+        self.uploader.upload_content(
             top_picks, self.DESTINATION_TOP_PICK_FILE_NAME
         )
         dated_blob: Blob = self.uploader.upload_content(top_picks, timestamp_file_name)

--- a/merino/jobs/navigational_suggestions/domain_metadata_uploader.py
+++ b/merino/jobs/navigational_suggestions/domain_metadata_uploader.py
@@ -45,7 +45,7 @@ class DomainMetadataUploader:
 
     def get_latest_file_for_diff(
         self,
-    ) -> dict[str, list[dict[str, str]]]:
+    ) -> dict[str, list[dict[str, str]]] | None:
         """Get the most recent top pick file with timestamp so a comparison
         can be made between the previous file and the new file to be written.
         """
@@ -53,7 +53,11 @@ class DomainMetadataUploader:
             exclusion=self.DESTINATION_TOP_PICK_FILE_NAME,
             sort_key=lambda blob: blob.name,
         )
-        data: Blob = most_recent.download_as_text()
+        # early exit if no file is returned from the uploader
+        if most_recent is None:
+            return None
+
+        data = most_recent.download_as_text()
         file_contents: dict = json.loads(data)
         logger.info(f"Domain file {most_recent.name} acquired.")
         return file_contents

--- a/merino/jobs/navigational_suggestions/domain_metadata_uploader.py
+++ b/merino/jobs/navigational_suggestions/domain_metadata_uploader.py
@@ -9,9 +9,6 @@ from google.cloud.storage import Blob, Bucket, Client
 from merino.content_handler.models import BaseContentUploader, Image
 from merino.jobs.navigational_suggestions.utils import FaviconDownloader
 
-# from urllib.parse import urljoin
-
-
 logger = logging.getLogger(__name__)
 
 
@@ -49,7 +46,7 @@ class DomainMetadataUploader:
         return dated_blob
 
     def get_latest_file_for_diff(
-        self, client: Client, bucket_name: str
+        self,
     ) -> dict[str, list[dict[str, str]]]:
         """Get the most recent top pick file with timestamp so a comparison
         can be made between the previous file and the new file to be written.

--- a/merino/jobs/navigational_suggestions/domain_metadata_uploader.py
+++ b/merino/jobs/navigational_suggestions/domain_metadata_uploader.py
@@ -4,7 +4,7 @@ import json
 import logging
 from datetime import datetime
 
-from google.cloud.storage import Blob, Bucket, Client
+from google.cloud.storage import Blob
 
 from merino.content_handler.models import BaseContentUploader, Image
 from merino.jobs.navigational_suggestions.utils import FaviconDownloader
@@ -53,7 +53,7 @@ class DomainMetadataUploader:
             exclusion=self.DESTINATION_TOP_PICK_FILE_NAME,
             sort_key=lambda blob: blob.name,
         )
-        data = most_recent.download_as_text()
+        data: Blob = most_recent.download_as_text()
         file_contents: dict = json.loads(data)
         logger.info(f"Domain file {most_recent.name} acquired.")
         return file_contents

--- a/merino/jobs/navigational_suggestions/utils.py
+++ b/merino/jobs/navigational_suggestions/utils.py
@@ -2,7 +2,8 @@
 import logging
 
 import requests
-from pydantic import BaseModel
+
+from merino.content_handler.models import Image
 
 REQUEST_HEADERS: dict[str, str] = {
     "User-Agent": (
@@ -32,28 +33,21 @@ FIREFOX_PACKAGED_FAVICONS: dict[str, str] = {
 logger = logging.getLogger(__name__)
 
 
-class FaviconImage(BaseModel):
-    """Data model for favicon image contents and associated metadata."""
-
-    content: bytes
-    content_type: str
-
-
 class FaviconDownloader:
     """Download favicon from the web"""
 
-    def download_favicon(self, url: str) -> FaviconImage | None:
+    def download_favicon(self, url: str) -> Image | None:
         """Download the favicon from the given url.
 
         Args:
             url: favicon URL
         Returns:
-            FaviconImage: favicon image content and associated metadata
+            Image: favicon image content and associated metadata
         """
         try:
             response = requests_get(url)
             return (
-                FaviconImage(
+                Image(
                     content=response.content,
                     content_type=str(response.headers.get("Content-Type")),
                 )

--- a/tests/unit/content_handler/test_gcp_uploader.py
+++ b/tests/unit/content_handler/test_gcp_uploader.py
@@ -1,3 +1,5 @@
+"""Unit tests for merino.content_handler.gcp_uploader"""
+
 from logging import ERROR, INFO, LogRecord
 
 import pytest
@@ -42,26 +44,31 @@ def mock_gcs_bucket(mocker):
 
 @pytest.fixture
 def test_https_cdn_host_name() -> str:
+    """Return a test host url with https prepended to it"""
     return "https://test-cdn-host"
 
 
 @pytest.fixture
 def test_cdn_host_name() -> str:
+    """Return a test host url"""
     return "test-cdn-host"
 
 
 @pytest.fixture
 def test_destination_name() -> str:
+    """Return a test destination name"""
     return "test-destination-name"
 
 
 @pytest.fixture
 def test_bucket_name() -> str:
+    """Return a test bucket name"""
     return "test-bucket-name"
 
 
 @pytest.fixture
 def test_image() -> Image:
+    """Return a test Image object of type png"""
     return Image(content=bytes(255), content_type="image/png")
 
 
@@ -74,8 +81,9 @@ def test_upload_image_with_non_https_cdn_host_name(
     test_destination_name,
     test_image,
 ) -> None:
-    """Test the upload_image method with the cdn_hostname class instance set to a non https value"""
-
+    """Test the upload_image method with the cdn_hostname class instance set to a non https
+    value
+    """
     # set the logger level to the same in source method
     caplog.set_level(INFO)
 
@@ -106,7 +114,6 @@ def test_upload_image_with_https_cdn_host_name(
     test_image,
 ) -> None:
     """Test the upload_image method with the cdn_hostname class instance set to a https value"""
-
     # set the logger level to the same in source method
     caplog.set_level(INFO)
 
@@ -138,7 +145,6 @@ def test_get_most_recent_file_with_two_files(
     test_bucket_name,
 ) -> None:
     """Test the get_most_recent_file method with bucket returning two blobs/files"""
-
     mock_gcs_blob.name = "20210101120555_top_picks.json"
     # set the mock bucket's blob list to the two mocked blobs
     mock_gcs_bucket.list_blobs.return_value = [mock_most_recent_gcs_blob, mock_gcs_blob]
@@ -152,7 +158,7 @@ def test_get_most_recent_file_with_two_files(
         exclusion=excluded_file, sort_key=lambda blob: blob.name
     )
 
-    # result should be the the most recent blob / file
+    # result should be the most recent blob / file
     assert result.name == mock_most_recent_gcs_blob.name
 
 
@@ -163,8 +169,9 @@ def test_get_most_recent_file_with_excluded_file(
     test_https_cdn_host_name,
     test_bucket_name,
 ) -> None:
-    """Test the get_most_recent_file method with the mock bucket containing only the excluded blob/file"""
-
+    """Test the get_most_recent_file method with the mock bucket containing only the excluded
+    blob/file
+    """
     excluded_file: str = "excluded.json"
     mock_gcs_blob.name = excluded_file
 
@@ -195,7 +202,6 @@ def test_upload_content_with_forced_upload_false_and_existing_blob(
     test_https_cdn_host_name,
 ) -> None:
     """Test the upload_content method with default arguments"""
-
     # set the logger level to the same in source method
     caplog.set_level(INFO)
 
@@ -273,6 +279,7 @@ def test_upload_content_with_exception_thrown(
     test_destination_name,
     test_https_cdn_host_name,
 ) -> None:
+    """Test the upload content method with a blob method throw an exception."""
     # set the logger level to ERROR for the exception
     caplog.set_level(ERROR)
 

--- a/tests/unit/content_handler/test_gcp_uploader.py
+++ b/tests/unit/content_handler/test_gcp_uploader.py
@@ -1,4 +1,4 @@
-from logging import INFO, LogRecord
+from logging import ERROR, INFO, LogRecord
 
 import pytest
 from pytest import LogCaptureFixture
@@ -9,9 +9,13 @@ from tests.types import FilterCaplogFixture
 
 
 @pytest.fixture
-def mock_gcs_client(mocker):
+def mock_gcs_client(mocker, mock_gcs_bucket):
     """Return a mock GCS Client instance"""
-    return mocker.patch("merino.content_handler.gcp_uploader.Client").return_value
+    mock_client = mocker.patch(
+        "merino.content_handler.gcp_uploader.Client"
+    ).return_value
+    mock_client.get_bucket.return_value = mock_gcs_bucket
+    return mock_client
 
 
 @pytest.fixture
@@ -21,23 +25,56 @@ def mock_gcs_blob(mocker):
 
 
 @pytest.fixture
+def mock_most_recent_gcs_blob(mocker):
+    """Return a mock GCS Blob instance"""
+    most_recent_blob = mocker.patch(
+        "merino.content_handler.gcp_uploader.Blob"
+    ).return_value
+    most_recent_blob.name = "20220101120555_top_picks.json"
+    return most_recent_blob
+
+
+@pytest.fixture
 def mock_gcs_bucket(mocker):
     """Return a mock GCS Bucket instance"""
     return mocker.patch("merino.content_handler.gcp_uploader.Bucket").return_value
 
 
+@pytest.fixture
+def test_https_cdn_host_name() -> str:
+    return "https://test-cdn-host"
+
+
+@pytest.fixture
+def test_cdn_host_name() -> str:
+    return "test-cdn-host"
+
+
+@pytest.fixture
+def test_destination_name() -> str:
+    return "test-destination-name"
+
+
+@pytest.fixture
+def test_bucket_name() -> str:
+    return "test-bucket-name"
+
+
+@pytest.fixture
+def test_image() -> Image:
+    return Image(content=bytes(255), content_type="image/png")
+
+
 def test_upload_image_with_non_https_cdn_host_name(
-    mock_gcs_client,
     caplog: LogCaptureFixture,
     filter_caplog: FilterCaplogFixture,
+    mock_gcs_client,
+    test_cdn_host_name,
+    test_bucket_name,
+    test_destination_name,
+    test_image,
 ) -> None:
     """Test the upload_image method with the cdn_hostname class instance set to a non https value"""
-
-    # test variables
-    test_cdn_host_name = "test_cdn_host_name"
-    test_bucket_name = "test_bucket_name"
-    test_destination_name = "test-destination"
-    test_image = Image(content=bytes(255), content_type="image/png")
 
     # set the logger level to the same in source method
     caplog.set_level(INFO)
@@ -47,6 +84,7 @@ def test_upload_image_with_non_https_cdn_host_name(
 
     # force upload is set to FALSE by default
     result = gcp_uploader.upload_image(test_image, test_destination_name)
+
     # capture logger info output
     log_records: list[LogRecord] = filter_caplog(
         caplog.records, "merino.content_handler.gcp_uploader"
@@ -59,17 +97,15 @@ def test_upload_image_with_non_https_cdn_host_name(
 
 
 def test_upload_image_with_https_cdn_host_name(
-    mock_gcs_client,
     caplog: LogCaptureFixture,
     filter_caplog: FilterCaplogFixture,
+    mock_gcs_client,
+    test_https_cdn_host_name,
+    test_bucket_name,
+    test_destination_name,
+    test_image,
 ) -> None:
     """Test the upload_image method with the cdn_hostname class instance set to a https value"""
-
-    # test variables
-    test_https_cdn_host_name = "https://test-cdn-host"
-    test_bucket_name = "test_bucket_name"
-    test_destination_name = "test-destination"
-    test_image = Image(content=bytes(255), content_type="image/png")
 
     # set the logger level to the same in source method
     caplog.set_level(INFO)
@@ -81,6 +117,7 @@ def test_upload_image_with_https_cdn_host_name(
 
     # force upload is set to FALSE by default
     result = gcp_uploader.upload_image(test_image, test_destination_name)
+
     # capture logger info output
     log_records: list[LogRecord] = filter_caplog(
         caplog.records, "merino.content_handler.gcp_uploader"
@@ -92,10 +129,173 @@ def test_upload_image_with_https_cdn_host_name(
     assert log_records[0].message.startswith(f"Content public url: {result}")
 
 
-# def test_upload_content() -> None:
-# 	# test goes here
-#
-#
-#
-# def test_get_most_recent_file() -> None:
-# 	# test goes here
+def test_get_most_recent_file_with_two_files(
+    mock_gcs_client,
+    mock_gcs_bucket,
+    mock_gcs_blob,
+    mock_most_recent_gcs_blob,
+    test_https_cdn_host_name,
+    test_bucket_name,
+) -> None:
+    """Test the get_most_recent_file method with bucket returning two blobs/files"""
+
+    mock_gcs_blob.name = "20210101120555_top_picks.json"
+    # set the mock bucket's blob list to the two mocked blobs
+    mock_gcs_bucket.list_blobs.return_value = [mock_most_recent_gcs_blob, mock_gcs_blob]
+
+    gcp_uploader = GcsUploader(
+        mock_gcs_client, test_bucket_name, test_https_cdn_host_name
+    )
+
+    excluded_file: str = "excluded.json"
+    result = gcp_uploader.get_most_recent_file(
+        exclusion=excluded_file, sort_key=lambda blob: blob.name
+    )
+
+    # result should be the the most recent blob / file
+    assert result.name == mock_most_recent_gcs_blob.name
+
+
+def test_get_most_recent_file_with_excluded_file(
+    mock_gcs_client,
+    mock_gcs_bucket,
+    mock_gcs_blob,
+    test_https_cdn_host_name,
+    test_bucket_name,
+) -> None:
+    """Test the get_most_recent_file method with the mock bucket containing only the excluded blob/file"""
+
+    excluded_file: str = "excluded.json"
+    mock_gcs_blob.name = excluded_file
+
+    # bucket only contains the excluded file
+    mock_gcs_bucket.list_blobs.return_value = [mock_gcs_blob]
+
+    gcp_uploader = GcsUploader(
+        mock_gcs_client, test_bucket_name, test_https_cdn_host_name
+    )
+
+    # call the method with the exclusion argument set to the excluded file
+    result = gcp_uploader.get_most_recent_file(
+        exclusion=excluded_file, sort_key=lambda blob: blob.name
+    )
+
+    # result should be none since the bucket only contains the excluded file
+    assert result is None
+
+
+def test_upload_content_with_forced_upload_false_and_existing_blob(
+    caplog: LogCaptureFixture,
+    filter_caplog: FilterCaplogFixture,
+    mock_gcs_client,
+    mock_gcs_bucket,
+    mock_gcs_blob,
+    test_bucket_name,
+    test_destination_name,
+    test_https_cdn_host_name,
+) -> None:
+    """Test the upload_content method with default arguments"""
+
+    # set the logger level to the same in source method
+    caplog.set_level(INFO)
+
+    mock_gcs_client.bucket.return_value = mock_gcs_bucket
+    mock_gcs_bucket.blob.return_value = mock_gcs_blob
+
+    gcp_uploader = GcsUploader(
+        mock_gcs_client, test_bucket_name, test_https_cdn_host_name
+    )
+    content = bytes(255)
+
+    # call the method
+    result = gcp_uploader.upload_content(content, test_destination_name)
+
+    # capture logger info output
+    log_records: list[LogRecord] = filter_caplog(
+        caplog.records, "merino.content_handler.gcp_uploader"
+    )
+
+    assert result == mock_gcs_blob
+    assert len(log_records) == 0
+
+    mock_gcs_blob.upload_from_string.assert_not_called()
+    mock_gcs_blob.make_public.assert_not_called()
+
+
+def test_upload_content_with_forced_upload_true_and_existing_blob(
+    caplog: LogCaptureFixture,
+    filter_caplog: FilterCaplogFixture,
+    mock_gcs_client,
+    mock_gcs_bucket,
+    mock_gcs_blob,
+    test_bucket_name,
+    test_destination_name,
+    test_https_cdn_host_name,
+) -> None:
+    """Test the upload_content method with forced_upload argument set to TRUE"""
+    # set the logger level to the same in source method
+    caplog.set_level(INFO)
+
+    mock_gcs_client.bucket.return_value = mock_gcs_bucket
+    mock_gcs_bucket.blob.return_value = mock_gcs_blob
+
+    gcp_uploader = GcsUploader(
+        mock_gcs_client, test_bucket_name, test_https_cdn_host_name
+    )
+    content = bytes(255)
+
+    result = gcp_uploader.upload_content(
+        content, test_destination_name, forced_upload=True
+    )
+
+    # capture logger info output
+    log_records: list[LogRecord] = filter_caplog(
+        caplog.records, "merino.content_handler.gcp_uploader"
+    )
+
+    assert result == mock_gcs_blob
+    assert len(log_records) == 1
+    assert log_records[0].message.startswith(f"Uploading blob: {mock_gcs_blob}")
+
+    mock_gcs_blob.upload_from_string.assert_called_once_with(
+        content, content_type="text/plain"
+    )
+    mock_gcs_blob.make_public.assert_called_once()
+
+
+@pytest.mark.skip(reason="Exception capture not working yet")
+def test_upload_content_with_exception_thrown(
+    caplog: LogCaptureFixture,
+    filter_caplog: FilterCaplogFixture,
+    mock_gcs_client,
+    mock_gcs_bucket,
+    mock_gcs_blob,
+    test_bucket_name,
+    test_destination_name,
+    test_https_cdn_host_name,
+) -> None:
+    # set the logger level to ERROR for the exception
+    caplog.set_level(ERROR)
+
+    content = bytes(255)
+
+    mock_gcs_client.bucket.return_value = mock_gcs_bucket
+    mock_gcs_bucket.blob.return_value = mock_gcs_blob
+    mock_gcs_blob.make_public.side_effect = Exception
+
+    gcp_uploader = GcsUploader(
+        mock_gcs_client, test_bucket_name, test_https_cdn_host_name
+    )
+
+    # capture logger info output
+    log_records: list[LogRecord] = filter_caplog(
+        caplog.records, "merino.content_handler.gcp_uploader"
+    )
+
+    # call the method
+    gcp_uploader.upload_content(content, test_destination_name, forced_upload=True)
+
+    assert len(log_records) == 1
+    assert log_records[0].message.startswith(
+        f"Exception {Exception} occurred while uploading {mock_gcs_blob}"
+    )

--- a/tests/unit/content_handler/test_gcp_uploader.py
+++ b/tests/unit/content_handler/test_gcp_uploader.py
@@ -1,0 +1,101 @@
+from logging import INFO, LogRecord
+
+import pytest
+from pytest import LogCaptureFixture
+
+from merino.content_handler.gcp_uploader import GcsUploader
+from merino.content_handler.models import Image
+from tests.types import FilterCaplogFixture
+
+
+@pytest.fixture
+def mock_gcs_client(mocker):
+    """Return a mock GCS Client instance"""
+    return mocker.patch("merino.content_handler.gcp_uploader.Client").return_value
+
+
+@pytest.fixture
+def mock_gcs_blob(mocker):
+    """Return a mock GCS Blob instance"""
+    return mocker.patch("merino.content_handler.gcp_uploader.Blob").return_value
+
+
+@pytest.fixture
+def mock_gcs_bucket(mocker):
+    """Return a mock GCS Bucket instance"""
+    return mocker.patch("merino.content_handler.gcp_uploader.Bucket").return_value
+
+
+def test_upload_image_with_non_https_cdn_host_name(
+    mock_gcs_client,
+    caplog: LogCaptureFixture,
+    filter_caplog: FilterCaplogFixture,
+) -> None:
+    """Test the upload_image method with the cdn_hostname class instance set to a non https value"""
+
+    # test variables
+    test_cdn_host_name = "test_cdn_host_name"
+    test_bucket_name = "test_bucket_name"
+    test_destination_name = "test-destination"
+    test_image = Image(content=bytes(255), content_type="image/png")
+
+    # set the logger level to the same in source method
+    caplog.set_level(INFO)
+
+    # creating the uploader object with cdn host name not containing "https"
+    gcp_uploader = GcsUploader(mock_gcs_client, test_bucket_name, test_cdn_host_name)
+
+    # force upload is set to FALSE by default
+    result = gcp_uploader.upload_image(test_image, test_destination_name)
+    # capture logger info output
+    log_records: list[LogRecord] = filter_caplog(
+        caplog.records, "merino.content_handler.gcp_uploader"
+    )
+
+    assert result == f"https://{test_cdn_host_name}/{test_destination_name}"
+    # assert on logger calls
+    assert len(log_records) == 1
+    assert log_records[0].message.startswith(f"Content public url: {result}")
+
+
+def test_upload_image_with_https_cdn_host_name(
+    mock_gcs_client,
+    caplog: LogCaptureFixture,
+    filter_caplog: FilterCaplogFixture,
+) -> None:
+    """Test the upload_image method with the cdn_hostname class instance set to a https value"""
+
+    # test variables
+    test_https_cdn_host_name = "https://test-cdn-host"
+    test_bucket_name = "test_bucket_name"
+    test_destination_name = "test-destination"
+    test_image = Image(content=bytes(255), content_type="image/png")
+
+    # set the logger level to the same in source method
+    caplog.set_level(INFO)
+
+    # creating the uploader object with cdn host name containing "https"
+    gcp_uploader = GcsUploader(
+        mock_gcs_client, test_bucket_name, test_https_cdn_host_name
+    )
+
+    # force upload is set to FALSE by default
+    result = gcp_uploader.upload_image(test_image, test_destination_name)
+    # capture logger info output
+    log_records: list[LogRecord] = filter_caplog(
+        caplog.records, "merino.content_handler.gcp_uploader"
+    )
+
+    assert result == f"{test_https_cdn_host_name}/{test_destination_name}"
+    # assert on logger calls
+    assert len(log_records) == 1
+    assert log_records[0].message.startswith(f"Content public url: {result}")
+
+
+# def test_upload_content() -> None:
+# 	# test goes here
+#
+#
+#
+# def test_get_most_recent_file() -> None:
+# 	# test goes here

--- a/tests/unit/content_handler/test_gcp_uploader.py
+++ b/tests/unit/content_handler/test_gcp_uploader.py
@@ -159,6 +159,7 @@ def test_get_most_recent_file_with_two_files(
     )
 
     # result should be the most recent blob / file
+    assert result is not None
     assert result.name == mock_most_recent_gcs_blob.name
 
 

--- a/tests/unit/jobs/navigational_suggestions/test_domain_metadata_extractor.py
+++ b/tests/unit/jobs/navigational_suggestions/test_domain_metadata_extractor.py
@@ -632,10 +632,16 @@ def test_get_domain_metadata(
     favicon_downloader_mock: Any = mocker.Mock(spec=FaviconDownloader)
     favicon_downloader_mock.download_favicon.side_effect = favicon_images
 
+    images_mock = []
+    for image_size in favicon_image_sizes or []:
+        image_mock: Any = mocker.Mock()
+        image_mock.size = image_size
+        images_mock.append(image_mock)
+
     # mock the PIL module's Image.open method in our custom Image model
     mocker.patch(
         "merino.content_handler.models.PILImage.open"
-    ).side_effect = favicon_image_sizes
+    ).side_effect = images_mock
 
     metadata_extractor: DomainMetadataExtractor = DomainMetadataExtractor(
         blocked_domains=domain_blocklist,

--- a/tests/unit/jobs/navigational_suggestions/test_domain_metadata_extractor.py
+++ b/tests/unit/jobs/navigational_suggestions/test_domain_metadata_extractor.py
@@ -8,13 +8,13 @@ from typing import Any
 import pytest
 from pytest_mock import MockerFixture
 
+from merino.content_handler.models import Image
 from merino.jobs.navigational_suggestions.domain_metadata_extractor import (
     DomainMetadataExtractor,
     FaviconData,
     Scraper,
 )
 from merino.jobs.navigational_suggestions.utils import FaviconDownloader
-from merino.content_handler.models import Image
 
 DomainMetadataScenario = tuple[
     FaviconData | None,

--- a/tests/unit/jobs/navigational_suggestions/test_domain_metadata_extractor.py
+++ b/tests/unit/jobs/navigational_suggestions/test_domain_metadata_extractor.py
@@ -632,15 +632,10 @@ def test_get_domain_metadata(
     favicon_downloader_mock: Any = mocker.Mock(spec=FaviconDownloader)
     favicon_downloader_mock.download_favicon.side_effect = favicon_images
 
-    images_mock = []
-    for image_size in favicon_image_sizes or []:
-        image_mock: Any = mocker.Mock()
-        image_mock.size = image_size
-        images_mock.append(image_mock)
-
+    # mock the PIL module's Image.open method in our custom Image model
     mocker.patch(
-        "merino.jobs.navigational_suggestions.domain_metadata_extractor.Image"
-    ).open.return_value.__enter__.side_effect = images_mock
+        "merino.content_handler.models.PILImage.open"
+    ).side_effect = favicon_image_sizes
 
     metadata_extractor: DomainMetadataExtractor = DomainMetadataExtractor(
         blocked_domains=domain_blocklist,

--- a/tests/unit/jobs/navigational_suggestions/test_domain_metadata_extractor.py
+++ b/tests/unit/jobs/navigational_suggestions/test_domain_metadata_extractor.py
@@ -13,12 +13,13 @@ from merino.jobs.navigational_suggestions.domain_metadata_extractor import (
     FaviconData,
     Scraper,
 )
-from merino.jobs.navigational_suggestions.utils import FaviconDownloader, FaviconImage
+from merino.jobs.navigational_suggestions.utils import FaviconDownloader
+from merino.content_handler.models import Image
 
 DomainMetadataScenario = tuple[
     FaviconData | None,
     list[dict[str, Any]],
-    list[FaviconImage] | None,
+    list[Image] | None,
     list[tuple[int, int]] | None,
     str | None,
     str | None,
@@ -32,7 +33,7 @@ DOMAIN_METADATA_SCENARIOS: list[DomainMetadataScenario] = [
         FaviconData(links=[], metas=[], manifests=[]),
         [],
         [
-            FaviconImage(content=b"\\x00", content_type="image/x-icon"),
+            Image(content=b"\\x00", content_type="image/x-icon"),
         ],
         [(32, 32)],
         "https://google.com/favicon.ico",
@@ -71,7 +72,7 @@ DOMAIN_METADATA_SCENARIOS: list[DomainMetadataScenario] = [
         ),
         [],
         [
-            FaviconImage(content=b"\\x00", content_type="image/png"),
+            Image(content=b"\\x00", content_type="image/png"),
         ],
         [(32, 32)],
         None,
@@ -112,7 +113,7 @@ DOMAIN_METADATA_SCENARIOS: list[DomainMetadataScenario] = [
         ),
         [],
         [
-            FaviconImage(content=b"\\x00", content_type="image/jpg"),
+            Image(content=b"\\x00", content_type="image/jpg"),
         ],
         [(32, 32)],
         None,
@@ -157,7 +158,7 @@ DOMAIN_METADATA_SCENARIOS: list[DomainMetadataScenario] = [
             }
         ],
         [
-            FaviconImage(content=b"\\x00", content_type="image/jpg"),
+            Image(content=b"\\x00", content_type="image/jpg"),
         ],
         [(32, 32)],
         None,
@@ -226,7 +227,7 @@ DOMAIN_METADATA_SCENARIOS: list[DomainMetadataScenario] = [
         ),
         [],
         [
-            FaviconImage(content=b"\\x00", content_type="image/svg+xml"),
+            Image(content=b"\\x00", content_type="image/svg+xml"),
         ],
         None,
         None,
@@ -271,8 +272,8 @@ DOMAIN_METADATA_SCENARIOS: list[DomainMetadataScenario] = [
         ),
         [],
         [
-            FaviconImage(content=b"\\x00", content_type="image/png"),
-            FaviconImage(content=b"\\x01", content_type="image/svg+xml"),
+            Image(content=b"\\x00", content_type="image/png"),
+            Image(content=b"\\x01", content_type="image/svg+xml"),
         ],
         [(32, 32)],
         None,
@@ -350,8 +351,8 @@ DOMAIN_METADATA_SCENARIOS: list[DomainMetadataScenario] = [
         ),
         [],
         [
-            FaviconImage(content=b"\\x00", content_type="image/x-icon"),
-            FaviconImage(content=b"\\x01", content_type="image/x-icon"),
+            Image(content=b"\\x00", content_type="image/x-icon"),
+            Image(content=b"\\x01", content_type="image/x-icon"),
         ],
         [(64, 64), (32, 32)],
         None,
@@ -390,7 +391,7 @@ DOMAIN_METADATA_SCENARIOS: list[DomainMetadataScenario] = [
         ),
         [],
         [
-            FaviconImage(content=b"\\x00", content_type="image/x-icon"),
+            Image(content=b"\\x00", content_type="image/x-icon"),
         ],
         [(16, 16)],
         None,
@@ -430,7 +431,7 @@ DOMAIN_METADATA_SCENARIOS: list[DomainMetadataScenario] = [
         ),
         [],
         [
-            FaviconImage(content=b"\\x00", content_type="text/html"),
+            Image(content=b"\\x00", content_type="text/html"),
         ],
         [(96, 96)],
         None,
@@ -540,7 +541,7 @@ DOMAIN_METADATA_SCENARIOS: list[DomainMetadataScenario] = [
         FaviconData(links=[], metas=[], manifests=[]),
         [],
         [
-            FaviconImage(content=b"\\x00", content_type="image/x-icon"),
+            Image(content=b"\\x00", content_type="image/x-icon"),
         ],
         [(32, 32)],
         "https://foo.eu/favicon.ico",
@@ -609,7 +610,7 @@ def test_get_domain_metadata(
     mocker: MockerFixture,
     favicon_data: FaviconData | None,
     scraped_favicons_from_manifest: list[dict[str, Any]],
-    favicon_images: list[FaviconImage] | None,
+    favicon_images: list[Image] | None,
     favicon_image_sizes: list[tuple[int, int]] | None,
     default_favicon: str | None,
     scraped_url: str | None,

--- a/tests/unit/jobs/navigational_suggestions/test_domain_metadata_extractor.py
+++ b/tests/unit/jobs/navigational_suggestions/test_domain_metadata_extractor.py
@@ -632,6 +632,7 @@ def test_get_domain_metadata(
     favicon_downloader_mock: Any = mocker.Mock(spec=FaviconDownloader)
     favicon_downloader_mock.download_favicon.side_effect = favicon_images
 
+    # set the values from favicon_image_size as the size property on each mock image object
     images_mock = []
     for image_size in favicon_image_sizes or []:
         image_mock: Any = mocker.Mock()
@@ -641,7 +642,7 @@ def test_get_domain_metadata(
     # mock the PIL module's Image.open method in our custom Image model
     mocker.patch(
         "merino.content_handler.models.PILImage.open"
-    ).side_effect = images_mock
+    ).return_value.__enter__.side_effect = images_mock
 
     metadata_extractor: DomainMetadataExtractor = DomainMetadataExtractor(
         blocked_domains=domain_blocklist,

--- a/tests/unit/jobs/navigational_suggestions/test_domain_metadata_uploader.py
+++ b/tests/unit/jobs/navigational_suggestions/test_domain_metadata_uploader.py
@@ -268,10 +268,6 @@ def test_upload_top_picks(
     assert result == mock_blob
     assert result.name == mock_blob.name
 
-    # TODO: ??
-    # assert uploader.upload_content is called with dummy top picks, timestamp.filename
-    # assert uploader's blob's upload_from_string is called with bytes, content_type
-
 
 def test_upload_favicons_upload_if_not_present(
     mock_favicon_downloader, mock_gcs_uploader
@@ -283,14 +279,6 @@ def test_upload_favicons_upload_if_not_present(
     UPLOADED_FAVICON_PUBLIC_URL = "DUMMY_PUBLIC_URL"
     dummy_favicon = Image(content=bytes(255), content_type="image/png")
 
-    # These variables are the values from the domain_metadata_uploader._destination_favicon_name()
-    # TODO: mock the private method to return a dummy value instead?
-    context_hex_digest = hashlib.sha256(dummy_favicon.content).hexdigest()
-    content_len: str = str(len(dummy_favicon.content))
-    extension = ".png"
-
-    destination_favicon_name = f"favicons/{context_hex_digest}_{content_len}{extension}"
-
     mock_gcs_uploader.upload_image.return_value = UPLOADED_FAVICON_PUBLIC_URL
 
     domain_metadata_uploader = DomainMetadataUploader(
@@ -298,7 +286,9 @@ def test_upload_favicons_upload_if_not_present(
         force_upload=FORCE_UPLOAD,
         favicon_downloader=mock_favicon_downloader,
     )
+
     uploaded_favicons = domain_metadata_uploader.upload_favicons(["favicon1.png"])
+    destination_favicon_name = domain_metadata_uploader.destination_favicon_name(dummy_favicon)
 
     assert uploaded_favicons == [UPLOADED_FAVICON_PUBLIC_URL]
     mock_gcs_uploader.upload_image.assert_called_once_with(
@@ -311,17 +301,8 @@ def test_upload_favicons_upload_if_force_upload_set(
 ) -> None:
     """Test that favicons are uploaded always when force upload is set"""
     FORCE_UPLOAD: bool = True
-
     UPLOADED_FAVICON_PUBLIC_URL = "DUMMY_PUBLIC_URL"
     dummy_favicon = Image(content=bytes(255), content_type="image/png")
-
-    # These variables are the values from the domain_metadata_uploader._destination_favicon_name()
-    # TODO: mock the private method to return a dummy value instead?
-    context_hex_digest = hashlib.sha256(dummy_favicon.content).hexdigest()
-    content_len: str = str(len(dummy_favicon.content))
-    extension = ".png"
-
-    destination_favicon_name = f"favicons/{context_hex_digest}_{content_len}{extension}"
 
     mock_gcs_uploader.upload_image.return_value = UPLOADED_FAVICON_PUBLIC_URL
 
@@ -330,7 +311,9 @@ def test_upload_favicons_upload_if_force_upload_set(
         force_upload=FORCE_UPLOAD,
         favicon_downloader=mock_favicon_downloader,
     )
+
     uploaded_favicons = domain_metadata_uploader.upload_favicons(["favicon1.png"])
+    destination_favicon_name = domain_metadata_uploader.destination_favicon_name(dummy_favicon)
 
     assert uploaded_favicons == [UPLOADED_FAVICON_PUBLIC_URL]
     mock_gcs_uploader.upload_image.assert_called_once_with(

--- a/tests/unit/jobs/navigational_suggestions/test_domain_metadata_uploader.py
+++ b/tests/unit/jobs/navigational_suggestions/test_domain_metadata_uploader.py
@@ -13,11 +13,11 @@ from google.cloud.storage import Blob, Bucket, Client
 from pytest import LogCaptureFixture
 from pytest_mock import MockerFixture
 
+from merino.content_handler.models import BaseContentUploader, Image
 from merino.jobs.navigational_suggestions.domain_metadata_uploader import (
     DomainMetadataUploader,
 )
 from merino.jobs.navigational_suggestions.utils import FaviconDownloader
-from merino.content_handler.models import Image, BaseContentUploader
 from tests.types import FilterCaplogFixture
 
 
@@ -240,6 +240,7 @@ def mock_favicon_downloader(mocker) -> Any:
     )
     return favicon_downloader_mock
 
+
 @pytest.fixture
 def mock_gcs_uploader(mocker) -> Any:
     """Return a mock FaviconDownloader instance"""
@@ -368,6 +369,7 @@ def test_upload_favicons_return_empty_url_for_failed_favicon_download(
         assert uploaded_favicon == ""
 
 
+# TODO work on this test first, mock the uploader to
 def test_get_latest_file_for_diff(
     mock_favicon_downloader,
     caplog: LogCaptureFixture,
@@ -384,7 +386,7 @@ def test_get_latest_file_for_diff(
     ).return_value = remote_client
     caplog.set_level(INFO)
     default_domain_metadata_uploader = DomainMetadataUploader(
-        uploader=,
+        uploader=mock_gcs_uploader,
         force_upload=False,
         favicon_downloader=mock_favicon_downloader,
     )

--- a/tests/unit/jobs/navigational_suggestions/test_domain_metadata_uploader.py
+++ b/tests/unit/jobs/navigational_suggestions/test_domain_metadata_uploader.py
@@ -173,14 +173,6 @@ def mock_gcs_client(mocker):
 
 
 @pytest.fixture
-def mock_gcs_bucket(mocker):
-    """Return a mock GCS Bucket instance"""
-    bucket = mocker.patch("merino.content_handler.gcp_uploader.Bucket").return_value
-    bucket.name = "mock-bucket"
-    return bucket
-
-
-@pytest.fixture
 def mock_gcs_blob(mocker):
     """Return a mock GCS Bucket instance"""
     return mocker.patch("merino.content_handler.gcp_uploader.Blob").return_value

--- a/tests/unit/jobs/navigational_suggestions/test_domain_metadata_uploader.py
+++ b/tests/unit/jobs/navigational_suggestions/test_domain_metadata_uploader.py
@@ -247,7 +247,7 @@ def test_upload_top_picks(
     mock_gcs_blob,
     mock_favicon_downloader,
 ) -> None:
-    """Test if upload top picks call relevant GCS API."""
+    """Test if upload top picks call relevant GCS API"""
     DUMMY_TOP_PICKS = "dummy top picks contents"
     mock_blob = mock_gcs_blob
 
@@ -270,8 +270,8 @@ def test_upload_top_picks(
 def test_upload_favicons_upload_if_not_present(
     mock_favicon_downloader, mock_gcs_uploader
 ) -> None:
-    """Test that favicons are uploaded only if not already present in GCS when
-    force upload is not set
+    """Test that favicons are uploaded only if not already present
+    in GCS when force upload is not set
     """
     FORCE_UPLOAD: bool = False
     UPLOADED_FAVICON_PUBLIC_URL = "DUMMY_PUBLIC_URL"
@@ -348,8 +348,8 @@ def test_upload_favicons_return_favicon_with_cdn_hostname_when_provided(
 def test_upload_favicons_return_empty_url_for_failed_favicon_download(
     mock_gcs_client, mock_favicon_downloader, mock_gcs_uploader
 ) -> None:
-    """Test if a failure in downloading favicon from the scraped url returns an empty
-    uploaded favicon url
+    """Test if a failure in downloading favicon from the scraped url returns an empty uploaded
+    favicon url
     """
     mock_favicon_downloader.download_favicon.return_value = None
 
@@ -372,9 +372,8 @@ def test_get_latest_file_for_diff(
     remote_blob_newest,
 ) -> None:
     """Test acquiring the latest file data from mock GCS bucket.
-    Also checks case if there is no data.
+    Also checks case if there is no data
     """
-
     caplog.set_level(INFO)
     default_domain_metadata_uploader = DomainMetadataUploader(
         uploader=mock_gcs_uploader,

--- a/tests/unit/jobs/navigational_suggestions/test_domain_metadata_uploader.py
+++ b/tests/unit/jobs/navigational_suggestions/test_domain_metadata_uploader.py
@@ -393,3 +393,21 @@ def test_get_latest_file_for_diff(
     assert records[0].message.startswith(
         f"Domain file {remote_blob_newest.name} acquired."
     )
+
+
+def test_get_latest_file_for_diff_when_no_file_is_returned_by_the_uploader(
+    mock_favicon_downloader,
+    mock_gcs_uploader,
+) -> None:
+    """Test the case where the uploader returns no most recent file"""
+    mock_gcs_uploader.get_most_recent_file.return_value = None
+
+    default_domain_metadata_uploader = DomainMetadataUploader(
+        uploader=mock_gcs_uploader,
+        force_upload=False,
+        favicon_downloader=mock_favicon_downloader,
+    )
+
+    result = default_domain_metadata_uploader.get_latest_file_for_diff()
+
+    assert result is None

--- a/tests/unit/jobs/navigational_suggestions/test_domain_metadata_uploader.py
+++ b/tests/unit/jobs/navigational_suggestions/test_domain_metadata_uploader.py
@@ -3,11 +3,9 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """Unit tests for domain_metadata_uploader.py module."""
-import hashlib
 import json
 from logging import INFO, LogRecord
 from typing import Any
-from unittest.mock import Mock
 
 import pytest
 from google.cloud.storage import Blob, Bucket, Client
@@ -288,7 +286,9 @@ def test_upload_favicons_upload_if_not_present(
     )
 
     uploaded_favicons = domain_metadata_uploader.upload_favicons(["favicon1.png"])
-    destination_favicon_name = domain_metadata_uploader.destination_favicon_name(dummy_favicon)
+    destination_favicon_name = domain_metadata_uploader.destination_favicon_name(
+        dummy_favicon
+    )
 
     assert uploaded_favicons == [UPLOADED_FAVICON_PUBLIC_URL]
     mock_gcs_uploader.upload_image.assert_called_once_with(
@@ -297,7 +297,7 @@ def test_upload_favicons_upload_if_not_present(
 
 
 def test_upload_favicons_upload_if_force_upload_set(
-     mock_favicon_downloader, mock_gcs_uploader
+    mock_favicon_downloader, mock_gcs_uploader
 ) -> None:
     """Test that favicons are uploaded always when force upload is set"""
     FORCE_UPLOAD: bool = True
@@ -313,13 +313,14 @@ def test_upload_favicons_upload_if_force_upload_set(
     )
 
     uploaded_favicons = domain_metadata_uploader.upload_favicons(["favicon1.png"])
-    destination_favicon_name = domain_metadata_uploader.destination_favicon_name(dummy_favicon)
+    destination_favicon_name = domain_metadata_uploader.destination_favicon_name(
+        dummy_favicon
+    )
 
     assert uploaded_favicons == [UPLOADED_FAVICON_PUBLIC_URL]
     mock_gcs_uploader.upload_image.assert_called_once_with(
         dummy_favicon, destination_favicon_name, forced_upload=FORCE_UPLOAD
     )
-
 
 
 def test_upload_favicons_return_favicon_with_cdn_hostname_when_provided(

--- a/tests/unit/jobs/navigational_suggestions/test_navigational_suggestions.py
+++ b/tests/unit/jobs/navigational_suggestions/test_navigational_suggestions.py
@@ -9,6 +9,7 @@ import json
 from merino.jobs.navigational_suggestions import prepare_domain_metadata
 
 
+# TODO fix this
 def test_prepare_domain_metadata_top_picks_construction(mocker):
     """Test whether top pick is constructed properly"""
     mock_domain_data_downloader = mocker.patch(

--- a/tests/unit/jobs/navigational_suggestions/test_navigational_suggestions.py
+++ b/tests/unit/jobs/navigational_suggestions/test_navigational_suggestions.py
@@ -9,7 +9,6 @@ import json
 from merino.jobs.navigational_suggestions import prepare_domain_metadata
 
 
-# TODO fix this
 def test_prepare_domain_metadata_top_picks_construction(mocker):
     """Test whether top pick is constructed properly"""
     mock_domain_data_downloader = mocker.patch(

--- a/tests/unit/jobs/navigational_suggestions/test_navigational_suggestions.py
+++ b/tests/unit/jobs/navigational_suggestions/test_navigational_suggestions.py
@@ -22,6 +22,9 @@ def test_prepare_domain_metadata_top_picks_construction(mocker):
         "merino.jobs.navigational_suggestions.DomainMetadataUploader"
     ).return_value
 
+    # Mock the GCS Uploader
+    mocker.patch("merino.jobs.navigational_suggestions.GcsUploader").return_value
+
     mock_domain_data_downloader.download_data.return_value = [
         {
             "rank": 1,


### PR DESCRIPTION
## References

JIRA: [DISCO-2742](https://mozilla-hub.atlassian.net/browse/DISCO-2742)

## Description
Refactoring and decoupling the GCP logic for uploading files into a separate module.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2742]: https://mozilla-hub.atlassian.net/browse/DISCO-2742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ