### PR TITLE
[DISCO-2913] Catch for httpx.HTTPError instead of Exception for location completion request

### DIFF
--- a/merino/providers/weather/backends/accuweather.py
+++ b/merino/providers/weather/backends/accuweather.py
@@ -789,7 +789,7 @@ class AccuweatherBackend:
                 response: Response = await self.http_client.get(url_path, params=params)
                 response.raise_for_status()
         except httpx.HTTPError as exc:
-            logger.error(f"Failed to get location completion from Accuweather: {exc}")
+            logger.warning(f"Failed to get location completion from Accuweather: {exc}")
             return None
 
         processed_location_completions = process_location_completion_response(response.json())

--- a/merino/providers/weather/backends/accuweather.py
+++ b/merino/providers/weather/backends/accuweather.py
@@ -10,6 +10,7 @@ from enum import Enum
 from typing import Any, Callable, NamedTuple, cast
 
 import aiodogstatsd
+import httpx
 from dateutil import parser
 from httpx import URL, AsyncClient, HTTPError, InvalidURL, Response
 from pydantic import BaseModel, ValidationError
@@ -787,7 +788,7 @@ class AccuweatherBackend:
             ):
                 response: Response = await self.http_client.get(url_path, params=params)
                 response.raise_for_status()
-        except Exception as exc:
+        except httpx.HTTPError as exc:
             logger.error(f"Failed to get location completion from Accuweather: {exc}")
             return None
 


### PR DESCRIPTION
## References

JIRA: [DISCO-2913](https://mozilla-hub.atlassian.net/browse/DISCO-2913)

## Description
Patching the previously merged PR, replacing the generic `Exception` class with `httpx.HTTPError` class.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2913]: https://mozilla-hub.atlassian.net/browse/DISCO-2913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ