### PR TITLE
[DISCO-2889]: Normalize geolocation city name

### DIFF
--- a/tests/unit/middleware/test_geolocation.py
+++ b/tests/unit/middleware/test_geolocation.py
@@ -10,7 +10,7 @@ from pytest_mock import MockerFixture
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 from merino.middleware import ScopeKey
-from merino.middleware.geolocation import GeolocationMiddleware, Location
+from merino.middleware.geolocation import GeolocationMiddleware, Location, normalize_string
 
 
 @pytest.fixture(name="geolocation_middleware")
@@ -163,3 +163,10 @@ async def test_geolocation_invalid_scope_type(
 
     assert ScopeKey.GEOLOCATION not in scope
     assert len(caplog.messages) == 0
+
+
+def test_normalize_string() -> None:
+    """Test the normalization of strings with special characters"""
+    assert normalize_string("Kīhei") == "Kihei"
+    assert normalize_string("‘Aiea") == "Aiea"
+    assert normalize_string("Querétaro") == "Queretaro"

--- a/tests/unit/middleware/test_geolocation.py
+++ b/tests/unit/middleware/test_geolocation.py
@@ -165,8 +165,14 @@ async def test_geolocation_invalid_scope_type(
     assert len(caplog.messages) == 0
 
 
-def test_normalize_string() -> None:
+@pytest.mark.parametrize(
+    "input_string, expected_output",
+    [
+        ("Kīhei", "Kihei"),
+        ("‘Aiea", "Aiea"),
+        ("Querétaro", "Queretaro"),
+    ],
+)
+def test_normalize_string(input_string, expected_output) -> None:
     """Test the normalization of strings with special characters"""
-    assert normalize_string("Kīhei") == "Kihei"
-    assert normalize_string("‘Aiea") == "Aiea"
-    assert normalize_string("Querétaro") == "Queretaro"
+    assert normalize_string(input_string) == expected_output


### PR DESCRIPTION
## References

JIRA: [DISCO-2889](https://mozilla-hub.atlassian.net/browse/DISCO-2889)

## Description
We have city names given by maxmind db like La’ie , ’Aiea, Kīhei, Querétaro, accuweather isn't able to handle them, so we should normalize them



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2889]: https://mozilla-hub.atlassian.net/browse/DISCO-2889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ