### PR TITLE
[DISCO-2834] Fakespot upload job

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -135,6 +135,9 @@ bucket = "main"
 # Ex: "quicksuggest".
 collection = "quicksuggest"
 
+# The collection to use for uploading fakespot suggestions if not specified on the command line
+collection_fakespot = "fakespot-suggest-products"
+
 # MERINO_REMOTE_SETTINGS__AUTH
 # Authorization token when uploading suggestions.
 auth = ""

--- a/merino/jobs/csv_rs_uploader/__init__.py
+++ b/merino/jobs/csv_rs_uploader/__init__.py
@@ -34,7 +34,7 @@ chunk_size_option = typer.Option(
 )
 
 collection_option = typer.Option(
-    rs_settings.collection,
+    "",
     "--collection",
     help="Remote settings collection ID",
 )
@@ -204,6 +204,8 @@ async def _upload_file_object(
             f"`{model_name}`. Please define a `Suggestion` class."
         )
 
+    if not collection:
+        collection = Suggestion.default_collection()
     csv_reader = csv.DictReader(file_object)
 
     # Generate the full list of suggestions before creating the chunked uploader

--- a/merino/jobs/csv_rs_uploader/base.py
+++ b/merino/jobs/csv_rs_uploader/base.py
@@ -2,8 +2,11 @@
 serialized in the output JSON, plus related helpers.
 """
 import re
+from typing import cast
 
 from pydantic import BaseModel
+
+from merino.config import settings
 
 
 class BaseSuggestion(BaseModel):
@@ -55,3 +58,12 @@ class BaseSuggestion(BaseModel):
         if not keywords or len(keywords) == 0:
             raise ValueError(f"{name} must not be empty")
         return keywords
+
+    @classmethod
+    def default_collection(cls) -> str:
+        """Get the collection to use if none is specified on the CLI
+
+        This returns the `remote_settings.collection` config value, which defaults to
+        `quicksuggest`.
+        """
+        return cast(str, settings.remote_settings.collection)

--- a/merino/jobs/csv_rs_uploader/fakespot.py
+++ b/merino/jobs/csv_rs_uploader/fakespot.py
@@ -1,0 +1,65 @@
+"""Pydantic model for MDN suggestions as they should be serialized in the
+output JSON.
+"""
+from typing import cast
+
+from pydantic import HttpUrl, field_validator
+
+from merino.config import settings
+from merino.jobs.csv_rs_uploader.row_major_base import RowMajorBaseSuggestion
+
+
+class Suggestion(RowMajorBaseSuggestion):
+    """Model for MDN suggestions as they should be serialized in the output
+    JSON.
+    """
+
+    fakespot_grade: str
+    product_id: str
+    rating: float
+    title: str
+    total_reviews: int
+    url: HttpUrl
+    score: float
+
+    @classmethod
+    def default_collection(cls) -> str:
+        """Use a different default collection, than the rest of the suggestion data
+
+        This returns the `remote_settings.collection_fakespot` config value, which defaults to
+        `fakespot-suggest-products`.
+        """
+        return cast(str, settings.remote_settings.collection_fakespot)
+
+    @classmethod
+    def row_major_field_map(cls) -> dict[str, str]:
+        """Map field (column) names in the input CSV to suggestion property
+        names in the output JSON.
+        """
+        return {
+            "fakespot_grade": "fakespot_grade",
+            "product_id": "product_id",
+            "rating": "rating",
+            "title": "title",
+            "total_reviews": "total_reviews",
+            "url": "url",
+            "score": "score",
+        }
+
+    @field_validator("fakespot_grade", mode="before")
+    @classmethod
+    def validate_fakespot_grade(cls, value):
+        """Validate fakespot_grade"""
+        return cls._validate_str(value, "fakespot_grade")
+
+    @field_validator("product_id", mode="before")
+    @classmethod
+    def validate_product_id(cls, value):
+        """Validate product_id"""
+        return cls._validate_str(value, "product_id")
+
+    @field_validator("title", mode="before")
+    @classmethod
+    def validate_title(cls, value):
+        """Validate title"""
+        return cls._validate_str(value, "title")

--- a/tests/unit/jobs/csv_rs_uploader/test_fakespot.py
+++ b/tests/unit/jobs/csv_rs_uploader/test_fakespot.py
@@ -1,0 +1,152 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Unit tests for the mdn.py model."""
+
+import pytest
+from pydantic import ValidationError
+
+from merino.jobs.csv_rs_uploader import MissingFieldError
+from tests.unit.jobs.csv_rs_uploader.utils import do_csv_test, do_error_test
+
+MODEL_NAME = "fakespot"
+
+TEST_CSV_ROW = {
+    "fakespot_grade": "A",
+    "product_id": "test-ABCDEF",
+    "rating": "3.6",
+    "title": "Brand new widget",
+    "total_reviews": "10",
+    "url": "https://example.com/new-widget",
+    "score": "8.5",
+}
+
+
+def test_upload(mocker):
+    """Suggestions should be added and validated."""
+    do_csv_test(
+        mocker=mocker,
+        model_name=MODEL_NAME,
+        csv_rows=[
+            {
+                "fakespot_grade": "A",
+                "product_id": "test-ABCDEF",
+                "rating": "3.6",
+                "title": "Brand new widget",
+                "total_reviews": "10",
+                "url": "https://example.com/new-widget",
+                "score": "8.5",
+            },
+            {
+                "fakespot_grade": "B",
+                "product_id": "  test-XYZ  ",
+                "rating": "3.0",
+                "title": "  Refurbished widget  \n  ",
+                "total_reviews": "15",
+                "url": "https://example.com/old-widget",
+                "score": "8.2",
+            },
+        ],
+        expected_suggestions=[
+            {
+                "fakespot_grade": "A",
+                "product_id": "test-ABCDEF",
+                "rating": 3.6,
+                "title": "Brand new widget",
+                "total_reviews": 10,
+                "url": "https://example.com/new-widget",
+                "score": 8.5,
+            },
+            {
+                "fakespot_grade": "B",
+                "product_id": "test-XYZ",
+                "rating": 3.0,
+                "title": "Refurbished widget",
+                "total_reviews": 15,
+                "url": "https://example.com/old-widget",
+                "score": 8.2,
+            },
+        ],
+    )
+
+
+@pytest.fixture
+def verify_field_validation_error(mocker):
+    """Verify that a value for a field will raise a ValidationError"""
+
+    def verify(field_name, field_value):
+        do_error_test(
+            mocker,
+            model_name=MODEL_NAME,
+            csv_rows=[
+                {**TEST_CSV_ROW, field_name: field_value},
+            ],
+            expected_error=ValidationError,
+        )
+
+    return verify
+
+
+@pytest.fixture
+def verify_field_required(mocker):
+    """Verify that a missing field value will raise a MissingFieldError"""
+
+    def verify(field_name):
+        row = {
+            name: value for (name, value) in TEST_CSV_ROW.items() if name != field_name
+        }
+        do_error_test(
+            mocker,
+            model_name=MODEL_NAME,
+            csv_rows=[row],
+            expected_error=MissingFieldError,
+        )
+
+    return verify
+
+
+def test_fakespot_grade(verify_field_validation_error, verify_field_required):
+    """Test validation for the fakespot_grade field"""
+    verify_field_required("fakespot_grade")
+    verify_field_validation_error("fakespot_grade", "")
+
+
+def test_product_id(verify_field_validation_error, verify_field_required):
+    """Test validation for the product_id field"""
+    verify_field_required("product_id")
+    verify_field_validation_error("product_id", "")
+
+
+def test_rating(verify_field_validation_error, verify_field_required):
+    """Test validation for the rating field"""
+    verify_field_required("rating")
+    verify_field_validation_error("rating", "")
+    verify_field_validation_error("rating", "four and a half")
+
+
+def test_title(verify_field_validation_error, verify_field_required):
+    """Test validation for the title field"""
+    verify_field_required("title")
+    verify_field_validation_error("title", "")
+
+
+def test_total_reviews(verify_field_validation_error, verify_field_required):
+    """Test validation for the total_reviews field"""
+    verify_field_required("total_reviews")
+    verify_field_validation_error("total_reviews", "")
+    verify_field_validation_error("total_reviews", "one-hundred")
+
+
+def test_url(verify_field_validation_error, verify_field_required):
+    """Test validation for the url field"""
+    verify_field_required("url")
+    verify_field_validation_error("url", "")
+    verify_field_validation_error("url", "not a valid URL")
+
+
+def test_score(verify_field_validation_error, verify_field_required):
+    """Test validation for the score field"""
+    verify_field_required("score")
+    verify_field_validation_error("score", "")
+    verify_field_validation_error("score", "five and a third")


### PR DESCRIPTION
Putting this one up for early review.  I haven't gotten this to successfully run because of issues with the schema for the fakespot collection.  I filed a bugzilla ticket for that, hopefully we can get it sorted out soon.

## References

JIRA: [DISCO-2834](https://mozilla-hub.atlassian.net/browse/DISCO-2834)

## Description

Added fakespot model to `csv_rs_uploader.

Reworked `csv_rs_uploader` so that models can specify their own default collection.  The fakespot data is going to live in a different collection and I didn't want to rely on users always typing that into the CLI.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2834]: https://mozilla-hub.atlassian.net/browse/DISCO-2834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ