### PR TITLE
[DISCO-2896] fix accuweather query/request_type logic

### DIFF
--- a/merino/providers/weather/backends/accuweather.py
+++ b/merino/providers/weather/backends/accuweather.py
@@ -292,9 +292,6 @@ class AccuweatherBackend:
             response.raise_for_status()
 
         if (response_dict := process_api_response(response.json())) is None:
-            logger.warning(
-                f"Unable to parse accuweather response from: {url_path}, params: {params.get("q")}"
-            )
             self.metrics_client.increment(f"accuweather.request.{request_type}.processor.error")
             return None
 

--- a/tests/integration/api/v1/suggest/test_suggest_weather.py
+++ b/tests/integration/api/v1/suggest/test_suggest_weather.py
@@ -206,7 +206,7 @@ def test_suggest_with_weather_report(client: TestClient, backend_mock: Any) -> N
     ]
     backend_mock.get_weather_report.return_value = weather_report
 
-    response = client.get("/api/v1/suggest?q=weather")
+    response = client.get("/api/v1/suggest?q=weather&request_type=weather")
 
     assert response.status_code == 200
     assert response.headers["Cache-Control"] == "private, max-age=500"

--- a/tests/unit/providers/weather/test_provider.py
+++ b/tests/unit/providers/weather/test_provider.py
@@ -134,3 +134,20 @@ async def test_query_no_weather_report_returned(
     )
 
     assert suggestions == expected_suggestions
+
+
+@pytest.mark.asyncio
+async def test_query_with_no_request_type_no_weather_report_returned(
+    backend_mock: Any, provider: Provider, geolocation: Location
+) -> None:
+    """Test that the query method doesn't provide a weather suggestion without
+    a request type.
+    """
+    expected_suggestions: list[Suggestion] = []
+    backend_mock.get_weather_report.return_value = None
+
+    suggestions: list[BaseSuggestion] = await provider.query(
+        SuggestionRequest(query="weather", geolocation=geolocation)
+    )
+
+    assert suggestions == expected_suggestions


### PR DESCRIPTION
## References

JIRA: [DISCO-2896](https://mozilla-hub.atlassian.net/browse/DISCO-2896)

## Description
So Merino's behavior is in line with its [api specs](https://docs.google.com/document/d/1yKjNjlXyDkEhaDp3BVcK4rcfsZJd7Xnqx928LzNpvZc/edit#heading=h.674etbhr3qaz) when query is not empty it should require a `request_type` as a parameter



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2896]: https://mozilla-hub.atlassian.net/browse/DISCO-2896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ