### PR TITLE
[DISCO-2766] Error with Poetry configurations/CLI arguments for contract tests in Merino [load test: warn]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,12 +23,14 @@ workflows:
           requires:
             - unit-tests
             - integration-tests
-      - docker-image-build:
-          <<: *pr-filters
       - contract-tests:
           <<: *pr-filters
           requires:
             - docker-image-build
+      - docker-image-build:
+          <<: *pr-filters
+      - docker-image-build-locust:
+          <<: *pr-filters
       - docs-build:
           <<: *pr-filters
 
@@ -47,12 +49,14 @@ workflows:
           requires:
             - unit-tests
             - integration-tests
-      - docker-image-build:
-          <<: *main-filters
       - contract-tests:
           <<: *main-filters
           requires:
             - docker-image-build
+      - docker-image-build:
+          <<: *main-filters
+      - docker-image-build-locust:
+          <<: *main-filters
       - docs-build:
           <<: *main-filters
       - docs-publish-github-pages:
@@ -65,6 +69,7 @@ workflows:
             - checks
             - test-coverage-check
             - contract-tests
+            - docker-image-build-locust
       - docker-image-publish:
           <<: *main-filters
           requires:
@@ -129,6 +134,26 @@ jobs:
           command: make test-coverage-check
           environment:
             TEST_RESULTS_DIR: workspace/test-results
+  contract-tests:
+    machine:
+      image: ubuntu-2004:2023.10.1
+    working_directory: ~/merino
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /tmp/workspace
+      - run:
+          name: Load Docker image from workspace
+          command: docker load -i /tmp/workspace/merinopy.tar.gz
+      - run:
+          name: Contract tests
+          environment:
+            TEST_RESULTS_DIR: workspace/test-results
+          command: |
+            sudo chown 1000:1000 tests/contract/kinto-attachments
+            make run-contract-tests
+      - store_test_results:
+          path: workspace/test-results
   docker-image-build:
     docker:
       - image: cimg/base:2022.08
@@ -152,26 +177,25 @@ jobs:
           root: /tmp/workspace
           paths:
             - merinopy.tar.gz
-  contract-tests:
-    machine:
-      image: ubuntu-2004:2023.10.1
-    working_directory: ~/merino
+  docker-image-build-locust:
+    docker:
+      - image: cimg/base:2024.02
     steps:
       - checkout
-      - attach_workspace:
-          at: /tmp/workspace
+      - setup_remote_docker:
+          docker_layer_caching: true
       - run:
-          name: Load Docker image from workspace
-          command: docker load -i /tmp/workspace/merinopy.tar.gz
+          name: Build image
+          command: docker build -t merino-locust -f ./tests/load/Dockerfile .
       - run:
-          name: Contract tests
-          environment:
-            TEST_RESULTS_DIR: workspace/test-results
+          name: Save image into workspace
           command: |
-            sudo chown 1000:1000 tests/contract/kinto-attachments
-            make run-contract-tests
-      - store_test_results:
-          path: workspace/test-results
+            mkdir -p /tmp/workspace
+            docker save -o /tmp/workspace/merino-locust.tar merino-locust
+      - persist_to_workspace:
+          root: /tmp/workspace
+          paths:
+            - merino-locust.tar
   docker-image-publish:
     # Pushing a new production Docker image to the Docker Hub registry triggers a
     # webhook that starts the Jenkins deployment workflow
@@ -225,11 +249,13 @@ jobs:
               echo "Skipping remaining steps in this job: load test not required."
               circleci-agent step halt
             fi
+      - attach_workspace:
+          at: /tmp/workspace
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
-          name: Build image
-          command: docker build -t merino-locust -f ./tests/load/Dockerfile .
+          name: Load Docker image from workspace
+          command: docker load -i /tmp/workspace/merino-locust.tar
       - dockerhub-login
       - run:
           name: Push to Docker Hub

--- a/tests/contract/client/Dockerfile
+++ b/tests/contract/client/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.12-slim-bookworm
 
 LABEL maintainer="Content Discovery Services (DISCO) Team <disco-team@mozilla.com>"
 
-ENV PYTHON_VENV=/venv
+ENV PYTHON_VENV=/.venv
 RUN python -m venv ${PYTHON_VENV}
 ENV PATH="${PYTHON_VENV}/bin:${PATH}"
 
@@ -13,7 +13,7 @@ ENV POETRY_VIRTUALENVS_CREATE=false \
     POETRY_VERSION=1.7
 RUN python -m pip install --no-cache-dir --quiet poetry
 COPY pyproject.toml poetry.lock ./
-RUN poetry install --without kinto --no-interaction --no-ansi
+RUN poetry install --without kinto --no-interaction --no-ansi --no-root
 
 COPY ./client /usr/src/client
 WORKDIR /usr/src/client

--- a/tests/contract/kinto-setup/Dockerfile
+++ b/tests/contract/kinto-setup/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.12-slim-bookworm
 
 LABEL maintainer="Content Discovery Services (DISCO) Team <disco-team@mozilla.com>"
 
-ENV PYTHON_VENV=/venv
+ENV PYTHON_VENV=/.venv
 RUN python -m venv ${PYTHON_VENV}
 ENV PATH="${PYTHON_VENV}/bin:${PATH}"
 
@@ -13,7 +13,7 @@ ENV POETRY_VIRTUALENVS_CREATE=false \
     POETRY_VERSION=1.7
 RUN python -m pip install --no-cache-dir --quiet poetry
 COPY pyproject.toml poetry.lock ./
-RUN poetry install --without client --no-interaction --no-ansi
+RUN poetry install --without client --no-interaction --no-ansi --no-root
 
 COPY ./kinto-setup /usr/src/cli
 WORKDIR /usr/src/cli

--- a/tests/load/Dockerfile
+++ b/tests/load/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y git && \
 ENV LANG=C.UTF-8
 ENV PYTHONUNBUFFERED=1
 
-ENV PYTHON_VENV=/venv
+ENV PYTHON_VENV=/.venv
 RUN python -m venv ${PYTHON_VENV}
 ENV PATH="${PYTHON_VENV}/bin:${PATH}"
 
@@ -25,7 +25,7 @@ ENV POETRY_VIRTUALENVS_CREATE=false \
   POETRY_VERSION=1.7.0
 RUN python -m pip install --no-cache-dir --quiet poetry
 COPY ./tests/load/pyproject.toml ./tests/load/poetry.lock ./
-RUN poetry install --no-interaction --no-ansi
+RUN poetry install --no-interaction --no-ansi --no-root
 
 RUN useradd --create-home locust
 WORKDIR /home/locust


### PR DESCRIPTION
## References

JIRA: [DISCO-2766](https://mozilla-hub.atlassian.net/browse/DISCO-2766)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->
- Fix the following error message by changing the `PYTHON_VENV`environment name from "venv" to ".venv". The [documentation](https://python-poetry.org/docs/configuration#virtualenvscreate) indicates that ".venv" is required when setting `POETRY_VIRTUALENVS_CREATE` to "false".
<img width="1225" alt="image" src="https://github.com/mozilla-services/merino-py/assets/3422688/259db716-c53f-4b09-b65d-9e30e4a96a39">

- Fix the following warning message with the `--no-root` option
<img width="1111" alt="image" src="https://github.com/mozilla-services/merino-py/assets/3422688/270944b2-66ef-42af-9c55-167cd4006e16">

- Add creation of load test Docker image to the PR workflow so that we get earlier notice of this type of break if it should happen in the load test solution. Load test Docker image publication was tested [here](https://app.circleci.com/pipelines/github/mozilla-services/merino-py/2435/workflows/ad9cc8cc-28b5-4c33-9452-f119b4aaa677) and [here](https://app.circleci.com/pipelines/github/mozilla-services/merino-py/2436/workflows/4f7f6c53-2c91-42d1-a401-5c3451eab16a).

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2766]: https://mozilla-hub.atlassian.net/browse/DISCO-2766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ