### PR TITLE
[hnt-142] feat: curated-recs endpoint accepts topics

### DIFF
--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -10,6 +10,7 @@ from merino.curated_recommendations.corpus_backends.protocol import (
     CorpusBackend,
     CorpusItem,
     ScheduledSurfaceId,
+    Topic,
 )
 
 
@@ -61,6 +62,7 @@ class CuratedRecommendationsRequest(BaseModel):
     locale: Locale
     region: str | None = None
     count: int = 100
+    topics: list[Topic] | None = None
 
 
 class CuratedRecommendationsResponse(BaseModel):

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -81,7 +81,7 @@ async def fetch_en_us(client: AsyncClient) -> Response:
 
 @freezegun.freeze_time("2012-01-14 03:21:34", tz_offset=0)
 @pytest.mark.asyncio
-async def test_curated_recommendations_locale():
+async def test_curated_recommendations():
     """Test the curated recommendations endpoint response is as expected."""
     async with AsyncClient(app=app, base_url="http://test") as ac:
         # expected recommendation with topic = None
@@ -115,6 +115,52 @@ async def test_curated_recommendations_locale():
         # Assert 2nd returned recommendation has topic = None & all fields returned are expected
         actual_recommendation: CuratedRecommendation = CuratedRecommendation(**corpus_items[1])
         assert actual_recommendation == expected_recommendation
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "locale",
+    [
+        "fr",
+        "fr-FR",
+        "es",
+        "es-ES",
+        "it",
+        "it-IT",
+        "en",
+        "en-CA",
+        "en-GB",
+        "en-US",
+        "de",
+        "de-DE",
+        "de-AT",
+        "de-CH",
+    ],
+)
+async def test_curated_recommendations_locales(locale):
+    """Test the curated recommendations endpoint accepts valid locales."""
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        response = await ac.post("/api/v1/curated-recommendations", json={"locale": locale})
+        assert response.status_code == 200, f"{locale} resulted in {response.status_code}"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "locale",
+    [
+        None,
+        "",
+        "invalid-locale",
+        "en-XX",
+        "de-XYZ",
+        "es_123",
+    ],
+)
+async def test_curated_recommendations_locales_failure(locale):
+    """Test the curated recommendations endpoint rejects invalid locales."""
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        response = await ac.post("/api/v1/curated-recommendations", json={"locale": locale})
+        assert response.status_code == 400
 
 
 @pytest.mark.asyncio
@@ -160,7 +206,7 @@ async def test_curated_recommendations_locale():
     ],
 )
 async def test_curated_recommendations_topics(topics):
-    """Test the curated recommendations endpoint response is as expected."""
+    """Test the curated recommendations endpoint accepts valid topics."""
     async with AsyncClient(app=app, base_url="http://test") as ac:
         response = await ac.post(
             "/api/v1/curated-recommendations", json={"locale": "en-US", "topics": topics}
@@ -177,7 +223,7 @@ async def test_curated_recommendations_topics(topics):
     ],
 )
 async def test_curated_recommendations_topics_failure(topics):
-    """Test the curated recommendations endpoint response is as expected."""
+    """Test the curated recommendations endpoint rejects invalid topics."""
     async with AsyncClient(app=app, base_url="http://test") as ac:
         response = await ac.post(
             "/api/v1/curated-recommendations", json={"locale": "en-US", "topics": topics}

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -118,6 +118,74 @@ async def test_curated_recommendations_locale():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "topics",
+    [
+        None,
+        [],
+        # Each topic by itself is accepted.
+        ["arts"],
+        ["education"],
+        ["hobbies"],
+        ["society-parenting"],
+        ["business"],
+        ["education-science"],
+        ["finance"],
+        ["food"],
+        ["government"],
+        ["health"],
+        ["society"],
+        ["sports"],
+        ["tech"],
+        ["travel"],
+        # Multiple topics
+        ["tech", "travel"],
+        ["arts", "education", "hobbies", "society-parenting"],
+        [
+            "arts",
+            "education",
+            "hobbies",
+            "society-parenting",
+            "business",
+            "education-science",
+            "finance",
+            "food",
+            "government",
+            "health",
+            "society",
+            "sports",
+            "tech",
+            "travel",
+        ],
+    ],
+)
+async def test_curated_recommendations_topics(topics):
+    """Test the curated recommendations endpoint response is as expected."""
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        response = await ac.post(
+            "/api/v1/curated-recommendations", json={"locale": "en-US", "topics": topics}
+        )
+        assert response.status_code == 200, f"{topics} resulted in {response.status_code}"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "topics",
+    [
+        "arts",  # Must be wrapped in a list
+        ["not-a-valid-topic"],
+    ],
+)
+async def test_curated_recommendations_topics_failure(topics):
+    """Test the curated recommendations endpoint response is as expected."""
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        response = await ac.post(
+            "/api/v1/curated-recommendations", json={"locale": "en-US", "topics": topics}
+        )
+        assert response.status_code == 400
+
+
+@pytest.mark.asyncio
 async def test_curated_recommendations_locale_bad_request():
     """Test the curated recommendations endpoint response is 400 if locale is not provided"""
     async with AsyncClient(app=app, base_url="http://test") as ac:

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -164,6 +164,50 @@ async def test_curated_recommendations_locales_failure(locale):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("count", [10, 50, 100])
+async def test_curated_recommendations_count(count):
+    """Test the curated recommendations endpoint accepts valid count."""
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        response = await ac.post(
+            "/api/v1/curated-recommendations", json={"locale": "en-US", "count": count}
+        )
+        assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("count", [None, 100.5])
+async def test_curated_recommendations_count_failure(count):
+    """Test the curated recommendations endpoint rejects invalid count."""
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        response = await ac.post(
+            "/api/v1/curated-recommendations", json={"locale": "en-US", "count": count}
+        )
+        assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("region", [None, "US", "DE", "SXM"])
+async def test_curated_recommendations_region(region):
+    """Test the curated recommendations endpoint accepts valid region."""
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        response = await ac.post(
+            "/api/v1/curated-recommendations", json={"locale": "en-US", "region": region}
+        )
+        assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("region", [675])
+async def test_curated_recommendations_region_failure(region):
+    """Test the curated recommendations endpoint rejects invalid region."""
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        response = await ac.post(
+            "/api/v1/curated-recommendations", json={"locale": "en-US", "region": region}
+        )
+        assert response.status_code == 400
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "topics",
     [


### PR DESCRIPTION
## References

JIRA: [HNT-142](https://mozilla-hub.atlassian.net/browse/HNT-142)

## Description
The curated-recs endpoint should accept a list of topics.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[HNT-142]: https://mozilla-hub.atlassian.net/browse/HNT-142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ