### PR TITLE
test: add integration tests for GcsUploader using testcontainers library

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,13 +104,14 @@ jobs:
           paths:
             - test-results
   integration-tests:
-    docker:
-      - image: cimg/python:3.12
+    machine:
+      image: ubuntu-2004:2024.01.1
     steps:
       - checkout
       - run:
           name: Create Workspace
           command: mkdir -p workspace
+      - setup-python-on-machine
       - run:
           name: Integration tests
           command: make integration-tests
@@ -136,7 +137,7 @@ jobs:
             TEST_RESULTS_DIR: workspace/test-results
   contract-tests:
     machine:
-      image: ubuntu-2004:2023.10.1
+      image: ubuntu-2004:2024.01.1
     working_directory: ~/merino
     steps:
       - checkout
@@ -332,6 +333,25 @@ commands:
             else
               echo "${DOCKER_PASS}" | docker login -u="${DOCKER_USER}" --password-stdin
             fi
+
+  # set up python3.12 and poetry on the ubuntu machine used to run integration tests
+  setup-python-on-machine:
+    steps:
+      - run:
+          # the ubuntu machine image we are using comes with python and pyenv
+          name: Set python version to 3.12
+          command: pyenv global 3.12
+      - run:
+          name: Install poetry
+          command: curl -sSL https://install.python-poetry.org | python3.12 -
+      - run:
+          name: Add poetry to PATH
+          command: echo 'export PATH="$HOME/.local/bin:$PATH"' >> $BASH_ENV
+      - run:
+          name: Verify Python and poetry installation
+          command: |
+            python3.12 --version
+            poetry --version
 
   write-version:
     steps:

--- a/docs/testing/integration-tests.md
+++ b/docs/testing/integration-tests.md
@@ -112,7 +112,7 @@ _**Usage:**_
 
 ```python
 @pytest.fixture(scope="module")
-def gcs_storage_container() -> DockerContainer:
+def your_docker_container() -> DockerContainer:
     os.environ.setdefault("STORAGE_EMULATOR_HOST", "http://localhost:4443")
 
     container = (

--- a/docs/testing/integration-tests.md
+++ b/docs/testing/integration-tests.md
@@ -3,7 +3,7 @@
 The integration layer of testing allows for verification of interactions between service components,
 with lower development, maintenance and execution costs compared with higher level tests, such as contract tests.
 
-To execute integration tests, use: `make integration-tests`
+To execute integration tests, make sure you have Docker installed and a docker daemon running. Then use: `make integration-tests`
 
 Integration tests are located in the `tests/integration` directory.
 They use pytest and the FastAPI `TestClient` to send requests to specific merino endpoints and verify responses as well as other outputs, such as logs.
@@ -11,6 +11,8 @@ Tests are organized according to the API path under test.
 Type aliases dedicated for test should be stored in the `types.py` module.
 Fake providers created for test should be stored in the `fake_providers.py` module.
 The `conftest.py` modules contain common utilities in fixtures.
+
+We have also added integration tests that use `Docker` via the `testcontainers` [library](https://testcontainers-python.readthedocs.io/en/latest/). See fixture example below.
 
 For a breakdown of fixtures in use per test, use: `make integration-test-fixtures`
 
@@ -99,4 +101,31 @@ _**Usage:**_
 def teardown(teardown_providers: TeardownProvidersFixture):
     yield
     teardown_providers()
+```
+
+### TestcontainersFixture
+See `tests/integration/jobs/navigational_suggestions/test_domain_metadata_uploader.py` for a detailed example.
+
+This is a lightweight example on how to set up a docker container for your integration tests.
+
+_**Usage:**_
+
+```python
+@pytest.fixture(scope="module")
+def gcs_storage_container() -> DockerContainer:
+    os.environ.setdefault("STORAGE_EMULATOR_HOST", "http://localhost:4443")
+
+    container = (
+        DockerContainer("your-docker-image")
+        .with_command("-scheme http")
+        .with_bind_ports(4443, 4443)
+    ).start()
+
+    # wait for the container to start and emit logs
+    delay = wait_for_logs(container, "server started at")
+    port = container.get_exposed_port(4443)
+
+    yield container
+
+    container.stop()
 ```

--- a/poetry.lock
+++ b/poetry.lock
@@ -658,6 +658,27 @@ files = [
 ]
 
 [[package]]
+name = "docker"
+version = "7.0.0"
+description = "A Python library for the Docker Engine API."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "docker-7.0.0-py3-none-any.whl", hash = "sha256:12ba681f2777a0ad28ffbcc846a69c31b4dfd9752b47eb425a274ee269c5e14b"},
+    {file = "docker-7.0.0.tar.gz", hash = "sha256:323736fb92cd9418fc5e7133bc953e11a9da04f4483f828b527db553f1e7e5a3"},
+]
+
+[package.dependencies]
+packaging = ">=14.0"
+pywin32 = {version = ">=304", markers = "sys_platform == \"win32\""}
+requests = ">=2.26.0"
+urllib3 = ">=1.26.0"
+
+[package.extras]
+ssh = ["paramiko (>=2.4.3)"]
+websockets = ["websocket-client (>=1.3.0)"]
+
+[[package]]
 name = "dockerflow"
 version = "2022.8.0"
 description = "Python tools and helpers for Mozilla's Dockerflow"
@@ -915,13 +936,13 @@ test = ["black", "coverage[toml]", "ddt (>=1.1.1,!=1.4.3)", "mock", "mypy", "pre
 
 [[package]]
 name = "google-api-core"
-version = "2.14.0"
+version = "2.18.0"
 description = "Google API client core library"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "google-api-core-2.14.0.tar.gz", hash = "sha256:5368a4502b793d9bbf812a5912e13e4e69f9bd87f6efb508460c43f5bbd1ce41"},
-    {file = "google_api_core-2.14.0-py3-none-any.whl", hash = "sha256:de2fb50ed34d47ddbb2bd2dcf680ee8fead46279f4ed6b16de362aca23a18952"},
+    {file = "google-api-core-2.18.0.tar.gz", hash = "sha256:62d97417bfc674d6cef251e5c4d639a9655e00c45528c4364fbfebb478ce72a9"},
+    {file = "google_api_core-2.18.0-py3-none-any.whl", hash = "sha256:5a63aa102e0049abe85b5b88cb9409234c1f70afcda21ce1e40b285b9629c1d6"},
 ]
 
 [package.dependencies]
@@ -929,6 +950,7 @@ google-auth = ">=2.14.1,<3.0.dev0"
 googleapis-common-protos = ">=1.56.2,<2.0.dev0"
 grpcio = {version = ">=1.49.1,<2.0dev", optional = true, markers = "python_version >= \"3.11\" and extra == \"grpc\""}
 grpcio-status = {version = ">=1.49.1,<2.0.dev0", optional = true, markers = "python_version >= \"3.11\" and extra == \"grpc\""}
+proto-plus = ">=1.22.3,<2.0.0dev"
 protobuf = ">=3.19.5,<3.20.0 || >3.20.0,<3.20.1 || >3.20.1,<4.21.0 || >4.21.0,<4.21.1 || >4.21.1,<4.21.2 || >4.21.2,<4.21.3 || >4.21.3,<4.21.4 || >4.21.4,<4.21.5 || >4.21.5,<5.0.0.dev0"
 requests = ">=2.18.0,<3.0.0.dev0"
 
@@ -939,13 +961,13 @@ grpcio-gcp = ["grpcio-gcp (>=0.2.2,<1.0.dev0)"]
 
 [[package]]
 name = "google-auth"
-version = "2.23.4"
+version = "2.29.0"
 description = "Google Authentication Library"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "google-auth-2.23.4.tar.gz", hash = "sha256:79905d6b1652187def79d491d6e23d0cbb3a21d3c7ba0dbaa9c8a01906b13ff3"},
-    {file = "google_auth-2.23.4-py2.py3-none-any.whl", hash = "sha256:d4bbc92fe4b8bfd2f3e8d88e5ba7085935da208ee38a134fc280e7ce682a05f2"},
+    {file = "google-auth-2.29.0.tar.gz", hash = "sha256:672dff332d073227550ffc7457868ac4218d6c500b155fe6cc17d2b13602c360"},
+    {file = "google_auth-2.29.0-py2.py3-none-any.whl", hash = "sha256:d452ad095688cd52bae0ad6fafe027f6a6d6f560e810fec20914e17a09526415"},
 ]
 
 [package.dependencies]
@@ -1012,18 +1034,18 @@ grpc = ["grpcio (>=1.38.0,<2.0dev)"]
 
 [[package]]
 name = "google-cloud-storage"
-version = "2.13.0"
+version = "2.16.0"
 description = "Google Cloud Storage API client library"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "google-cloud-storage-2.13.0.tar.gz", hash = "sha256:f62dc4c7b6cd4360d072e3deb28035fbdad491ac3d9b0b1815a12daea10f37c7"},
-    {file = "google_cloud_storage-2.13.0-py2.py3-none-any.whl", hash = "sha256:ab0bf2e1780a1b74cf17fccb13788070b729f50c252f0c94ada2aae0ca95437d"},
+    {file = "google-cloud-storage-2.16.0.tar.gz", hash = "sha256:dda485fa503710a828d01246bd16ce9db0823dc51bbca742ce96a6817d58669f"},
+    {file = "google_cloud_storage-2.16.0-py2.py3-none-any.whl", hash = "sha256:91a06b96fb79cf9cdfb4e759f178ce11ea885c79938f89590344d079305f5852"},
 ]
 
 [package.dependencies]
-google-api-core = ">=1.31.5,<2.0.dev0 || >2.3.0,<3.0.0dev"
-google-auth = ">=2.23.3,<3.0dev"
+google-api-core = ">=2.15.0,<3.0.0dev"
+google-auth = ">=2.26.1,<3.0dev"
 google-cloud-core = ">=2.3.0,<3.0dev"
 google-crc32c = ">=1.0,<2.0dev"
 google-resumable-media = ">=2.6.0"
@@ -2282,6 +2304,29 @@ files = [
 cli = ["click (>=5.0)"]
 
 [[package]]
+name = "pywin32"
+version = "306"
+description = "Python for Window Extensions"
+optional = false
+python-versions = "*"
+files = [
+    {file = "pywin32-306-cp310-cp310-win32.whl", hash = "sha256:06d3420a5155ba65f0b72f2699b5bacf3109f36acbe8923765c22938a69dfc8d"},
+    {file = "pywin32-306-cp310-cp310-win_amd64.whl", hash = "sha256:84f4471dbca1887ea3803d8848a1616429ac94a4a8d05f4bc9c5dcfd42ca99c8"},
+    {file = "pywin32-306-cp311-cp311-win32.whl", hash = "sha256:e65028133d15b64d2ed8f06dd9fbc268352478d4f9289e69c190ecd6818b6407"},
+    {file = "pywin32-306-cp311-cp311-win_amd64.whl", hash = "sha256:a7639f51c184c0272e93f244eb24dafca9b1855707d94c192d4a0b4c01e1100e"},
+    {file = "pywin32-306-cp311-cp311-win_arm64.whl", hash = "sha256:70dba0c913d19f942a2db25217d9a1b726c278f483a919f1abfed79c9cf64d3a"},
+    {file = "pywin32-306-cp312-cp312-win32.whl", hash = "sha256:383229d515657f4e3ed1343da8be101000562bf514591ff383ae940cad65458b"},
+    {file = "pywin32-306-cp312-cp312-win_amd64.whl", hash = "sha256:37257794c1ad39ee9be652da0462dc2e394c8159dfd913a8a4e8eb6fd346da0e"},
+    {file = "pywin32-306-cp312-cp312-win_arm64.whl", hash = "sha256:5821ec52f6d321aa59e2db7e0a35b997de60c201943557d108af9d4ae1ec7040"},
+    {file = "pywin32-306-cp37-cp37m-win32.whl", hash = "sha256:1c73ea9a0d2283d889001998059f5eaaba3b6238f767c9cf2833b13e6a685f65"},
+    {file = "pywin32-306-cp37-cp37m-win_amd64.whl", hash = "sha256:72c5f621542d7bdd4fdb716227be0dd3f8565c11b280be6315b06ace35487d36"},
+    {file = "pywin32-306-cp38-cp38-win32.whl", hash = "sha256:e4c092e2589b5cf0d365849e73e02c391c1349958c5ac3e9d5ccb9a28e017b3a"},
+    {file = "pywin32-306-cp38-cp38-win_amd64.whl", hash = "sha256:e8ac1ae3601bee6ca9f7cb4b5363bf1c0badb935ef243c4733ff9a393b1690c0"},
+    {file = "pywin32-306-cp39-cp39-win32.whl", hash = "sha256:e25fd5b485b55ac9c057f67d94bc203f3f6595078d1fb3b458c9c28b7153a802"},
+    {file = "pywin32-306-cp39-cp39-win_amd64.whl", hash = "sha256:39b61c15272833b5c329a2989999dcae836b1eed650252ab1b7bfbe1d59f30f4"},
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.1"
 description = "YAML parser and emitter for Python"
@@ -2656,6 +2701,42 @@ files = [
 
 [package.dependencies]
 pbr = ">=2.0.0,<2.1.0 || >2.1.0"
+
+[[package]]
+name = "testcontainers"
+version = "4.0.1"
+description = "Python library for throwaway instances of anything that can run in a Docker container"
+optional = false
+python-versions = ">=3.9,<4.0"
+files = [
+    {file = "testcontainers-4.0.1-py3-none-any.whl", hash = "sha256:0359c1391124d594caeb96f0adddbf16fd07aeec8cea5bbc00f9c44a140e3b25"},
+    {file = "testcontainers-4.0.1.tar.gz", hash = "sha256:2c91b1fd8fc9901a08054206f1df108cb07685fc30232e6332ee12f292a17ea1"},
+]
+
+[package.dependencies]
+docker = "*"
+urllib3 = "*"
+wrapt = "*"
+
+[package.extras]
+arangodb = ["python-arango (>=7.8,<8.0)"]
+azurite = ["azure-storage-blob (>=12.19,<13.0)"]
+clickhouse = ["clickhouse-driver"]
+google = ["google-cloud-pubsub (>=2)"]
+k3s = ["kubernetes", "pyyaml"]
+kafka = ["kafka-python"]
+keycloak = ["python-keycloak"]
+localstack = ["boto3"]
+minio = ["minio"]
+mongodb = ["pymongo"]
+mssql = ["pymssql", "sqlalchemy"]
+mysql = ["pymysql[rsa]", "sqlalchemy"]
+neo4j = ["neo4j"]
+opensearch = ["opensearch-py"]
+oracle = ["cx_Oracle", "sqlalchemy"]
+rabbitmq = ["pika"]
+redis = ["redis"]
+selenium = ["selenium"]
 
 [[package]]
 name = "typer"
@@ -3288,4 +3369,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "ccfd11609a4585ae7fa93890754fdc6960580ea2b02f7eb54c81debf6283f371"
+content-hash = "beb4032340cd504a71ed8d4f5218591c9d82ca3e807dd7eb60caecaf5b6cde2f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ geoip2 = "^4.6.0"
 rich = "^12.5.1"
 wrapt = "^1.14.1"
 elasticsearch = {extras = ["async"], version = "^8.5.0"}
-google-cloud-storage = "^2.6.0"
+google-cloud-storage = "^2.16.0"
 google-cloud-bigquery = "^3.9.0"
 Pillow = "^10.2.0"
 robobro = "^0.5.3"
@@ -85,7 +85,7 @@ redis = "^4.5.4"
 types-python-dateutil = "^2.8.19.13"
 pydantic = "^2.1.0"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 black = "^23.7.0"
 flake8 = "^6.1.0"
 isort = "^5.10.1"
@@ -105,6 +105,7 @@ freezegun = "^1.2.2"
 requests-mock = "^1.10.0"
 requests-toolbelt = "^1.0.0"
 types-redis = "^4.5.1.1"
+testcontainers = "^4.0.1"
 
 [build-system]
 requires = ["poetry-core>=1.8.1"]

--- a/tests/integration/jobs/navigational_suggestions/test_domain_metadata_uploader.py
+++ b/tests/integration/jobs/navigational_suggestions/test_domain_metadata_uploader.py
@@ -245,3 +245,27 @@ def test_get_latest_file_for_diff(gcs_storage_client, gcs_storage_bucket):
 
     # this should return the test_top_picks_1 since it's the latest one amongst the two files
     assert latest_file == test_top_picks_1
+
+
+def test_get_latest_file_for_diff_when_no_file_is_found(
+    gcs_storage_client, gcs_storage_bucket
+):
+    """Test get_latest_file_for_diff method of DomainMetaDataUploader. This test also tests
+    implicitly the get_latest_file_for_diff method on the GcsUploader
+    """
+    # create a GcsUploader instance
+    gcp_uploader = GcsUploader(
+        destination_gcp_project=gcs_storage_client.project,
+        destination_bucket_name=gcs_storage_bucket.name,
+        destination_cdn_hostname="test_cdn_hostname",
+    )
+
+    # create a DomainMetadataUploader instance
+    domain_metadata_uploader = DomainMetadataUploader(
+        uploader=gcp_uploader, force_upload=False
+    )
+
+    # this should return None since we didn't upload anything to our gcs bucket
+    latest_file = domain_metadata_uploader.get_latest_file_for_diff()
+
+    assert latest_file is None

--- a/tests/integration/jobs/navigational_suggestions/test_domain_metadata_uploader.py
+++ b/tests/integration/jobs/navigational_suggestions/test_domain_metadata_uploader.py
@@ -1,0 +1,247 @@
+"""Integration tests for DomainMetadataUploader class. These tests use the testcontainers
+library to emulate GCS Storage entities used by the GcsUploader class in a docker container
+"""
+import json
+import logging
+import os
+from datetime import datetime
+
+import pytest
+from google.auth.credentials import AnonymousCredentials
+from google.cloud.storage import Bucket, Client
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.waiting_utils import wait_for_logs
+
+from merino.content_handler.gcp_uploader import GcsUploader
+from merino.content_handler.models import Image
+from merino.jobs.navigational_suggestions.domain_metadata_uploader import (
+    DomainMetadataUploader,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="module")
+def gcs_storage_container() -> DockerContainer:
+    """Create and return a docker container for google cloud storage entities. Tear it down
+    after all the tests have finished running
+    """
+    logger.info("Starting up GCS storage container")
+
+    os.environ.setdefault("STORAGE_EMULATOR_HOST", "http://localhost:4443")
+
+    # create a docker container using the `fake-gcs-server` image
+    container = (
+        DockerContainer("fsouza/fake-gcs-server")
+        .with_command("-scheme http")
+        .with_bind_ports(4443, 4443)
+    ).start()
+
+    # wait for the container to start and emit logs
+    delay = wait_for_logs(container, "server started at")
+    port = container.get_exposed_port(4443)
+
+    logger.info(f"\n GCS server started with delay: {delay} seconds on port: {port}")
+    yield container
+
+    container.stop()
+    logger.info("\n GCS storage container stopped")
+
+
+@pytest.fixture(scope="module")
+def gcs_storage_client(gcs_storage_container) -> Client:
+    """Return a test google storage client object to be used by all tests and close it
+    after this test suite has finished running
+    """
+    client: Client = Client(
+        credentials=AnonymousCredentials(), project="test_gcp_uploader_project"
+    )
+
+    yield client
+
+    client.close()
+
+
+@pytest.fixture(scope="function")
+def gcs_storage_bucket(gcs_storage_client) -> Bucket:
+    """Return a test google storage bucket object to be used by all tests. Delete it
+    after each test run to ensure isolation
+    """
+    bucket: Bucket = gcs_storage_client.create_bucket("test_gcp_uploader_bucket")
+
+    # Yield the bucket object for the test to use
+    yield bucket
+
+    # Force delete allows us to delete the bucket even if it has blobs in it
+    bucket.delete(force=True)
+
+
+@pytest.fixture
+def mock_favicon_downloader(mocker):
+    """Return a Favicon downloader instance"""
+    favicon_downloader = mocker.patch(
+        "merino.jobs.navigational_suggestions.utils.FaviconDownloader"
+    ).return_value
+
+    # mocking the download method to return a Image type instead of making an actual get request
+    favicon_downloader.download_favicon.return_value = Image(
+        content=bytes(255), content_type="image/jpeg"
+    )
+    return favicon_downloader
+
+
+test_top_picks_1 = {
+    "domains": [
+        {
+            "rank": 1,
+            "title": "Example",
+            "domain": "example",
+            "url": "https://example.com",
+            "icon": "",
+            "categories": ["web-browser"],
+            "similars": ["exxample", "exampple", "eexample"],
+        },
+        {
+            "rank": 2,
+            "title": "Firefox",
+            "domain": "firefox",
+            "url": "https://firefox.com",
+            "icon": "",
+            "categories": ["web-browser"],
+            "similars": ["firefoxx", "foyerfox", "fiirefox", "firesfox", "firefoxes"],
+        },
+        {
+            "rank": 3,
+            "title": "Mozilla",
+            "domain": "mozilla",
+            "url": "https://mozilla.org/en-US/",
+            "icon": "",
+            "categories": ["web-browser"],
+            "similars": ["mozzilla", "mozila"],
+        },
+    ]
+}
+
+test_top_picks_2 = {
+    "domains": [
+        {
+            "rank": 1,
+            "title": "Abc",
+            "domain": "abc",
+            "url": "https://abc.test",
+            "icon": "",
+            "categories": ["web-browser"],
+            "similars": ["aa", "ab", "acb"],
+        },
+        {
+            "rank": 2,
+            "title": "Banana",
+            "domain": "banana",
+            "url": "https://banana.test",
+            "icon": "",
+            "categories": ["web-browser"],
+            "similars": ["banan", "bannana", "banana"],
+        },
+    ]
+}
+
+
+def test_upload_top_picks(gcs_storage_client, gcs_storage_bucket):
+    """Test upload_top_picks method of DomainMetaDataUploader. This test also implicitly tests
+    the underlying gcs uploader methods.
+    """
+    # create a GcsUploader instance
+    gcp_uploader = GcsUploader(
+        destination_gcp_project=gcs_storage_client.project,
+        destination_bucket_name=gcs_storage_bucket.name,
+        destination_cdn_hostname="test_cdn_hostname",
+    )
+
+    # create a DomainMetadataUploader instance
+    domain_metadata_uploader = DomainMetadataUploader(
+        uploader=gcp_uploader, force_upload=False
+    )
+
+    timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
+
+    # call the upload method with a test top picks json
+    uploaded_top_picks_blob = domain_metadata_uploader.upload_top_picks(
+        json.dumps(test_top_picks_1)
+    )
+
+    top_picks_latest_blob = gcs_storage_bucket.get_blob("top_picks_latest.json")
+
+    assert uploaded_top_picks_blob is not None
+    assert uploaded_top_picks_blob.name.startswith(timestamp)
+    assert top_picks_latest_blob is not None
+
+
+def test_upload_favicons(
+    gcs_storage_client, gcs_storage_bucket, mock_favicon_downloader
+):
+    """Test upload_favicons method of DomainMetaDataUploader. This test uses the mocked version
+    of the favicon downloader. This test also implicitly tests the underlying gcs uploader methods.
+    """
+    # create a GcsUploader instance
+    gcp_uploader = GcsUploader(
+        destination_gcp_project=gcs_storage_client.project,
+        destination_bucket_name=gcs_storage_bucket.name,
+        destination_cdn_hostname="test_cdn_hostname",
+    )
+
+    # create a DomainMetadataUploader instance
+    domain_metadata_uploader = DomainMetadataUploader(
+        uploader=gcp_uploader,
+        force_upload=False,
+        favicon_downloader=mock_favicon_downloader,
+    )
+
+    test_favicons = ["favicon1.jpg", "favicon2.jpg", "favicon3.jpg", "favicon4.jpg"]
+
+    # call the upload method with a test top picks json
+    uploaded_favicons = domain_metadata_uploader.upload_favicons(test_favicons)
+
+    bucket_with_uploaded_favicons = gcp_uploader.storage_client.get_bucket(
+        gcs_storage_bucket.name
+    )
+
+    assert uploaded_favicons is not None
+    assert len(uploaded_favicons) == len(test_favicons)
+
+    for favicon in uploaded_favicons:
+        assert favicon.startswith("https://test_cdn_hostname")
+
+    for favicon in bucket_with_uploaded_favicons.list_blobs():
+        assert favicon.download_as_bytes() == bytes(255)
+
+
+def test_get_latest_file_for_diff(gcs_storage_client, gcs_storage_bucket):
+    """Test get_latest_file_for_diff method of DomainMetaDataUploader. This test also tests
+    implicitly the get_latest_file_for_diff method on the GcsUploader
+    """
+    # create a GcsUploader instance
+    gcp_uploader = GcsUploader(
+        destination_gcp_project=gcs_storage_client.project,
+        destination_bucket_name=gcs_storage_bucket.name,
+        destination_cdn_hostname="test_cdn_hostname",
+    )
+
+    # create a DomainMetadataUploader instance
+    domain_metadata_uploader = DomainMetadataUploader(
+        uploader=gcp_uploader, force_upload=False
+    )
+
+    # upload test_top_picks_1 for the 2024... file
+    gcp_uploader.upload_content(
+        json.dumps(test_top_picks_1), "20240101120555_top_picks.json"
+    )
+    # upload test_top_picks_2 for the 2023... file
+    gcp_uploader.upload_content(
+        json.dumps(test_top_picks_2), "20230101120555_top_picks.json"
+    )
+
+    # get the latest file
+    latest_file = domain_metadata_uploader.get_latest_file_for_diff()
+
+    # this should return the test_top_picks_1 since it's the latest one amongst the two files
+    assert latest_file == test_top_picks_1


### PR DESCRIPTION
## References

JIRA: [DISCO-2767](https://mozilla-hub.atlassian.net/browse/DISCO-2767)

## Description
Add integration tests for `GcsUploader` using `testcontainers` library

We had to switch to using `machine` executors for running the `integration-tests` check since the `testcontainers` test spin up a docker container at run time. This wasn't working if we were using the docker container to run those tests in. Surprisingly, setting up a python environment on a bare bones ubuntu VM and running the tests seems to be slightly faster than using a pre-built python docker image

In the `project.toml` file, you'll see that the new dev dependencies are added under `tool.poetry.group.dev.dependencies` and not `tool.poetry.dev.dependencies`. This is because the latter has been deprecated. Poetry wants us to use `...group...` now. Can make this change for the rest of the dev dependencies in the next PR.

## PR Review Checklist

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2767]: https://mozilla-hub.atlassian.net/browse/DISCO-2767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ