### PR TITLE
[load test: warn] [MC-1229] feat: add metrics to curated-recommendations

### DIFF
--- a/docs/data.md
+++ b/docs/data.md
@@ -153,7 +153,7 @@ The weather provider records additional metrics.
 
 The following additional metrics are recorded when curated recommendations are requested.
 
-- `curated_recommendations.corpus_api_backend.request.timing` -
+- `corpus_api.request.timing` -
  A timer to measure the duration (in ms) of looking up a list of scheduled corpus items.
-- `curated_recommendations.corpus_api_backend.request.status_codes.{res.status_code}` -
+- `corpus_api.request.status_codes.{res.status_code}` -
  A counter to measure the status codes of an HTTP request to the curated-corpus-api.

--- a/docs/data.md
+++ b/docs/data.md
@@ -69,6 +69,13 @@ log inspection interfaces.
 - `ERROR merino.featureflags` - There was an error while attempting to assign a
   feature flag for a suggest API request.
 
+### Curated Recommendations
+
+- `ERROR merino.curated_recommendations.corpus_backends.corpus_api_backend` -
+ Failed to get timezone for scheduled surface.
+- `WARNING merino.curated_recommendations.corpus_backends.corpus_api_backend` -
+ Retrying CorpusApiBackend after an http client exception was raised.
+
 ## Metrics
 
 > A note on timers: Statsd timers are measured in milliseconds, and are reported
@@ -141,3 +148,12 @@ The weather provider records additional metrics.
   cache store returned an error when fetching or storing a weather report. This should be 0 in
   normal operation. In case of an error, the logs will include a `WARNING` with the full error
   message.
+
+### Curated Recommendations
+
+The following additional metrics are recorded when curated recommendations are requested.
+
+- `curated_recommendations.corpus_api_backend.request.timing` -
+ A timer to measure the duration (in ms) of looking up a list of scheduled corpus items.
+- `curated_recommendations.corpus_api_backend.request.status_codes.{res.status_code}` -
+ A counter to measure the status codes of an HTTP request to the curated-corpus-api.

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,11 +1,11 @@
 # Merino
 
-Merino is a service that provides address bar suggestions to Firefox. Some of this content
-comes from third party providers. In this case, Merino serves as a privacy preserving
-buffer. User input in the address bar is handled by Merino and any clicked impression
-will be delegated to a Mozilla-controlled service which will then send an interaction
-ping if defined in the request and not to a provider directly. See API documentation
-for more details.
+Merino is a service that provides address bar suggestions and curated recommendations
+to Firefox. Some of this content comes from third party providers. In this case, Merino
+serves as a privacy preserving buffer. User input in the address bar is handled by Merino
+and any clicked impression will be delegated to a Mozilla-controlled service which will
+then send an interaction ping if defined in the request and not to a provider directly.
+See [API documentation](https://merinopy.services.mozilla.com) for more details.
 
 ## Table of Contents
 [api.md - API Documentation][1] describes endpoints, query parameters, request and response headers, response objects and details on the suggestion objects.

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -5,7 +5,7 @@ to Firefox. Some of this content comes from third party providers. In this case,
 serves as a privacy preserving buffer. User input in the address bar is handled by Merino
 and any clicked impression will be delegated to a Mozilla-controlled service which will
 then send an interaction ping if defined in the request and not to a provider directly.
-See [API documentation](https://merinopy.services.mozilla.com) for more details.
+See [API documentation](https://merino.services.mozilla.com/docs) for more details.
 
 ## Table of Contents
 [api.md - API Documentation][1] describes endpoints, query parameters, request and response headers, response objects and details on the suggestion objects.

--- a/merino/curated_recommendations/__init__.py
+++ b/merino/curated_recommendations/__init__.py
@@ -8,6 +8,7 @@ from merino.curated_recommendations.corpus_backends.corpus_api_backend import (
     CorpusApiGraphConfig,
 )
 from merino.curated_recommendations.provider import CuratedRecommendationsProvider
+from merino.metrics import get_metrics_client
 from merino.utils.http_client import create_http_client
 
 _provider: CuratedRecommendationsProvider
@@ -20,6 +21,7 @@ def init_provider() -> None:
         corpus_backend=CorpusApiBackend(
             http_client=create_http_client(base_url=""),
             graph_config=CorpusApiGraphConfig(),
+            metrics_client=get_metrics_client(),
         )
     )
 

--- a/merino/curated_recommendations/corpus_backends/corpus_api_backend.py
+++ b/merino/curated_recommendations/corpus_backends/corpus_api_backend.py
@@ -156,11 +156,9 @@ class CorpusApiBackend(CorpusBackend):
                 self._background_tasks.add(task)
                 task.add_done_callback(self._background_tasks.discard)
 
-            self.metrics_client.increment("curated_recommendations.corpus_api_backend.cache.hit")
             return self._cache[cache_key]
 
         # If no cache value exists, fetch new data and await the result.
-        self.metrics_client.increment("curated_recommendations.corpus_api_backend.cache.miss")
         return await self._revalidate_cache(surface_id)
 
     async def _fetch_from_backend(self, surface_id: ScheduledSurfaceId) -> list[CorpusItem]:

--- a/merino/curated_recommendations/corpus_backends/corpus_api_backend.py
+++ b/merino/curated_recommendations/corpus_backends/corpus_api_backend.py
@@ -195,18 +195,14 @@ class CorpusApiBackend(CorpusBackend):
             },
         }
 
-        with self.metrics_client.timeit(
-            "curated_recommendations.corpus_api_backend.request.timing"
-        ):
+        with self.metrics_client.timeit("corpus_api.request.timing"):
             res = await self.http_client.post(
                 self.graph_config.endpoint,
                 json=body,
                 headers=self.graph_config.headers,
             )
 
-        self.metrics_client.increment(
-            f"curated_recommendations.corpus_api_backend.request.status_codes.{res.status_code}"
-        )
+        self.metrics_client.increment(f"corpus_api.request.status_codes.{res.status_code}")
 
         res.raise_for_status()
         data = res.json()

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -407,7 +407,6 @@ async def test_curated_recommendations_metrics(
         # TODO: Remove reliance on internal details of aiodogstatsd
         metric_keys_cache_miss: list[str] = [call.args[0] for call in report.call_args_list]
         assert metric_keys_cache_miss == [
-            "curated_recommendations.corpus_api_backend.cache.miss",
             "curated_recommendations.corpus_api_backend.request.timing",
             "curated_recommendations.corpus_api_backend.request.status_codes.200",
             "post.api.v1.curated-recommendations.timing",
@@ -420,7 +419,6 @@ async def test_curated_recommendations_metrics(
 
         metric_keys_cache_hit: list[str] = [call.args[0] for call in report.call_args_list]
         assert metric_keys_cache_hit == [
-            "curated_recommendations.corpus_api_backend.cache.hit",
             "post.api.v1.curated-recommendations.timing",
             "post.api.v1.curated-recommendations.status_codes.200",
             "response.status_codes.200",

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -126,300 +126,332 @@ async def test_curated_recommendations():
         assert actual_recommendation == expected_recommendation
 
 
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "locale",
-    [
-        "fr",
-        "fr-FR",
-        "es",
-        "es-ES",
-        "it",
-        "it-IT",
-        "en",
-        "en-CA",
-        "en-GB",
-        "en-US",
-        "de",
-        "de-DE",
-        "de-AT",
-        "de-CH",
-    ],
-)
-async def test_curated_recommendations_locales(locale):
-    """Test the curated recommendations endpoint accepts valid locales."""
-    async with AsyncClient(app=app, base_url="http://test") as ac:
-        response = await ac.post("/api/v1/curated-recommendations", json={"locale": locale})
-        assert response.status_code == 200, f"{locale} resulted in {response.status_code}"
+class TestCuratedRecommendationsRequestParameters:
+    """Test request body parameters for the curated-recommendations endpoint"""
 
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "locale",
-    [
-        None,
-        "",
-        "invalid-locale",
-        "en-XX",
-        "de-XYZ",
-        "es_123",
-    ],
-)
-async def test_curated_recommendations_locales_failure(locale):
-    """Test the curated recommendations endpoint rejects invalid locales."""
-    async with AsyncClient(app=app, base_url="http://test") as ac:
-        response = await ac.post("/api/v1/curated-recommendations", json={"locale": locale})
-        assert response.status_code == 400
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("count", [10, 50, 100])
-async def test_curated_recommendations_count(count):
-    """Test the curated recommendations endpoint accepts valid count."""
-    async with AsyncClient(app=app, base_url="http://test") as ac:
-        response = await ac.post(
-            "/api/v1/curated-recommendations", json={"locale": "en-US", "count": count}
-        )
-        assert response.status_code == 200
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("count", [None, 100.5])
-async def test_curated_recommendations_count_failure(count):
-    """Test the curated recommendations endpoint rejects invalid count."""
-    async with AsyncClient(app=app, base_url="http://test") as ac:
-        response = await ac.post(
-            "/api/v1/curated-recommendations", json={"locale": "en-US", "count": count}
-        )
-        assert response.status_code == 400
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("region", [None, "US", "DE", "SXM"])
-async def test_curated_recommendations_region(region):
-    """Test the curated recommendations endpoint accepts valid region."""
-    async with AsyncClient(app=app, base_url="http://test") as ac:
-        response = await ac.post(
-            "/api/v1/curated-recommendations", json={"locale": "en-US", "region": region}
-        )
-        assert response.status_code == 200
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("region", [675])
-async def test_curated_recommendations_region_failure(region):
-    """Test the curated recommendations endpoint rejects invalid region."""
-    async with AsyncClient(app=app, base_url="http://test") as ac:
-        response = await ac.post(
-            "/api/v1/curated-recommendations", json={"locale": "en-US", "region": region}
-        )
-        assert response.status_code == 400
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "topics",
-    [
-        None,
-        [],
-        # Each topic by itself is accepted.
-        ["arts"],
-        ["education"],
-        ["hobbies"],
-        ["society-parenting"],
-        ["business"],
-        ["education-science"],
-        ["finance"],
-        ["food"],
-        ["government"],
-        ["health"],
-        ["society"],
-        ["sports"],
-        ["tech"],
-        ["travel"],
-        # Multiple topics
-        ["tech", "travel"],
-        ["arts", "education", "hobbies", "society-parenting"],
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "locale",
         [
-            "arts",
-            "education",
-            "hobbies",
-            "society-parenting",
-            "business",
-            "education-science",
-            "finance",
-            "food",
-            "government",
-            "health",
-            "society",
-            "sports",
-            "tech",
-            "travel",
+            "fr",
+            "fr-FR",
+            "es",
+            "es-ES",
+            "it",
+            "it-IT",
+            "en",
+            "en-CA",
+            "en-GB",
+            "en-US",
+            "de",
+            "de-DE",
+            "de-AT",
+            "de-CH",
         ],
-    ],
-)
-async def test_curated_recommendations_topics(topics):
-    """Test the curated recommendations endpoint accepts valid topics."""
-    async with AsyncClient(app=app, base_url="http://test") as ac:
-        response = await ac.post(
-            "/api/v1/curated-recommendations", json={"locale": "en-US", "topics": topics}
-        )
-        assert response.status_code == 200, f"{topics} resulted in {response.status_code}"
+    )
+    async def test_curated_recommendations_locales(self, locale):
+        """Test the curated recommendations endpoint accepts valid locales."""
+        async with AsyncClient(app=app, base_url="http://test") as ac:
+            response = await ac.post("/api/v1/curated-recommendations", json={"locale": locale})
+            assert response.status_code == 200, f"{locale} resulted in {response.status_code}"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "locale",
+        [
+            None,
+            "",
+            "invalid-locale",
+            "en-XX",
+            "de-XYZ",
+            "es_123",
+        ],
+    )
+    async def test_curated_recommendations_locales_failure(self, locale):
+        """Test the curated recommendations endpoint rejects invalid locales."""
+        async with AsyncClient(app=app, base_url="http://test") as ac:
+            response = await ac.post("/api/v1/curated-recommendations", json={"locale": locale})
+            assert response.status_code == 400
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("count", [10, 50, 100])
+    async def test_curated_recommendations_count(self, count):
+        """Test the curated recommendations endpoint accepts valid count."""
+        async with AsyncClient(app=app, base_url="http://test") as ac:
+            response = await ac.post(
+                "/api/v1/curated-recommendations", json={"locale": "en-US", "count": count}
+            )
+            assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("count", [None, 100.5])
+    async def test_curated_recommendations_count_failure(self, count):
+        """Test the curated recommendations endpoint rejects invalid count."""
+        async with AsyncClient(app=app, base_url="http://test") as ac:
+            response = await ac.post(
+                "/api/v1/curated-recommendations", json={"locale": "en-US", "count": count}
+            )
+            assert response.status_code == 400
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("region", [None, "US", "DE", "SXM"])
+    async def test_curated_recommendations_region(self, region):
+        """Test the curated recommendations endpoint accepts valid region."""
+        async with AsyncClient(app=app, base_url="http://test") as ac:
+            response = await ac.post(
+                "/api/v1/curated-recommendations", json={"locale": "en-US", "region": region}
+            )
+            assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("region", [675])
+    async def test_curated_recommendations_region_failure(self, region):
+        """Test the curated recommendations endpoint rejects invalid region."""
+        async with AsyncClient(app=app, base_url="http://test") as ac:
+            response = await ac.post(
+                "/api/v1/curated-recommendations", json={"locale": "en-US", "region": region}
+            )
+            assert response.status_code == 400
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "topics",
+        [
+            None,
+            [],
+            # Each topic by itself is accepted.
+            ["arts"],
+            ["education"],
+            ["hobbies"],
+            ["society-parenting"],
+            ["business"],
+            ["education-science"],
+            ["finance"],
+            ["food"],
+            ["government"],
+            ["health"],
+            ["society"],
+            ["sports"],
+            ["tech"],
+            ["travel"],
+            # Multiple topics
+            ["tech", "travel"],
+            ["arts", "education", "hobbies", "society-parenting"],
+            [
+                "arts",
+                "education",
+                "hobbies",
+                "society-parenting",
+                "business",
+                "education-science",
+                "finance",
+                "food",
+                "government",
+                "health",
+                "society",
+                "sports",
+                "tech",
+                "travel",
+            ],
+        ],
+    )
+    async def test_curated_recommendations_topics(self, topics):
+        """Test the curated recommendations endpoint accepts valid topics."""
+        async with AsyncClient(app=app, base_url="http://test") as ac:
+            response = await ac.post(
+                "/api/v1/curated-recommendations", json={"locale": "en-US", "topics": topics}
+            )
+            assert response.status_code == 200, f"{topics} resulted in {response.status_code}"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "topics",
+        [
+            "arts",  # Must be wrapped in a list
+            ["not-a-valid-topic"],
+        ],
+    )
+    async def test_curated_recommendations_topics_failure(self, topics):
+        """Test the curated recommendations endpoint rejects invalid topics."""
+        async with AsyncClient(app=app, base_url="http://test") as ac:
+            response = await ac.post(
+                "/api/v1/curated-recommendations", json={"locale": "en-US", "topics": topics}
+            )
+            assert response.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_curated_recommendations_locale_bad_request(self):
+        """Test the curated recommendations endpoint response is 400 if locale is not provided"""
+        async with AsyncClient(app=app, base_url="http://test") as ac:
+            # Mock the endpoint
+            response = await ac.post("/api/v1/curated-recommendations", json={"foo": "bar"})
+
+            # Check if the response returns 400
+            assert response.status_code == 400
 
 
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "topics",
-    [
-        "arts",  # Must be wrapped in a list
-        ["not-a-valid-topic"],
-    ],
-)
-async def test_curated_recommendations_topics_failure(topics):
-    """Test the curated recommendations endpoint rejects invalid topics."""
-    async with AsyncClient(app=app, base_url="http://test") as ac:
-        response = await ac.post(
-            "/api/v1/curated-recommendations", json={"locale": "en-US", "topics": topics}
-        )
-        assert response.status_code == 400
+class TestCorpusApiCaching:
+    """Tests covering the caching behavior of the Corpus backend"""
 
+    @freezegun.freeze_time("2012-01-14 03:21:34", tz_offset=0)
+    @pytest.mark.asyncio
+    async def test_single_request_multiple_fetches(self, corpus_http_client):
+        """Test that only a single request is made to the curated-corpus-api."""
+        async with AsyncClient(app=app, base_url="http://test") as ac:
+            # Gather multiple fetch calls
+            results = await asyncio.gather(fetch_en_us(ac), fetch_en_us(ac), fetch_en_us(ac))
 
-@pytest.mark.asyncio
-async def test_curated_recommendations_locale_bad_request():
-    """Test the curated recommendations endpoint response is 400 if locale is not provided"""
-    async with AsyncClient(app=app, base_url="http://test") as ac:
-        # Mock the endpoint
-        response = await ac.post("/api/v1/curated-recommendations", json={"foo": "bar"})
+            # Assert that exactly one request was made to the corpus api
+            corpus_http_client.post.assert_called_once()
 
-        # Check if the response returns 400
-        assert response.status_code == 400
+            # Assert that the results are the same
+            assert all(results[0].json() == result.json() for result in results)
 
+    @freezegun.freeze_time("2012-01-14 00:00:00", tick=True, tz_offset=0)
+    @pytest.mark.asyncio
+    async def test_single_request_multiple_failed_fetches(
+        self, corpus_http_client, fixture_request_data, fixture_response_data, caplog
+    ):
+        """Test that only a few requests are made to the curated-corpus-api when it is down."""
+        async with AsyncClient(app=app, base_url="http://test") as ac:
+            start_time = datetime.now()
 
-@freezegun.freeze_time("2012-01-14 03:21:34", tz_offset=0)
-@pytest.mark.asyncio
-async def test_single_request_multiple_fetches(corpus_http_client):
-    """Test that only a single request is made to the curated-corpus-api."""
-    async with AsyncClient(app=app, base_url="http://test") as ac:
-        # Gather multiple fetch calls
-        results = await asyncio.gather(fetch_en_us(ac), fetch_en_us(ac), fetch_en_us(ac))
+            def temporary_downtime(*args, **kwargs):
+                # Simulate the backend being unavailable for 0.2 seconds.
+                if datetime.now() < start_time + timedelta(seconds=0.2):
+                    return Response(status_code=503, request=fixture_request_data)
+                else:
+                    return Response(
+                        status_code=200,
+                        json=fixture_response_data,
+                        request=fixture_request_data,
+                    )
 
-        # Assert that exactly one request was made to the corpus api
-        corpus_http_client.post.assert_called_once()
+            corpus_http_client.post = AsyncMock(side_effect=temporary_downtime)
 
-        # Assert that the results are the same
-        assert all(results[0].json() == result.json() for result in results)
+            # Hit the endpoint until a 200 response is received.
+            while datetime.now() < start_time + timedelta(seconds=1):
+                try:
+                    result = await fetch_en_us(ac)
+                    if result.status_code == 200:
+                        break
+                except HTTPStatusError:
+                    pass
 
+            assert result.status_code == 200
 
-@freezegun.freeze_time("2012-01-14 00:00:00", tick=True, tz_offset=0)
-@pytest.mark.asyncio
-async def test_single_request_multiple_failed_fetches(
-    corpus_http_client, fixture_request_data, fixture_response_data, caplog
-):
-    """Test that only a few requests are made to the curated-corpus-api when it is down."""
-    async with AsyncClient(app=app, base_url="http://test") as ac:
-        start_time = datetime.now()
+            # Assert that we did not send a lot of requests to the backend
+            # call_count is 400+ for me locally when CorpusApiBackend._backoff_time is changed to 0.
+            print("call_count", corpus_http_client.post.call_count)
+            assert corpus_http_client.post.call_count == 2
 
-        def temporary_downtime(*args, **kwargs):
-            # Simulate the backend being unavailable for 0.2 seconds.
-            if datetime.now() < start_time + timedelta(seconds=0.2):
-                return Response(status_code=503, request=fixture_request_data)
-            else:
-                return Response(
+            # Assert that a warning was logged with a descriptive message.
+            warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+            assert len(warnings) == 1
+            assert (
+                "Retrying CorpusApiBackend._fetch_from_backend once after "
+                "Server error '503 Service Unavailable'"
+            ) in warnings[0].message
+
+    @pytest.mark.asyncio
+    async def test_cache_returned_on_subsequent_calls(
+        self, corpus_http_client, fixture_response_data, fixture_request_data
+    ):
+        """Test that the cache expires, and subsequent requests return new data."""
+        with freezegun.freeze_time(tick=True) as frozen_datetime:
+            async with AsyncClient(app=app, base_url="http://test") as ac:
+                # First fetch to populate cache
+                initial_response = await fetch_en_us(ac)
+                initial_data = initial_response.json()
+
+                for item in fixture_response_data["data"]["scheduledSurface"]["items"]:
+                    item["corpusItem"]["title"] += " (NEW)"  # Change all the titles
+                corpus_http_client.post.return_value = Response(
                     status_code=200,
                     json=fixture_response_data,
                     request=fixture_request_data,
                 )
 
-        corpus_http_client.post = AsyncMock(side_effect=temporary_downtime)
+                # Progress time to after the cache expires.
+                frozen_datetime.tick(delta=CorpusApiBackend.cache_time_to_live_max)
+                frozen_datetime.tick(delta=timedelta(seconds=1))
 
-        # Hit the endpoint until a 200 response is received.
-        while datetime.now() < start_time + timedelta(seconds=1):
-            try:
-                result = await fetch_en_us(ac)
-                if result.status_code == 200:
-                    break
-            except HTTPStatusError:
-                pass
+                # When the cache is expired, the first fetch may return stale data.
+                await fetch_en_us(ac)
+                await asyncio.sleep(0.01)  # Allow asyncio background task to make an API request
 
-        assert result.status_code == 200
-
-        # Assert that we did not send a lot of requests to the backend
-        # call_count is 400+ for me locally when CorpusApiBackend._backoff_time is changed to 0.
-        print("call_count", corpus_http_client.post.call_count)
-        assert corpus_http_client.post.call_count == 2
-
-        # Assert that a warning was logged with a descriptive message.
-        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
-        assert len(warnings) == 1
-        assert (
-            "Retrying CorpusApiBackend._fetch_from_backend once after "
-            "Server error '503 Service Unavailable'"
-        ) in warnings[0].message
+                # Next fetch should get the new data
+                new_response = await fetch_en_us(ac)
+                assert corpus_http_client.post.call_count == 2
+                new_data = new_response.json()
+                assert new_data["recommendedAt"] > initial_data["recommendedAt"]
+                assert all("NEW" in item["title"] for item in new_data["data"])
 
 
-@pytest.mark.asyncio
-async def test_cache_returned_on_subsequent_calls(
-    corpus_http_client, fixture_response_data, fixture_request_data
-):
-    """Test that the cache expires, and subsequent requests return new data."""
-    with freezegun.freeze_time(tick=True) as frozen_datetime:
+class TestCuratedRecommendationsMetrics:
+    """Tests that the right metrics are recorded for curated-recommendations requests"""
+
+    @pytest.mark.asyncio
+    async def test_metrics_cache_miss(self, mocker: MockerFixture) -> None:
+        """Test that metrics are recorded when corpus api items are not yet cached."""
+        report = mocker.patch.object(aiodogstatsd.Client, "_report")
+
         async with AsyncClient(app=app, base_url="http://test") as ac:
-            # First fetch to populate cache
-            initial_response = await fetch_en_us(ac)
-            initial_data = initial_response.json()
+            await fetch_en_us(ac)
 
-            for item in fixture_response_data["data"]["scheduledSurface"]["items"]:
-                item["corpusItem"]["title"] += " (NEW)"  # Change all the titles
+            # TODO: Remove reliance on internal details of aiodogstatsd
+            metric_keys_cache_miss: list[str] = [call.args[0] for call in report.call_args_list]
+            assert metric_keys_cache_miss == [
+                "corpus_api.request.timing",
+                "corpus_api.request.status_codes.200",
+                "post.api.v1.curated-recommendations.timing",
+                "post.api.v1.curated-recommendations.status_codes.200",
+                "response.status_codes.200",
+            ]
+
+    @pytest.mark.asyncio
+    async def test_metrics_cache_hit(self, mocker: MockerFixture) -> None:
+        """Test that metrics are recorded when corpus api items are cached."""
+        async with AsyncClient(app=app, base_url="http://test") as ac:
+            # First call populates the cache.
+            await fetch_en_us(ac)
+
+            # This test covers the metrics emitted from the cached call.
+            report = mocker.patch.object(aiodogstatsd.Client, "_report")
+            await fetch_en_us(ac)
+
+            # TODO: Remove reliance on internal details of aiodogstatsd
+            metric_keys_cache_hit: list[str] = [call.args[0] for call in report.call_args_list]
+            assert metric_keys_cache_hit == [
+                "post.api.v1.curated-recommendations.timing",
+                "post.api.v1.curated-recommendations.status_codes.200",
+                "response.status_codes.200",
+            ]
+
+    @pytest.mark.asyncio
+    async def test_metrics_corpus_api_error(
+        self, mocker: MockerFixture, corpus_http_client, fixture_request_data
+    ) -> None:
+        """Test that metrics are recorded when the curated-corpus-api returns a 500 error"""
+        report = mocker.patch.object(aiodogstatsd.Client, "_report")
+
+        async with AsyncClient(app=app, base_url="http://test") as ac:
             corpus_http_client.post.return_value = Response(
-                status_code=200,
-                json=fixture_response_data,
+                status_code=500,
                 request=fixture_request_data,
             )
 
-            # Progress time to after the cache expires.
-            frozen_datetime.tick(delta=CorpusApiBackend.cache_time_to_live_max)
-            frozen_datetime.tick(delta=timedelta(seconds=1))
+            with pytest.raises(HTTPStatusError):
+                await fetch_en_us(ac)
 
-            # When the cache is expired, the first fetch may return stale data.
-            await fetch_en_us(ac)
-            await asyncio.sleep(0.01)  # Allow asyncio background task to make an API request
-
-            # Next fetch should get the new data
-            new_response = await fetch_en_us(ac)
-            assert corpus_http_client.post.call_count == 2
-            new_data = new_response.json()
-            assert new_data["recommendedAt"] > initial_data["recommendedAt"]
-            assert all("NEW" in item["title"] for item in new_data["data"])
-
-
-@pytest.mark.asyncio
-async def test_curated_recommendations_metrics(
-    mocker: MockerFixture,
-) -> None:
-    """Test that metrics are recorded for the 'suggest' endpoint
-    (status codes: 200 & 400).
-    """
-    report = mocker.patch.object(aiodogstatsd.Client, "_report")
-
-    async with AsyncClient(app=app, base_url="http://test") as ac:
-        await fetch_en_us(ac)
-
-        # TODO: Remove reliance on internal details of aiodogstatsd
-        metric_keys_cache_miss: list[str] = [call.args[0] for call in report.call_args_list]
-        assert metric_keys_cache_miss == [
-            "curated_recommendations.corpus_api_backend.request.timing",
-            "curated_recommendations.corpus_api_backend.request.status_codes.200",
-            "post.api.v1.curated-recommendations.timing",
-            "post.api.v1.curated-recommendations.status_codes.200",
-            "response.status_codes.200",
-        ]
-
-        report.reset_mock()
-        await fetch_en_us(ac)
-
-        metric_keys_cache_hit: list[str] = [call.args[0] for call in report.call_args_list]
-        assert metric_keys_cache_hit == [
-            "post.api.v1.curated-recommendations.timing",
-            "post.api.v1.curated-recommendations.status_codes.200",
-            "response.status_codes.200",
-        ]
+            # TODO: Remove reliance on internal details of aiodogstatsd
+            metric_keys_cache_miss: list[str] = [call.args[0] for call in report.call_args_list]
+            assert metric_keys_cache_miss == [
+                "corpus_api.request.timing",
+                "corpus_api.request.status_codes.500",
+                "corpus_api.request.timing",
+                "corpus_api.request.status_codes.500",
+                "post.api.v1.curated-recommendations.timing",
+                "post.api.v1.curated-recommendations.status_codes.500",
+                "response.status_codes.500",
+            ]

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -122,7 +122,7 @@ async def test_curated_recommendations():
         assert all(item["imageUrl"] for item in corpus_items)
 
         # Assert 2nd returned recommendation has topic = None & all fields returned are expected
-        actual_recommendation: CuratedRecommendation = CuratedRecommendation(**corpus_items[1])
+        actual_recommendation = CuratedRecommendation(**corpus_items[1])
         assert actual_recommendation == expected_recommendation
 
 

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -400,8 +400,8 @@ class TestCuratedRecommendationsMetrics:
             await fetch_en_us(ac)
 
             # TODO: Remove reliance on internal details of aiodogstatsd
-            metric_keys_cache_miss: list[str] = [call.args[0] for call in report.call_args_list]
-            assert metric_keys_cache_miss == [
+            metric_keys: list[str] = [call.args[0] for call in report.call_args_list]
+            assert metric_keys == [
                 "corpus_api.request.timing",
                 "corpus_api.request.status_codes.200",
                 "post.api.v1.curated-recommendations.timing",
@@ -413,16 +413,16 @@ class TestCuratedRecommendationsMetrics:
     async def test_metrics_cache_hit(self, mocker: MockerFixture) -> None:
         """Test that metrics are recorded when corpus api items are cached."""
         async with AsyncClient(app=app, base_url="http://test") as ac:
-            # First call populates the cache.
+            # The first call populates the cache.
             await fetch_en_us(ac)
 
-            # This test covers the metrics emitted from the cached call.
+            # This test covers only the metrics emitted from the following cached call.
             report = mocker.patch.object(aiodogstatsd.Client, "_report")
             await fetch_en_us(ac)
 
             # TODO: Remove reliance on internal details of aiodogstatsd
-            metric_keys_cache_hit: list[str] = [call.args[0] for call in report.call_args_list]
-            assert metric_keys_cache_hit == [
+            metric_keys: list[str] = [call.args[0] for call in report.call_args_list]
+            assert metric_keys == [
                 "post.api.v1.curated-recommendations.timing",
                 "post.api.v1.curated-recommendations.status_codes.200",
                 "response.status_codes.200",
@@ -445,8 +445,8 @@ class TestCuratedRecommendationsMetrics:
                 await fetch_en_us(ac)
 
             # TODO: Remove reliance on internal details of aiodogstatsd
-            metric_keys_cache_miss: list[str] = [call.args[0] for call in report.call_args_list]
-            assert metric_keys_cache_miss == [
+            metric_keys: list[str] = [call.args[0] for call in report.call_args_list]
+            assert metric_keys == [
                 "corpus_api.request.timing",
                 "corpus_api.request.status_codes.500",
                 "corpus_api.request.timing",


### PR DESCRIPTION
## References

JIRA: [MC-1229](https://mozilla-hub.atlassian.net/browse/MC-1229)
Graphana: [Merino Curated Recommendations dashboard](https://earthangel-b40313e5.influxcloud.net/d/nqIyrq_Sk/merino-py-curated-recommendations?orgId=1&var-environment=stagepy&var-canary=All&from=1721076381565&to=1721077470717)

## Description
Create a Graphana dashboard for the curated-recommendations endpoint, to be used in addition to the [existing Merino dashboard](https://earthangel-b40313e5.influxcloud.net/d/rQAfYKIVk/merino-py-application-and-infrastructure?orgId=1&refresh=1m). We want to start simple with metrics that are essential for monitoring after the roll-out to release, and for analyzing a load test.

## Implementation decision
I think the following are essential:
- Endpoint latency (p50, p95, p99)
- Endpoint status codes
- Curated-corpus-api latency (p50, p95, p99)
- Curated-corpus-api status codes

![image](https://github.com/user-attachments/assets/a8d88e6e-255b-4a34-b174-56b55d984ada)

Source: [Merino Curated Recommendations dashboard](https://earthangel-b40313e5.influxcloud.net/d/nqIyrq_Sk/merino-py-curated-recommendations?orgId=1&var-environment=stagepy&var-canary=All&from=1721076381565&to=1721077470717)


## Deployment

After deployment, check and create panels in Graphana for metrics created in this PR. It's expected that it shows "No data" until this is merged.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[MC-1229]: https://mozilla-hub.atlassian.net/browse/MC-1229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ