### PR TITLE
[DISCO-2883] Add 'Distributed GCP Execution - CI Trigger' section to load-test.md

### DIFF
--- a/docs/operations/testfailures.md
+++ b/docs/operations/testfailures.md
@@ -4,17 +4,8 @@
     - For functional tests (unit, integration or contract), logs can be found on
       [CircleCI][circleci]
     - For performance tests (load), insights can be found on [Grafana][merino_app_info] and in the
-      Locust logs. To access the Locust logs:
-      1. Open a cloud shell in the [Merino stage environment][merino_gcp_stage]
-      2. Authenticate by executing the following command:
-      ```shell
-      gcloud container clusters get-credentials merino-nonprod-v1 \
-        --region us-west1 --project moz-fx-merino-nonprod-ee93
-      ```
-      3. Access the data in the Kubernetes pod by executing the following command:
-      ```shell
-        kubectl exec -it -n locust-merino locust-master-0 -- bash -c "cd /data && /bin/bash"
-      ```
+      Locust logs. To access the Locust logs see the [Distributed GCP Exection - CI Trigger][load_tests]
+      section of the load test documentation.
 
 2. Fix or mitigate the failure
     - If a fix can be identified in a relatively short time, then submit a fix
@@ -33,3 +24,4 @@
 [merino_app_info]: https://earthangel-b40313e5.influxcloud.net/d/rQAfYKIVk/wip-merino-py-application-and-infrastructure?orgId=1&from=now-24h&to=now&var-environment=prodpy&refresh=1m
 [merino_gcp_stage]: https://console.cloud.google.com/kubernetes/list/overview?project=moz-fx-merino-nonprod-ee93
 [pytest_xfail]: https://docs.pytest.org/en/latest/how-to/skipping.html
+[load_tests]: https://mozilla-services.github.io/merino-py/testing/load-tests.html


### PR DESCRIPTION
## References

JIRA: [DISCO-2883](https://mozilla-hub.atlassian.net/browse/DISCO-2883)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->

- update the documentation to distinguish between the manual and CI processes for execution of distributed load tests  


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2883]: https://mozilla-hub.atlassian.net/browse/DISCO-2883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ