### PR TITLE
[DISCO-2860] fix(geolocation): use the most specific subdivision for …

### DIFF
--- a/merino/middleware/geolocation.py
+++ b/merino/middleware/geolocation.py
@@ -68,12 +68,8 @@ class GeolocationMiddleware:
             Location(
                 country=record.country.iso_code,
                 country_name=record.country.names.get("en"),
-                region=record.subdivisions[0].iso_code if record.subdivisions else None,
-                region_name=(
-                    record.subdivisions[0].names.get("en")
-                    if record.subdivisions
-                    else None
-                ),
+                region=record.subdivisions.most_specific.iso_code,
+                region_name=record.subdivisions.most_specific.names.get("en"),
                 city=record.city.names.get("en"),
                 dma=record.location.metro_code,
                 postal_code=record.postal.code if record.postal else None,

--- a/tests/unit/middleware/test_geolocation.py
+++ b/tests/unit/middleware/test_geolocation.py
@@ -40,8 +40,8 @@ def fixture_geolocation_middleware(mocker: MockerFixture) -> GeolocationMiddlewa
             Location(
                 country="GB",
                 country_name="United Kingdom",
-                region="ENG",
-                region_name="England",
+                region="WBK",
+                region_name="West Berkshire",
                 city="Boxford",
                 postal_code="OX1",
             ),


### PR DESCRIPTION
…geolocation

## References

JIRA: [DISCO-2860](https://mozilla-hub.atlassian.net/browse/DISCO-2860)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->

The `most_specific` subdivision works better for UK regions.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2860]: https://mozilla-hub.atlassian.net/browse/DISCO-2860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ