### PR TITLE
[MC-1100] feat: add curated-recommendations endpoint

### DIFF
--- a/merino/curated_recommendations/__init__.py
+++ b/merino/curated_recommendations/__init__.py
@@ -1,0 +1,5 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Module dedicated to providing curated recommendations to New Tab."""

--- a/merino/curated_recommendations/corpus_backends/__init__.py
+++ b/merino/curated_recommendations/corpus_backends/__init__.py
@@ -1,0 +1,5 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Module dedicated to backends for our corpus of curated items"""

--- a/merino/curated_recommendations/corpus_backends/fake_backends.py
+++ b/merino/curated_recommendations/corpus_backends/fake_backends.py
@@ -1,0 +1,34 @@
+"""Test backends"""
+
+from pydantic import HttpUrl
+
+from merino.curated_recommendations.corpus_backends.protocol import (
+    CorpusBackend,
+    CorpusItem,
+    Topic,
+)
+
+
+class FakeCuratedCorpusBackend(CorpusBackend):
+    """A fake backend that returns static content."""
+
+    async def fetch(self) -> list[CorpusItem]:
+        """Echoing the query as the single suggestion."""
+        return [
+            CorpusItem(
+                scheduledCorpusItemId="50f86ebe-3f25-41d8-bd84-53ead7bdc76e",
+                url=HttpUrl(
+                    "https://www.themarginalian.org/2024/05/28/passenger-pigeon/"
+                ),
+                title="Thunder, Bells, and Silence: the Eclipse That Went Extinct",
+                excerpt="What was it like for Martha, the endling of her species, to die alone at "
+                "the Cincinnati Zoo that late-summer day in 1914, all the other "
+                "passenger pigeons gone from the face of the Earth, having onc…",
+                topic=Topic.EDUCATION,
+                publisher="The Marginalian",
+                imageUrl=HttpUrl(
+                    "https://www.themarginalian.org/wp-content/uploads/2024/05"
+                    "/PassengerPigeon_Audubon_TheMarginalian.jpg?fit=1200%2C630&ssl=1"
+                ),
+            )
+        ]

--- a/merino/curated_recommendations/corpus_backends/protocol.py
+++ b/merino/curated_recommendations/corpus_backends/protocol.py
@@ -1,0 +1,46 @@
+"""Protocol for the Corpus provider backend."""
+
+from enum import Enum, unique
+from typing import Protocol
+
+from pydantic import BaseModel, HttpUrl
+
+
+@unique
+class Topic(str, Enum):
+    """Topics supported for curated recommendations."""
+
+    ARTS = ("arts",)
+    BUSINESS = ("business",)
+    EDUCATION = ("education",)
+    FINANCE = ("finance",)
+    FOOD = ("food",)
+    GOVERNMENT = ("government",)
+    HEALTH = ("health",)
+    SOCIETY = ("society",)
+    SPORTS = ("sports",)
+    TECH = ("tech",)
+    TRAVEL = ("travel",)
+
+
+class CorpusItem(BaseModel):
+    """Represents a scheduled item from our 'corpus'.
+
+    The corpus is the set of all curated items deemed recommendable.
+    """
+
+    scheduledCorpusItemId: str
+    url: HttpUrl
+    title: str
+    excerpt: str
+    topic: Topic
+    publisher: str
+    imageUrl: HttpUrl
+
+
+class CorpusBackend(Protocol):
+    """Protocol for Curated Recommendation backend that the provider depends on."""
+
+    async def fetch(self) -> list[CorpusItem]:  # pragma: no cover
+        """Fetch Curated Recommendations"""
+        ...

--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -1,0 +1,101 @@
+"""Provider for curated recommendations on New Tab."""
+
+import logging
+import time
+from enum import Enum, unique
+
+from pydantic import BaseModel
+
+from merino.curated_recommendations.corpus_backends.protocol import (
+    CorpusBackend,
+    CorpusItem,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@unique
+class TypeName(str, Enum):
+    """This value could be used in the future to distinguish between different types of content.
+
+    Currently, the only value is recommendation.
+    """
+
+    RECOMMENDATION = "recommendation"
+
+
+@unique
+class Locale(str, Enum):
+    """Supported locales for curated recommendations on New Tab"""
+
+    FR = ("fr",)
+    FR_FR = ("fr-FR",)
+    ES = ("es",)
+    ES_ES = ("es-ES",)
+    IT = ("it",)
+    IT_IT = ("it-IT",)
+    EN = ("en",)
+    EN_CA = ("en-CA",)
+    EN_GB = ("en-GB",)
+    EN_US = ("en-US",)
+    DE = ("de",)
+    DE_DE = ("de-DE",)
+    DE_AT = ("de-AT",)
+    DE_CH = ("de-CH",)
+
+
+class CuratedRecommendation(CorpusItem):
+    """Extends CorpusItem with additional fields for a curated recommendation"""
+
+    __typename: TypeName = TypeName.RECOMMENDATION
+    receivedRank: int
+
+
+class CuratedRecommendationsRequest(BaseModel):
+    """Body schema for requesting a list of curated recommendations"""
+
+    locale: Locale
+    region: str | None = None
+    count: int = 100
+
+
+class CuratedRecommendationsResponse(BaseModel):
+    """Response schema for a list of curated recommendations"""
+
+    recommendedAt: int
+    data: list[CuratedRecommendation]
+
+
+class CuratedRecommendationsProvider:
+    """Provider for recommendations that have been reviewed by human curators."""
+
+    corpus_backend: CorpusBackend
+
+    def __init__(
+        self,
+        corpus_backend: CorpusBackend,
+    ) -> None:
+        self.corpus_backend = corpus_backend
+
+    async def fetch(self) -> CuratedRecommendationsResponse:
+        """Provide curated recommendations."""
+        corpus_items = await self.corpus_backend.fetch()
+
+        # Convert the CorpusItem list to a CuratedRecommendation list.
+        recommendations = [
+            CuratedRecommendation(
+                **item.model_dump(),
+                receivedRank=rank,
+            )
+            for rank, item in enumerate(corpus_items)
+        ]
+
+        return CuratedRecommendationsResponse(
+            recommendedAt=self.time_ms(),
+            data=recommendations,
+        )
+
+    @staticmethod
+    def time_ms() -> int:
+        """Return the time in milliseconds since the epoch as an integer."""
+        return int(time.time() * 1000)

--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -1,6 +1,5 @@
 """Provider for curated recommendations on New Tab."""
 
-import logging
 import time
 from enum import Enum, unique
 
@@ -10,8 +9,6 @@ from merino.curated_recommendations.corpus_backends.protocol import (
     CorpusBackend,
     CorpusItem,
 )
-
-logger = logging.getLogger(__name__)
 
 
 @unique

--- a/tests/integration/api/v1/curated_recommendations/__init__.py
+++ b/tests/integration/api/v1/curated_recommendations/__init__.py
@@ -1,0 +1,5 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Module dedicated to testing the curated recommendations API."""

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -1,0 +1,46 @@
+"""Tests the curated recommendation endpoint /api/v1/curated-recommendations"""
+
+import freezegun
+from fastapi.testclient import TestClient
+from pydantic import HttpUrl
+
+from merino.curated_recommendations.corpus_backends.protocol import Topic
+from merino.curated_recommendations.provider import CuratedRecommendation
+
+
+@freezegun.freeze_time("2012-01-14 03:21:34", tz_offset=0)
+def test_curated_recommendations_locale(client: TestClient) -> None:
+    """Test if curated-recommendations endpoint returns result."""
+    expected_recommendation = CuratedRecommendation(
+        scheduledCorpusItemId="50f86ebe-3f25-41d8-bd84-53ead7bdc76e",
+        url=HttpUrl("https://www.themarginalian.org/2024/05/28/passenger-pigeon/"),
+        title="Thunder, Bells, and Silence: the Eclipse That Went Extinct",
+        excerpt="What was it like for Martha, the endling of her species, to die alone at "
+        "the Cincinnati Zoo that late-summer day in 1914, all the other "
+        "passenger pigeons gone from the face of the Earth, having onc…",
+        topic=Topic.EDUCATION,
+        publisher="The Marginalian",
+        imageUrl=HttpUrl(
+            "https://www.themarginalian.org/wp-content/uploads/2024/05"
+            "/PassengerPigeon_Audubon_TheMarginalian.jpg?fit=1200%2C630&ssl=1"
+        ),
+        receivedRank=0,
+    )
+
+    response = client.post("/api/v1/curated-recommendations", json={"locale": "en-US"})
+    assert response.status_code == 200
+
+    result = response.json()
+    assert result["recommendedAt"] == 1326511294000  # 2012-01-14 03:21:34 UTC
+
+    actual_recommendation: CuratedRecommendation = CuratedRecommendation(
+        **result["data"][0]
+    )
+
+    assert actual_recommendation == expected_recommendation
+
+
+def test_curated_recommendations_missing_locale(client: TestClient) -> None:
+    """Test if curated-recommendations endpoint returns an error if locale is missing."""
+    response = client.post("/api/v1/curated-recommendations", json={})
+    assert response.status_code == 400


### PR DESCRIPTION
## References

JIRA: [MC-1100](https://mozilla-hub.atlassian.net/browse/MC-1100)

## Description
This is the first step in moving the endpoint for New Tab curated recommendations to Merino. As outlined in the [Merino migration tech spec](https://mozilla-hub.atlassian.net/wiki/spaces/MozSocial/pages/726466605/New+Tab+Merino+migration), our objectives are to consolidate, improve scalability, and support topic preferences.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[MC-1100]: https://mozilla-hub.atlassian.net/browse/MC-1100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ