### PR TITLE
[load test: warn] fix failing redis accuweather integration tests

### DIFF
--- a/tests/integration/providers/weather/backends/test_accuweather.py
+++ b/tests/integration/providers/weather/backends/test_accuweather.py
@@ -455,6 +455,7 @@ async def test_get_weather_report_from_cache_without_ttl(
 
     assert metrics_increment_called == [
         "accuweather.cache.hit.locations",
+        "accuweather.cache.fetch.miss.ttl",
         "accuweather.cache.hit.currentconditions",
         "accuweather.cache.hit.forecasts",
     ]
@@ -664,6 +665,7 @@ async def test_get_weather_report_with_location_key_from_cache(
     ]
 
     assert metrics_increment_called == [
+        "accuweather.cache.fetch.miss.ttl",
         "accuweather.cache.hit.currentconditions",
         "accuweather.cache.hit.forecasts",
     ]


### PR DESCRIPTION
## References

JIRA: [DISCO-2324](https://mozilla-hub.atlassian.net/browse/DISCO-2324)

## Description
Fixing asserts on two tests that I missed due to not rebasing on `main` branch in this [pull request](https://github.com/mozilla-services/merino-py/pull/545)


## PR Review Checklist

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2324]: https://mozilla-hub.atlassian.net/browse/DISCO-2324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ