### PR TITLE
[DISCO-2843] Accuweather - Handle case when there are multiple location keys for a given city

### DIFF
--- a/merino/providers/weather/backends/accuweather.py
+++ b/merino/providers/weather/backends/accuweather.py
@@ -466,13 +466,11 @@ class AccuweatherBackend:
                     # The order matters below.
                     # See `LUA_SCRIPT_CACHE_BULK_FETCH_VIA_LOCATION` for details.
                     args=[
-                        self.cache_key_for_accuweather_request(
-                            self.url_current_conditions_path.format(
-                                location_key=location_key
-                            )
-                        ),
-                        self.cache_key_for_accuweather_request(
-                            self.url_forecasts_path.format(location_key=location_key)
+                        self.cache_key_template(
+                            WeatherDataType.CURRENT_CONDITIONS
+                        ).format(location_key=location_key),
+                        self.cache_key_template(WeatherDataType.FORECAST).format(
+                            location_key=location_key
                         ),
                     ],
                 )
@@ -816,6 +814,7 @@ def process_location_response(response: Any) -> dict[str, Any] | None:
                 "Key": key,
                 "LocalizedName": localized_name,
             },
+            *_,
         ]:
             # `type: ignore` is necessary because mypy gets confused when
             # matching structures of type `Any` and reports the following

--- a/tests/unit/providers/weather/backends/test_accuweather.py
+++ b/tests/unit/providers/weather/backends/test_accuweather.py
@@ -378,7 +378,74 @@ def fixture_accuweather_location_response() -> bytes:
                 "MinuteCast",
                 "Radar",
             ],
-        }
+        },
+        {
+            "Version": 2,
+            "Key": "888888",
+            "Type": "City",
+            "Rank": 135,
+            "LocalizedName": "San Francisco",
+            "EnglishName": "San Francisco",
+            "PrimaryPostalCode": "94105",
+            "Region": {
+                "ID": "NAM",
+                "LocalizedName": "North America",
+                "EnglishName": "North America",
+            },
+            "Country": {
+                "ID": "US",
+                "LocalizedName": "United States",
+                "EnglishName": "United States",
+            },
+            "AdministrativeArea": {
+                "ID": "CA",
+                "LocalizedName": "California",
+                "EnglishName": "California",
+                "Level": 1,
+                "LocalizedType": "State",
+                "EnglishType": "State",
+                "CountryID": "US",
+            },
+            "TimeZone": {
+                "Code": "PDT",
+                "Name": "America/Los_Angeles",
+                "GmtOffset": -7.0,
+                "IsDaylightSaving": True,
+                "NextOffsetChange": "2022-11-06T09:00:00Z",
+            },
+            "GeoPosition": {
+                "Latitude": 37.792,
+                "Longitude": -122.392,
+                "Elevation": {
+                    "Metric": {"Value": 19.0, "Unit": "m", "UnitType": 5},
+                    "Imperial": {"Value": 62.0, "Unit": "ft", "UnitType": 0},
+                },
+            },
+            "IsAlias": False,
+            "ParentCity": {
+                "Key": "347629",
+                "LocalizedName": "San Francisco",
+                "EnglishName": "San Francisco",
+            },
+            "SupplementalAdminAreas": [
+                {
+                    "Level": 2,
+                    "LocalizedName": "San Francisco",
+                    "EnglishName": "San Francisco",
+                }
+            ],
+            "DataSets": [
+                "AirQualityCurrentConditions",
+                "AirQualityForecasts",
+                "Alerts",
+                "DailyAirQualityForecast",
+                "DailyPollenForecast",
+                "ForecastConfidence",
+                "FutureRadar",
+                "MinuteCast",
+                "Radar",
+            ],
+        },
     ]
     return json.dumps(response).encode("utf-8")
 


### PR DESCRIPTION

## References

JIRA: [DISCO-2843](https://mozilla-hub.atlassian.net/browse/DISCO-2843)

## Description
Current implementation assumes that there is only one entry in the response from Accuweather's city look up API.
This isn't always the case, and when there is more than one entry, Merino currently returns None rather than the first entry of the response, which is the highest ranked entry.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2843]: https://mozilla-hub.atlassian.net/browse/DISCO-2843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ