### PR TITLE
[DISCO-2806]: Add location completion via accuweather api

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -262,6 +262,10 @@ url_forecasts_path = "/forecasts/v1/daily/1day/{location_key}.json"
 # Note that this is the name of the partner code parameter, not the partner code itself.
 url_param_partner_code = "partner"
 
+# MERINO_ACCUWEATHER__URL_LOCATION_COMPLETION_PATH
+# The url path for accuweather locations autocomplete.
+url_location_completion_path = "/locations/v1/{country_code}/autocomplete.json"
+
 # MERINO_ACCUWEATHER__URL_POSTALCODES_PATH
 # The URL path for postal codes.
 url_postalcodes_path = "/locations/v1/postalcodes/{country_code}/search.json"

--- a/merino/providers/base.py
+++ b/merino/providers/base.py
@@ -13,7 +13,7 @@ class SuggestionRequest(BaseModel):
 
     query: str
     geolocation: Location
-    is_location_completion_request: bool = False
+    request_type: str | None = None
 
 
 class BaseSuggestion(BaseModel):

--- a/merino/providers/base.py
+++ b/merino/providers/base.py
@@ -13,7 +13,7 @@ class SuggestionRequest(BaseModel):
 
     query: str
     geolocation: Location
-    request_type: str | None = None
+    is_location_completion_request: bool = False
 
 
 class BaseSuggestion(BaseModel):

--- a/merino/providers/base.py
+++ b/merino/providers/base.py
@@ -13,6 +13,7 @@ class SuggestionRequest(BaseModel):
 
     query: str
     geolocation: Location
+    request_type: str | None = None
 
 
 class BaseSuggestion(BaseModel):

--- a/merino/providers/manager.py
+++ b/merino/providers/manager.py
@@ -76,7 +76,6 @@ def _create_provider(provider_id: str, setting: Settings) -> BaseProvider:
                     url_postalcodes_param_query=settings.accuweather.url_postalcodes_param_query,
                     url_current_conditions_path=settings.accuweather.url_current_conditions_path,
                     url_forecasts_path=settings.accuweather.url_forecasts_path,
-                    url_location_completion_path=settings.accuweather.url_location_completion_path,
                     url_location_key_placeholder=settings.accuweather.url_location_key_placeholder,
                 )
                 if setting.backend == "accuweather"
@@ -109,6 +108,7 @@ def _create_provider(provider_id: str, setting: Settings) -> BaseProvider:
                     url_cities_param_query=settings.accuweather.url_cities_param_query,
                     url_current_conditions_path=settings.accuweather.url_current_conditions_path,
                     url_forecasts_path=settings.accuweather.url_forecasts_path,
+                    url_location_completion_path=settings.accuweather.url_location_completion_path,
                     url_location_key_placeholder=settings.accuweather.url_location_key_placeholder,
                 )
                 if setting.backend == "accuweather"

--- a/merino/providers/manager.py
+++ b/merino/providers/manager.py
@@ -76,6 +76,7 @@ def _create_provider(provider_id: str, setting: Settings) -> BaseProvider:
                     url_postalcodes_param_query=settings.accuweather.url_postalcodes_param_query,
                     url_current_conditions_path=settings.accuweather.url_current_conditions_path,
                     url_forecasts_path=settings.accuweather.url_forecasts_path,
+                    url_location_completion_path=settings.accuweather.url_location_completion_path,
                     url_location_key_placeholder=settings.accuweather.url_location_key_placeholder,
                 )
                 if setting.backend == "accuweather"

--- a/merino/providers/weather/backends/accuweather.py
+++ b/merino/providers/weather/backends/accuweather.py
@@ -614,7 +614,6 @@ class AccuweatherBackend:
         self, geolocation: Location, search_term: str
     ) -> list[LocationCompletion] | None:
         """Fetch a list of locations from the Accuweather API given a search term and location."""
-
         url_path = self.url_location_completion_path.format(
             country_code=geolocation.country
         )

--- a/merino/providers/weather/backends/accuweather.py
+++ b/merino/providers/weather/backends/accuweather.py
@@ -614,6 +614,9 @@ class AccuweatherBackend:
         self, geolocation: Location, search_term: str
     ) -> list[LocationCompletion] | None:
         """Fetch a list of locations from the Accuweather API given a search term and location."""
+        if not search_term:
+            return None
+
         url_path = self.url_location_completion_path.format(
             country_code=geolocation.country
         )

--- a/merino/providers/weather/backends/protocol.py
+++ b/merino/providers/weather/backends/protocol.py
@@ -26,6 +26,13 @@ class Temperature(BaseModel):
         super().__init__(c=cc, f=ff)
 
 
+class LocationCompletionGeoDetails(BaseModel):
+    """Model for a location completion's country and administrative area attributes."""
+
+    id: str
+    localized_name: str
+
+
 class CurrentConditions(BaseModel):
     """Model for weather current conditions."""
 
@@ -57,8 +64,11 @@ class LocationCompletion(BaseModel):
     """Model for location completion."""
 
     key: str
+    rank: int
+    type: str
     localized_name: str
-    country: str
+    country: LocationCompletionGeoDetails
+    administrative_area: LocationCompletionGeoDetails
 
 
 class WeatherBackend(Protocol):

--- a/merino/providers/weather/backends/protocol.py
+++ b/merino/providers/weather/backends/protocol.py
@@ -54,7 +54,11 @@ class WeatherReport(BaseModel):
 
 
 class LocationCompletion(BaseModel):
-    """TODO add stuff here"""
+    """Model for location completion."""
+
+    key: str
+    localized_name: str
+    country: str
 
 
 class WeatherBackend(Protocol):
@@ -75,11 +79,10 @@ class WeatherBackend(Protocol):
         """
         ...
 
-    # TODO add return type of LocationCompletion
     async def get_location_completion(
         self, geolocation: Location, search_term: str
-    ):  # pragma: no cover
-        """TODO
+    ) -> list[LocationCompletion] | None:  # pragma: no cover
+        """Get a list of locations (cities and country) from partner
         Raises:
             BackendError: Category of error specific to provider backends.
         """

--- a/merino/providers/weather/backends/protocol.py
+++ b/merino/providers/weather/backends/protocol.py
@@ -53,6 +53,10 @@ class WeatherReport(BaseModel):
     ttl: int
 
 
+class LocationCompletion(BaseModel):
+    """TODO add stuff here"""
+
+
 class WeatherBackend(Protocol):
     """Protocol for a weather backend that this provider depends on.
 
@@ -66,6 +70,16 @@ class WeatherBackend(Protocol):
     ) -> WeatherReport | None:  # pragma: no cover
         """Get weather information from partner.
 
+        Raises:
+            BackendError: Category of error specific to provider backends.
+        """
+        ...
+
+    # TODO add return type of LocationCompletion
+    async def get_location_completion(
+        self, geolocation: Location, search_term: str
+    ):  # pragma: no cover
+        """TODO
         Raises:
             BackendError: Category of error specific to provider backends.
         """

--- a/merino/providers/weather/provider.py
+++ b/merino/providers/weather/provider.py
@@ -73,12 +73,13 @@ class Provider(BaseProvider):
     async def query(self, srequest: SuggestionRequest) -> list[BaseSuggestion]:
         """Provide weather suggestions."""
         geolocation: Location = srequest.geolocation
+        is_location_completion_request = srequest.request_type == "location"
         weather_report: WeatherReport | None = None
         location_completions: list[LocationCompletion] | None = None
 
         try:
             with self.metrics_client.timeit(f"providers.{self.name}.query.backend.get"):
-                if srequest.is_location_completion_request:
+                if is_location_completion_request:
                     location_completions = await self.backend.get_location_completion(
                         geolocation, search_term=srequest.query
                     )
@@ -92,6 +93,9 @@ class Provider(BaseProvider):
         if weather_report:
             return [self.build_suggestion(weather_report)]
         if location_completions:
+            print("\n------ PROVIDER")
+            print(f"{location_completions}")
+            print("\n")
             return [self.build_suggestion(location_completions)]
         else:
             return []
@@ -117,7 +121,7 @@ class Provider(BaseProvider):
             )
         else:
             return LocationCompletionSuggestion(
-                title=f"Location completions",
+                title="Location completions",
                 url=self.dummy_url,
                 provider=self.name,
                 is_sponsored=False,

--- a/merino/providers/weather/provider.py
+++ b/merino/providers/weather/provider.py
@@ -93,9 +93,6 @@ class Provider(BaseProvider):
         if weather_report:
             return [self.build_suggestion(weather_report)]
         if location_completions:
-            print("\n------ PROVIDER")
-            print(f"{location_completions}")
-            print("\n")
             return [self.build_suggestion(location_completions)]
         else:
             return []

--- a/merino/providers/weather/provider.py
+++ b/merino/providers/weather/provider.py
@@ -73,13 +73,12 @@ class Provider(BaseProvider):
     async def query(self, srequest: SuggestionRequest) -> list[BaseSuggestion]:
         """Provide weather suggestions."""
         geolocation: Location = srequest.geolocation
-        is_location_completion_request = srequest.request_type == "location"
         weather_report: WeatherReport | None = None
         location_completions: list[LocationCompletion] | None = None
 
         try:
             with self.metrics_client.timeit(f"providers.{self.name}.query.backend.get"):
-                if is_location_completion_request:
+                if srequest.is_location_completion_request:
                     location_completions = await self.backend.get_location_completion(
                         geolocation, search_term=srequest.query
                     )
@@ -99,7 +98,7 @@ class Provider(BaseProvider):
 
     def build_suggestion(
         self, data: WeatherReport | list[LocationCompletion]
-    ) -> BaseSuggestion:
+    ) -> Suggestion | LocationCompletionSuggestion:
         """Build either a weather suggestion or a location completion suggestion."""
         if isinstance(data, WeatherReport):
             return Suggestion(

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -92,7 +92,10 @@ async def suggest(
         value to the `providers` parameter will return suggestions from the default providers.
         You can then pass other providers that are not enabled after `default`,
         allowing for customization of the suggestion request.
-    - `request_type`: [Optional] TODO add comment
+    - `request_type`: [Optional] For AccuWeather provider, the request type should be either a
+        "location" or "weather" string. For "location" it will get location completion
+        suggestion. For "weather" it will return weather suggestions. If omitted, it defaults
+        to weather suggestions.
 
     **Headers:**
 

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -4,6 +4,7 @@ from asyncio import Task
 from collections import Counter
 from functools import partial
 from itertools import chain
+from typing import Annotated
 
 from asgi_correlation_id.context import correlation_id
 from fastapi import APIRouter, Depends, Query
@@ -64,7 +65,7 @@ async def suggest(
     sources: tuple[dict[str, BaseProvider], list[BaseProvider]] = Depends(
         get_providers
     ),
-    request_type: str | None = None,
+    request_type: Annotated[str | None, Query(pattern="^(location|weather)$")] = None,
 ) -> JSONResponse:
     """Query Merino for suggestions.
 
@@ -171,7 +172,7 @@ async def suggest(
         srequest = SuggestionRequest(
             query=p.normalize_query(q),
             geolocation=request.scope[ScopeKey.GEOLOCATION],
-            request_type=request_type,
+            is_location_completion_request=request_type == "location",
         )
         task = metrics_client.timeit_task(
             p.query(srequest), f"providers.{p.name}.query"

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -220,8 +220,6 @@ async def suggest(
     ttl = get_ttl_for_cache_control_header_for_suggestions(search_from, suggestions)
     response_headers["Cache-control"] = f"private, max-age={ttl}"
 
-    print(f"--------------------------> RESPONSE: {response}")
-
     return JSONResponse(
         content=jsonable_encoder(response, exclude_none=True),
         headers=response_headers,

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -172,7 +172,7 @@ async def suggest(
         srequest = SuggestionRequest(
             query=p.normalize_query(q),
             geolocation=request.scope[ScopeKey.GEOLOCATION],
-            is_location_completion_request=request_type == "location",
+            request_type=request_type,
         )
         task = metrics_client.timeit_task(
             p.query(srequest), f"providers.{p.name}.query"
@@ -219,6 +219,8 @@ async def suggest(
     # could be specific or default
     ttl = get_ttl_for_cache_control_header_for_suggestions(search_from, suggestions)
     response_headers["Cache-control"] = f"private, max-age={ttl}"
+
+    print(f"--------------------------> RESPONSE: {response}")
 
     return JSONResponse(
         content=jsonable_encoder(response, exclude_none=True),

--- a/tests/integration/api/v1/suggest/test_suggest_weather.py
+++ b/tests/integration/api/v1/suggest/test_suggest_weather.py
@@ -350,7 +350,7 @@ def test_suggest_with_location_completion(
 
 
 def test_suggest_with_location_completion_with_empty_search_term(
-    client: TestClient, backend_mock: Any, location_completion_sample_cities
+    client: TestClient,
 ) -> None:
     """Test that the suggest endpoint response returns empty location_completion when the q
     param (search_term) is an empty string
@@ -366,7 +366,7 @@ def test_suggest_with_location_completion_with_empty_search_term(
 
 
 def test_suggest_with_location_completion_with_incorrect_request_type_param(
-    client: TestClient, backend_mock: Any, location_completion_sample_cities
+    client: TestClient,
 ) -> None:
     """Test that the suggest endpoint response does not return a response when the request_type
     query param is invalid.

--- a/tests/integration/api/v1/suggest/test_suggest_weather.py
+++ b/tests/integration/api/v1/suggest/test_suggest_weather.py
@@ -337,3 +337,33 @@ def test_suggest_with_location_completion(
     assert expected_suggestion == TypeAdapter(
         list[LocationCompletionSuggestion]
     ).validate_python(result["suggestions"])
+
+
+def test_suggest_with_location_completion_with_empty_search_term(
+    client: TestClient, backend_mock: Any, location_completion_sample_cities
+) -> None:
+    """Test that the suggest endpoint response returns empty location_completion when the q
+    param (search_term) is an empty string
+    """
+    response = client.get(
+        url="/api/v1/suggest",
+        params={"q": "", "providers": "weather", "request_type": "location"},
+    )
+    expected_suggestion = response.json()["suggestions"][0]["locations"]
+
+    assert response.status_code == 200
+    assert expected_suggestion == []
+
+
+def test_suggest_with_location_completion_with_incorrect_request_type_param(
+    client: TestClient, backend_mock: Any, location_completion_sample_cities
+) -> None:
+    """Test that the suggest endpoint response does not return a response when the request_type
+    query param is invalid.
+    """
+    response = client.get(
+        url="/api/v1/suggest",
+        params={"q": "new", "providers": "weather", "request_type": "unsupported"},
+    )
+
+    assert response.status_code == 400

--- a/tests/integration/api/v1/suggest/test_suggest_weather.py
+++ b/tests/integration/api/v1/suggest/test_suggest_weather.py
@@ -24,7 +24,7 @@ from merino.providers.weather.backends.protocol import (
     LocationCompletion,
     Temperature,
     WeatherBackend,
-    WeatherReport,
+    WeatherReport, LocationCompletionGeoDetails,
 )
 from merino.providers.weather.provider import (
     LocationCompletionSuggestion,
@@ -307,8 +307,17 @@ def test_suggest_with_location_completion(
     location_completion: list[LocationCompletion] = [
         LocationCompletion(
             key=location["Key"],
+            rank=location["Rank"],
+            type=location["Type"],
             localized_name=location["LocalizedName"],
-            country=location["Country"]["LocalizedName"],
+            country=LocationCompletionGeoDetails(
+                id=location["Country"]["ID"],
+                localized_name=location["Country"]["LocalizedName"],
+            ),
+            administrative_area=LocationCompletionGeoDetails(
+                id=location["AdministrativeArea"]["ID"],
+                localized_name=location["AdministrativeArea"]["LocalizedName"],
+            ),
         )
         for location in location_completion_sample_cities
     ]

--- a/tests/integration/api/v1/suggest/test_suggest_weather.py
+++ b/tests/integration/api/v1/suggest/test_suggest_weather.py
@@ -22,9 +22,10 @@ from merino.providers.weather.backends.protocol import (
     CurrentConditions,
     Forecast,
     LocationCompletion,
+    LocationCompletionGeoDetails,
     Temperature,
     WeatherBackend,
-    WeatherReport, LocationCompletionGeoDetails,
+    WeatherReport,
 )
 from merino.providers.weather.provider import (
     LocationCompletionSuggestion,

--- a/tests/unit/providers/weather/backends/test_accuweather.py
+++ b/tests/unit/providers/weather/backends/test_accuweather.py
@@ -84,6 +84,7 @@ def fixture_accuweather_parameters(
         "url_current_conditions_path": "/currentconditions/v1/{location_key}.json",
         "url_forecasts_path": "/forecasts/v1/daily/1day/{location_key}.json",
         "url_location_key_placeholder": "{location_key}",
+        "url_location_completion_path": "/locations/v1/{country_code}/autocomplete.json"
     }
 
 

--- a/tests/unit/providers/weather/backends/test_accuweather.py
+++ b/tests/unit/providers/weather/backends/test_accuweather.py
@@ -1866,3 +1866,37 @@ async def test_get_location_completion(
     ] = await accuweather.get_location_completion(geolocation, search_term)
 
     assert location_completions == expected_location_completion
+
+
+@pytest.mark.asyncio
+async def test_get_location_completion_with_empty_search_term(
+    accuweather: AccuweatherBackend,
+    geolocation: Location,
+    accuweather_location_completion_response: bytes,
+) -> None:
+    """Test that the get_location_completion method returns None when the search_term parameter
+    is an empty string.
+    """
+    client_mock: AsyncMock = cast(AsyncMock, accuweather.http_client)
+
+    search_term = ""
+    client_mock.get.side_effect = [
+        Response(
+            status_code=200,
+            content=accuweather_location_completion_response,
+            request=Request(
+                method="GET",
+                url=(
+                    f"http://www.accuweather.com/locations/v1/"
+                    f"{geolocation.country}/autocomplete.json?apikey=test&q"
+                    f"={search_term}"
+                ),
+            ),
+        )
+    ]
+
+    location_completions: Optional[
+        list[LocationCompletion]
+    ] = await accuweather.get_location_completion(geolocation, search_term)
+
+    assert location_completions is None

--- a/tests/unit/providers/weather/backends/test_accuweather.py
+++ b/tests/unit/providers/weather/backends/test_accuweather.py
@@ -1933,7 +1933,8 @@ async def test_get_location_completion_with_no_geolocation_country_code(
             request=Request(
                 method="GET",
                 url=(
-                    f"http://www.accuweather.com/locations/v1/autocomplete.json?apikey=test&q{search_term}"
+                    f"http://www.accuweather.com/locations/v1/autocomplete.json?"
+                    f"apikey=test&q{search_term}"
                 ),
             ),
         )

--- a/tests/unit/providers/weather/backends/test_accuweather.py
+++ b/tests/unit/providers/weather/backends/test_accuweather.py
@@ -33,8 +33,6 @@ from merino.providers.weather.backends.accuweather import (
 from merino.providers.weather.backends.protocol import (
     CurrentConditions,
     Forecast,
-    LocationCompletion,
-    LocationCompletionGeoDetails,
     Temperature,
     WeatherReport,
 )
@@ -68,103 +66,6 @@ def fixture_redis_mock_cache_miss(mocker: MockerFixture) -> Any:
     return mock
 
 
-@pytest.fixture(name="location_completion_sample_cities")
-def fixture_location_completion_sample_cities() -> list[dict[str, Any]]:
-    """Create a list of sample location completions for the search term 'new'"""
-    return [
-        {
-            "Version": 1,
-            "Key": "349727",
-            "Type": "City",
-            "Rank": 15,
-            "LocalizedName": "New York",
-            "Country": {"ID": "US", "LocalizedName": "United States"},
-            "AdministrativeArea": {"ID": "NY", "LocalizedName": "New York"},
-        },
-        {
-            "Version": 1,
-            "Key": "348585",
-            "Type": "City",
-            "Rank": 35,
-            "LocalizedName": "New Orleans",
-            "Country": {"ID": "US", "LocalizedName": "United States"},
-            "AdministrativeArea": {"ID": "LA", "LocalizedName": "Louisiana"},
-        },
-        {
-            "Version": 1,
-            "Key": "349530",
-            "Type": "City",
-            "Rank": 35,
-            "LocalizedName": "Newark",
-            "Country": {"ID": "US", "LocalizedName": "United States"},
-            "AdministrativeArea": {"ID": "NJ", "LocalizedName": "New Jersey"},
-        },
-        {
-            "Version": 1,
-            "Key": "331967",
-            "Type": "City",
-            "Rank": 45,
-            "LocalizedName": "Newport Beach",
-            "Country": {"ID": "US", "LocalizedName": "United States"},
-            "AdministrativeArea": {"ID": "CA", "LocalizedName": "California"},
-        },
-        {
-            "Version": 1,
-            "Key": "327357",
-            "Type": "City",
-            "Rank": 45,
-            "LocalizedName": "New Haven",
-            "Country": {"ID": "US", "LocalizedName": "United States"},
-            "AdministrativeArea": {"ID": "CT", "LocalizedName": "Connecticut"},
-        },
-        {
-            "Version": 1,
-            "Key": "333575",
-            "Type": "City",
-            "Rank": 45,
-            "LocalizedName": "New Bedford",
-            "Country": {"ID": "US", "LocalizedName": "United States"},
-            "AdministrativeArea": {"ID": "MA", "LocalizedName": "Massachusetts"},
-        },
-        {
-            "Version": 1,
-            "Key": "338640",
-            "Type": "City",
-            "Rank": 45,
-            "LocalizedName": "Newton",
-            "Country": {"ID": "US", "LocalizedName": "United States"},
-            "AdministrativeArea": {"ID": "MA", "LocalizedName": "Massachusetts"},
-        },
-        {
-            "Version": 1,
-            "Key": "339713",
-            "Type": "City",
-            "Rank": 45,
-            "LocalizedName": "New Rochelle",
-            "Country": {"ID": "US", "LocalizedName": "United States"},
-            "AdministrativeArea": {"ID": "NY", "LocalizedName": "New York"},
-        },
-        {
-            "Version": 1,
-            "Key": "336210",
-            "Type": "City",
-            "Rank": 45,
-            "LocalizedName": "Newport News",
-            "Country": {"ID": "US", "LocalizedName": "United States"},
-            "AdministrativeArea": {"ID": "VA", "LocalizedName": "Virginia"},
-        },
-        {
-            "Version": 1,
-            "Key": "2626691",
-            "Type": "City",
-            "Rank": 55,
-            "LocalizedName": "Near Eastside",
-            "Country": {"ID": "US", "LocalizedName": "United States"},
-            "AdministrativeArea": {"ID": "IN", "LocalizedName": "Indiana"},
-        },
-    ]
-
-
 @pytest.fixture(name="accuweather_parameters")
 def fixture_accuweather_parameters(
     mocker: MockerFixture, statsd_mock: Any
@@ -183,7 +84,6 @@ def fixture_accuweather_parameters(
         "url_current_conditions_path": "/currentconditions/v1/{location_key}.json",
         "url_forecasts_path": "/forecasts/v1/daily/1day/{location_key}.json",
         "url_location_key_placeholder": "{location_key}",
-        "url_location_completion_path": "/locations/v1/{country_code}/autocomplete.json",
     }
 
 
@@ -212,30 +112,6 @@ def fixture_expected_weather_report() -> WeatherReport:
         ),
         ttl=TEST_DEFAULT_WEATHER_REPORT_CACHE_TTL_SEC,
     )
-
-
-@pytest.fixture(name="expected_location_completion")
-def fixture_expected_location_completion(
-    location_completion_sample_cities,
-) -> list[LocationCompletion]:
-    """Create a `LocationCompletion` list for assertions"""
-    return [
-        LocationCompletion(
-            key=location["Key"],
-            rank=location["Rank"],
-            type=location["Type"],
-            localized_name=location["LocalizedName"],
-            country=LocationCompletionGeoDetails(
-                id=location["Country"]["ID"],
-                localized_name=location["Country"]["LocalizedName"],
-            ),
-            administrative_area=LocationCompletionGeoDetails(
-                id=location["AdministrativeArea"]["ID"],
-                localized_name=location["AdministrativeArea"]["LocalizedName"],
-            ),
-        )
-        for location in location_completion_sample_cities
-    ]
 
 
 @pytest.fixture(name="response_header")
@@ -340,14 +216,6 @@ def fixture_accuweather_location_response() -> bytes:
         }
     ]
     return json.dumps(response).encode("utf-8")
-
-
-@pytest.fixture(name="accuweather_location_completion_response")
-def fixture_accuweather_location_completion_response(
-    location_completion_sample_cities,
-) -> bytes:
-    """Return response content for AccuWeather location autocomplete endpoint."""
-    return json.dumps(location_completion_sample_cities).encode("utf-8")
 
 
 @pytest.fixture(name="accuweather_cached_location_key")
@@ -1843,105 +1711,3 @@ def test_parse_cached_data_error(
     assert records[0].message.startswith(
         "Failed to load weather report data from Redis:"
     )
-
-
-@pytest.mark.asyncio
-async def test_get_location_completion(
-    accuweather: AccuweatherBackend,
-    expected_location_completion: list[LocationCompletion],
-    geolocation: Location,
-    accuweather_location_completion_response: bytes,
-) -> None:
-    """Test that the get_location_completion method returns a list of LocationCompletion."""
-    client_mock: AsyncMock = cast(AsyncMock, accuweather.http_client)
-
-    search_term = "new"
-    client_mock.get.side_effect = [
-        Response(
-            status_code=200,
-            content=accuweather_location_completion_response,
-            request=Request(
-                method="GET",
-                url=(
-                    f"http://www.accuweather.com/locations/v1/"
-                    f"{geolocation.country}/autocomplete.json?apikey=test&q"
-                    f"={search_term}"
-                ),
-            ),
-        )
-    ]
-
-    location_completions: Optional[
-        list[LocationCompletion]
-    ] = await accuweather.get_location_completion(geolocation, search_term)
-
-    assert location_completions == expected_location_completion
-
-
-@pytest.mark.asyncio
-async def test_get_location_completion_with_empty_search_term(
-    accuweather: AccuweatherBackend,
-    geolocation: Location,
-    accuweather_location_completion_response: bytes,
-) -> None:
-    """Test that the get_location_completion method returns None when the search_term parameter
-    is an empty string.
-    """
-    client_mock: AsyncMock = cast(AsyncMock, accuweather.http_client)
-
-    search_term = ""
-    client_mock.get.side_effect = [
-        Response(
-            status_code=200,
-            content=accuweather_location_completion_response,
-            request=Request(
-                method="GET",
-                url=(
-                    f"http://www.accuweather.com/locations/v1/"
-                    f"{geolocation.country}/autocomplete.json?apikey=test&q"
-                    f"={search_term}"
-                ),
-            ),
-        )
-    ]
-
-    location_completions: Optional[
-        list[LocationCompletion]
-    ] = await accuweather.get_location_completion(geolocation, search_term)
-
-    assert location_completions is None
-
-
-@pytest.mark.asyncio
-async def test_get_location_completion_with_no_geolocation_country_code(
-    accuweather: AccuweatherBackend,
-    expected_location_completion: list[LocationCompletion],
-    geolocation: Location,
-    accuweather_location_completion_response: bytes,
-) -> None:
-    """Test that the get_location_completion method returns a list of LocationCompletion
-    when no geolocation country code is provided.
-    """
-    client_mock: AsyncMock = cast(AsyncMock, accuweather.http_client)
-
-    search_term = "new"
-    geolocation.country = None
-    client_mock.get.side_effect = [
-        Response(
-            status_code=200,
-            content=accuweather_location_completion_response,
-            request=Request(
-                method="GET",
-                url=(
-                    f"http://www.accuweather.com/locations/v1/autocomplete.json?"
-                    f"apikey=test&q{search_term}"
-                ),
-            ),
-        )
-    ]
-
-    location_completions: Optional[
-        list[LocationCompletion]
-    ] = await accuweather.get_location_completion(geolocation, search_term)
-
-    assert location_completions == expected_location_completion

--- a/tests/unit/providers/weather/backends/test_accuweather.py
+++ b/tests/unit/providers/weather/backends/test_accuweather.py
@@ -67,8 +67,9 @@ def fixture_redis_mock_cache_miss(mocker: MockerFixture) -> Any:
     return mock
 
 
-@pytest.fixture(name="location_completion_test_cities")
-def fixture_location_completion_test_cities() -> list[dict[str, Any]]:
+@pytest.fixture(name="location_completion_sample_cities")
+def fixture_location_completion_sample_cities() -> list[dict[str, Any]]:
+    """Create a list of sample location completions for the search term 'new'"""
     return [
         {
             "Version": 1,
@@ -214,7 +215,7 @@ def fixture_expected_weather_report() -> WeatherReport:
 
 @pytest.fixture(name="expected_location_completion")
 def fixture_expected_location_completion(
-    location_completion_test_cities,
+    location_completion_sample_cities,
 ) -> list[LocationCompletion]:
     """Create a `LocationCompletion` list for assertions"""
     return [
@@ -223,7 +224,7 @@ def fixture_expected_location_completion(
             localized_name=location["LocalizedName"],
             country=location["Country"]["LocalizedName"],
         )
-        for location in location_completion_test_cities
+        for location in location_completion_sample_cities
     ]
 
 
@@ -333,10 +334,10 @@ def fixture_accuweather_location_response() -> bytes:
 
 @pytest.fixture(name="accuweather_location_completion_response")
 def fixture_accuweather_location_completion_response(
-    location_completion_test_cities,
+    location_completion_sample_cities,
 ) -> bytes:
     """Return response content for AccuWeather location autocomplete endpoint."""
-    return json.dumps(location_completion_test_cities).encode("utf-8")
+    return json.dumps(location_completion_sample_cities).encode("utf-8")
 
 
 @pytest.fixture(name="accuweather_cached_location_key")
@@ -1844,7 +1845,7 @@ async def test_get_location_completion(
     """Test that the get_location_completion method returns a list of LocationCompletion."""
     client_mock: AsyncMock = cast(AsyncMock, accuweather.http_client)
 
-    search_term = "ne"
+    search_term = "new"
     client_mock.get.side_effect = [
         Response(
             status_code=200,


### PR DESCRIPTION
## References

JIRA: [DISCO-2806](https://mozilla-hub.atlassian.net/browse/DISCO-2806)

## Description
Adding functionality to provide location completion suggestions via Accuweather api by modifying our existing `/suggest` endpoint.

## Testing
- Make sure your `default.local.toml` has the correct settings and the `accuweather_city` provider's `cache` is set to `redis`. 
- Start the redis instance: `cd dev && docker-compose up`
- Start merino `make dev`

#### Backwards compatibility tests
This should return empty suggestions:
`curl -i -X 'GET' 'localhost:8000/api/v1/suggest?q=new&providers=accuweather&request_type=location'`

This should return weather suggestions:
`curl -i -X 'GET' 'localhost:8000/api/v1/suggest?q=&providers=accuweather&request_type=weather'`

This should also return weather suggestions:
`curl -i -X 'GET' 'localhost:8000/api/v1/suggest?q=&providers=accuweather'`

#### New provider tests
This should return location completion suggestions:
`curl -i -X 'GET' 'localhost:8000/api/v1/suggest?q=new&providers=accuweather_city&request_type=location`

This should return weather suggestions:
`curl -i -X 'GET' 'localhost:8000/api/v1/suggest?q=new&providers=accuweather_city&request_type=weather'`

This should return an error (400):
`curl -i -X 'GET' 'localhost:8000/api/v1/suggest?q=new&providers=accuweather_city&request_type=unsupported'`

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2806]: https://mozilla-hub.atlassian.net/browse/DISCO-2806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ