### PR TITLE
[DISCO-2893] Fallback to /locations/v1/cities/<country_code>/search w…

### DIFF
--- a/merino/cache/protocol.py
+++ b/merino/cache/protocol.py
@@ -55,7 +55,7 @@ class CacheAdapter(Protocol):
             - `keys` list[str], a list of keys used as the global `KEYS` in Redis scripting
             - `args` list[str], a list of arguments used as the global `ARGV` in Redis scripting
         Returns:
-            A Reids value based on the return value of the specified script
+            A Redis value based on the return value of the specified script
         Raises:
             - `CacheAdapterError` if Redis returns an error.
         """

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -274,8 +274,11 @@ url_postalcodes_path = "/locations/v1/postalcodes/{country_code}/search.json"
 url_postalcodes_param_query = "q"
 
 # MERINO_ACCUWEATHER__URL_CITIES_PATH
-# The URL path for cities
-url_cities_path = "/locations/v1/cities/{country_code}/{admin_code}/search.json"
+# The URL path for cities using country and admin code
+url_cities_admin_path = "/locations/v1/cities/{country_code}/{admin_code}/search.json"
+
+# The URL path for cities using country code
+url_cities_path = "/locations/v1/cities/{country_code}/search.json"
 
 # MERINO_ACCUWEATHER__URL_CITIES_PARAM_QUERY
 # The query parameter for cities

--- a/merino/providers/manager.py
+++ b/merino/providers/manager.py
@@ -69,6 +69,7 @@ def _create_provider(provider_id: str, setting: Settings) -> BaseProvider:
                         metrics_client=get_metrics_client(),
                         http_client=create_http_client(base_url=settings.accuweather.url_base),
                         url_param_api_key=settings.accuweather.url_param_api_key,
+                        url_cities_admin_path=settings.accuweather.url_cities_admin_path,
                         url_cities_path=settings.accuweather.url_cities_path,
                         url_cities_param_query=settings.accuweather.url_cities_param_query,
                         url_current_conditions_path=(

--- a/merino/providers/weather/backends/accuweather.py
+++ b/merino/providers/weather/backends/accuweather.py
@@ -172,6 +172,7 @@ class AccuweatherBackend:
     cached_forecast_ttl_sec: int
     metrics_client: aiodogstatsd.Client
     url_param_api_key: str
+    url_cities_admin_path: str
     url_cities_path: str
     url_cities_param_query: str
     url_current_conditions_path: str
@@ -191,6 +192,7 @@ class AccuweatherBackend:
         metrics_client: aiodogstatsd.Client,
         http_client: AsyncClient,
         url_param_api_key: str,
+        url_cities_admin_path: str,
         url_cities_path: str,
         url_cities_param_query: str,
         url_current_conditions_path: str,
@@ -208,6 +210,7 @@ class AccuweatherBackend:
 
         if (
             not url_param_api_key
+            or not url_cities_admin_path
             or not url_cities_path
             or not url_cities_param_query
             or not url_current_conditions_path
@@ -229,6 +232,7 @@ class AccuweatherBackend:
         self.metrics_client = metrics_client
         self.http_client = http_client
         self.url_param_api_key = url_param_api_key
+        self.url_cities_admin_path = url_cities_admin_path
         self.url_cities_path = url_cities_path
         self.url_cities_param_query = url_cities_param_query
         self.url_current_conditions_path = url_current_conditions_path
@@ -508,34 +512,35 @@ class AccuweatherBackend:
         if not country or not region or not city:
             self.metrics_client.increment("accuweather.request.location.not_provided")
             return None
-        for subdivision in [
-            region,
-            *alternative_regions,
-        ]:
-            cache_key: str = self.cache_key_for_accuweather_request(
-                self.url_cities_path.format(country_code=country, admin_code=subdivision),
-                query_params=self.get_location_key_query_params(city),
-            )
-            # Look up for all the weather data from the cache.
-            try:
-                with self.metrics_client.timeit("accuweather.cache.fetch"):
-                    cached_data: list[bytes | None] = await self.cache.run_script(
-                        sid=SCRIPT_ID,
-                        keys=[cache_key],
-                        # The order matters below. See `LUA_SCRIPT_CACHE_BULK_FETCH` for details.
-                        args=[
-                            self.cache_key_template(WeatherDataType.CURRENT_CONDITIONS),
-                            self.cache_key_template(WeatherDataType.FORECAST),
-                            self.url_location_key_placeholder,
-                        ],
-                    )
-            except CacheAdapterError as exc:
-                logger.error(f"Failed to fetch weather report from Redis: {exc}")
-                self.metrics_client.increment("accuweather.cache.fetch.error")
-                return None
+        try:
+            for subdivision in [
+                region,
+                *alternative_regions,
+            ]:
+                cache_key: str = self.cache_key_for_accuweather_request(
+                    self.url_cities_admin_path.format(
+                        country_code=country, admin_code=subdivision
+                    ),
+                    query_params=self.get_location_key_query_params(city),
+                )
+                # Look up for all the weather data from the cache.
+                cached_data = await self.check_cache_for_weather(cache_key)
 
-            if cached_data:
-                break
+                if cached_data:
+                    break
+
+            # cycling through alternative regions returns nothing, retry using just country code
+            if not cached_data:
+                country_only_cache_key: str = self.cache_key_for_accuweather_request(
+                    self.url_cities_path.format(country_code=country),
+                    query_params=self.get_location_key_query_params(city),
+                )
+                cached_data = await self.check_cache_for_weather(country_only_cache_key)
+
+        except CacheAdapterError as exc:
+            logger.error(f"Failed to fetch weather report from Redis: {exc}")
+            self.metrics_client.increment("accuweather.cache.fetch.error")
+            return None
 
         self.emit_cache_fetch_metrics(cached_data)
         cached_report = self.parse_cached_data(cached_data)
@@ -597,12 +602,12 @@ class AccuweatherBackend:
                             )
                         break
                 if location is None:
-                    self.metrics_client.increment("accuweather.request.locations.processor.error")
                     logger.warning(
-                        f"Unable to get location from {country}/{city} using region: {region}, or {alternative_regions}"
+                        f"Using fallback country only endpoint after trying {country}/{city}/{region}, alt regions:{alternative_regions}"
                     )
-                    return None
+                    location = await self.get_location_by_geolocation(country, city)
             if location is None:
+                logger.warning(f"Unable to find location for {country}/{city}")
                 return None
 
         try:
@@ -648,7 +653,7 @@ class AccuweatherBackend:
             return None
 
     async def get_location_by_geolocation(
-        self, country: str, city: str, region: str
+        self, country: str, city: str, region: str | None = None
     ) -> AccuweatherLocation | None:
         """Return location data for a specific country and city or None if
         location data is not found.
@@ -658,17 +663,23 @@ class AccuweatherBackend:
         Reference:
             https://developer.accuweather.com/accuweather-locations-api/apis/get/locations/v1/cities/{countryCode}/{adminCode}/search
         """
+        if region:
+            url_path = self.url_cities_admin_path.format(country_code=country, admin_code=region)
+            log_failure = False
+        else:
+            url_path = self.url_cities_path.format(country_code=country)
+            log_failure = True
         try:
             response: dict[str, Any] | None = await self.get_request(
-                self.url_cities_path.format(country_code=country, admin_code=region),
+                url_path,
                 params=self.get_location_key_query_params(city),
                 process_api_response=process_location_response,
                 cache_ttl_sec=self.cached_location_key_ttl_sec,
-                log_failure=False,
+                log_failure=log_failure,
             )
         except HTTPError as error:
             raise AccuweatherError(
-                f"Unexpected location response from: {self.url_cities_path.format(country_code=country, admin_code=region)}, city: {city}"
+                f"Unexpected location response from: {url_path}, city: {city}"
             ) from error
 
         return AccuweatherLocation(**response) if response else None
@@ -781,6 +792,23 @@ class AccuweatherBackend:
         ]
 
         return location_completions
+
+    async def check_cache_for_weather(self, cache_key) -> list[bytes | None]:
+        """Get cached weather data."""
+        with self.metrics_client.timeit("accuweather.cache.fetch"):
+            cached_data = await self.cache.run_script(
+                sid=SCRIPT_ID,
+                keys=[cache_key],
+                # The order matters below. See `LUA_SCRIPT_CACHE_BULK_FETCH` for details.
+                args=[
+                    self.cache_key_template(WeatherDataType.CURRENT_CONDITIONS),
+                    self.cache_key_template(WeatherDataType.FORECAST),
+                    self.url_location_key_placeholder,
+                ],
+            )
+            if not isinstance(cached_data, list):
+                return []
+            return cached_data
 
     async def shutdown(self) -> None:
         """Close out the cache during shutdown."""

--- a/merino/providers/weather/backends/accuweather.py
+++ b/merino/providers/weather/backends/accuweather.py
@@ -665,17 +665,18 @@ class AccuweatherBackend:
         """
         if region:
             url_path = self.url_cities_admin_path.format(country_code=country, admin_code=region)
+            processor = process_location_response_with_country_and_region
             log_failure = False
+
         else:
             url_path = self.url_cities_path.format(country_code=country)
+            processor = process_location_response_with_country
             log_failure = True
         try:
             response: dict[str, Any] | None = await self.get_request(
                 url_path,
                 params=self.get_location_key_query_params(city),
-                process_api_response=process_location_response_with_country_and_region
-                if region
-                else process_location_response_with_country,
+                process_api_response=processor,
                 cache_ttl_sec=self.cached_location_key_ttl_sec,
                 log_failure=log_failure,
             )
@@ -881,7 +882,7 @@ def process_location_response_with_country_and_region(response: Any) -> dict[str
 
 
 def process_location_response_with_country(response: Any) -> dict[str, Any] | None:
-    """Process the API response for location keys from country code endpoint.
+    """Process the API response for a single location key from country code endpoint.
 
     Note that if you change the return format, ensure you update `LUA_SCRIPT_CACHE_BULK_FETCH`
     to reflect the change(s) here.

--- a/tests/integration/providers/weather/backends/test_accuweather.py
+++ b/tests/integration/providers/weather/backends/test_accuweather.py
@@ -57,7 +57,8 @@ def fixture_accuweather_parameters(mocker: MockerFixture, statsd_mock: Any) -> d
         "metrics_client": statsd_mock,
         "http_client": mocker.AsyncMock(spec=AsyncClient),
         "url_param_api_key": "apikey",
-        "url_cities_path": "/locations/v1/cities/{country_code}/{admin_code}/search.json",
+        "url_cities_admin_path": "/locations/v1/cities/{country_code}/{admin_code}/search.json",
+        "url_cities_path": "/locations/v1/cities/{country_code}/search.json",
         "url_cities_param_query": "q",
         "url_current_conditions_path": "/currentconditions/v1/{location_key}.json",
         "url_forecasts_path": "/forecasts/v1/daily/1day/{location_key}.json",
@@ -332,7 +333,7 @@ def generate_accuweather_cache_keys(
     assert geolocation.city is not None
 
     location_key: str = accuweather.cache_key_for_accuweather_request(
-        accuweather.url_cities_path.format(
+        accuweather.url_cities_admin_path.format(
             country_code=geolocation.country, admin_code=geolocation.region
         ),
         query_params=accuweather.get_location_key_query_params(geolocation.city),


### PR DESCRIPTION
…hen regions return empty

## References

JIRA: [DISCO-2893](https://mozilla-hub.atlassian.net/browse/DISCO-2893)

## Description
There are cases where maxmind does not return any regions that accuweather expects, so we should fall back to just using the country_code endpoint in this case


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2893]: https://mozilla-hub.atlassian.net/browse/DISCO-2893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ