### PR TITLE
[load test: warn] [MC-1352] feat: add tileId to curated-recommendations

### DIFF
--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -1,12 +1,14 @@
 """Provider for curated recommendations on New Tab."""
 
+import hashlib
 import time
 import re
 
 from copy import copy
 from enum import Enum, unique
+from typing import Annotated
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, model_validator
 
 from merino.curated_recommendations.corpus_backends.protocol import (
     CorpusBackend,
@@ -51,11 +53,43 @@ class Locale(str, Enum):
         return Locale._value2member_map_
 
 
+# Maximum tileId that Firefox can support. Firefox uses Javascript to store this value. The max
+# value of a Javascript number can be found using `Number.MAX_SAFE_INTEGER`. which is 2^53 - 1
+# because it uses a 64-bit IEEE 754 float.
+MAX_TILE_ID = (1 << 53) - 1
+# Generate tile_ids well out of the range of the old MySQL-based system, which has a max tile_id of
+# 99,999 as of 2023-03-13. This is done to make it easy for engineers/analysts to see which system
+# generated the identifier.
+MIN_TILE_ID = 10000000
+
+
 class CuratedRecommendation(CorpusItem):
     """Extends CorpusItem with additional fields for a curated recommendation"""
 
     __typename: TypeName = TypeName.RECOMMENDATION
+    tileId: Annotated[int, Field(strict=True, ge=MIN_TILE_ID, le=MAX_TILE_ID)]
     receivedRank: int
+
+    @model_validator(mode="before")
+    def set_tileId(cls, values):
+        """Set the tileId field automatically."""
+        scheduled_corpus_item_id = values.get("scheduledCorpusItemId")
+
+        if scheduled_corpus_item_id and "tileId" not in values:
+            values["tileId"] = cls._integer_hash(
+                scheduled_corpus_item_id, MIN_TILE_ID, MAX_TILE_ID
+            )
+
+        return values
+
+    @staticmethod
+    def _integer_hash(s: str, start: int, stop: int) -> int:
+        """:param s: String to be hashed.
+        :param start: Minimum integer to be returned.
+        :param stop: Integer that is greater than start. Maximum return value is stop - 1.
+        :return: Integer hash of s in the range [start, stop)
+        """
+        return start + (int(hashlib.sha256(s.encode("utf-8")).hexdigest(), 16) % (stop - start))
 
 
 class CuratedRecommendationsRequest(BaseModel):

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -122,6 +122,7 @@ async def test_curated_recommendations():
         assert all(item["url"] for item in corpus_items)
         assert all(item["publisher"] for item in corpus_items)
         assert all(item["imageUrl"] for item in corpus_items)
+        assert all(item["tileId"] for item in corpus_items)
 
         # Assert 2nd returned recommendation has topic = None & all fields returned are expected
         actual_recommendation = CuratedRecommendation(**corpus_items[1])

--- a/tests/unit/curated_recommendations/test_provider.py
+++ b/tests/unit/curated_recommendations/test_provider.py
@@ -10,6 +10,8 @@ from merino.curated_recommendations.provider import (
     CuratedRecommendation,
     CuratedRecommendationsProvider,
     Locale,
+    MAX_TILE_ID,
+    MIN_TILE_ID,
 )
 
 
@@ -192,6 +194,7 @@ class TestCuratedRecommendationsProviderSpreadPublishers:
         recs = []
         for item_id in item_ids:
             rec = CuratedRecommendation(
+                tileId=MIN_TILE_ID + random.randint(0, 101),
                 receivedRank=random.randint(0, 101),
                 scheduledCorpusItemId=item_id,
                 url=HttpUrl("https://littlelarry.com/"),
@@ -338,3 +341,59 @@ class TestCuratedRecommendationsProviderSpreadPublishers:
             "7",
             "8",
         ]
+
+
+class TestCuratedRecommendationTileId:
+    """Unit tests for CuratedRecommendation tileId generation."""
+
+    # Common parameters for initializing CuratedRecommendation
+    common_params = {
+        "url": HttpUrl("https://example.com"),
+        "title": "Example Title",
+        "excerpt": "Example Excerpt",
+        "topic": Topic.CAREER,
+        "publisher": "Example Publisher",
+        "imageUrl": HttpUrl("https://example.com/image.jpg"),
+        "receivedRank": 1,
+    }
+
+    @pytest.mark.parametrize(
+        "scheduled_corpus_item_id, expected",
+        [
+            # Test random inputs. Boundary cases are not covered because sha256 is hard to reverse.
+            ("550e8400-e29b-41d4-a716-446655440000", 367820988390657),
+            ("6ba7b810-9dad-11d1-80b4-00c04fd430c8", 1754091520067902),
+            ("123e4567-e89b-12d3-a456-426614174000", 1021785982574447),
+            ("a3bb189e-8bf9-3888-9912-ace4e6543002", 4390412044299399),
+            ("c1a5fc62-9a4e-43f3-b748-2106a12e8151", 8630494423250594),
+        ],
+    )
+    def test_tile_id_generation(self, scheduled_corpus_item_id, expected):
+        """Testing the tile_id generation in the CuratedRecommendation constructor."""
+        # Create a CuratedRecommendation instance with the given scheduledCorpusItemId
+        recommendation = CuratedRecommendation(
+            scheduledCorpusItemId=scheduled_corpus_item_id,
+            **self.common_params,
+        )
+
+        assert recommendation.tileId == expected
+
+    @pytest.mark.parametrize("tile_id", [MIN_TILE_ID, MAX_TILE_ID])
+    def test_tile_id_min_max(self, tile_id):
+        """Test that the model can be initialized with MIN_TILE_ID and MAX_TILE_ID."""
+        recommendation = CuratedRecommendation(
+            scheduledCorpusItemId="550e8400-e29b-41d4-a716-446655440000",
+            tileId=tile_id,
+            **self.common_params,
+        )
+        assert recommendation.tileId == tile_id
+
+    @pytest.mark.parametrize("invalid_tile_id", [0, 999999, -1, (1 << 53)])
+    def test_invalid_tile_id(self, invalid_tile_id):
+        """Test that the model cannot be initialized with invalid tile IDs."""
+        with pytest.raises(ValueError):
+            CuratedRecommendation(
+                scheduledCorpusItemId="550e8400-e29b-41d4-a716-446655440000",
+                tileId=invalid_tile_id,
+                **self.common_params,
+            )


### PR DESCRIPTION
## References

JIRA: [MC-1352](https://mozilla-hub.atlassian.net/browse/MC-1352)

## Description

We've decided to keep emitting tileId to de-risk maintaining existing Mode reports that rely on tile_id.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[MC-1352]: https://mozilla-hub.atlassian.net/browse/MC-1352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ