### PR TITLE
[DISCO-2850] Fix option to delete records for jobs

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -147,8 +147,8 @@ auth = ""
 chunk_size = 200
 
 # MERINO_REMOTE_SETTINGS__DELETE_EXISTING_RECORDS
-# Delete existing records before uploading new records.
-delete_existing_records = true
+# keep existing records before uploading new records.
+keep_existing_records = false
 
 # MERINO_REMOTE_SETTINGS__DRY_RUN
 # Log changes but don't actually make them when uploading suggestions.

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -146,10 +146,6 @@ auth = ""
 # The maximum number of suggestions to store in each attachment when uploading suggestions.
 chunk_size = 200
 
-# MERINO_REMOTE_SETTINGS__DELETE_EXISTING_RECORDS
-# keep existing records before uploading new records.
-keep_existing_records = false
-
 # MERINO_REMOTE_SETTINGS__DRY_RUN
 # Log changes but don't actually make them when uploading suggestions.
 dry_run = false

--- a/merino/jobs/amo_rs_uploader/__init__.py
+++ b/merino/jobs/amo_rs_uploader/__init__.py
@@ -42,10 +42,10 @@ collection_option = typer.Option(
     help="Remote settings collection ID",
 )
 
-delete_existing_records_option = typer.Option(
-    rs_settings.delete_existing_records,
-    "--delete-existing-records",
-    help="Delete existing records before uploading new records",
+keep_existing_records_option = typer.Option(
+    rs_settings.keep_existing_records,
+    "--keep-existing-records",
+    help="Keep existing records before uploading new records",
 )
 
 dry_run_option = typer.Option(
@@ -84,7 +84,7 @@ def upload(
     bucket: str = bucket_option,
     chunk_size: int = chunk_size_option,
     collection: str = collection_option,
-    delete_existing_records: bool = delete_existing_records_option,
+    keep_existing_records: bool = keep_existing_records_option,
     dry_run: bool = dry_run_option,
     record_type: str = record_type_option,
     score: float = score_option,
@@ -97,7 +97,7 @@ def upload(
             bucket=bucket,
             chunk_size=chunk_size,
             collection=collection,
-            delete_existing_records=delete_existing_records,
+            keep_existing_records=keep_existing_records,
             dry_run=dry_run,
             record_type=record_type,
             score=score,
@@ -111,7 +111,7 @@ async def _upload(
     bucket: str,
     chunk_size: int,
     collection: str,
-    delete_existing_records: bool,
+    keep_existing_records: bool,
     dry_run: bool,
     record_type: str,
     score: float,
@@ -132,7 +132,7 @@ async def _upload(
         suggestion_score_fallback=score,
         total_data_count=len(backend.dynamic_data),
     ) as uploader:
-        if delete_existing_records:
+        if not keep_existing_records:
             uploader.delete_records()
 
         for addon, dynamic_data in backend.dynamic_data.items():

--- a/merino/jobs/amo_rs_uploader/__init__.py
+++ b/merino/jobs/amo_rs_uploader/__init__.py
@@ -43,7 +43,7 @@ collection_option = typer.Option(
 )
 
 keep_existing_records_option = typer.Option(
-    rs_settings.keep_existing_records,
+    False,
     "--keep-existing-records",
     help="Keep existing records before uploading new records",
 )

--- a/merino/jobs/csv_rs_uploader/__init__.py
+++ b/merino/jobs/csv_rs_uploader/__init__.py
@@ -40,10 +40,10 @@ collection_option = typer.Option(
     help="Remote settings collection ID",
 )
 
-delete_existing_records_option = typer.Option(
-    rs_settings.delete_existing_records,
-    "--delete-existing-records",
-    help="Delete existing records before uploading new records",
+keep_existing_records_option = typer.Option(
+    rs_settings.keep_existing_records,
+    "--keep-existing-records",
+    help="Keep existing records before uploading new records",
 )
 
 dry_run_option = typer.Option(
@@ -107,7 +107,7 @@ def upload(
     chunk_size: int = chunk_size_option,
     collection: str = collection_option,
     csv_path: str = csv_path_option,
-    delete_existing_records: bool = delete_existing_records_option,
+    keep_existing_records: bool = keep_existing_records_option,
     dry_run: bool = dry_run_option,
     model_name: str = model_name_option,
     model_package: str = model_package_option,
@@ -128,7 +128,7 @@ def upload(
             chunk_size=chunk_size,
             collection=collection,
             csv_path=csv_path,
-            delete_existing_records=delete_existing_records,
+            keep_existing_records=keep_existing_records,
             dry_run=dry_run,
             model_name=model_name,
             model_package=model_package,
@@ -145,7 +145,7 @@ async def _upload(
     chunk_size: int,
     collection: str,
     csv_path: str,
-    delete_existing_records: bool,
+    keep_existing_records: bool,
     dry_run: bool,
     model_name: str,
     model_package: str,
@@ -159,7 +159,7 @@ async def _upload(
             bucket=bucket,
             chunk_size=chunk_size,
             collection=collection,
-            delete_existing_records=delete_existing_records,
+            keep_existing_records=keep_existing_records,
             dry_run=dry_run,
             file_object=csv_file,
             model_name=model_name,
@@ -176,7 +176,7 @@ async def _upload_file_object(
     chunk_size: int,
     collection: str,
     file_object: io.TextIOWrapper,
-    delete_existing_records: bool,
+    keep_existing_records: bool,
     dry_run: bool,
     model_name: str,
     model_package: str,
@@ -225,7 +225,7 @@ async def _upload_file_object(
         suggestion_score_fallback=score,
         total_data_count=len(suggestions),
     ) as uploader:
-        if delete_existing_records:
+        if not keep_existing_records:
             uploader.delete_records()
 
         for suggestion in suggestions:

--- a/merino/jobs/csv_rs_uploader/__init__.py
+++ b/merino/jobs/csv_rs_uploader/__init__.py
@@ -41,7 +41,7 @@ collection_option = typer.Option(
 )
 
 keep_existing_records_option = typer.Option(
-    rs_settings.keep_existing_records,
+    False,
     "--keep-existing-records",
     help="Keep existing records before uploading new records",
 )

--- a/merino/jobs/relevancy_uploader/__init__.py
+++ b/merino/jobs/relevancy_uploader/__init__.py
@@ -136,7 +136,7 @@ collection_option = typer.Option(
 )
 
 keep_existing_records_option = typer.Option(
-    rs_settings.keep_existing_records,
+    False,
     "--keep-existing-records",
     help="Keep existing records before uploading new records",
 )

--- a/merino/jobs/relevancy_uploader/__init__.py
+++ b/merino/jobs/relevancy_uploader/__init__.py
@@ -135,10 +135,10 @@ collection_option = typer.Option(
     help="Remote settings collection ID",
 )
 
-delete_existing_records_option = typer.Option(
-    rs_settings.delete_existing_records,
-    "--delete-existing-records",
-    help="Delete existing records before uploading new records",
+keep_existing_records_option = typer.Option(
+    rs_settings.keep_existing_records,
+    "--keep-existing-records",
+    help="Keep existing records before uploading new records",
 )
 
 dry_run_option = typer.Option(
@@ -185,7 +185,7 @@ def upload(
     chunk_size: int = chunk_size_option,
     collection: str = collection_option,
     csv_path: str = csv_path_option,
-    delete_existing_records: bool = delete_existing_records_option,
+    keep_existing_records: bool = keep_existing_records_option,
     dry_run: bool = dry_run_option,
     server: str = server_option,
     version: int = version_option,
@@ -201,7 +201,7 @@ def upload(
             chunk_size=chunk_size,
             collection=collection,
             csv_path=csv_path,
-            delete_existing_records=delete_existing_records,
+            keep_existing_records=keep_existing_records,
             dry_run=dry_run,
             server=server,
             version=version,
@@ -215,7 +215,7 @@ async def _upload(
     chunk_size: int,
     collection: str,
     csv_path: str,
-    delete_existing_records: bool,
+    keep_existing_records: bool,
     dry_run: bool,
     server: str,
     version: int,
@@ -226,7 +226,7 @@ async def _upload(
             bucket=bucket,
             chunk_size=chunk_size,
             collection=collection,
-            delete_existing_records=delete_existing_records,
+            keep_existing_records=keep_existing_records,
             dry_run=dry_run,
             file_object=csv_file,
             server=server,
@@ -240,7 +240,7 @@ async def _upload_file_object(
     chunk_size: int,
     collection: str,
     file_object: io.TextIOWrapper,
-    delete_existing_records: bool,
+    keep_existing_records: bool,
     dry_run: bool,
     server: str,
     version: int,
@@ -265,7 +265,7 @@ async def _upload_file_object(
             category_code=category.value,
             version=version,
         ) as uploader:
-            if delete_existing_records:
+            if not keep_existing_records:
                 uploader.delete_records()
 
             for domain in domains:

--- a/tests/unit/jobs/amo_rs_uploader/test_amo_rs_uploader.py
+++ b/tests/unit/jobs/amo_rs_uploader/test_amo_rs_uploader.py
@@ -81,7 +81,7 @@ def expected_add_suggestion_calls(
 
 def do_upload_test(
     mocker,
-    delete_existing_records: bool = False,
+    keep_existing_records: bool = True,
     score: float = 0.99,
 ) -> None:
     """Perform an upload test."""
@@ -113,7 +113,7 @@ def do_upload_test(
     }
     upload(
         **common_kwargs,
-        delete_existing_records=delete_existing_records,
+        keep_existing_records=keep_existing_records,
         score=score,
     )
 
@@ -127,7 +127,7 @@ def do_upload_test(
         total_data_count=TEST_ADDON_COUNT,
     )
 
-    if delete_existing_records:
+    if not keep_existing_records:
         mock_chunked_uploader.delete_records.assert_called_once()
     else:
         mock_chunked_uploader.delete_records.assert_not_called()
@@ -138,13 +138,13 @@ def do_upload_test(
 
 
 def test_upload_without_deleting(mocker):
-    """Tests `upload(delete_existing_records=False)`"""
-    do_upload_test(mocker, delete_existing_records=False)
+    """Tests `upload(keep_existing_records=True)`"""
+    do_upload_test(mocker, keep_existing_records=True)
 
 
 def test_delete_and_upload(mocker):
-    """Tests `upload(delete_existing_records=True)`"""
-    do_upload_test(mocker, delete_existing_records=True)
+    """Tests `upload(keep_existing_records=True)`"""
+    do_upload_test(mocker, keep_existing_records=False)
 
 
 def test_upload_with_score(mocker):

--- a/tests/unit/jobs/csv_rs_uploader/test_csv_rs_uploader.py
+++ b/tests/unit/jobs/csv_rs_uploader/test_csv_rs_uploader.py
@@ -75,26 +75,26 @@ def expected_primary_suggestions() -> list[dict[str, Any]]:
 
 
 def test_upload_without_deleting(mocker):
-    """upload(delete_existing_records=False) with the primary CSV test data"""
+    """upload(keep_existing_records=True) with the primary CSV test data"""
     do_csv_test(
         mocker=mocker,
         csv_path=PRIMARY_CSV_PATH,
         model_name=MODEL_NAME,
         model_package=MODEL_PACKAGE,
         expected_suggestions=expected_primary_suggestions(),
-        delete_existing_records=False,
+        keep_existing_records=True,
     )
 
 
 def test_delete_and_upload(mocker):
-    """upload(delete_existing_records=True) with the primary CSV test data"""
+    """upload(keep_existing_records=True) with the primary CSV test data"""
     do_csv_test(
         mocker=mocker,
         csv_path=PRIMARY_CSV_PATH,
         model_name=MODEL_NAME,
         model_package=MODEL_PACKAGE,
         expected_suggestions=expected_primary_suggestions(),
-        delete_existing_records=True,
+        keep_existing_records=False,
     )
 
 

--- a/tests/unit/jobs/csv_rs_uploader/utils.py
+++ b/tests/unit/jobs/csv_rs_uploader/utils.py
@@ -26,7 +26,7 @@ def _do_csv_test(
     model_name: str,
     model_package: str,
     upload_callable: Callable[[dict[str, Any]], None],
-    delete_existing_records: bool,
+    keep_existing_records: bool,
     record_type: str,
     score: float,
     expected_suggestions: list[dict[str, Any]],
@@ -54,7 +54,7 @@ def _do_csv_test(
     upload_callable(
         {
             **common_kwargs,
-            "delete_existing_records": delete_existing_records,
+            "keep_existing_records": keep_existing_records,
             "score": score,
             "model_name": model_name,
             "model_package": model_package,
@@ -70,7 +70,7 @@ def _do_csv_test(
         total_data_count=len(expected_suggestions),
     )
 
-    if delete_existing_records:
+    if not keep_existing_records:
         mock_chunked_uploader.delete_records.assert_called_once()
     else:
         mock_chunked_uploader.delete_records.assert_not_called()
@@ -86,7 +86,7 @@ def do_csv_test(
     expected_suggestions: list[dict[str, Any]],
     csv_path: str | None = None,
     csv_rows: list[dict[str, str]] | None = None,
-    delete_existing_records: bool = False,
+    keep_existing_records: bool = True,
     record_type: str = "record_type",
     expected_record_type: str = "record_type",
     score: float = 0.99,
@@ -108,7 +108,7 @@ def do_csv_test(
         model_name=model_name,
         model_package=model_package,
         upload_callable=uploader,
-        delete_existing_records=delete_existing_records,
+        keep_existing_records=keep_existing_records,
         record_type=record_type,
         score=score,
         expected_suggestions=expected_suggestions,
@@ -135,7 +135,7 @@ def do_error_test(
                 bucket="bucket",
                 chunk_size=99,
                 collection="collection",
-                delete_existing_records=False,
+                keep_existing_records=True,
                 dry_run=False,
                 file_object=file_object,
                 model_name=model_name,

--- a/tests/unit/jobs/relevancy_uploader/test_relevancy_csv_uploader.py
+++ b/tests/unit/jobs/relevancy_uploader/test_relevancy_csv_uploader.py
@@ -51,26 +51,26 @@ def expected_inconclusive_category_data() -> list[dict[str, Any]]:
 
 
 def test_upload_without_deleting(mocker):
-    """upload(delete_existing_records=False) with the primary CSV test data"""
+    """upload(keep_existing_records=True) with the primary CSV test data"""
     do_csv_test(
         mocker=mocker,
         csv_path=PRIMARY_CSV_PATH,
         primary_category_data=expected_primary_category_data(),
         secondary_category_data=expected_secondary_category_data(),
         inconclusive_category_data=expected_inconclusive_category_data(),
-        delete_existing_records=False,
+        keep_existing_records=True,
     )
 
 
 def test_delete_and_upload(mocker):
-    """upload(delete_existing_records=True) with the primary CSV test data"""
+    """upload(keep_existing_records=False) with the primary CSV test data"""
     do_csv_test(
         mocker=mocker,
         csv_path=PRIMARY_CSV_PATH,
         primary_category_data=expected_primary_category_data(),
         secondary_category_data=expected_secondary_category_data(),
         inconclusive_category_data=expected_inconclusive_category_data(),
-        delete_existing_records=True,
+        keep_existing_records=False,
     )
 
 

--- a/tests/unit/jobs/relevancy_uploader/utils.py
+++ b/tests/unit/jobs/relevancy_uploader/utils.py
@@ -24,7 +24,7 @@ def _make_csv_file_object(csv_rows: list[dict[str, str]]) -> io.TextIOWrapper:
 def _do_csv_test(
     mocker,
     upload_callable: Callable[[dict[str, Any]], None],
-    delete_existing_records: bool,
+    keep_existing_records: bool,
     primary_category_data: list[dict[str, Any]],
     secondary_category_data: list[dict[str, Any]] = [],
     inconclusive_category_data: list[dict[str, Any]] = [],
@@ -52,7 +52,7 @@ def _do_csv_test(
     upload_callable(
         {
             **common_kwargs,
-            "delete_existing_records": delete_existing_records,
+            "keep_existing_records": keep_existing_records,
         }
     )
     mock_chunked_uploader_ctor.assert_any_call(
@@ -79,7 +79,7 @@ def _do_csv_test(
         category_code=0
     )
 
-    if delete_existing_records and version == 1:
+    if not keep_existing_records and version == 1:
         mock_chunked_uploader.delete_records.assert_called()
     else:
         mock_chunked_uploader.delete_records.assert_not_called()
@@ -96,7 +96,7 @@ def do_csv_test(
     inconclusive_category_data: list[dict[str, Any]],
     csv_path: str | None = None,
     csv_rows: list[dict[str, str]] | None = None,
-    delete_existing_records: bool = False,
+    keep_existing_records: bool = False,
     version: int = 1,
 ) -> None:
     """Perform an upload test that is expected to succeed."""
@@ -113,7 +113,7 @@ def do_csv_test(
     _do_csv_test(
         mocker=mocker,
         upload_callable=uploader,
-        delete_existing_records=delete_existing_records,
+        keep_existing_records=keep_existing_records,
         primary_category_data=primary_category_data,
         secondary_category_data=secondary_category_data,
         inconclusive_category_data=inconclusive_category_data,
@@ -138,7 +138,7 @@ def do_error_test(
                 bucket="bucket",
                 chunk_size=99,
                 collection="collection",
-                delete_existing_records=False,
+                keep_existing_records=True,
                 dry_run=False,
                 file_object=file_object,
                 server="server",


### PR DESCRIPTION
## References

JIRA: [DISCO-2850](https://mozilla-hub.atlassian.net/browse/DISCO-2850)
fixes #531 
## Description
It was confusing when we had  `--delete-existing-records`, since when you add flag to the command line it will toggle the value and turn it to False, which isn't what we want...
Renamed it to `keep-existing-records` with a default to false instead



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2850]: https://mozilla-hub.atlassian.net/browse/DISCO-2850?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ