### PR TITLE
[DISCO-2794] RS job refactor

### DIFF
--- a/merino/jobs/amo_rs_uploader/__init__.py
+++ b/merino/jobs/amo_rs_uploader/__init__.py
@@ -6,7 +6,7 @@ from typing import Any
 import typer
 
 from merino.config import settings as config
-from merino.jobs.utils.chunked_rs_uploader import ChunkedRemoteSettingsUploader
+from merino.jobs.csv_rs_uploader import ChunkedRemoteSettingsSuggestionUploader
 from merino.providers.amo.addons_data import ADDON_DATA, ADDON_KEYWORDS
 from merino.providers.amo.backends.dynamic import DynamicAmoBackend
 
@@ -120,7 +120,7 @@ async def _upload(
     backend = DynamicAmoBackend(config.amo.dynamic.api_url)
     await backend.fetch_and_cache_addons_info()
 
-    with ChunkedRemoteSettingsUploader(
+    with ChunkedRemoteSettingsSuggestionUploader(
         auth=auth,
         bucket=bucket,
         chunk_size=chunk_size,

--- a/merino/jobs/csv_rs_uploader/__init__.py
+++ b/merino/jobs/csv_rs_uploader/__init__.py
@@ -7,6 +7,9 @@ import io
 import typer
 
 from merino.config import settings as config
+from merino.jobs.csv_rs_uploader.chunked_rs_uploader import (
+    ChunkedRemoteSettingsSuggestionUploader,
+)
 from merino.jobs.utils.chunked_rs_uploader import ChunkedRemoteSettingsUploader
 
 rs_settings = config.remote_settings
@@ -208,7 +211,7 @@ async def _upload_file_object(
     # starting the upload.
     suggestions = Suggestion.csv_to_suggestions(csv_reader)
 
-    with ChunkedRemoteSettingsUploader(
+    with ChunkedRemoteSettingsSuggestionUploader(
         auth=auth,
         bucket=bucket,
         chunk_size=chunk_size,

--- a/merino/jobs/csv_rs_uploader/chunked_rs_uploader.py
+++ b/merino/jobs/csv_rs_uploader/chunked_rs_uploader.py
@@ -10,59 +10,7 @@ logger = logging.getLogger(__name__)
 
 
 class ChunkedRemoteSettingsSuggestionUploader(ChunkedRemoteSettingsUploader):
-    """A class that uploads suggestion data to remote settings.
-    Data is uploaded and stored in chunks. Chunking is handled
-    automatically, and the caller only needs to specify a chunk size and call
-    `add_data()` until all data has been added:
-
-        with ChunkedRemoteSettingsSuggestionUploader(
-            chunk_size=200,
-            record_type="my-record-type",
-            auth="my-auth",
-            bucket="my-bucket",
-            collection="my-collection",
-            server="http://example.com/",
-            total_suggestion_count=1234
-        ) as uploader:
-            for s in my_data:
-                uploader.add_data(s)
-
-    This class can be used with any type of data regardless of schema. The
-    values passed to `add_data()` are dictionaries that can contain
-    anything. However, the dictionaries must be JSON serializable, i.e., they
-    must be able to be passed to `json.dumps()`. It's the consumer's
-    responsibility to convert unserializable dicts to serializable dicts before
-    passing them to the uploader.
-
-    For each chunk, the uploader will create a record with an attachment. The
-    record represents the chunk and the attachment contains the chunk's
-    data as JSON. All chunks will contain the number of data
-    specified by the uploader's `chunk_size` except possibly the final chunk,
-    which may contain fewer suggestions.
-
-    Each record's "id" will encode the uploader's `record_type` and the range of
-    data contained in the record's chunk, and its "type" will be the
-    uploader's `record_type`, like this:
-
-        {
-            "id": f"{uploader.record_type}-{chunk.start_index}-{chunk.start_index + chunk.size}",
-            "type": uploader.record_type
-        }
-
-    For example, if the uploader's `record_type` is "my-record-type", then the
-    record for a chunk with start index 400 and size 200 will look like this:
-
-        { "id": "my-record-type-400-600", "type": "my-record-type" }
-
-    The record's attachment will be the list of suggestions in the chunk as JSON
-    (MIME type "application/json").
-
-    It's common to delete existing suggestions before uploading new ones, so as
-    a convenience the uploader can also delete all records of its `record_type`:
-
-        uploader.delete_records()
-
-    """
+    """A class that uploads suggestion data to remote settings."""
 
     chunk_size: int
     current_chunk: Chunk

--- a/merino/jobs/csv_rs_uploader/chunked_rs_uploader.py
+++ b/merino/jobs/csv_rs_uploader/chunked_rs_uploader.py
@@ -1,0 +1,109 @@
+"""Chunked remote settings uploader"""
+import logging
+from typing import Any
+
+import kinto_http
+
+from merino.jobs.utils.chunked_rs_uploader import Chunk, ChunkedRemoteSettingsUploader
+
+logger = logging.getLogger(__name__)
+
+
+class ChunkedRemoteSettingsSuggestionUploader(ChunkedRemoteSettingsUploader):
+    """A class that uploads suggestion data to remote settings.
+    Data is uploaded and stored in chunks. Chunking is handled
+    automatically, and the caller only needs to specify a chunk size and call
+    `add_data()` until all data has been added:
+
+        with ChunkedRemoteSettingsSuggestionUploader(
+            chunk_size=200,
+            record_type="my-record-type",
+            auth="my-auth",
+            bucket="my-bucket",
+            collection="my-collection",
+            server="http://example.com/",
+            total_suggestion_count=1234
+        ) as uploader:
+            for s in my_data:
+                uploader.add_data(s)
+
+    This class can be used with any type of data regardless of schema. The
+    values passed to `add_data()` are dictionaries that can contain
+    anything. However, the dictionaries must be JSON serializable, i.e., they
+    must be able to be passed to `json.dumps()`. It's the consumer's
+    responsibility to convert unserializable dicts to serializable dicts before
+    passing them to the uploader.
+
+    For each chunk, the uploader will create a record with an attachment. The
+    record represents the chunk and the attachment contains the chunk's
+    data as JSON. All chunks will contain the number of data
+    specified by the uploader's `chunk_size` except possibly the final chunk,
+    which may contain fewer suggestions.
+
+    Each record's "id" will encode the uploader's `record_type` and the range of
+    data contained in the record's chunk, and its "type" will be the
+    uploader's `record_type`, like this:
+
+        {
+            "id": f"{uploader.record_type}-{chunk.start_index}-{chunk.start_index + chunk.size}",
+            "type": uploader.record_type
+        }
+
+    For example, if the uploader's `record_type` is "my-record-type", then the
+    record for a chunk with start index 400 and size 200 will look like this:
+
+        { "id": "my-record-type-400-600", "type": "my-record-type" }
+
+    The record's attachment will be the list of suggestions in the chunk as JSON
+    (MIME type "application/json").
+
+    It's common to delete existing suggestions before uploading new ones, so as
+    a convenience the uploader can also delete all records of its `record_type`:
+
+        uploader.delete_records()
+
+    """
+
+    chunk_size: int
+    current_chunk: Chunk
+    dry_run: bool
+    kinto: kinto_http.Client
+    record_type: str
+    suggestion_score_fallback: float | None
+    total_data_count: int | None
+
+    def __init__(
+        self,
+        auth: str,
+        bucket: str,
+        chunk_size: int,
+        collection: str,
+        record_type: str,
+        server: str,
+        dry_run: bool = False,
+        suggestion_score_fallback: float | None = None,
+        total_data_count: int | None = None,
+    ):
+        """Initialize the uploader."""
+        super(ChunkedRemoteSettingsSuggestionUploader, self).__init__(
+            auth,
+            bucket,
+            chunk_size,
+            collection,
+            record_type,
+            server,
+            dry_run,
+            total_data_count,
+        )
+        self.suggestion_score_fallback = suggestion_score_fallback
+        self.total_data_count = total_data_count
+
+    def add_suggestion(self, suggestion: dict[str, Any]) -> None:
+        """Add a suggestion. If the current chunk becomes full as a result, it
+        will be uploaded before this method returns.
+        """
+        if self.suggestion_score_fallback and "score" not in suggestion:
+            suggestion |= {"score": self.suggestion_score_fallback}
+        self.current_chunk.add_data(suggestion)
+        if self.current_chunk.size == self.chunk_size:
+            self._finish_current_chunk()

--- a/merino/jobs/relevancy_uploader/__init__.py
+++ b/merino/jobs/relevancy_uploader/__init__.py
@@ -251,8 +251,6 @@ async def _upload_file_object(
     # starting the upload.
     data = RelevancyData.csv_to_relevancy_data(csv_reader)
     for category, domains in data.items():
-        # TODO: We want to clean this up and no need suggestion_score_fallback
-        #  https://mozilla-hub.atlassian.net/browse/DISCO-2794
         with ChunkedRemoteSettingsRelevancyUploader(
             auth=auth,
             bucket=bucket,
@@ -261,7 +259,6 @@ async def _upload_file_object(
             dry_run=dry_run,
             record_type=RELEVANCY_RECORD_TYPE,
             server=server,
-            suggestion_score_fallback=0,
             total_data_count=len(data[category]),
             category_name=category.name,
             category_code=category.value,

--- a/merino/jobs/relevancy_uploader/__init__.py
+++ b/merino/jobs/relevancy_uploader/__init__.py
@@ -268,4 +268,4 @@ async def _upload_file_object(
                 uploader.delete_records()
 
             for domain in domains:
-                uploader.add_relevancy_data(domain)
+                uploader.add_data(domain)

--- a/merino/jobs/relevancy_uploader/chunked_rs_uploader.py
+++ b/merino/jobs/relevancy_uploader/chunked_rs_uploader.py
@@ -2,7 +2,6 @@
 import io
 import json
 import logging
-from typing import Any
 
 from merino.jobs.utils.chunked_rs_uploader import Chunk, ChunkedRemoteSettingsUploader
 
@@ -60,12 +59,6 @@ class ChunkedRemoteSettingsRelevancyUploader(ChunkedRemoteSettingsUploader):
                     self.kinto.delete_record(id=record["id"])
                     count += 1
         logger.info(f"Deleted {count} records")
-
-    def add_relevancy_data(self, data: Any) -> None:
-        """Add Relevancy data to the current chunk."""
-        self.current_chunk.add_data(data)
-        if self.current_chunk.size == self.chunk_size:
-            self._finish_current_chunk()
 
     def _upload_chunk(self, chunk: Chunk) -> None:
         """Create a record and attachment for a chunk."""

--- a/merino/jobs/relevancy_uploader/chunked_rs_uploader.py
+++ b/merino/jobs/relevancy_uploader/chunked_rs_uploader.py
@@ -26,7 +26,6 @@ class ChunkedRemoteSettingsRelevancyUploader(ChunkedRemoteSettingsUploader):
         category_code: int,
         version: int,
         dry_run: bool = False,
-        suggestion_score_fallback: float | None = None,
         total_data_count: int | None = None,
     ):
         """Initialize the uploader."""
@@ -38,7 +37,6 @@ class ChunkedRemoteSettingsRelevancyUploader(ChunkedRemoteSettingsUploader):
             record_type,
             server,
             dry_run,
-            suggestion_score_fallback,
             total_data_count,
         )
         self.category_name = category_name

--- a/merino/jobs/utils/chunked_rs_uploader.py
+++ b/merino/jobs/utils/chunked_rs_uploader.py
@@ -112,6 +112,14 @@ class ChunkedRemoteSettingsUploader:
             server_url=server, bucket=bucket, collection=collection, auth=auth
         )
 
+    def add_data(self, data: dict[str, Any]) -> None:
+        """Add data to the current_chunk. If the current chunk becomes full as a result, it
+        will be uploaded before this method returns.
+        """
+        self.current_chunk.add_data(data)
+        if self.current_chunk.size == self.chunk_size:
+            self._finish_current_chunk()
+
     def finish(self) -> None:
         """Finish the currrent chunk. If the chunk is not empty, it will be
         uploaded before this method returns. This method should be called when

--- a/tests/unit/jobs/amo_rs_uploader/test_amo_rs_uploader.py
+++ b/tests/unit/jobs/amo_rs_uploader/test_amo_rs_uploader.py
@@ -95,7 +95,7 @@ def do_upload_test(
 
     # Mock the chunked uploader.
     mock_chunked_uploader_ctor = mocker.patch(
-        "merino.jobs.amo_rs_uploader.ChunkedRemoteSettingsUploader"
+        "merino.jobs.amo_rs_uploader.ChunkedRemoteSettingsSuggestionUploader"
     )
     mock_chunked_uploader = (
         mock_chunked_uploader_ctor.return_value.__enter__.return_value

--- a/tests/unit/jobs/csv_rs_uploader/utils.py
+++ b/tests/unit/jobs/csv_rs_uploader/utils.py
@@ -34,7 +34,7 @@ def _do_csv_test(
     """Helper-method for `do_csv_test()`"""
     # Mock the chunked uploader.
     mock_chunked_uploader_ctor = mocker.patch(
-        "merino.jobs.csv_rs_uploader.ChunkedRemoteSettingsUploader"
+        "merino.jobs.csv_rs_uploader.ChunkedRemoteSettingsSuggestionUploader"
     )
     mock_chunked_uploader = (
         mock_chunked_uploader_ctor.return_value.__enter__.return_value

--- a/tests/unit/jobs/relevancy_uploader/test_chunked_relevancy_rs_uploader.py
+++ b/tests/unit/jobs/relevancy_uploader/test_chunked_relevancy_rs_uploader.py
@@ -172,7 +172,7 @@ def do_upload_test(
     ) as uploader:
         for i in range(data_count):
             data: dict[str, Any] = {"i": i}
-            uploader.add_relevancy_data(data)
+            uploader.add_data(data)
 
     check_upload_requests(requests_mock.request_history, expected_records)
 

--- a/tests/unit/jobs/relevancy_uploader/utils.py
+++ b/tests/unit/jobs/relevancy_uploader/utils.py
@@ -83,7 +83,7 @@ def _do_csv_test(
     else:
         mock_chunked_uploader.delete_records.assert_not_called()
 
-    mock_chunked_uploader.add_relevancy_data.assert_has_calls(
+    mock_chunked_uploader.add_data.assert_has_calls(
         [*map(mocker.call, primary_category_data)]
     )
 

--- a/tests/unit/jobs/relevancy_uploader/utils.py
+++ b/tests/unit/jobs/relevancy_uploader/utils.py
@@ -57,7 +57,6 @@ def _do_csv_test(
     mock_chunked_uploader_ctor.assert_any_call(
         **common_kwargs,
         record_type="category_to_domains",
-        suggestion_score_fallback=0,
         total_data_count=len(primary_category_data),
         category_name="Sports",
         category_code=17
@@ -66,7 +65,6 @@ def _do_csv_test(
     mock_chunked_uploader_ctor.assert_any_call(
         **common_kwargs,
         record_type="category_to_domains",
-        suggestion_score_fallback=0,
         total_data_count=len(secondary_category_data),
         category_name="News",
         category_code=14
@@ -75,7 +73,6 @@ def _do_csv_test(
     mock_chunked_uploader_ctor.assert_any_call(
         **common_kwargs,
         record_type="category_to_domains",
-        suggestion_score_fallback=0,
         total_data_count=len(inconclusive_category_data),
         category_name="Inconclusive",
         category_code=0

--- a/tests/unit/jobs/utils/test_chunked_rs_uploader.py
+++ b/tests/unit/jobs/utils/test_chunked_rs_uploader.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from requests_toolbelt.multipart.decoder import MultipartDecoder
 
-from merino.jobs.utils.chunked_rs_uploader import ChunkedRemoteSettingsUploader
+from merino.jobs.csv_rs_uploader import ChunkedRemoteSettingsSuggestionUploader
 
 TEST_UPLOADER_KWARGS: dict[str, Any] = {
     "auth": "Bearer auth",
@@ -156,7 +156,7 @@ def do_upload_test(
         requests_mock.put(record.url, json={})  # nosec
         requests_mock.post(record.attachment_url, json={})  # nosec
 
-    with ChunkedRemoteSettingsUploader(
+    with ChunkedRemoteSettingsSuggestionUploader(
         chunk_size=chunk_size,
         **TEST_UPLOADER_KWARGS,
         **uploader_kwargs,
@@ -350,7 +350,7 @@ def test_delete_records(requests_mock):
     for r in records:
         requests_mock.delete(r.url, json={"data": {}})  # nosec
 
-    with ChunkedRemoteSettingsUploader(
+    with ChunkedRemoteSettingsSuggestionUploader(
         chunk_size=10, **TEST_UPLOADER_KWARGS
     ) as uploader:
         uploader.delete_records()


### PR DESCRIPTION
## References

JIRA: [DISCO-2794](https://mozilla-hub.atlassian.net/browse/DISCO-2794)

## Description
I took out the common components of the uploader job and kept them in `merino/jobs/utils/chunked_rs_uploader.py`.
Added a `ChunkedRemoteSettingsSuggestionUploader` class that has the extra fallback score field and the `add_suggestion` logic



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2794]: https://mozilla-hub.atlassian.net/browse/DISCO-2794?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ