### PR TITLE
[MC-1208] feat: add caching to CorpusApiBackend

### DIFF
--- a/merino/curated_recommendations/corpus_backends/corpus_api_backend.py
+++ b/merino/curated_recommendations/corpus_backends/corpus_api_backend.py
@@ -5,7 +5,7 @@ import random
 from datetime import datetime, timedelta
 import asyncio
 
-from httpx import AsyncClient, HTTPStatusError
+from httpx import AsyncClient, HTTPError
 
 from merino.curated_recommendations.corpus_backends.protocol import (
     CorpusBackend,
@@ -176,7 +176,7 @@ class CorpusApiBackend(CorpusBackend):
             # Fetch new data from the backend.
             try:
                 data = await self._fetch_from_backend(surface_id)
-            except HTTPStatusError as e:
+            except HTTPError as e:
                 logger.warning(f"Retrying CorpusApiBackend._fetch_from_backend once after {e}")
                 # Backoff prevents high API rate during downtime.
                 await asyncio.sleep(self._backoff_time.total_seconds())

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -1,12 +1,13 @@
 """Tests the curated recommendation endpoint /api/v1/curated-recommendations"""
 
+import asyncio
 import json
+from datetime import timedelta
 from unittest.mock import AsyncMock
 
 import freezegun
 import pytest
-from fastapi.testclient import TestClient
-from httpx import AsyncClient, Request, Response
+from httpx import AsyncClient, Response
 from pydantic import HttpUrl
 
 from merino.curated_recommendations import (
@@ -14,33 +15,27 @@ from merino.curated_recommendations import (
     CuratedRecommendationsProvider,
     get_provider,
 )
-from merino.curated_recommendations.corpus_backends.corpus_api_backend import (
-    CorpusApiGraphConfig,
-)
 from merino.curated_recommendations.provider import CuratedRecommendation
 from merino.main import app
 
 
-@pytest.fixture(name="corpus_http_client")
-def fixture_mock_corpus_http_client() -> AsyncMock:
-    """Mock curated corpus api HTTP client."""
-    # load json mock data
+@pytest.fixture()
+def fixture_response_data():
+    """Load mock response data for the scheduledSurface query"""
     with open("tests/data/scheduled_surface.json") as f:
-        scheduled_surface_data = json.load(f)
+        return json.load(f)
 
+
+@pytest.fixture(name="corpus_http_client")
+def fixture_mock_corpus_http_client(fixture_response_data) -> AsyncMock:
+    """Mock curated corpus api HTTP client."""
     # Create a mock HTTP client
     mock_http_client = AsyncMock(spec=AsyncClient)
 
     # Mock the POST request response with the loaded json mock data
     mock_http_client.post.return_value = Response(
         status_code=200,
-        json=scheduled_surface_data,
-        request=Request(
-            method="POST",
-            url=CorpusApiGraphConfig.CORPUS_API_PROD_ENDPOINT,
-            headers=CorpusApiGraphConfig.HEADERS,
-            json={"locale": "en-US"},
-        ),
+        json=fixture_response_data,
     )
 
     return mock_http_client
@@ -67,46 +62,103 @@ def setup_providers(provider):
 
 @freezegun.freeze_time("2012-01-14 03:21:34", tz_offset=0)
 @pytest.mark.asyncio
-async def test_curated_recommendations_locale(client: TestClient):
+async def test_curated_recommendations_locale():
     """Test the curated recommendations endpoint response is as expected."""
-    # expected recommendation with topic = None
-    expected_recommendation = CuratedRecommendation(
-        scheduledCorpusItemId="50f86ebe-3f25-41d8-bd84-53ead7bdc76e",
-        url=HttpUrl("https://www.themarginalian.org/2024/05/28/passenger-pigeon/"),
-        title="Thunder, Bells, and Silence: the Eclipse That Went Extinct",
-        excerpt="Juneteenth isn’t the “other” Independence Day, it is THE Independence Day.",
-        topic=None,
-        publisher="The Marginalian",
-        imageUrl=HttpUrl(
-            "https://s3.us-east-1.amazonaws.com/pocket-curatedcorpusapi-prod-images/87fd6901-5bf5-4b12-8bde-24b86be79003.jpeg"  # noqa
-        ),
-        receivedRank=1,
-    )
-    # Mock the endpoint
-    response = client.post("/api/v1/curated-recommendations", json={"locale": "en-US"})
-    data = response.json()
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        # expected recommendation with topic = None
+        expected_recommendation = CuratedRecommendation(
+            scheduledCorpusItemId="50f86ebe-3f25-41d8-bd84-53ead7bdc76e",
+            url=HttpUrl("https://www.themarginalian.org/2024/05/28/passenger-pigeon/"),
+            title="Thunder, Bells, and Silence: the Eclipse That Went Extinct",
+            excerpt="Juneteenth isn’t the “other” Independence Day, it is THE Independence Day.",
+            topic=None,
+            publisher="The Marginalian",
+            imageUrl=HttpUrl(
+                "https://s3.us-east-1.amazonaws.com/pocket-curatedcorpusapi-prod-images/87fd6901-5bf5-4b12-8bde-24b86be79003.jpeg"
+            ),
+            receivedRank=1,
+        )
+        # Mock the endpoint
+        response = await ac.post("/api/v1/curated-recommendations", json={"locale": "en-US"})
+        data = response.json()
 
-    # Check if the mock response is valid
-    assert response.status_code == 200
+        # Check if the mock response is valid
+        assert response.status_code == 200
 
-    corpus_items = data["data"]
-    # assert total of 80 items returned
-    assert len(corpus_items) == 80
-    # Assert all corpus_items have expected fields populated.
-    assert all(item["url"] for item in corpus_items)
-    assert all(item["publisher"] for item in corpus_items)
-    assert all(item["imageUrl"] for item in corpus_items)
+        corpus_items = data["data"]
+        # assert total of 80 items returned
+        assert len(corpus_items) == 80
+        # Assert all corpus_items have expected fields populated.
+        assert all(item["url"] for item in corpus_items)
+        assert all(item["publisher"] for item in corpus_items)
+        assert all(item["imageUrl"] for item in corpus_items)
 
-    # Assert 2nd returned recommendation has topic = None & all fields returned are expected
-    actual_recommendation: CuratedRecommendation = CuratedRecommendation(**corpus_items[1])
-    assert actual_recommendation == expected_recommendation
+        # Assert 2nd returned recommendation has topic = None & all fields returned are expected
+        actual_recommendation: CuratedRecommendation = CuratedRecommendation(**corpus_items[1])
+        assert actual_recommendation == expected_recommendation
 
 
 @pytest.mark.asyncio
-async def test_curated_recommendations_locale_bad_request(client: TestClient):
+async def test_curated_recommendations_locale_bad_request():
     """Test the curated recommendations endpoint response is 400 if locale is not provided"""
-    # Mock the endpoint
-    response = client.post("/api/v1/curated-recommendations", json={"foo": "bar"})
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        # Mock the endpoint
+        response = await ac.post("/api/v1/curated-recommendations", json={"foo": "bar"})
 
-    # Check if the response returns 400
-    assert response.status_code == 400
+        # Check if the response returns 400
+        assert response.status_code == 400
+
+
+@freezegun.freeze_time("2012-01-14 03:21:34", tz_offset=0)
+@pytest.mark.asyncio
+async def test_single_request_multiple_fetches(corpus_http_client):
+    """Test that only a single request is made if multiple fetch() calls are gathered."""
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+
+        async def fetch():
+            return await ac.post("/api/v1/curated-recommendations", json={"locale": "en-US"})
+
+        # Gather multiple fetch calls
+        results = await asyncio.gather(fetch(), fetch(), fetch(), fetch(), fetch())
+
+        # Assert that exactly one request was made to the corpus api
+        corpus_http_client.post.assert_called_once()
+
+        # Assert that the results are the same
+        assert all(results[0].json() == result.json() for result in results)
+
+
+@pytest.mark.asyncio
+async def test_cache_returned_on_subsequent_calls(corpus_http_client, fixture_response_data):
+    """Test that the cached value is returned on subsequent calls."""
+    with freezegun.freeze_time(tick=True) as frozen_datetime:
+        async with AsyncClient(app=app, base_url="http://test") as ac:
+
+            async def fetch():
+                return await ac.post("/api/v1/curated-recommendations", json={"locale": "en-US"})
+
+            # First fetch to populate cache
+            initial_response = await fetch()
+            initial_data = initial_response.json()
+
+            for item in fixture_response_data["data"]["scheduledSurface"]["items"]:
+                item["corpusItem"]["title"] += " (NEW)"  # Change all the titles
+            corpus_http_client.post.return_value = Response(
+                status_code=200,
+                json=fixture_response_data,
+            )
+
+            # Progress time to when the cache expires.
+            frozen_datetime.tick(delta=CorpusApiBackend.cache_expiration_time)
+            frozen_datetime.tick(delta=timedelta(seconds=1))
+
+            # When the cache is expired, the first fetch may return stale data.
+            await fetch()
+            await asyncio.sleep(0.01)  # Allow asyncio background task to make an API request
+
+            # Next fetch should get the new data
+            new_response = await fetch()
+            assert corpus_http_client.post.call_count == 2
+            new_data = new_response.json()
+            assert new_data["recommendedAt"] > initial_data["recommendedAt"]
+            assert all("NEW" in item["title"] for item in new_data["data"])

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -112,7 +112,7 @@ async def test_curated_recommendations_locale_bad_request():
 @freezegun.freeze_time("2012-01-14 03:21:34", tz_offset=0)
 @pytest.mark.asyncio
 async def test_single_request_multiple_fetches(corpus_http_client):
-    """Test that only a single request is made if multiple fetch() calls are gathered."""
+    """Test that only a single request is made to the curated-corpus-api."""
     async with AsyncClient(app=app, base_url="http://test") as ac:
 
         async def fetch():
@@ -130,7 +130,7 @@ async def test_single_request_multiple_fetches(corpus_http_client):
 
 @pytest.mark.asyncio
 async def test_cache_returned_on_subsequent_calls(corpus_http_client, fixture_response_data):
-    """Test that the cached value is returned on subsequent calls."""
+    """Test that the cache expires, and subsequent requests return new data."""
     with freezegun.freeze_time(tick=True) as frozen_datetime:
         async with AsyncClient(app=app, base_url="http://test") as ac:
 
@@ -148,8 +148,8 @@ async def test_cache_returned_on_subsequent_calls(corpus_http_client, fixture_re
                 json=fixture_response_data,
             )
 
-            # Progress time to when the cache expires.
-            frozen_datetime.tick(delta=CorpusApiBackend.cache_expiration_time)
+            # Progress time to after the cache expires.
+            frozen_datetime.tick(delta=CorpusApiBackend.cache_time_to_live_max)
             frozen_datetime.tick(delta=timedelta(seconds=1))
 
             # When the cache is expired, the first fetch may return stale data.

--- a/tests/unit/curated_recommendations/test_corpus_api_backend.py
+++ b/tests/unit/curated_recommendations/test_corpus_api_backend.py
@@ -1,9 +1,13 @@
 """Unit test for map_corpus_to_serp_topic."""
 
+from datetime import datetime
+
 import pytest
+from freezegun import freeze_time
 
 from merino.curated_recommendations.corpus_backends.corpus_api_backend import (
     map_corpus_topic_to_serp_topic,
+    CorpusApiBackend,
 )
 
 
@@ -38,3 +42,17 @@ def test_map_corpus_to_serp_topic(topic, mapped_topic):
     https://docs.google.com/document/d/1ICCHi1haxR-jIi_uZ3xQfPmphZm39MOmwQh0BRTXLHA/edit
     """
     assert map_corpus_topic_to_serp_topic(topic) == mapped_topic
+
+
+@freeze_time("2012-01-14 00:00:00", tz_offset=0)
+def test_get_expiration_time():
+    """Testing the generation of expiration times"""
+    times = [CorpusApiBackend.get_expiration_time() for _ in range(10)]
+
+    # Assert that times are within the expected range
+    min_expected_time = datetime(2012, 1, 14, 0, 0, 50)
+    max_expected_time = datetime(2012, 1, 14, 0, 1, 10)
+    assert all(min_expected_time <= t <= max_expected_time for t in times)
+
+    # Assert that all returned times are different
+    assert len(set(times)) == len(times)


### PR DESCRIPTION
## References

JIRA: [MC-1208](https://mozilla-hub.atlassian.net/browse/MC-1208)

## Description

Guarantee reliability of the Pocket Graph and Merino, even when Merino will be handling thousands of requests per second for curated recommendations. This isn't an issue today, because a CDN sits in front of the firefox-proxy-api to cache and [coalesce requests](https://cloud.google.com/cdn/docs/caching#request-coalescing).

1. The curated corpus api should be guarded against high request volumes. The [ScheduledSurface query](https://studio.apollographql.com/graph/pocket-client-api/variant/current/insights?insightsTab=operations&operationSearch=scheduledsurf&operationsPage=0&query=31f1c92b1287f1f5a8d9b85f4d6806f5ac85d91a&queryName=ScheduledSurface) currently handles 90 requests/min, and Merino shouldn't send it much more traffic than that. We can accomplish this by adding a cache. When this cache expires, we should send a single "coalesced" request to the backend, to prevent the [thundering herd problem](https://en.wikipedia.org/wiki/Thundering_herd_problem).
2. Merino should be guarded against requests piling up while we make a request to the curated-corpus-api. When we have a stale value available in cache, we should use it, instead of blocking requests until the backend responds.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[MC-1208]: https://mozilla-hub.atlassian.net/browse/MC-1208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ