### PR TITLE
Fix: Validate class methods

### DIFF
--- a/merino/jobs/csv_rs_uploader/base.py
+++ b/merino/jobs/csv_rs_uploader/base.py
@@ -18,6 +18,7 @@ class BaseSuggestion(BaseModel):
         """
         raise Exception("Subclass must override")
 
+    @classmethod
     def _validate_str(cls, value: str, name: str) -> str:
         """Validate a string value and return the validated value. Leading and
         trailing whitespace is stripped, and all whitespace is replaced with
@@ -30,6 +31,7 @@ class BaseSuggestion(BaseModel):
             raise ValueError(f"{name} must not be empty")
         return value
 
+    @classmethod
     def _validate_keywords(cls, value: str, name: str) -> list[str]:
         """Validate a comma-separated string of keywords and return the
         validated list of keyword strings. Each keyword is converted to

--- a/merino/jobs/csv_rs_uploader/mdn.py
+++ b/merino/jobs/csv_rs_uploader/mdn.py
@@ -37,16 +37,16 @@ class Suggestion(RowMajorBaseSuggestion):
     @classmethod
     def validate_title(cls, value):
         """Validate title"""
-        return cls._validate_str(cls, value, "title")
+        return cls._validate_str(value, "title")
 
     @field_validator("description", mode="before")
     @classmethod
     def validate_description(cls, value):
         """Validate description"""
-        return cls._validate_str(cls, value, "description")
+        return cls._validate_str(value, "description")
 
     @field_validator("keywords", mode="before")
     @classmethod
     def validate_keywords(cls, value):
         """Validate keywords"""
-        return cls._validate_keywords(cls, value, "keywords")
+        return cls._validate_keywords(value, "keywords")

--- a/merino/jobs/csv_rs_uploader/pocket.py
+++ b/merino/jobs/csv_rs_uploader/pocket.py
@@ -40,25 +40,25 @@ class Suggestion(RowMajorBaseSuggestion):
     @classmethod
     def validate_title(cls, value):
         """Validate title"""
-        return cls._validate_str(cls, value, "title")
+        return cls._validate_str(value, "title")
 
     @field_validator("description", mode="before")
     @classmethod
     def validate_description(cls, value):
         """Validate description"""
-        return cls._validate_str(cls, value, "description")
+        return cls._validate_str(value, "description")
 
     @field_validator("lowConfidenceKeywords", mode="before")
     @classmethod
     def validate_lowConfidenceKeywords(cls, value):
         """Validate lowConfidenceKeywords"""
-        return cls._validate_keywords(cls, value, "lowConfidenceKeywords")
+        return cls._validate_keywords(value, "lowConfidenceKeywords")
 
     @field_validator("highConfidenceKeywords", mode="before")
     @classmethod
     def validate_highConfidenceKeywords(cls, value):
         """Validate highConfidenceKeywords"""
-        return cls._validate_keywords(cls, value, "highConfidenceKeywords")
+        return cls._validate_keywords(value, "highConfidenceKeywords")
 
     @model_validator(mode="after")
     def validate_model(self) -> "Suggestion":

--- a/tests/unit/jobs/csv_rs_uploader/model.py
+++ b/tests/unit/jobs/csv_rs_uploader/model.py
@@ -37,22 +37,22 @@ class Suggestion(RowMajorBaseSuggestion):
     @classmethod
     def validate_title(cls, value):
         """Validate title"""
-        return cls._validate_str(cls, value, "title")
+        return cls._validate_str(value, "title")
 
     @field_validator("description", mode="before")
     @classmethod
     def validate_description(cls, value):
         """Validate description"""
-        return cls._validate_str(cls, value, "description")
+        return cls._validate_str(value, "description")
 
     @field_validator("lowConfidenceKeywords", mode="before")
     @classmethod
     def validate_lowConfidenceKeywords(cls, value):
         """Validate lowConfidenceKeywords"""
-        return cls._validate_keywords(cls, value, "lowConfidenceKeywords")
+        return cls._validate_keywords(value, "lowConfidenceKeywords")
 
     @field_validator("highConfidenceKeywords", mode="before")
     @classmethod
     def validate_highConfidenceKeywords(cls, value):
         """Validate highConfidenceKeywords"""
-        return cls._validate_keywords(cls, value, "highConfidenceKeywords")
+        return cls._validate_keywords(value, "highConfidenceKeywords")


### PR DESCRIPTION
Trying my hand at a Merino PR, how does this one look?

This doesn't match all of the contribution guidelines, but it seems like those aren't being strictly followed based on the latest PRs in the queue.  Is there something important I'm missing?



## Description

_validate_str and _validate_keywords were logically class methods, but without the @classmethod decorator which lead to them being called in a non-standard way.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
