### PR TITLE
[DISCO-2833] Fakespot blocklists

### DIFF
--- a/merino/jobs/csv_rs_uploader/base.py
+++ b/merino/jobs/csv_rs_uploader/base.py
@@ -3,7 +3,7 @@ serialized in the output JSON, plus related helpers.
 """
 
 import re
-from typing import cast
+from typing import cast, Self
 
 from pydantic import BaseModel
 
@@ -16,7 +16,7 @@ class BaseSuggestion(BaseModel):
     """
 
     @classmethod
-    def csv_to_suggestions(cls, csv_reader) -> list["BaseSuggestion"]:
+    def csv_to_suggestions(cls, csv_reader) -> list[Self]:
         """Convert CSV content to Suggestions. Subclasses must override this
         method.
         """

--- a/merino/jobs/csv_rs_uploader/fakespot.py
+++ b/merino/jobs/csv_rs_uploader/fakespot.py
@@ -7,6 +7,7 @@ from typing import cast
 from pydantic import HttpUrl, field_validator
 
 from merino.config import settings
+from merino.utils.blocklists import FAKESPOT_CSV_UPLOADER_BLOCKLIST
 from merino.jobs.csv_rs_uploader.row_major_base import RowMajorBaseSuggestion
 
 
@@ -22,6 +23,18 @@ class Suggestion(RowMajorBaseSuggestion):
     total_reviews: int
     url: HttpUrl
     score: float
+
+    @classmethod
+    def csv_to_suggestions(cls, csv_reader) -> list["Suggestion"]:
+        """Convert CSV content to Suggestions.
+
+        Override the base method to filter out items using the blocklist.
+        """
+        return [
+            suggestion
+            for suggestion in super().csv_to_suggestions(csv_reader)
+            if suggestion.product_id not in FAKESPOT_CSV_UPLOADER_BLOCKLIST
+        ]
 
     @classmethod
     def default_collection(cls) -> str:

--- a/merino/jobs/csv_rs_uploader/row_major_base.py
+++ b/merino/jobs/csv_rs_uploader/row_major_base.py
@@ -2,6 +2,8 @@
 the output JSON.
 """
 
+from typing import Self
+
 from merino.jobs.csv_rs_uploader import MissingFieldError
 from merino.jobs.csv_rs_uploader.base import BaseSuggestion
 
@@ -12,7 +14,7 @@ class RowMajorBaseSuggestion(BaseSuggestion):
     """
 
     @classmethod
-    def csv_to_suggestions(cls, csv_reader) -> list[BaseSuggestion]:
+    def csv_to_suggestions(cls, csv_reader) -> list[Self]:
         """Convert row-major based CSV content to Suggestions."""
         field_map = cls.row_major_field_map()
         suggestions: list = []

--- a/merino/jobs/csv_rs_uploader/yelp.py
+++ b/merino/jobs/csv_rs_uploader/yelp.py
@@ -42,7 +42,7 @@ class Suggestion(BaseSuggestion):
     icon: str
 
     @classmethod
-    def csv_to_suggestions(cls, csv_reader) -> list[BaseSuggestion]:
+    def csv_to_suggestions(cls, csv_reader) -> list["Suggestion"]:
         """Convert CSV content to Yelp Suggestions."""
         subjects = []
         pre_modifiers = []

--- a/merino/utils/blocklists.py
+++ b/merino/utils/blocklists.py
@@ -14,3 +14,5 @@ TOP_PICKS_BLOCKLIST: set[str] = {
     "draftkings",
     "internalfb",
 }
+
+FAKESPOT_CSV_UPLOADER_BLOCKLIST: set[str] = set()


### PR DESCRIPTION
Added code in the fakespot model to filter out items based on a blocklist.

Changed the signature of `csv_to_suggestions` to return `list[typing.Self]`.  I think this is more correct since the method should return instances of the subclass.  It's also needed to prevent lint errors.

It's possible we end up using a different system for the experiment, but this was easy to implement so I figured we might as well just do it.  If we need  to throw away the code later, it's fine.

## References

JIRA: [DISCO-TODO](https://mozilla-hub.atlassian.net/browse/DISCO-TODO)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
