### PR TITLE
[DISCO-2838] Add alias param for accuweather city endpoint

### DIFF
--- a/merino/providers/weather/backends/accuweather.py
+++ b/merino/providers/weather/backends/accuweather.py
@@ -120,6 +120,11 @@ LUA_SCRIPT_CACHE_BULK_FETCH_VIA_LOCATION: str = """
 SCRIPT_LOCATION_KEY_ID = "bulk_fetch_by_location_key"
 LOCATION_COMPLETION_REQUEST_TYPE: str = "autocomplete"
 
+ALIAS_PARAM: str = "alias"
+ALIAS_PARAM_VALUE: str = "always"
+LOCATION_COMPLETE_ALIAS_PARAM: str = "includealiases"
+LOCATION_COMPLETE_ALIAS_PARAM_VALUE: str = "true"
+
 
 class AccuweatherLocation(BaseModel):
     """Location model for response data from AccuWeather endpoints."""
@@ -427,6 +432,7 @@ class AccuweatherBackend:
         return {
             self.url_param_api_key: self.api_key,
             self.url_cities_param_query: city,
+            ALIAS_PARAM: ALIAS_PARAM_VALUE,
         }
 
     async def get_weather_report(
@@ -745,6 +751,7 @@ class AccuweatherBackend:
         params = {
             "q": search_term,
             self.url_param_api_key: self.api_key,
+            LOCATION_COMPLETE_ALIAS_PARAM: LOCATION_COMPLETE_ALIAS_PARAM_VALUE,
         }
 
         with self.metrics_client.timeit(


### PR DESCRIPTION
## References

JIRA: [DISCO-2838](https://mozilla-hub.atlassian.net/browse/DISCO-2838)

## Description
Added the `alias` param for the cities accuweather endpoint.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2838]: https://mozilla-hub.atlassian.net/browse/DISCO-2838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ