### PR TITLE
[MC-212] feat: Adding utm_source param to curated rec url

### DIFF
--- a/tests/data/scheduled_surface.json
+++ b/tests/data/scheduled_surface.json
@@ -27,8 +27,8 @@
         {
           "id": "1452b7ea-7ba9-4da9-ba39-ab44e8147d5e",
           "corpusItem": {
-            "url": "https://getpocket.com/explore/item/other-countries-have-social-safety-nets-the-u-s-has-women",
-            "title": "“Other Countries Have Social Safety Nets. The U.S. Has Women.”",
+            "url": "https://getpocket.com/explore/item/other-countries-have-social-safety-nets-the-u-s-has-women?utm_source=old_source",
+            "title": "Other Countries Have Social Safety Nets. The U.S. Has Women.",
             "excerpt": "Anne Helen Petersen and Jessica Calarco discuss how mothers are experiencing and responding to pandemic-related disruptions in their normal routines.",
             "topic": "PARENTING",
             "publisher": "Culture Study",

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -133,23 +133,6 @@ async def test_curated_recommendations():
 async def test_curated_recommendations_utm_source():
     """Test the curated recommendations endpoint returns urls with correct(new) utm_source"""
     async with AsyncClient(app=app, base_url="http://test") as ac:
-        # expected recommendation with new utm_source
-        expected_recommendation = CuratedRecommendation(
-            scheduledCorpusItemId="1452b7ea-7ba9-4da9-ba39-ab44e8147d5e",
-            url=HttpUrl(
-                "https://getpocket.com/explore/item/other-countries-have-social-safety-nets-the-u-s-has-women"
-                "?utm_source=pocket-newtab-en-us"
-            ),
-            title="Other Countries Have Social Safety Nets. The U.S. Has Women.",
-            excerpt="Anne Helen Petersen and Jessica Calarco discuss how mothers are experiencing and responding to "
-            "pandemic-related disruptions in their normal routines.",
-            topic=Topic.PARENTING,
-            publisher="Culture Study",
-            imageUrl=HttpUrl(
-                "https://s3.amazonaws.com/pocket-curatedcorpusapi-prod-images/3a4a6ed6-a1df-497d-8d31-f777534806ac.jpeg"
-            ),
-            receivedRank=2,
-        )
         # Mock the endpoint
         response = await fetch_en_us(ac)
         data = response.json()
@@ -161,13 +144,10 @@ async def test_curated_recommendations_utm_source():
         # assert total of 80 items returned
         assert len(corpus_items) == 80
         # Assert all corpus_items have expected fields populated.
-        assert all(item["url"] for item in corpus_items)
+        # check that utm_source is present and has the correct value in all urls
+        assert all("?utm_source=pocket-newtab-en-us" in item["url"] for item in corpus_items)
         assert all(item["publisher"] for item in corpus_items)
         assert all(item["imageUrl"] for item in corpus_items)
-
-        # Assert 2nd returned recommendation has topic = None & all fields returned are expected
-        actual_recommendation: CuratedRecommendation = CuratedRecommendation(**corpus_items[2])
-        assert actual_recommendation == expected_recommendation
 
 
 @pytest.mark.asyncio

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -142,7 +142,7 @@ async def test_curated_recommendations_utm_source():
             ),
             title="Other Countries Have Social Safety Nets. The U.S. Has Women.",
             excerpt="Anne Helen Petersen and Jessica Calarco discuss how mothers are experiencing and responding to "
-                    "pandemic-related disruptions in their normal routines.",
+            "pandemic-related disruptions in their normal routines.",
             topic=Topic.PARENTING,
             publisher="Culture Study",
             imageUrl=HttpUrl(
@@ -381,7 +381,7 @@ class TestCorpusApiCaching:
     @freezegun.freeze_time("2012-01-14 00:00:00", tick=True, tz_offset=0)
     @pytest.mark.asyncio
     async def test_single_request_multiple_failed_fetches(
-            self, corpus_http_client, fixture_request_data, fixture_response_data, caplog
+        self, corpus_http_client, fixture_request_data, fixture_response_data, caplog
     ):
         """Test that only a few requests are made to the curated-corpus-api when it is down."""
         async with AsyncClient(app=app, base_url="http://test") as ac:
@@ -420,13 +420,13 @@ class TestCorpusApiCaching:
             warnings = [r for r in caplog.records if r.levelname == "WARNING"]
             assert len(warnings) == 1
             assert (
-                       "Retrying CorpusApiBackend._fetch_from_backend once after "
-                       "Server error '503 Service Unavailable'"
-                   ) in warnings[0].message
+                "Retrying CorpusApiBackend._fetch_from_backend once after "
+                "Server error '503 Service Unavailable'"
+            ) in warnings[0].message
 
     @pytest.mark.asyncio
     async def test_cache_returned_on_subsequent_calls(
-            self, corpus_http_client, fixture_response_data, fixture_request_data
+        self, corpus_http_client, fixture_response_data, fixture_request_data
     ):
         """Test that the cache expires, and subsequent requests return new data."""
         with freezegun.freeze_time(tick=True) as frozen_datetime:
@@ -501,7 +501,7 @@ class TestCuratedRecommendationsMetrics:
 
     @pytest.mark.asyncio
     async def test_metrics_corpus_api_error(
-            self, mocker: MockerFixture, corpus_http_client, fixture_request_data
+        self, mocker: MockerFixture, corpus_http_client, fixture_request_data
     ) -> None:
         """Test that metrics are recorded when the curated-corpus-api returns a 500 error"""
         report = mocker.patch.object(aiodogstatsd.Client, "_report")

--- a/tests/unit/curated_recommendations/test_corpus_api_backend.py
+++ b/tests/unit/curated_recommendations/test_corpus_api_backend.py
@@ -6,10 +6,11 @@ import pytest
 from freezegun import freeze_time
 
 from merino.curated_recommendations.corpus_backends.corpus_api_backend import (
-    map_corpus_topic_to_serp_topic,
     CorpusApiBackend,
 )
 from pytest import LogCaptureFixture
+
+from merino.curated_recommendations.corpus_backends.protocol import ScheduledSurfaceId
 
 
 @pytest.mark.parametrize("topic", ["CORONAVIRUS"])
@@ -18,7 +19,7 @@ def test_map_corpus_to_serp_topic_return_none(topic):
     & ensuring topics that don't have a mapping return None.
     See for reference mapped topics: https://docs.google.com/document/d/1ICCHi1haxR-jIi_uZ3xQfPmphZm39MOmwQh0BRTXLHA/edit # noqa
     """
-    assert map_corpus_topic_to_serp_topic(topic) is None
+    assert CorpusApiBackend.map_corpus_topic_to_serp_topic(topic) is None
 
 
 @pytest.mark.parametrize(
@@ -45,19 +46,19 @@ def test_map_corpus_to_serp_topic(topic, mapped_topic):
     See for reference mapped topics:
     https://docs.google.com/document/d/1ICCHi1haxR-jIi_uZ3xQfPmphZm39MOmwQh0BRTXLHA/edit
     """
-    assert map_corpus_topic_to_serp_topic(topic).value == mapped_topic
+    assert CorpusApiBackend.map_corpus_topic_to_serp_topic(topic).value == mapped_topic
 
 
 @pytest.mark.parametrize(
     "surface_id, timezone",
     [
-        ("NEW_TAB_EN_US", "America/New_York"),
-        ("NEW_TAB_EN_GB", "Europe/London"),
-        ("NEW_TAB_EN_INTL", "Asia/Kolkata"),
-        ("NEW_TAB_DE_DE", "Europe/Berlin"),
-        ("NEW_TAB_ES_ES", "Europe/Madrid"),
-        ("NEW_TAB_FR_FR", "Europe/Paris"),
-        ("NEW_TAB_IT_IT", "Europe/Rome"),
+        (ScheduledSurfaceId.NEW_TAB_EN_US, "America/New_York"),
+        (ScheduledSurfaceId.NEW_TAB_EN_GB, "Europe/London"),
+        (ScheduledSurfaceId.NEW_TAB_EN_INTL, "Asia/Kolkata"),
+        (ScheduledSurfaceId.NEW_TAB_DE_DE, "Europe/Berlin"),
+        (ScheduledSurfaceId.NEW_TAB_ES_ES, "Europe/Madrid"),
+        (ScheduledSurfaceId.NEW_TAB_FR_FR, "Europe/Paris"),
+        (ScheduledSurfaceId.NEW_TAB_IT_IT, "Europe/Rome"),
     ],
 )
 def test_get_surface_timezone(surface_id, timezone, caplog: LogCaptureFixture):
@@ -75,7 +76,7 @@ def test_get_surface_timezone_bad_input(caplog: LogCaptureFixture):
     a bad input is provided, UTC is returned.
     """
     # Should default to UTC if bad input
-    tz = CorpusApiBackend.get_surface_timezone("foobar")
+    tz = CorpusApiBackend.get_surface_timezone("foobar")  # type: ignore
     assert tz.key == "UTC"
     # Error was logged
     error_logs = [r for r in caplog.records if r.levelname == "ERROR"]
@@ -137,13 +138,13 @@ def test_get_utm_source_return_none(scheduled_surface_id):
 @pytest.mark.parametrize(
     ("scheduled_surface_id", "expected_utm_source"),
     [
-        ("NEW_TAB_EN_US", "pocket-newtab-en-us"),
-        ("NEW_TAB_EN_GB", "pocket-newtab-en-gb"),
-        ("NEW_TAB_EN_INTL", "pocket-newtab-en-intl"),
-        ("NEW_TAB_DE_DE", "pocket-newtab-de-de"),
-        ("NEW_TAB_ES_ES", "pocket-newtab-es-es"),
-        ("NEW_TAB_FR_FR", "pocket-newtab-fr-fr"),
-        ("NEW_TAB_IT_IT", "pocket-newtab-it-it"),
+        (ScheduledSurfaceId.NEW_TAB_EN_US, "pocket-newtab-en-us"),
+        (ScheduledSurfaceId.NEW_TAB_EN_GB, "pocket-newtab-en-gb"),
+        (ScheduledSurfaceId.NEW_TAB_EN_INTL, "pocket-newtab-en-intl"),
+        (ScheduledSurfaceId.NEW_TAB_DE_DE, "pocket-newtab-de-de"),
+        (ScheduledSurfaceId.NEW_TAB_ES_ES, "pocket-newtab-es-es"),
+        (ScheduledSurfaceId.NEW_TAB_FR_FR, "pocket-newtab-fr-fr"),
+        (ScheduledSurfaceId.NEW_TAB_IT_IT, "pocket-newtab-it-it"),
     ],
 )
 def test_get_utm_source(scheduled_surface_id, expected_utm_source):

--- a/tests/unit/curated_recommendations/test_corpus_api_backend.py
+++ b/tests/unit/curated_recommendations/test_corpus_api_backend.py
@@ -124,3 +124,72 @@ def test_get_expiration_time():
 
     # Assert that all returned times are different
     assert len(set(times)) == len(times)
+
+
+@pytest.mark.parametrize("scheduled_surface_id", ["bad-scheduled-surface-id"])
+def test_get_utm_source_return_none(scheduled_surface_id):
+    """Testing the get_utm_source() method
+    & ensuring ids that don't have utm_source return None.
+    """
+    assert CorpusApiBackend.get_utm_source(scheduled_surface_id) is None
+
+
+@pytest.mark.parametrize(
+    ("scheduled_surface_id", "expected_utm_source"),
+    [
+        ("NEW_TAB_EN_US", "pocket-newtab-en-us"),
+        ("NEW_TAB_EN_GB", "pocket-newtab-en-gb"),
+        ("NEW_TAB_EN_INTL", "pocket-newtab-en-intl"),
+        ("NEW_TAB_DE_DE", "pocket-newtab-de-de"),
+        ("NEW_TAB_ES_ES", "pocket-newtab-es-es"),
+        ("NEW_TAB_FR_FR", "pocket-newtab-fr-fr"),
+        ("NEW_TAB_IT_IT", "pocket-newtab-it-it"),
+    ],
+)
+def test_get_utm_source(scheduled_surface_id, expected_utm_source):
+    """Testing the get_utm_source() method
+    & ensuring correct utm_source is returned for a scheduled surface id.
+    """
+    assert CorpusApiBackend.get_utm_source(scheduled_surface_id) == expected_utm_source
+
+
+@pytest.mark.parametrize(
+    ("url", "utm_source", "expected_url"),
+    [
+        # add new utm_source
+        (
+            "https://getpocket.com/explore/item/example-article",
+            "pocket-newtab-en-us",
+            "https://getpocket.com/explore/item/example-article?utm_source=pocket-newtab-en-us",
+        ),
+        # add new utm_source with another query param present in url
+        (
+            "https://getpocket.com/explore/item/example-article?foo=bar",
+            "pocket-newtab-en-gb",
+            "https://getpocket.com/explore/item/example-article?foo=bar&utm_source=pocket-newtab-en-gb",
+        ),
+        # replace old utm_source with new one
+        (
+            "https://getpocket.com/explore/item/example-article?utm_source=old_source",
+            "pocket-newtab-en-intl",
+            "https://getpocket.com/explore/item/example-article?utm_source=pocket-newtab-en-intl",
+        ),
+        # replace old utm_source with new one & when another query param present in url
+        (
+            "https://getpocket.com/explore/item/example-article?utm_source=old_source&foo=bar",
+            "pocket-newtab-de-de",
+            "https://getpocket.com/explore/item/example-article?utm_source=pocket-newtab-de-de&foo=bar",
+        ),
+        # pass empty utm_source (when no mapping is found)
+        (
+            "https://getpocket.com/explore/item/example-article?foo=bar",
+            "",
+            "https://getpocket.com/explore/item/example-article?foo=bar&utm_source=",
+        ),
+    ],
+)
+def test_update_url_utm_source(url, utm_source, expected_url):
+    """Testing the update_url_utm_source() method
+    & ensuring url is updated correctly.
+    """
+    assert CorpusApiBackend.update_url_utm_source(url, utm_source) == expected_url


### PR DESCRIPTION
## References

JIRA: https://mozilla-hub.atlassian.net/browse/MC-1212

## Description
Adding `utm_source` param to the curated rec url returned from corpus API. Adding a new one or replacing existing one. Created a `SCHEDULED_SURFACE_ID_TO_UTM_SOURCE` dict to map to the appropriate `utm_source`. Using `urllib.parse` to add/replace `utm_source` in a url.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
