### PR TITLE
feat: increase counter instead of logging warning

### DIFF
--- a/docs/data.md
+++ b/docs/data.md
@@ -124,6 +124,7 @@ log inspection interfaces.
 
 The weather provider records additional metrics.
 
+- `accuweather.request.location.not_provided` - A counter to measure the number of times a query was send without a location being provided, and therefore unable to process a weather request.
 - `merino.providers.accuweather.query.cache.fetch` - A timer to measure the duration (in ms) of
   looking up a weather report in the cache.
 - `merino.providers.accuweather.query.cache.fetch.miss.locations` - A counter to measure the number of times weather location was not in the cache.

--- a/merino/providers/weather/backends/accuweather.py
+++ b/merino/providers/weather/backends/accuweather.py
@@ -493,7 +493,8 @@ class AccuweatherBackend:
         region: str | None = geolocation.region
         city: str | None = geolocation.city
         if not country or not region or not city:
-            raise AccuweatherError("Country and/or region/city unknown")
+            self.metrics_client.increment("accuweather.request.location.not_provided")
+            return None
 
         cache_key: str = self.cache_key_for_accuweather_request(
             self.url_cities_path.format(country_code=country, admin_code=region),

--- a/merino/providers/weather/provider.py
+++ b/merino/providers/weather/provider.py
@@ -6,6 +6,7 @@ from typing import Any
 import aiodogstatsd
 from pydantic import HttpUrl
 
+from merino.exceptions import BackendError
 from merino.middleware.geolocation import Location
 from merino.providers.base import BaseProvider, BaseSuggestion, SuggestionRequest
 from merino.providers.custom_details import CustomDetails, WeatherDetails
@@ -76,13 +77,19 @@ class Provider(BaseProvider):
         weather_report: WeatherReport | None = None
         location_completions: list[LocationCompletion] | None = None
 
-        with self.metrics_client.timeit(f"providers.{self.name}.query.backend.get"):
-            if is_location_completion_request:
-                location_completions = await self.backend.get_location_completion(
-                    geolocation, search_term=srequest.query
-                )
-            else:
-                weather_report = await self.backend.get_weather_report(geolocation, srequest.query)
+        try:
+            with self.metrics_client.timeit(f"providers.{self.name}.query.backend.get"):
+                if is_location_completion_request:
+                    location_completions = await self.backend.get_location_completion(
+                        geolocation, search_term=srequest.query
+                    )
+                else:
+                    weather_report = await self.backend.get_weather_report(
+                        geolocation, srequest.query
+                    )
+
+        except BackendError as backend_error:
+            logger.warning(backend_error)
 
         # for this provider, the request can be either for weather or location completion
         if weather_report:

--- a/tests/unit/providers/weather/backends/test_accuweather.py
+++ b/tests/unit/providers/weather/backends/test_accuweather.py
@@ -1466,17 +1466,23 @@ async def test_get_weather_report_failed_forecast_query(
 )
 @pytest.mark.asyncio
 async def test_get_weather_report_invalid_location(
-    accuweather: AccuweatherBackend, location: Location
+    accuweather: AccuweatherBackend,
+    location: Location,
+    statsd_mock: Any,
 ) -> None:
     """Test that the get_weather_report method raises an error if location information
     is missing.
     """
-    expected_error_value: str = "Country and/or region/city unknown"
+    expected_result = None
 
-    with pytest.raises(AccuweatherError) as accuweather_error:
-        await accuweather.get_weather_report(location)
+    result = await accuweather.get_weather_report(location)
 
-    assert str(accuweather_error.value) == expected_error_value
+    assert expected_result == result
+
+    metrics_called = [call_arg[0][0] for call_arg in statsd_mock.increment.call_args_list]
+    assert [
+        "accuweather.request.location.not_provided",
+    ] == metrics_called
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## References

JIRA: [DISCO-2858](https://mozilla-hub.atlassian.net/jira/software/c/projects/DISCO/boards/301?selectedIssue=DISCO-2858)

## Description

From Jira:

> The warning Country and/or region/city unknown is dominating the warning logs of Merino and making log consumption noisy. We can replace it with a metric (e.g. a counter) to mitigate that.

This PR removes the `raise AccuweatherError("Country and/or region/city unknown")` and instead adds a new counter called `accuweather.request.location.not_provided`. It increments each time a query for fetching a weather report was made without a proper city or country code. 

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2858]: https://mozilla-hub.atlassian.net/browse/DISCO-2858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ