### PR TITLE
[DISCO-2913] Handle accuweather location completion errors

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -204,9 +204,14 @@ enabled_by_default = false
 score = 0.3
 
 # MERINO_PROVIDERS__ACCUWEATHER__QUERY_TIMEOUT_SEC
-# A floating  point (in seconds) indicating the maximum waiting period when Merino queries
+# A floating point (in seconds) indicating the maximum waiting period when Merino queries
 # for weather forecasts. This will override the default global query timeout.
 query_timeout_sec = 5.0
+
+# MERINO_PROVIDERS__ACCUWEATHER__CONNECT_TIMEOUT_SEC
+# A floating point (in seconds) indicating the maximum waiting period for the
+# accuweather backend http client to establish a connection to the host.
+connect_timeout_sec = 3.0
 
 
 # MERINO_REDIS__SERVER - redis.server (Currently not configured here)

--- a/merino/providers/manager.py
+++ b/merino/providers/manager.py
@@ -67,7 +67,10 @@ def _create_provider(provider_id: str, setting: Settings) -> BaseProvider:
                         ),
                         cached_forecast_ttl_sec=setting.cache_ttls.forecast_ttl_sec,
                         metrics_client=get_metrics_client(),
-                        http_client=create_http_client(base_url=settings.accuweather.url_base),
+                        http_client=create_http_client(
+                            base_url=settings.accuweather.url_base,
+                            connect_timeout=settings.providers.accuweather.connect_timeout_sec,
+                        ),
                         url_param_api_key=settings.accuweather.url_param_api_key,
                         url_cities_admin_path=settings.accuweather.url_cities_admin_path,
                         url_cities_path=settings.accuweather.url_cities_path,

--- a/merino/providers/weather/backends/accuweather.py
+++ b/merino/providers/weather/backends/accuweather.py
@@ -789,6 +789,7 @@ class AccuweatherBackend:
                 response.raise_for_status()
         except Exception as exc:
             logger.error(f"Failed to get location completion from Accuweather: {exc}")
+            return None
 
         processed_location_completions = process_location_completion_response(response.json())
 

--- a/merino/providers/weather/backends/accuweather.py
+++ b/merino/providers/weather/backends/accuweather.py
@@ -781,12 +781,14 @@ class AccuweatherBackend:
             self.url_param_api_key: self.api_key,
             LOCATION_COMPLETE_ALIAS_PARAM: LOCATION_COMPLETE_ALIAS_PARAM_VALUE,
         }
-
-        with self.metrics_client.timeit(
-            f"accuweather.request." f"{LOCATION_COMPLETION_REQUEST_TYPE}.get"
-        ):
-            response: Response = await self.http_client.get(url_path, params=params)
-            response.raise_for_status()
+        try:
+            with self.metrics_client.timeit(
+                f"accuweather.request. {LOCATION_COMPLETION_REQUEST_TYPE}.get"
+            ):
+                response: Response = await self.http_client.get(url_path, params=params)
+                response.raise_for_status()
+        except Exception as exc:
+            logger.error(f"Failed to get location completion from Accuweather: {exc}")
 
         processed_location_completions = process_location_completion_response(response.json())
 


### PR DESCRIPTION
## References

JIRA: [DISCO-2913](https://mozilla-hub.atlassian.net/browse/DISCO-2913)

## Description
We need to handle accuweather location completion request errors. There has been a sudden uptick in the `ConnectTimeout` errors when trying to request the location autocomplete endpoint of accuweather. We are also increasing the connect timeout for its http client.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2913]: https://mozilla-hub.atlassian.net/browse/DISCO-2913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ