### PR TITLE
[MC-1294] feat: add GcsEngagement to get aggregate clicks & impressions

### DIFF
--- a/docs/data.md
+++ b/docs/data.md
@@ -75,6 +75,12 @@ log inspection interfaces.
  Failed to get timezone for scheduled surface.
 - `WARNING merino.curated_recommendations.corpus_backends.corpus_api_backend` -
  Retrying CorpusApiBackend after an http client exception was raised.
+- `ERROR GcsEngagement failed to update cache: {e}` - unexpected exception when updating engagement.
+- `ERROR Curated recommendations engagement size {blob.size} > {self.max_size}` -
+ Max engagement blob size is exceeded. The backend will gracefully fall back to cached data or 0's.
+- `INFO Curated recommendations engagement unchanged since {self.last_updated}.` -
+ The engagement blob was not updated since the last check. `last_updated` is expected to be
+ between 0 and 30 minutes.
 
 ## Metrics
 

--- a/docs/data.md
+++ b/docs/data.md
@@ -157,3 +157,11 @@ The following additional metrics are recorded when curated recommendations are r
  A timer to measure the duration (in ms) of looking up a list of scheduled corpus items.
 - `corpus_api.request.status_codes.{res.status_code}` -
  A counter to measure the status codes of an HTTP request to the curated-corpus-api.
+- `recommendation.engagement.update.timing` -
+ A timer to measure the duration (in ms) of updating the engagement data from GCS.
+- `recommendation.engagement.size` - A gauge to track the size of the blob on GCS.
+- `recommendation.engagement.count` - A gauge to measure the number of scheduled corpus items with
+ engagement data.
+- `recommendation.engagement.last_updated` -
+ A gauge for the staleness (in seconds) of the engagement data, measured between when the data was
+ updated in GCS and the current time.

--- a/merino/cron.py
+++ b/merino/cron.py
@@ -27,7 +27,7 @@ class Task(Protocol):
 
 
 class Job:
-    """Periodally run a given task if a given condition is met."""
+    """Periodically run a given task if a given condition is met."""
 
     name: str
     interval: float
@@ -35,6 +35,14 @@ class Job:
     task: Task
 
     def __init__(self, *, name: str, interval: float, condition: Condition, task: Task) -> None:
+        """Create a cron job to periodically run a given task asynchronously.
+
+        Args:
+            name: The name used to identify the cron job in logs.
+            interval: The interval in seconds between each run of the task.
+            condition: A synchronous callable that determines whether the task should run.
+            task: An asynchronous callable that defines the task to be run.
+        """
         self.name = name
         self.interval = interval
         self.condition = condition

--- a/merino/curated_recommendations/engagement_backends/__init__.py
+++ b/merino/curated_recommendations/engagement_backends/__init__.py
@@ -1,0 +1,5 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Module dedicated to backends for curated recommendation aggregate click & impression counts"""

--- a/merino/curated_recommendations/engagement_backends/gcs_engagement.py
+++ b/merino/curated_recommendations/engagement_backends/gcs_engagement.py
@@ -1,0 +1,125 @@
+"""Wrapper for engagement data from Google Cloud Storage."""
+
+import json
+import logging
+import threading
+import time
+from datetime import datetime, timedelta
+from typing import Dict
+
+from google.cloud.storage import Client
+from .protocol import Engagement, EngagementBackend
+
+logger = logging.getLogger(__name__)
+
+
+class GcsEngagement(EngagementBackend):
+    """Backend that retrieves engagement data from Google Cloud Storage.
+
+    This class will fetch engagement data from Google Cloud Storage in a background thread.
+    A thread is used because Google Cloud library does not support asyncio. This class uses a
+    single thread with a low request rate to GCS, so thread performance should not be an issue.
+    Alternatively, the gcloud-aio-storage library provides asyncio access to GCS.
+    """
+
+    _thread: threading.Thread | None
+
+    def __init__(
+        self,
+        client: Client,
+        bucket_name: str,
+        blob_name: str,
+        max_size: int,
+        thread_sleep_period: timedelta = timedelta(seconds=1),
+        gcs_check_interval: timedelta = timedelta(seconds=60),
+    ) -> None:
+        """Initialize the engagement backend but do not start the background task.
+
+        Args:
+            client: GCS client initialized to the correct project
+            bucket_name: GCS bucket name
+            blob_name: GCS blob path
+            max_size: Maximum size in bytes of the GCS blob. If exceeded, an error will be logged
+             and new engagement data will not be loaded. This guards against out-of-memory errors.
+            thread_sleep_period: Max time that thread will stay alive after shutdown() is called.
+            gcs_check_interval: Interval at which to check GCS for updates.
+        """
+        self.client = client
+        self.bucket_name = bucket_name
+        self.blob_name = blob_name
+        self.max_size = max_size
+        self.thread_sleep_period = thread_sleep_period
+        self.gcs_check_interval = gcs_check_interval
+        self.last_updated = datetime.min
+        self._cache: Dict[str, Engagement] = {}
+        self._shutdown_event = threading.Event()
+        self._thread = None
+
+    def initialize(self):
+        """Start the background thread to get new data."""
+        self._thread = threading.Thread(target=self._update_cache_loop, daemon=True)
+        self._thread.start()
+
+    def shutdown(self) -> None:
+        """Clean up resources and stop the cache update loop."""
+        self._shutdown_event.set()
+        if self._thread:
+            self._thread.join()
+        self.client.close()
+
+    def __getitem__(self, scheduled_corpus_item_id: str) -> Engagement:
+        """Get engagement data for the given scheduled corpus item id from cache.
+
+        Args:
+            scheduled_corpus_item_id: The id of the scheduled corpus item for which
+                                      to return engagement data.
+
+        Returns:
+            Engagement: This method always immediately returns an Engagement object containing
+                        engagement data for the specified id. If the id does not exist in the
+                        cache, the returned Engagement object will have 0 clicks and impressions.
+        """
+        if scheduled_corpus_item_id in self._cache:
+            return self._cache[scheduled_corpus_item_id]
+        return Engagement(
+            scheduled_corpus_item_id=scheduled_corpus_item_id, clicks=0, impressions=0
+        )
+
+    def _update_task(self):
+        """Task to update the cache with the latest engagement data from GCS."""
+        bucket = self.client.bucket(self.bucket_name)
+        blob = bucket.blob(self.blob_name)
+        # Reload properties from Cloud Storage. This populates blob.size and blob.updated.
+        blob.reload()
+
+        if blob.size > self.max_size:
+            logger.error(f"Curated recommendations engagement size {blob.size} > {self.max_size}")
+        elif blob.updated <= self.last_updated:
+            logger.info(f"Curated recommendations engagement unchanged since {self.last_updated}.")
+        else:
+            data = blob.download_as_text()
+            engagement_data = self._parse_data(data)
+            self._cache.update(engagement_data)
+            self.last_updated = blob.updated
+
+    def _update_cache_loop(self):
+        """Loop to periodically update the cache with the latest engagement data from GCS."""
+        next_update_time = datetime.now()
+
+        while not self._shutdown_event.is_set():
+            try:
+                if datetime.now() >= next_update_time:
+                    next_update_time += self.gcs_check_interval
+                    self._update_task()
+            except Exception as e:
+                # Log unexpected exceptions to Sentry, and retry the update in the next interval.
+                logger.error(f"Failed to update cache: {e}")
+            finally:
+                # Sleep between request (success or failure) to limit resource usage.
+                time.sleep(self.thread_sleep_period.total_seconds())
+
+    @staticmethod
+    def _parse_data(data: str) -> Dict[str, Engagement]:
+        """Parse the raw JSON data into a dictionary of Engagement objects."""
+        raw_data = json.loads(data)
+        return {item["scheduled_corpus_item_id"]: Engagement(**item) for item in raw_data}

--- a/merino/curated_recommendations/engagement_backends/gcs_engagement.py
+++ b/merino/curated_recommendations/engagement_backends/gcs_engagement.py
@@ -17,9 +17,9 @@ logger = logging.getLogger(__name__)
 class GcsEngagement(EngagementBackend):
     """Backend that retrieves engagement data from Google Cloud Storage.
 
-    This class will fetch engagement data from Google Cloud Storage in a background thread.
-    A thread is used because Google Cloud library does not support asyncio. This class uses a
-    single thread with a low request rate to GCS, so thread performance should not be an issue.
+    This class fetches engagement data from Google Cloud Storage in a background thread.
+    A thread is used because the Google Cloud library does not support asyncio. This class uses
+    a single thread with a low request rate to GCS, ensuring thread performance is not an issue.
     Alternatively, the gcloud-aio-storage library provides asyncio access to GCS.
     """
 
@@ -123,7 +123,7 @@ class GcsEngagement(EngagementBackend):
                         self._update_task()
             except Exception as e:
                 # Log unexpected exceptions to Sentry, and retry the update in the next interval.
-                logger.error(f"Failed to update cache: {e}")
+                logger.error(f"GcsEngagement failed to update cache: {e}")
             finally:
                 # Sleep between request (success or failure) to limit resource usage.
                 time.sleep(self.thread_sleep_period.total_seconds())

--- a/merino/curated_recommendations/engagement_backends/gcs_engagement.py
+++ b/merino/curated_recommendations/engagement_backends/gcs_engagement.py
@@ -1,15 +1,20 @@
 """Wrapper for engagement data from Google Cloud Storage."""
 
+import asyncio
 import json
 import logging
-import threading
 import time
 from datetime import datetime, timedelta
 from typing import Dict
 
 from google.cloud.storage import Client
 from aiodogstatsd import Client as StatsdClient
-from .protocol import Engagement, EngagementBackend
+
+from merino import cron
+from merino.curated_recommendations.engagement_backends.protocol import (
+    Engagement,
+    EngagementBackend,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -17,13 +22,10 @@ logger = logging.getLogger(__name__)
 class GcsEngagement(EngagementBackend):
     """Backend that retrieves engagement data from Google Cloud Storage.
 
-    This class fetches engagement data from Google Cloud Storage in a background thread.
-    A thread is used because the Google Cloud library does not support asyncio. This class uses
-    a single thread with a low request rate to GCS, ensuring thread performance is not an issue.
-    Alternatively, the gcloud-aio-storage library provides asyncio access to GCS.
+    This class periodically fetches engagement data from Google Cloud Storage in the background.
     """
 
-    _thread: threading.Thread | None
+    cron_task: asyncio.Task
 
     def __init__(
         self,
@@ -32,8 +34,7 @@ class GcsEngagement(EngagementBackend):
         bucket_name: str,
         blob_name: str,
         max_size: int,
-        thread_sleep_period: timedelta = timedelta(seconds=1),
-        gcs_check_interval: timedelta = timedelta(seconds=60),
+        cron_interval: timedelta = timedelta(seconds=60),
     ) -> None:
         """Initialize the engagement backend but do not start the background task.
 
@@ -44,35 +45,32 @@ class GcsEngagement(EngagementBackend):
             blob_name: GCS blob path
             max_size: Maximum size in bytes of the GCS blob. If exceeded, an error will be logged
              and new engagement data will not be loaded. This guards against out-of-memory errors.
-            thread_sleep_period: Max time that thread will stay alive after shutdown() is called.
-            gcs_check_interval: Interval at which to check GCS for updates.
+            cron_interval: Interval at which to check GCS for updates.
         """
         self.storage_client = storage_client
         self.metrics_client = metrics_client
         self.bucket_name = bucket_name
         self.blob_name = blob_name
         self.max_size = max_size
-        self.thread_sleep_period = thread_sleep_period
-        self.gcs_check_interval = gcs_check_interval
+        self.cron_interval_sec = cron_interval
         self.last_updated = datetime.min
         self._cache: Dict[str, Engagement] = {}
-        self._shutdown_event = threading.Event()
-        self._thread = None
 
     def initialize(self):
-        """Start the background thread to get new data."""
-        self._thread = threading.Thread(target=self._update_cache_loop, daemon=True)
-        self._thread.start()
-
-    def shutdown(self) -> None:
-        """Clean up resources and stop the cache update loop."""
-        self._shutdown_event.set()
-        if self._thread:
-            self._thread.join()
-        self.storage_client.close()
+        """Start the background cron job to get new data."""
+        # Run a cron job that resyncs data from Remote Settings in the background.
+        cron_job = cron.Job(
+            name="fetch_recommendation_engagement",
+            interval=self.cron_interval_sec.total_seconds(),
+            condition=lambda: True,
+            task=self._update_task_async,
+        )
+        # Store the created task on the instance variable. Otherwise, it will get
+        # garbage collected because asyncio's runtime only holds a weak reference to it.
+        self.cron_task = asyncio.create_task(cron_job())
 
     def __getitem__(self, scheduled_corpus_item_id: str) -> Engagement:
-        """Get engagement data for the given scheduled corpus item id from cache.
+        """Get cached click and impression counts from the last 24h for the scheduled corpus item id
 
         Args:
             scheduled_corpus_item_id: The id of the scheduled corpus item for which
@@ -89,45 +87,43 @@ class GcsEngagement(EngagementBackend):
             scheduled_corpus_item_id=scheduled_corpus_item_id, clicks=0, impressions=0
         )
 
+    async def _update_task_async(self) -> None:
+        """Run _update_task in a thread to prevent blocking the event loop
+
+        A thread is used because the Google Cloud library does not support asyncio.
+        Alternatively, the gcloud-aio-storage library provides asyncio access to GCS.
+        """
+        await asyncio.to_thread(self._update_task)
+
     def _update_task(self):
         """Task to update the cache with the latest engagement data from GCS."""
-        bucket = self.storage_client.bucket(self.bucket_name)
-        blob = bucket.blob(self.blob_name)
-        # Reload properties from Cloud Storage. This populates blob.size and blob.updated.
-        blob.reload()
+        with self.metrics_client.timeit("recommendation.engagement.update.timing"):
+            bucket = self.storage_client.bucket(self.bucket_name)
+            blob = bucket.blob(self.blob_name)
+            # Reload properties from Cloud Storage. This populates blob.size and blob.updated.
+            blob.reload()
 
-        self.metrics_client.gauge("recommendation.engagement.size", value=blob.size)
+            self.metrics_client.gauge("recommendation.engagement.size", value=blob.size)
 
-        if blob.size > self.max_size:
-            logger.error(f"Curated recommendations engagement size {blob.size} > {self.max_size}")
-        elif blob.updated <= self.last_updated:
-            logger.info(f"Curated recommendations engagement unchanged since {self.last_updated}.")
-        else:
-            data = blob.download_as_text()
-            engagement_data = self._parse_data(data)
-            self._cache = engagement_data
-            self.last_updated = blob.updated
-            self.metrics_client.gauge(
-                "recommendation.engagement.count", value=len(engagement_data)
-            )
+            if blob.size > self.max_size:
+                logger.error(
+                    f"Curated recommendations engagement size {blob.size} exceeds {self.max_size}"
+                )
+            elif blob.updated <= self.last_updated:
+                logger.info(
+                    f"Curated recommendations engagement unchanged since {self.last_updated}."
+                )
+            else:
+                data = blob.download_as_text()
+                engagement_data = self._parse_data(data)
+                self._cache = engagement_data
+                self.last_updated = blob.updated
+                self.metrics_client.gauge(
+                    "recommendation.engagement.count", value=len(engagement_data)
+                )
 
-    def _update_cache_loop(self):
-        """Loop to periodically update the cache with the latest engagement data from GCS."""
-        next_update_time = datetime.now()
-
-        while not self._shutdown_event.is_set():
-            try:
-                if datetime.now() >= next_update_time:
-                    next_update_time += self.gcs_check_interval
-                    with self.metrics_client.timeit("recommendation.engagement.update.timing"):
-                        self._update_task()
-            except Exception as e:
-                # Log unexpected exceptions to Sentry, and retry the update in the next interval.
-                logger.error(f"GcsEngagement failed to update cache: {e}")
-            finally:
-                # Sleep between request (success or failure) to limit resource usage.
-                time.sleep(self.thread_sleep_period.total_seconds())
-                # Report the staleness of the engagement data in seconds.
+            # Report the staleness of the engagement data in seconds.
+            if self.last_updated != datetime.min:
                 self.metrics_client.gauge(
                     "recommendation.engagement.last_updated",
                     value=time.time() - self.last_updated.timestamp(),

--- a/merino/curated_recommendations/engagement_backends/protocol.py
+++ b/merino/curated_recommendations/engagement_backends/protocol.py
@@ -5,7 +5,12 @@ from pydantic import BaseModel
 
 
 class Engagement(BaseModel):
-    """Represents the engagement data for a scheduled corpus item."""
+    """Represents the engagement data from the last 24 hours for a scheduled corpus item.
+
+    Engagement is aggregated over a rolling 24-hour window by scheduled_corpus_item_id, a unique ID
+     for the URL, scheduled date, and surface (e.g., "New Tab en-US"). It's expected to be updated
+     periodically with a delay of < 30 minutes from when clicks or impressions happen in the client.
+    """
 
     scheduled_corpus_item_id: str
     clicks: int
@@ -19,6 +24,6 @@ class EngagementBackend(Protocol):
         """Fetch engagement data for the given scheduled corpus item id"""
         ...
 
-    def shutdown(self) -> None:
-        """Clean up any resources"""
+    def initialize(self) -> None:
+        """Start any background jobs"""
         ...

--- a/merino/curated_recommendations/engagement_backends/protocol.py
+++ b/merino/curated_recommendations/engagement_backends/protocol.py
@@ -1,0 +1,24 @@
+"""Protocol and Pydantic models for the Engagement provider backend."""
+
+from typing import Protocol
+from pydantic import BaseModel
+
+
+class Engagement(BaseModel):
+    """Represents the engagement data for a scheduled corpus item."""
+
+    scheduled_corpus_item_id: str
+    clicks: int
+    impressions: int
+
+
+class EngagementBackend(Protocol):
+    """Protocol for Engagement backend that the provider depends on."""
+
+    def __getitem__(self, scheduled_corpus_item_id: str) -> Engagement:
+        """Fetch engagement data for the given scheduled corpus item id"""
+        ...
+
+    def shutdown(self) -> None:
+        """Clean up any resources"""
+        ...

--- a/tests/integration/api/v1/curated_recommendations/engagement_backends/test_gcs_engagement.py
+++ b/tests/integration/api/v1/curated_recommendations/engagement_backends/test_gcs_engagement.py
@@ -2,7 +2,6 @@
 
 import json
 import logging
-import time
 from datetime import datetime, timedelta
 from unittest.mock import MagicMock
 
@@ -12,6 +11,8 @@ from google.cloud.storage import Client, Blob, Bucket
 
 from merino.curated_recommendations.engagement_backends.gcs_engagement import GcsEngagement
 from merino.curated_recommendations.engagement_backends.protocol import Engagement
+
+import asyncio
 
 
 @pytest.fixture
@@ -46,28 +47,28 @@ def mock_metrics_client(mocker):
 
 
 @pytest.fixture(name="gcs_engagement")
-def mock_gcs_engagement(mock_gcs_client, mock_metrics_client):
+def mock_gcs_engagement(mock_gcs_client, mock_metrics_client) -> GcsEngagement:
     """Return a mock GCS Engagement instance"""
-    gcs_engagement = GcsEngagement(
+    return GcsEngagement(
         storage_client=mock_gcs_client,
         metrics_client=mock_metrics_client,
         bucket_name="test-bucket",
         blob_name="test-blob",
         max_size=1024 * 1024,
-        thread_sleep_period=timedelta(milliseconds=10),
+        cron_interval=timedelta(milliseconds=10),  # Short interval ensures tests execute quickly.
     )
-    yield gcs_engagement
-    gcs_engagement.shutdown()
 
 
-def test_gcs_engagement_backend_return_zero_for_missing_keys(gcs_engagement):
+@pytest.mark.asyncio
+async def test_gcs_engagement_backend_return_zero_for_missing_keys(gcs_engagement):
     """Test that the backend returns 0 clicks and impressions for keys not in the fixture"""
     assert gcs_engagement["missing_key"] == Engagement(
         scheduled_corpus_item_id="missing_key", clicks=0, impressions=0
     )
 
 
-def test_gcs_engagement_backend_fetches_data(gcs_engagement, mock_gcs_blob):
+@pytest.mark.asyncio
+async def test_gcs_engagement_backend_fetches_data(gcs_engagement, mock_gcs_blob):
     """Test that the backend fetches data from GCS and returns engagement data"""
     engagement_data = [
         {"scheduled_corpus_item_id": "12345", "clicks": 10, "impressions": 100},
@@ -78,7 +79,7 @@ def test_gcs_engagement_backend_fetches_data(gcs_engagement, mock_gcs_blob):
     mock_gcs_blob.updated = datetime(2024, 1, 1, 0, 0, 0)
 
     gcs_engagement.initialize()
-    time.sleep(0.02)  # Allow the background thread to fetch data.
+    await asyncio.sleep(0.02)  # Allow the cron job to fetch data.
 
     assert gcs_engagement["12345"] == Engagement(
         scheduled_corpus_item_id="12345", clicks=10, impressions=100
@@ -88,55 +89,45 @@ def test_gcs_engagement_backend_fetches_data(gcs_engagement, mock_gcs_blob):
     )
 
 
-def test_gcs_engagement_backend_logs_error_for_large_blob(gcs_engagement, mock_gcs_blob, caplog):
+@pytest.mark.asyncio
+async def test_gcs_engagement_backend_logs_error_for_large_blob(
+    gcs_engagement, mock_gcs_blob, caplog
+):
     """Test that the backend logs an error if the blob size exceeds the max size"""
     caplog.set_level(logging.ERROR)
     mock_gcs_blob.size = 1024 * 1024 + 1  # 1 byte over the limit
     mock_gcs_blob.updated = datetime(2024, 1, 1, 0, 0, 0)
 
     gcs_engagement.initialize()
-    time.sleep(0.01)  # Allow the background thread to fetch data.
+    await asyncio.sleep(0.01)  # Allow the cron job to fetch data.
 
-    assert "Curated recommendations engagement size 1048577 > 1048576" in caplog.text
+    assert "Curated recommendations engagement size 1048577 exceeds 1048576" in caplog.text
 
 
-def test_gcs_engagement_backend_download_count(mock_gcs_blob, mock_gcs_client):
-    """Test that the backend periodically updates engagement from GCS
-
-    This test uses actual time because freezegun cannot freeze time in threads:
-    https://github.com/spulec/freezegun/issues/307
-    Alternatively, the 'time-machine' library does support mocking time in threads.
-    """
-    gcs_engagement = GcsEngagement(
-        storage_client=mock_gcs_client,
-        metrics_client=MagicMock(spec=StatsdClient),
-        bucket_name="test-bucket",
-        blob_name="test-blob",
-        max_size=1024 * 1024,
-        thread_sleep_period=timedelta(milliseconds=1),
-        gcs_check_interval=timedelta(milliseconds=10),  # A short interval keeps this test fast.
-    )
-
+@pytest.mark.asyncio
+async def test_gcs_engagement_backend_download_count(
+    gcs_engagement, mock_gcs_blob, mock_gcs_client
+):
+    """Test that the backend periodically updates engagement from GCS"""
     start_time = datetime.now()
     mock_gcs_blob.updated = start_time
     mock_gcs_blob.download_as_text.return_value = json.dumps([])
     mock_gcs_blob.size = 512
 
-    gcs_engagement.initialize()  # Start the background task
+    gcs_engagement.initialize()  # Start the cron job
 
-    # Sleep for a set period of time, while periodically increasing the mock 'updated' attribute.
+    # Simulate time progression and updates
     expected_downloads = 3
     update_period = timedelta(milliseconds=100)  # Time between simulated updates to the blob
     for i in range(expected_downloads):
         mock_gcs_blob.updated = start_time + (i * update_period)
-        time.sleep(update_period.total_seconds())
+        await asyncio.sleep(update_period.total_seconds())
 
     assert mock_gcs_blob.download_as_text.call_count == expected_downloads
 
-    gcs_engagement.shutdown()
 
-
-def test_gcs_engagement_metrics(gcs_engagement, mock_gcs_blob, mock_metrics_client):
+@pytest.mark.asyncio
+async def test_gcs_engagement_metrics(gcs_engagement, mock_gcs_blob, mock_metrics_client):
     """Test that the backend records the correct metrics."""
     engagement_data = [
         {"scheduled_corpus_item_id": "12345", "clicks": 10, "impressions": 100},
@@ -147,7 +138,7 @@ def test_gcs_engagement_metrics(gcs_engagement, mock_gcs_blob, mock_metrics_clie
     mock_gcs_blob.updated = datetime.now()
 
     gcs_engagement.initialize()
-    time.sleep(0.02)  # Allow the background thread to fetch data.
+    await asyncio.sleep(0.1)  # Give the cron job time to run
 
     # Verify the metrics are recorded correctly
     mock_metrics_client.gauge.assert_any_call("recommendation.engagement.size", value=512)

--- a/tests/integration/api/v1/curated_recommendations/engagement_backends/test_gcs_engagement.py
+++ b/tests/integration/api/v1/curated_recommendations/engagement_backends/test_gcs_engagement.py
@@ -1,0 +1,124 @@
+"""Tests loading engagement data from Google Cloud Storage."""
+
+import json
+import logging
+import time
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock
+
+import pytest
+from google.cloud.storage import Client, Blob, Bucket
+
+from merino.curated_recommendations.engagement_backends.gcs_engagement import GcsEngagement
+from merino.curated_recommendations.engagement_backends.protocol import Engagement
+
+
+@pytest.fixture
+def mock_gcs_client():
+    """Return a mock GCS Client instance"""
+    return MagicMock(spec=Client)
+
+
+@pytest.fixture
+def mock_gcs_bucket(mock_gcs_client):
+    """Return a mock GCS Bucket instance"""
+    bucket = MagicMock(spec=Bucket)
+    mock_gcs_client.bucket.return_value = bucket
+    return bucket
+
+
+@pytest.fixture
+def mock_gcs_blob(mock_gcs_bucket):
+    """Return a mock GCS Blob instance"""
+    blob = MagicMock(spec=Blob)
+    mock_gcs_bucket.blob.return_value = blob
+    return blob
+
+
+@pytest.fixture(name="gcs_engagement")
+def mock_gcs_engagement(mock_gcs_client):
+    """Return a mock GCS Engagement instance"""
+    gcs_engagement = GcsEngagement(
+        client=mock_gcs_client,
+        bucket_name="test-bucket",
+        blob_name="test-blob",
+        max_size=1024 * 1024,
+        thread_sleep_period=timedelta(milliseconds=10),
+    )
+    yield gcs_engagement
+    gcs_engagement.shutdown()
+
+
+def test_gcs_engagement_backend_return_zero_for_missing_keys(gcs_engagement):
+    """Test that the backend returns 0 clicks and impressions for keys not in the fixture"""
+    assert gcs_engagement["missing_key"] == Engagement(
+        scheduled_corpus_item_id="missing_key", clicks=0, impressions=0
+    )
+
+
+def test_gcs_engagement_backend_fetches_data(gcs_engagement, mock_gcs_blob):
+    """Test that the backend fetches data from GCS and returns engagement data"""
+    engagement_data = [
+        {"scheduled_corpus_item_id": "12345", "clicks": 10, "impressions": 100},
+        {"scheduled_corpus_item_id": "67890", "clicks": 20, "impressions": 200},
+    ]
+    mock_gcs_blob.download_as_text.return_value = json.dumps(engagement_data)
+    mock_gcs_blob.size = 512
+    mock_gcs_blob.updated = datetime(2024, 1, 1, 0, 0, 0)
+
+    gcs_engagement.initialize()
+    time.sleep(0.02)  # Allow the background thread to fetch data.
+
+    assert gcs_engagement["12345"] == Engagement(
+        scheduled_corpus_item_id="12345", clicks=10, impressions=100
+    )
+    assert gcs_engagement["67890"] == Engagement(
+        scheduled_corpus_item_id="67890", clicks=20, impressions=200
+    )
+
+
+def test_gcs_engagement_backend_logs_error_for_large_blob(gcs_engagement, mock_gcs_blob, caplog):
+    """Test that the backend logs an error if the blob size exceeds the max size"""
+    caplog.set_level(logging.ERROR)
+    mock_gcs_blob.size = 1024 * 1024 + 1  # 1 byte over the limit
+    mock_gcs_blob.updated = datetime(2024, 1, 1, 0, 0, 0)
+
+    gcs_engagement.initialize()
+    time.sleep(0.01)  # Allow the background thread to fetch data.
+
+    assert "Curated recommendations engagement size 1048577 > 1048576" in caplog.text
+
+
+def test_gcs_engagement_backend_download_count(mock_gcs_blob, mock_gcs_client):
+    """Test that the backend periodically updates engagement from GCS
+
+    This test uses actual time because freezegun cannot freeze time in threads:
+    https://github.com/spulec/freezegun/issues/307
+    Alternatively, the 'time-machine' library does support mocking time in threads.
+    """
+    gcs_engagement = GcsEngagement(
+        client=mock_gcs_client,
+        bucket_name="test-bucket",
+        blob_name="test-blob",
+        max_size=1024 * 1024,
+        thread_sleep_period=timedelta(milliseconds=1),
+        gcs_check_interval=timedelta(milliseconds=10),  # A short interval keeps this test fast.
+    )
+
+    start_time = datetime.now()
+    mock_gcs_blob.updated = start_time
+    mock_gcs_blob.download_as_text.return_value = json.dumps([])
+    mock_gcs_blob.size = 512
+
+    gcs_engagement.initialize()  # Start the background task
+
+    # Sleep for a set period of time, while periodically increasing the mock 'updated' attribute.
+    expected_downloads = 3
+    update_period = timedelta(milliseconds=100)  # Time between simulated updates to the blob
+    for i in range(expected_downloads):
+        mock_gcs_blob.updated = start_time + (i * update_period)
+        time.sleep(update_period.total_seconds())
+
+    assert mock_gcs_blob.download_as_text.call_count == expected_downloads
+
+    gcs_engagement.shutdown()


### PR DESCRIPTION
## References

- PR JIRA task: [MC-1294](https://mozilla-hub.atlassian.net/browse/MC-1294)
- JIRA story: [MC-1256](https://mozilla-hub.atlassian.net/browse/MC-1256)
- [GCP Blob class documentation](https://cloud.google.com/python/docs/reference/storage/latest/google.cloud.storage.blob.Blob#google_cloud_storage_blob_Blob_reload)
- staging bucket (empty): [merino-airflow-data-stagepy ](https://console.cloud.google.com/storage/browser/merino-airflow-data-stagepy;tab=objects?forceOnBucketsSortingFiltering=true&project=moz-fx-merino-nonprod-ee93&prefix=&forceOnObjectsSortingFiltering=false)
- production bucket (empty): [merino-airflow-data-prodpy ](https://console.cloud.google.com/storage/browser/merino-airflow-data-prodpy;tab=objects?forceOnBucketsSortingFiltering=true&project=moz-fx-merino-prod-1c2f&prefix=&forceOnObjectsSortingFiltering=false)
- bucket permissions: https://github.com/mozilla-services/cloudops-infra/pull/5776

## Description

Create a backend to load aggregate engagement for curated recommendations.

Currently, this backend is unused. In [MC-1302](https://mozilla-hub.atlassian.net/browse/MC-1302) we will use this backend to load engagement data and apply Thompson sampling.

We can't test this end-to-end yet because the data does not yet exists in GCS. I've done my best to follow the [Blob doc](https://cloud.google.com/python/docs/reference/storage/latest/google.cloud.storage.blob.Blob#google_cloud_storage_blob_Blob_reload), but I imagine we might run into a bug or two once we can test this against GCS. I think that's fine because this class is not actively used, and is designed to fail gracefully.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[MC-1294]: https://mozilla-hub.atlassian.net/browse/MC-1294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[MC-1256]: https://mozilla-hub.atlassian.net/browse/MC-1256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MC-1302]: https://mozilla-hub.atlassian.net/browse/MC-1302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ