### PR TITLE
[DISCO-2795] fix: relevancy job to delete records by category

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -142,7 +142,7 @@ chunk_size = 200
 
 # MERINO_REMOTE_SETTINGS__DELETE_EXISTING_RECORDS
 # Delete existing records before uploading new records.
-delete_existing_records = false
+delete_existing_records = true
 
 # MERINO_REMOTE_SETTINGS__DRY_RUN
 # Log changes but don't actually make them when uploading suggestions.

--- a/merino/jobs/relevancy_uploader/__init__.py
+++ b/merino/jobs/relevancy_uploader/__init__.py
@@ -15,6 +15,8 @@ from merino.jobs.relevancy_uploader.chunked_rs_uploader import (
     ChunkedRemoteSettingsRelevancyUploader,
 )
 
+CLASSIFICATION_CURRENT_VERSION = 1
+
 
 class Category(Enum):
     """Enum of possible interests for a domain."""
@@ -156,6 +158,12 @@ csv_path_option = typer.Option(
     help="Path to CSV file containing the source data",
 )
 
+version_option = typer.Option(
+    CLASSIFICATION_CURRENT_VERSION,
+    "--version",
+    help="version of the classification data",
+)
+
 
 relevancy_csv_rs_uploader_cmd = typer.Typer(
     name="relevancy-csv-rs-uploader",
@@ -179,6 +187,7 @@ def upload(
     delete_existing_records: bool = delete_existing_records_option,
     dry_run: bool = dry_run_option,
     server: str = server_option,
+    version: int = version_option,
 ):
     """Upload relevancy domains from a CSV file to remote settings."""
     if not csv_path:
@@ -194,6 +203,7 @@ def upload(
             delete_existing_records=delete_existing_records,
             dry_run=dry_run,
             server=server,
+            version=version,
         )
     )
 
@@ -207,6 +217,7 @@ async def _upload(
     delete_existing_records: bool,
     dry_run: bool,
     server: str,
+    version: int,
 ):
     with open(csv_path, newline="", encoding="utf-8-sig") as csv_file:
         await _upload_file_object(
@@ -218,6 +229,7 @@ async def _upload(
             dry_run=dry_run,
             file_object=csv_file,
             server=server,
+            version=version,
         )
 
 
@@ -230,6 +242,7 @@ async def _upload_file_object(
     delete_existing_records: bool,
     dry_run: bool,
     server: str,
+    version: int,
 ):
     csv_reader = csv.DictReader(file_object)
 
@@ -252,6 +265,7 @@ async def _upload_file_object(
             total_data_count=len(data[category]),
             category_name=category.name,
             category_code=category.value,
+            version=version,
         ) as uploader:
             if delete_existing_records:
                 uploader.delete_records()

--- a/merino/jobs/relevancy_uploader/chunked_rs_uploader.py
+++ b/merino/jobs/relevancy_uploader/chunked_rs_uploader.py
@@ -8,8 +8,6 @@ from merino.jobs.utils.chunked_rs_uploader import Chunk, ChunkedRemoteSettingsUp
 
 logger = logging.getLogger(__name__)
 
-CURRENT_VERSION = 1
-
 
 class ChunkedRemoteSettingsRelevancyUploader(ChunkedRemoteSettingsUploader):
     """A class that uploads relevancy data to remote settings."""
@@ -26,6 +24,7 @@ class ChunkedRemoteSettingsRelevancyUploader(ChunkedRemoteSettingsUploader):
         server: str,
         category_name: str,
         category_code: int,
+        version: int,
         dry_run: bool = False,
         suggestion_score_fallback: float | None = None,
         total_data_count: int | None = None,
@@ -44,6 +43,7 @@ class ChunkedRemoteSettingsRelevancyUploader(ChunkedRemoteSettingsUploader):
         )
         self.category_name = category_name
         self.category_code = category_code
+        self.version = version
 
     def delete_records(self) -> None:
         """Delete records whose "category_code" is equal to the uploader's
@@ -55,7 +55,7 @@ class ChunkedRemoteSettingsRelevancyUploader(ChunkedRemoteSettingsUploader):
             record_details = record.get("record_custom_details", {})
             if (
                 record_details.get("category_code") == self.category_code
-                and record_details.get("version") == CURRENT_VERSION
+                and record_details.get("version") == self.version
             ):
                 logger.info(f"Deleting record: {record['id']}")
                 if not self.dry_run:
@@ -84,7 +84,7 @@ class ChunkedRemoteSettingsRelevancyUploader(ChunkedRemoteSettingsUploader):
                 "category_to_domains": {
                     "category": self.category_name.lower(),
                     "category_code": self.category_code,
-                    "version": CURRENT_VERSION,
+                    "version": self.version,
                 }
             },
         }

--- a/tests/unit/jobs/relevancy_uploader/test_chunked_relevancy_rs_uploader.py
+++ b/tests/unit/jobs/relevancy_uploader/test_chunked_relevancy_rs_uploader.py
@@ -166,6 +166,7 @@ def do_upload_test(
 
     with ChunkedRemoteSettingsRelevancyUploader(
         chunk_size=chunk_size,
+        version=1,
         **TEST_UPLOADER_KWARGS,
         **uploader_kwargs,
     ) as uploader:

--- a/tests/unit/jobs/relevancy_uploader/utils.py
+++ b/tests/unit/jobs/relevancy_uploader/utils.py
@@ -27,6 +27,7 @@ def _do_csv_test(
     primary_category_data: list[dict[str, Any]],
     secondary_category_data: list[dict[str, Any]] = [],
     inconclusive_category_data: list[dict[str, Any]] = [],
+    version: int = 1,
 ) -> None:
     """Helper-method for `do_csv_test()`"""
     # Mock the chunked uploader.
@@ -45,6 +46,7 @@ def _do_csv_test(
         "collection": "collection",
         "dry_run": False,
         "server": "server",
+        "version": version,
     }
     upload_callable(
         {
@@ -79,7 +81,7 @@ def _do_csv_test(
         category_code=0
     )
 
-    if delete_existing_records:
+    if delete_existing_records and version == 1:
         mock_chunked_uploader.delete_records.assert_called()
     else:
         mock_chunked_uploader.delete_records.assert_not_called()
@@ -97,6 +99,7 @@ def do_csv_test(
     csv_path: str | None = None,
     csv_rows: list[dict[str, str]] | None = None,
     delete_existing_records: bool = False,
+    version: int = 1,
 ) -> None:
     """Perform an upload test that is expected to succeed."""
     file_object = None
@@ -116,6 +119,7 @@ def do_csv_test(
         primary_category_data=primary_category_data,
         secondary_category_data=secondary_category_data,
         inconclusive_category_data=inconclusive_category_data,
+        version=version,
     )
 
     if file_object:
@@ -140,6 +144,7 @@ def do_error_test(
                 dry_run=False,
                 file_object=file_object,
                 server="server",
+                version=1,
             )
         )
     file_object.close()


### PR DESCRIPTION
## References

JIRA: [DISCO-2795](https://mozilla-hub.atlassian.net/browse/DISCO-2795)

## Description
I accidentally edited `delete_existing_records` default config value by accident
and delete records wasn't deleting properly since I didn't override it for relevancy specifically


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2795]: https://mozilla-hub.atlassian.net/browse/DISCO-2795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ