### PR TITLE
[DISCO-2857] Introduce more logs for accuweather debugging

### DIFF
--- a/merino/providers/weather/backends/accuweather.py
+++ b/merino/providers/weather/backends/accuweather.py
@@ -598,6 +598,9 @@ class AccuweatherBackend:
                         break
                 if location is None:
                     self.metrics_client.increment("accuweather.request.locations.processor.error")
+                    logger.warning(
+                        f"Unable to get location from {country}/{city} using region: {region}, or {alternative_regions}"
+                    )
                     return None
             if location is None:
                 return None
@@ -664,7 +667,9 @@ class AccuweatherBackend:
                 log_failure=False,
             )
         except HTTPError as error:
-            raise AccuweatherError("Unexpected location response") from error
+            raise AccuweatherError(
+                f"Unexpected location response from: {self.url_cities_path.format(country_code=country, admin_code=region)}, city: {city}"
+            ) from error
 
         return AccuweatherLocation(**response) if response else None
 


### PR DESCRIPTION
## References

JIRA: [DISCO-2857](https://mozilla-hub.atlassian.net/browse/DISCO-2857)

## Description
We're still seeing spikes in not being able to retrieve a non empty


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2857]: https://mozilla-hub.atlassian.net/browse/DISCO-2857?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ