### PR TITLE
DISCO-2846: report ttl misses to metrics

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,10 +7,6 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-added-large-files
-  - repo: "https://github.com/psf/black"
-    rev: 24.4.2
-    hooks:
-      - id: black
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.4.10
     hooks:

--- a/docs/data.md
+++ b/docs/data.md
@@ -126,10 +126,12 @@ The weather provider records additional metrics.
 
 - `merino.providers.accuweather.query.cache.fetch` - A timer to measure the duration (in ms) of
   looking up a weather report in the cache.
-- `merino.providers.accuweather.query.cache.hit` - A counter to measure the number of times a
-  cached weather report is available.
-- `merino.providers.accuweather.query.cache.miss` - A counter to measure the number of times a
-  weather report isn't in the cache.
+- `merino.providers.accuweather.query.cache.fetch.miss.locations` - A counter to measure the number of times weather location was not in the cache.
+- `merino.providers.accuweather.query.cache.fetch.miss.currentconditions` - A counter to measure the number of times a current conditions was not in the cache.
+- `merino.providers.accuweather.query.cache.fetch.miss.forecasts` - A counter to measure the number of times a forecast for a location was not in the cache.
+- `merino.providers.accuweather.query.cache.fetch.miss.ttl` - A counter to measure the number of times a weather report was available but expired or had an invalid TTL.
+- `merino.providers.accuweather.query.cache.fetch.hit.{locations | currentconditions | forecasts}` - A counter to measure the number of times a
+  requested value like a location or forecast is in the cache. We don't count TTL hits explicitly, just misses.
 - `merino.providers.accuweather.query.backend.get` - A timer to measure the duration (in ms) of a
   request for a weather report from the backend. This metric isn't recorded for cache hits.
 - `merino.providers.accuweather.query.cache.store` - A timer to measure the duration (in ms) of

--- a/docs/data.md
+++ b/docs/data.md
@@ -130,6 +130,7 @@ The weather provider records additional metrics.
   cached weather report is available.
 - `merino.providers.accuweather.query.cache.miss` - A counter to measure the number of times a
   weather report isn't in the cache.
+- `merino.providers.accuweather.query.cache.ttl`
 - `merino.providers.accuweather.query.backend.get` - A timer to measure the duration (in ms) of a
   request for a weather report from the backend. This metric isn't recorded for cache hits.
 - `merino.providers.accuweather.query.cache.store` - A timer to measure the duration (in ms) of

--- a/docs/data.md
+++ b/docs/data.md
@@ -130,7 +130,6 @@ The weather provider records additional metrics.
   cached weather report is available.
 - `merino.providers.accuweather.query.cache.miss` - A counter to measure the number of times a
   weather report isn't in the cache.
-- `merino.providers.accuweather.query.cache.ttl`
 - `merino.providers.accuweather.query.backend.get` - A timer to measure the duration (in ms) of a
   request for a weather report from the backend. This metric isn't recorded for cache hits.
 - `merino.providers.accuweather.query.cache.store` - A timer to measure the duration (in ms) of

--- a/merino/providers/weather/backends/accuweather.py
+++ b/merino/providers/weather/backends/accuweather.py
@@ -353,7 +353,6 @@ class AccuweatherBackend:
                     current_cached is not None,
                     forecast_cached is not None,
                     ttl_cached is not False,
-
                 )
             case _:  # pragma: no cover
                 pass
@@ -374,9 +373,7 @@ class AccuweatherBackend:
             else "accuweather.cache.fetch.miss.forecasts"
         )
         self.metrics_client.increment(
-            "accuweather.cache.hit.ttl"
-            if ttl
-            else "accuweather.cache.fetch.miss.ttl"
+            "accuweather.cache.hit.ttl" if ttl else "accuweather.cache.fetch.miss.ttl"
         )
 
     def parse_cached_data(self, cached_data: list[bytes | None]) -> WeatherData:

--- a/merino/providers/weather/backends/accuweather.py
+++ b/merino/providers/weather/backends/accuweather.py
@@ -352,7 +352,7 @@ class AccuweatherBackend:
                     location_cached is not None,
                     current_cached is not None,
                     forecast_cached is not None,
-                    ttl_cached is not False,
+                    ttl_cached is not None,
                 )
             case _:  # pragma: no cover
                 pass

--- a/merino/providers/weather/backends/accuweather.py
+++ b/merino/providers/weather/backends/accuweather.py
@@ -362,6 +362,8 @@ class AccuweatherBackend:
                 if location
                 else "accuweather.cache.fetch.miss.locations"
             )
+        if not ttl:
+            self.metrics_client.increment("accuweather.cache.fetch.miss.ttl")
         self.metrics_client.increment(
             "accuweather.cache.hit.currentconditions"
             if current
@@ -371,9 +373,6 @@ class AccuweatherBackend:
             "accuweather.cache.hit.forecasts"
             if forecast
             else "accuweather.cache.fetch.miss.forecasts"
-        )
-        self.metrics_client.increment(
-            "accuweather.cache.hit.ttl" if ttl else "accuweather.cache.fetch.miss.ttl"
         )
 
     def parse_cached_data(self, cached_data: list[bytes | None]) -> WeatherData:

--- a/merino/providers/weather/backends/accuweather.py
+++ b/merino/providers/weather/backends/accuweather.py
@@ -44,11 +44,11 @@ PARTNER_CODE: str | None = settings.accuweather.get("partner_code")
 #   - The placeholder for location key (i.e. `self.url_location_key_placeholder`)
 #     is passed via `ARGV[3]`
 #   - If the location key is present in the cache, it uses the key to fetch the current
-#     conditions and forecast for that key in the cache. It returns a 3-element array
-#     `[location_key, current_condition, forecast]`. The last two element can be `nil`
+#     conditions and forecast for that key in the cache. It returns a 4-element array
+#     `[location_key, current_condition, forecast, ttl]`. The `current_condition` and `forecast` are `nil`
 #     if they are not present in the cache
 #   - If the location key is missing, it will return an empty array
-#   - If the forecast and current_conditions TTLs are a non-positive value (-1 or -2),
+#   - If the current_conditions and forecast TTLs are a non-positive value (-1 or -2),
 #     it will return ttl as false, which is translated to None type in app code.
 LUA_SCRIPT_CACHE_BULK_FETCH: str = """
     local location_key = redis.call("GET", KEYS[1])
@@ -341,17 +341,19 @@ class AccuweatherBackend:
               current_condition, forecast
             -  `skip_location_key` A boolean to determine whether location was looked up.
         """
-        location, current, forecast = False, False, False
+        location, current, forecast, ttl = False, False, False, False
         match cached_data:
             case []:
                 pass
             # the last variable is ttl but is omitted here since we don't need to use but need
             # it to satisfy this match case
-            case [location_cached, current_cached, forecast_cached, _]:
-                location, current, forecast = (
+            case [location_cached, current_cached, forecast_cached, ttl_cached]:
+                location, current, forecast, ttl = (
                     location_cached is not None,
                     current_cached is not None,
                     forecast_cached is not None,
+                    ttl_cached is not False,
+
                 )
             case _:  # pragma: no cover
                 pass
@@ -370,6 +372,11 @@ class AccuweatherBackend:
             "accuweather.cache.hit.forecasts"
             if forecast
             else "accuweather.cache.fetch.miss.forecasts"
+        )
+        self.metrics_client.increment(
+            "accuweather.cache.hit.ttl"
+            if ttl
+            else "accuweather.cache.fetch.miss.ttl"
         )
 
     def parse_cached_data(self, cached_data: list[bytes | None]) -> WeatherData:

--- a/tests/unit/providers/weather/backends/test_accuweather.py
+++ b/tests/unit/providers/weather/backends/test_accuweather.py
@@ -976,7 +976,6 @@ async def test_get_weather_report_from_cache(
         "accuweather.cache.hit.locations",
         "accuweather.cache.hit.currentconditions",
         "accuweather.cache.hit.forecasts",
-        "accuweather.cache.hit.ttl",
     ]
 
 
@@ -1029,7 +1028,6 @@ async def test_get_weather_report_with_location_key_from_cache(
     assert metrics_increment_called == [
         "accuweather.cache.hit.currentconditions",
         "accuweather.cache.hit.forecasts",
-        "accuweather.cache.hit.ttl",
     ]
 
 
@@ -2000,31 +1998,31 @@ def test_add_partner_code(
     [
         (
             ["location", "current", "forecast", "ttl"],
-            ("hit.locations", "hit.currentconditions", "hit.forecasts", "hit.ttl"),
+            ("hit.locations", "hit.currentconditions", "hit.forecasts"),
         ),
         (
             ["location", None, "forecast", "ttl"],
-            ("hit.locations", "fetch.miss.currentconditions", "hit.forecasts", "hit.ttl"),
+            ("hit.locations", "fetch.miss.currentconditions", "hit.forecasts"),
         ),
         (
             ["location", "current", None, "ttl"],
-            ("hit.locations", "hit.currentconditions", "fetch.miss.forecasts", "hit.ttl"),
+            ("hit.locations", "hit.currentconditions", "fetch.miss.forecasts"),
         ),
         (
             ["location", None, None, "ttl"],
-            ("hit.locations", "fetch.miss.currentconditions", "fetch.miss.forecasts", "hit.ttl"),
+            ("hit.locations", "fetch.miss.currentconditions", "fetch.miss.forecasts"),
         ),
         (
             ["location", "current", "forecast", None],
-            ("hit.locations", "hit.currentconditions", "hit.forecasts", "fetch.miss.ttl"),
+            ("hit.locations", "fetch.miss.ttl", "hit.currentconditions", "hit.forecasts"),
         ),
         (
             [None, None, None, None],
             (
                 "fetch.miss.locations",
+                "fetch.miss.ttl",
                 "fetch.miss.currentconditions",
                 "fetch.miss.forecasts",
-                "fetch.miss.ttl",
             ),
         ),
     ],


### PR DESCRIPTION
## References

JIRA: [DISCO-2846](https://mozilla-hub.atlassian.net/jira/software/c/projects/DISCO/boards/301?selectedIssue=DISCO-2846)

## Description
We want to report `TTL` misses when trying to get the weather results from the cache. So far, we just report `None` if [Redis returns `-1` or `-2`:](https://redis.io/docs/latest/commands/ttl/)

```md
* The command returns -2 if the key does not exist.
* The command returns -1 if the key exists but has no associated expire.
```

We will report now if we hit or miss a `TTL`:

```python
self.metrics_client.increment(
    "accuweather.cache.hit.ttl" if ttl else "accuweather.cache.fetch.miss.ttl"
)
```

Needs to be reviewed by someone who has experience with the Redis cache. I am not sure if, from a business point of view, we want to report on every TTL hit, or if we want to adjust the reporting and return `-1` or `-2` from Redis to make sense of our cache handling a bit more.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2846]: https://mozilla-hub.atlassian.net/browse/DISCO-2846?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ