### PR TITLE
MC-1199: curated-recs: map UTC date to scheduled date for timezone

### DIFF
--- a/merino/curated_recommendations/corpus_backends/corpus_api_backend.py
+++ b/merino/curated_recommendations/corpus_backends/corpus_api_backend.py
@@ -91,6 +91,11 @@ class CorpusApiBackend(CorpusBackend):
             )
             return default_tz
 
+    @staticmethod
+    def get_scheduled_surface_date(surface_timezone: ZoneInfo) -> datetime:
+        """Return scheduled surface date based on timezone."""
+        return datetime.now(tz=surface_timezone) - timedelta(hours=3)
+
     async def fetch(self, surface_id: ScheduledSurfaceId) -> list[CorpusItem]:
         """Issue a scheduledSurface query"""
         query = """
@@ -115,8 +120,7 @@ class CorpusApiBackend(CorpusBackend):
         # where 'local time' is based on the timezone associated with the scheduled surface.
         # This requirement is documented in the NewTab slate spec:
         # https://getpocket.atlassian.net/wiki/spaces/PE/pages/2927100008/Fx+NewTab+Slate+spec
-        # today = datetime.now()
-        today = datetime.now(tz=self.get_surface_timezone(surface_id)) - timedelta(hours=3)
+        today = self.get_scheduled_surface_date(self.get_surface_timezone(surface_id))
 
         body = {
             "query": query,

--- a/merino/curated_recommendations/corpus_backends/corpus_api_backend.py
+++ b/merino/curated_recommendations/corpus_backends/corpus_api_backend.py
@@ -1,4 +1,5 @@
 """Corpus API backend for making GRAPHQL requests"""
+
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 import logging
 import random

--- a/tests/unit/curated_recommendations/test_corpus_api_backend.py
+++ b/tests/unit/curated_recommendations/test_corpus_api_backend.py
@@ -4,7 +4,9 @@ import pytest
 
 from merino.curated_recommendations.corpus_backends.corpus_api_backend import (
     map_corpus_topic_to_serp_topic,
+    CorpusApiBackend,
 )
+from pytest import LogCaptureFixture
 
 
 @pytest.mark.parametrize("topic", ["PARENTING", "CORONAVIRUS", "GAMING", "CAREER", "EDUCATION"])
@@ -38,3 +40,38 @@ def test_map_corpus_to_serp_topic(topic, mapped_topic):
     https://docs.google.com/document/d/1ICCHi1haxR-jIi_uZ3xQfPmphZm39MOmwQh0BRTXLHA/edit
     """
     assert map_corpus_topic_to_serp_topic(topic) == mapped_topic
+
+
+@pytest.mark.parametrize(
+    "surface_id, timezone",
+    [
+        ("NEW_TAB_EN_US", "America/New_York"),
+        ("NEW_TAB_EN_GB", "Europe/London"),
+        ("NEW_TAB_EN_INTL", "Asia/Kolkata"),
+        ("NEW_TAB_DE_DE", "Europe/Berlin"),
+        ("NEW_TAB_ES_ES", "Europe/Madrid"),
+        ("NEW_TAB_FR_FR", "Europe/Paris"),
+        ("NEW_TAB_IT_IT", "Europe/Rome"),
+    ],
+)
+def test_get_surface_timezone(surface_id, timezone, caplog: LogCaptureFixture):
+    """Testing get_surface_timezone method & ensuring correct
+    timezone is returned for a scheduled surface.
+    """
+    tz = CorpusApiBackend.get_surface_timezone(surface_id)
+    assert timezone == tz.key
+    # No warnings or errors were logged.
+    assert not any(r for r in caplog.records if r.levelname in ("WARNING", "ERROR", "CRITICAL"))
+
+
+def test_get_surface_timezone_bad_input(caplog: LogCaptureFixture):
+    """Testing get_surface_timezone method & ensuring if
+    a bad input is provided, UTC is returned.
+    """
+    # Should default to UTC if bad input
+    tz = CorpusApiBackend.get_surface_timezone("foobar")
+    assert tz.key == "UTC"
+    # Error was logged
+    error_logs = [r for r in caplog.records if r.levelname == "ERROR"]
+    assert len(error_logs) == 1
+    assert "Failed to get timezone for foobar, so defaulting to UTC" in error_logs[0].message

--- a/tests/unit/curated_recommendations/test_corpus_api_backend.py
+++ b/tests/unit/curated_recommendations/test_corpus_api_backend.py
@@ -80,33 +80,29 @@ def test_get_surface_timezone_bad_input(caplog: LogCaptureFixture):
 
 
 @pytest.mark.parametrize(
-    ("surface_id", "time_to_freeze", "expected_date"),
+    ("time_zone", "time_to_freeze", "expected_date"),
     [
         # The publishing day rolls over at 3:00am local time. At 2:59am, content from the previous day is requested.
         ("America/New_York", "2023-08-01 7:00:00", "2023-08-01"),  # 3:00am New York
         ("America/New_York", "2023-08-01 6:59:00", "2023-07-31"),  # 2:59am New York
-        ("Asia/Kolkata", "2023-08-01 7:00:00", "2023-08-01"),  # 3:00am Kolkata
+        ("Asia/Kolkata", "2023-07-31 21:30:00", "2023-08-01"),  # 3:00am Kolkata
         ("Asia/Kolkata", "2023-07-31 21:29:00", "2023-07-31"),  # 2:59am Kolkata
-        ("Europe/London", "2023-08-01 7:00:00", "2023-08-01"),  # 3:00am London
-        ("Europe/London", "2023-08-01 6:59:00", "2023-07-31"),  # 3:00am London
-        ("Europe/Berlin", "2023-08-01 7:00:00", "2023-08-01"),  # 3:00am Berlin
-        ("Europe/Berlin", "2023-08-01 6:59:00", "2023-07-31"),  # 2:59am Berlin
-        ("Europe/Madrid", "2023-08-01 7:00:00", "2023-08-01"),  # 3:00am Madrid
-        ("Europe/Madrid", "2023-08-01 6:59:00", "2023-07-31"),  # 2:59am Madrid
-        ("Europe/Paris", "2023-08-01 7:00:00", "2023-08-01"),  # 3:00am Paris
-        ("Europe/Paris", "2023-08-01 6:59:00", "2023-07-31"),  # 2:59am Paris
-        ("Europe/Rome", "2023-08-01 7:00:00", "2023-08-01"),  # 3:00am Rome
-        ("Europe/Rome", "2023-08-01 6:59:00", "2023-07-31"),  # 2:59am Rome
+        ("Europe/London", "2023-08-01 2:00:00", "2023-08-01"),  # 3:00am London
+        ("Europe/London", "2023-08-01 1:59:00", "2023-07-31"),  # 3:00am London
+        ("Europe/Berlin", "2023-08-01 1:00:00", "2023-08-01"),  # 3:00am Berlin
+        ("Europe/Berlin", "2023-08-01 0:59:00", "2023-07-31"),  # 2:59am Berlin
+        ("Europe/Madrid", "2023-08-01 1:00:00", "2023-08-01"),  # 3:00am Madrid
+        ("Europe/Madrid", "2023-08-01 0:59:00", "2023-07-31"),  # 2:59am Madrid
+        ("Europe/Paris", "2023-08-01 1:00:00", "2023-08-01"),  # 3:00am Paris
+        ("Europe/Paris", "2023-08-01 0:59:00", "2023-07-31"),  # 2:59am Paris
+        ("Europe/Rome", "2023-08-01 1:00:00", "2023-08-01"),  # 3:00am Rome
+        ("Europe/Rome", "2023-08-01 0:59:00", "2023-07-31"),  # 2:59am Rome
     ],
 )
-def test_get_scheduled_surface_date(surface_id, time_to_freeze, expected_date):
+def test_get_scheduled_surface_date(time_zone, time_to_freeze, expected_date):
     """Testing the get_scheduled_surface_date method & ensuring
     the correct date is returned for a scheduled surface.
     """
     with freeze_time(time_to_freeze, tz_offset=0):
-        assert (
-            CorpusApiBackend.get_scheduled_surface_date(ZoneInfo("America/New_York")).strftime(
-                "%Y-%m-%d"
-            )
-            == expected_date
-        )  # noqa
+        scheduled_surface_date = CorpusApiBackend.get_scheduled_surface_date(ZoneInfo(time_zone))
+        assert scheduled_surface_date.strftime("%Y-%m-%d") == expected_date

--- a/tests/unit/curated_recommendations/test_corpus_api_backend.py
+++ b/tests/unit/curated_recommendations/test_corpus_api_backend.py
@@ -1,4 +1,5 @@
 """Unit test for map_corpus_to_serp_topic."""
+
 from zoneinfo import ZoneInfo
 from datetime import datetime
 import pytest


### PR DESCRIPTION
## References

JIRA: https://mozilla-hub.atlassian.net/browse/MC-1199

## Description
The date for requesting curated recs is supposed to progress at 3am local time, where 'local time' is based on the timezone associated with the scheduled surface. Ported `get_surface_timezone` from recs-api & changed it to return a `ZoneInfo` obj instead of `pytz.timezone` so that we don't need to install the new package.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
