### PR TITLE
[DISCO-2785]: Refactor lua script to fetch ttl only when both keys exist

### DIFF
--- a/merino/providers/weather/backends/accuweather.py
+++ b/merino/providers/weather/backends/accuweather.py
@@ -64,14 +64,14 @@ LUA_SCRIPT_CACHE_BULK_FETCH: str = """
 
     local current_conditions = redis.call("GET", condition_key)
     local forecast = redis.call("GET", forecast_key)
-
-    local current_conditions_ttl = redis.call("TTL", condition_key)
-    local forecast_ttl = redis.call("TTL", forecast_key)
     local ttl = false
 
-    if current_conditions_ttl >= 0 and forecast_ttl >= 0 then
+    if current_conditions and forecast then
+        local current_conditions_ttl = redis.call("TTL", condition_key)
+        local forecast_ttl = redis.call("TTL", forecast_key)
         ttl = math.min(current_conditions_ttl, forecast_ttl)
     end
+
     return {location_key, current_conditions, forecast, ttl}
 """
 SCRIPT_ID: str = "bulk_fetch"
@@ -94,12 +94,11 @@ LUA_SCRIPT_CACHE_BULK_FETCH_VIA_LOCATION: str = """
 
     local current_conditions = redis.call("GET", condition_key)
     local forecast = redis.call("GET", forecast_key)
-
-    local current_conditions_ttl = redis.call("TTL", condition_key)
-    local forecast_ttl = redis.call("TTL", forecast_key)
     local ttl = false
 
-    if current_conditions_ttl >= 0 and forecast_ttl >= 0 then
+    if current_conditions and forecast then
+        local current_conditions_ttl = redis.call("TTL", condition_key)
+        local forecast_ttl = redis.call("TTL", forecast_key)
         ttl = math.min(current_conditions_ttl, forecast_ttl)
     end
     

--- a/tests/integration/providers/weather/backends/test_accuweather.py
+++ b/tests/integration/providers/weather/backends/test_accuweather.py
@@ -39,7 +39,10 @@ from merino.providers.weather.backends.protocol import (
 
 ACCUWEATHER_CACHE_EXPIRY_DATE_FORMAT = "%a, %d %b %Y %H:%M:%S %Z"
 ACCUWEATHER_LOCATION_KEY = "39376"
-TEST_CACHE_TTL_SEC = 1800
+WEATHER_REPORT_TTL_SEC = 1800
+CURRENT_CONDITIONS_TTL_SEC = 1800
+FORECAST_TTL_SEC = 3600
+LOCATION_KEY_TTL_SEC = 604800
 TEST_CACHE_ERROR = "test cache error"
 
 CacheKeys = namedtuple("CacheKeys", ["location_key", "current_conditions_key", "forecast_key"])
@@ -51,9 +54,9 @@ def fixture_accuweather_parameters(mocker: MockerFixture, statsd_mock: Any) -> d
     """Create an Accuweather object for test."""
     return {
         "api_key": "test",
-        "cached_location_key_ttl_sec": TEST_CACHE_TTL_SEC,
-        "cached_current_condition_ttl_sec": TEST_CACHE_TTL_SEC,
-        "cached_forecast_ttl_sec": TEST_CACHE_TTL_SEC,
+        "cached_location_key_ttl_sec": LOCATION_KEY_TTL_SEC,
+        "cached_current_condition_ttl_sec": CURRENT_CONDITIONS_TTL_SEC,
+        "cached_forecast_ttl_sec": FORECAST_TTL_SEC,
         "metrics_client": statsd_mock,
         "http_client": mocker.AsyncMock(spec=AsyncClient),
         "url_param_api_key": "apikey",
@@ -90,7 +93,7 @@ def fixture_expected_weather_report() -> WeatherReport:
             high=Temperature(c=21.1, f=70.0),
             low=Temperature(c=13.9, f=57.0),
         ),
-        ttl=TEST_CACHE_TTL_SEC,
+        ttl=WEATHER_REPORT_TTL_SEC,
     )
 
 
@@ -117,7 +120,7 @@ def fixture_expected_weather_report_via_location_key() -> WeatherReport:
             high=Temperature(c=21.1, f=70.0),
             low=Temperature(c=13.9, f=57.0),
         ),
-        ttl=TEST_CACHE_TTL_SEC,
+        ttl=WEATHER_REPORT_TTL_SEC,
     )
 
 
@@ -354,11 +357,9 @@ def generate_accuweather_cache_keys(
     )
 
 
-async def set_redis_keys(
-    redis_client: Redis, keys_and_values: list[tuple], expiry: Optional[int] = None
-) -> None:
+async def set_redis_keys(redis_client: Redis, keys_and_values: list[tuple]) -> None:
     """Set redis cache keys and values after flushing the db"""
-    for key, value in keys_and_values:
+    for key, value, expiry in keys_and_values:
         await redis_client.set(key, value, ex=expiry)
 
 
@@ -385,12 +386,16 @@ async def test_get_weather_report_from_cache_with_ttl(
     cache_keys = generate_accuweather_cache_keys(accuweather, geolocation)
 
     # set the above keys with their values as their corresponding fixtures
-    keys_and_values = [
-        (cache_keys.location_key, accuweather_cached_location_key),
-        (cache_keys.current_conditions_key, accuweather_cached_current_conditions),
-        (cache_keys.forecast_key, accuweather_cached_forecast_fahrenheit),
+    keys_values_expiry = [
+        (cache_keys.location_key, accuweather_cached_location_key, LOCATION_KEY_TTL_SEC),
+        (
+            cache_keys.current_conditions_key,
+            accuweather_cached_current_conditions,
+            CURRENT_CONDITIONS_TTL_SEC,
+        ),
+        (cache_keys.forecast_key, accuweather_cached_forecast_fahrenheit, FORECAST_TTL_SEC),
     ]
-    await set_redis_keys(redis_client, keys_and_values, expiry=TEST_CACHE_TTL_SEC)
+    await set_redis_keys(redis_client, keys_values_expiry)
 
     # this http client mock isn't used to make any calls, but we do assert below on it not being
     # called
@@ -410,60 +415,6 @@ async def test_get_weather_report_from_cache_with_ttl(
 
     assert metrics_increment_called == [
         "accuweather.cache.hit.locations",
-        "accuweather.cache.hit.currentconditions",
-        "accuweather.cache.hit.forecasts",
-    ]
-
-
-@pytest.mark.asyncio
-async def test_get_weather_report_from_cache_without_ttl(
-    redis_client: Redis,
-    geolocation: Location,
-    statsd_mock: Any,
-    expected_weather_report: WeatherReport,
-    accuweather_parameters: dict[str, Any],
-    accuweather_cached_location_key: bytes,
-    accuweather_cached_current_conditions: bytes,
-    accuweather_cached_forecast_fahrenheit: bytes,
-) -> None:
-    """Test that we can get the weather report from cache without a TTL set for forecast and
-    current conditions
-    """
-    # set up the accuweather backend object with the testcontainer redis client
-    accuweather: AccuweatherBackend = AccuweatherBackend(
-        cache=RedisAdapter(redis_client), **accuweather_parameters
-    )
-
-    # get cache keys
-    cache_keys = generate_accuweather_cache_keys(accuweather, geolocation)
-
-    # set the above keys with their values as their corresponding fixtures
-    keys_and_values = [
-        (cache_keys.location_key, accuweather_cached_location_key),
-        (cache_keys.current_conditions_key, accuweather_cached_current_conditions),
-        (cache_keys.forecast_key, accuweather_cached_forecast_fahrenheit),
-    ]
-    await set_redis_keys(redis_client, keys_and_values)
-
-    # this http client mock isn't used to make any calls, but we do assert below on it not being
-    # called
-    client_mock: AsyncMock = cast(AsyncMock, accuweather.http_client)
-
-    report: Optional[WeatherReport] = await accuweather.get_weather_report(geolocation)
-
-    assert report == expected_weather_report
-    client_mock.get.assert_not_called()
-
-    metrics_timeit_called = [call_arg[0][0] for call_arg in statsd_mock.timeit.call_args_list]
-    assert metrics_timeit_called == ["accuweather.cache.fetch"]
-
-    metrics_increment_called = [
-        call_arg[0][0] for call_arg in statsd_mock.increment.call_args_list
-    ]
-
-    assert metrics_increment_called == [
-        "accuweather.cache.hit.locations",
-        "accuweather.cache.fetch.miss.ttl",
         "accuweather.cache.hit.currentconditions",
         "accuweather.cache.hit.forecasts",
     ]
@@ -491,7 +442,8 @@ async def test_get_weather_report_with_both_current_conditions_and_forecast_cach
     cache_keys = generate_accuweather_cache_keys(accuweather, geolocation)
 
     await set_redis_keys(
-        redis_client, [(cache_keys.location_key, accuweather_cached_location_key)]
+        redis_client,
+        [(cache_keys.location_key, accuweather_cached_location_key, LOCATION_KEY_TTL_SEC)],
     )
     # generating a datetime of now to resemble source code and set it as the 'Expiry' response
     # header
@@ -548,12 +500,12 @@ async def test_get_weather_report_with_only_current_conditions_cache_miss(
     # get and set cache keys
     cache_keys = generate_accuweather_cache_keys(accuweather, geolocation)
 
-    cache_keys_values = [
-        (cache_keys.location_key, accuweather_cached_location_key),
-        (cache_keys.forecast_key, accuweather_cached_forecast_fahrenheit),
+    keys_values_expiry = [
+        (cache_keys.location_key, accuweather_cached_location_key, LOCATION_KEY_TTL_SEC),
+        (cache_keys.forecast_key, accuweather_cached_forecast_fahrenheit, FORECAST_TTL_SEC),
     ]
 
-    await set_redis_keys(redis_client, cache_keys_values)
+    await set_redis_keys(redis_client, keys_values_expiry)
 
     # generating a datetime of now to resemble source code and set it as the 'Expiry' response
     # header
@@ -599,12 +551,16 @@ async def test_get_weather_report_with_only_forecast_cache_miss(
     # get and set cache keys
     cache_keys = generate_accuweather_cache_keys(accuweather, geolocation)
 
-    cache_keys_values = [
-        (cache_keys.location_key, accuweather_cached_location_key),
-        (cache_keys.current_conditions_key, accuweather_cached_current_conditions),
+    keys_values_expiry = [
+        (cache_keys.location_key, accuweather_cached_location_key, LOCATION_KEY_TTL_SEC),
+        (
+            cache_keys.current_conditions_key,
+            accuweather_cached_current_conditions,
+            CURRENT_CONDITIONS_TTL_SEC,
+        ),
     ]
 
-    await set_redis_keys(redis_client, cache_keys_values)
+    await set_redis_keys(redis_client, keys_values_expiry)
 
     # generating a datetime of now to resemble source code and set it as the 'Expiry' response
     # header
@@ -654,8 +610,12 @@ async def test_get_weather_report_with_location_key_from_cache(
 
     # set the above keys with their values as their corresponding fixtures
     keys_and_values = [
-        (cache_keys.current_conditions_key, accuweather_cached_current_conditions),
-        (cache_keys.forecast_key, accuweather_cached_forecast_fahrenheit),
+        (
+            cache_keys.current_conditions_key,
+            accuweather_cached_current_conditions,
+            CURRENT_CONDITIONS_TTL_SEC,
+        ),
+        (cache_keys.forecast_key, accuweather_cached_forecast_fahrenheit, FORECAST_TTL_SEC),
     ]
     await set_redis_keys(redis_client, keys_and_values)
 
@@ -673,7 +633,6 @@ async def test_get_weather_report_with_location_key_from_cache(
     ]
 
     assert metrics_increment_called == [
-        "accuweather.cache.fetch.miss.ttl",
         "accuweather.cache.hit.currentconditions",
         "accuweather.cache.hit.forecasts",
     ]
@@ -690,7 +649,7 @@ async def test_get_weather_report_via_location_key_with_both_current_conditions_
     accuweather_cached_forecast_fahrenheit: bytes,
     accuweather_forecast_response_fahrenheit: bytes,
 ) -> None:
-    """Test that we can get weather report via location key with both current conditionsand
+    """Test that we can get weather report via location key with both current conditions and
     forecast cache miss
     """
     accuweather: AccuweatherBackend = AccuweatherBackend(
@@ -758,11 +717,11 @@ async def test_get_weather_report_via_location_key_with_only_current_conditions_
     # get and set cache keys
     cache_keys = generate_accuweather_cache_keys(accuweather, geolocation)
 
-    cache_keys_values = [
-        (cache_keys.forecast_key, accuweather_cached_forecast_fahrenheit),
+    keys_values_expiry = [
+        (cache_keys.forecast_key, accuweather_cached_forecast_fahrenheit, FORECAST_TTL_SEC),
     ]
 
-    await set_redis_keys(redis_client, cache_keys_values)
+    await set_redis_keys(redis_client, keys_values_expiry)
 
     # generating a datetime of now to resemble source code and set it as the 'Expiry' response
     # header
@@ -809,11 +768,15 @@ async def test_get_weather_report_via_location_key_with_only_forecast_cache_miss
     # get and set cache keys
     cache_keys = generate_accuweather_cache_keys(accuweather, geolocation)
 
-    cache_keys_values = [
-        (cache_keys.current_conditions_key, accuweather_cached_current_conditions),
+    keys_values_expiry = [
+        (
+            cache_keys.current_conditions_key,
+            accuweather_cached_current_conditions,
+            CURRENT_CONDITIONS_TTL_SEC,
+        ),
     ]
 
-    await set_redis_keys(redis_client, cache_keys_values)
+    await set_redis_keys(redis_client, keys_values_expiry)
 
     # generating a datetime of now to resemble source code and set it as the 'Expiry' response
     # header

--- a/tests/integration/providers/weather/backends/test_accuweather.py
+++ b/tests/integration/providers/weather/backends/test_accuweather.py
@@ -39,10 +39,13 @@ from merino.providers.weather.backends.protocol import (
 
 ACCUWEATHER_CACHE_EXPIRY_DATE_FORMAT = "%a, %d %b %Y %H:%M:%S %Z"
 ACCUWEATHER_LOCATION_KEY = "39376"
+
+# these TTL values below are the same as the default accuweather config values
 WEATHER_REPORT_TTL_SEC = 1800
 CURRENT_CONDITIONS_TTL_SEC = 1800
 FORECAST_TTL_SEC = 3600
 LOCATION_KEY_TTL_SEC = 604800
+
 TEST_CACHE_ERROR = "test cache error"
 
 CacheKeys = namedtuple("CacheKeys", ["location_key", "current_conditions_key", "forecast_key"])


### PR DESCRIPTION
## References

JIRA: [DISCO-2785](https://mozilla-hub.atlassian.net/browse/DISCO-2785)

## Description
- Refactoring the Lua script to conditionally get the TTLs only if both keys exist. 
- Removing an invalid test since that use case is not applicable (see comment below).
- Minor tests refactor to use more accurate TTL values for different entities.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2785]: https://mozilla-hub.atlassian.net/browse/DISCO-2785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ