### PR TITLE
[DISCO-2908] fix: relevancy uploader to delete records before upload

### DIFF
--- a/merino/jobs/relevancy_uploader/chunked_rs_uploader.py
+++ b/merino/jobs/relevancy_uploader/chunked_rs_uploader.py
@@ -51,10 +51,8 @@ class ChunkedRemoteSettingsRelevancyUploader(ChunkedRemoteSettingsUploader):
         count = 0
         for record in self.kinto.get_records():
             record_details = record.get("record_custom_details", {})
-            if (
-                record_details.get("category_code") == self.category_code
-                and record_details.get("version") == self.version
-            ):
+            cat_to_domains_details = record_details.get("category_to_domains", {})
+            if cat_to_domains_details.get("version") == self.version:
                 logger.info(f"Deleting record: {record['id']}")
                 if not self.dry_run:
                     self.kinto.delete_record(id=record["id"])

--- a/tests/unit/jobs/relevancy_uploader/utils.py
+++ b/tests/unit/jobs/relevancy_uploader/utils.py
@@ -78,7 +78,7 @@ def _do_csv_test(
     )
 
     if not keep_existing_records and version == 1:
-        mock_chunked_uploader.delete_records.assert_called()
+        mock_chunked_uploader.delete_records.assert_called_once()
     else:
         mock_chunked_uploader.delete_records.assert_not_called()
 


### PR DESCRIPTION
## References

JIRA: [DISCO-2908](https://mozilla-hub.atlassian.net/browse/DISCO-2908)

## Description
Delete logic wasn't correct, `version` was 1 level deeper.
Current behaviour is that we delete per category, but that doesn't work when a new upload doesn't include a preexisting category, those records would stay in the collection



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2908]: https://mozilla-hub.atlassian.net/browse/DISCO-2908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ