### PR TITLE
[MC-1309] fix: curated-recommendations body description

### DIFF
--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -327,17 +327,15 @@ async def curated_content(
 
     **JSON body:**
 
-    locale: Locale
-    region: str | None = None
-    count: int = 100
     - `locale`: The Firefox installed locale, for example en, en-US, de-DE.
-        See the [Merino API docs][merino-api-docs] for the full list of supported values.
+        See the Request body schema below for the full list of supported values.
         This will determine the language of the recommendations.
     - `region`: [Optional] The country-level region, for example US or IE (Ireland).
         This will help return more relevant recommendations. If `region` is not provided,
         then region is extracted from the `locale` parameter if it contains two parts (e.g. en-US).
     - `count`: [Optional] The maximum number of recommendations to return. Defaults to 100.
+    - `topics`: [Optional] A list of preferred [topics][curated-topics-doc].
 
-    [merino-api-docs]: https://merinopy.services.mozilla.com/docs
+    [curated-topics-doc]: https://mozilla-hub.atlassian.net/wiki/x/LQDaMg
     """
     return await provider.fetch(curated_recommendations_request)


### PR DESCRIPTION
## References

JIRA: [MC-1309](https://mozilla-hub.atlassian.net/browse/MC-1309)

## Description
Fix the description in the [API documentation](https://merino.services.mozilla.com/docs#/) for the curated-recommendation endpoint.

Currently the topics parameter is missing:

![image](https://github.com/user-attachments/assets/b7d87e0d-940a-469e-8768-71fb772f4c1c)


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[MC-1309]: https://mozilla-hub.atlassian.net/browse/MC-1309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ