### PR TITLE
[DISCO-2914]: Handle location completion empty request responses

### DIFF
--- a/merino/providers/weather/backends/accuweather.py
+++ b/merino/providers/weather/backends/accuweather.py
@@ -791,7 +791,20 @@ class AccuweatherBackend:
             logger.warning(f"Failed to get location completion from Accuweather: {exc}")
             return None
 
-        processed_location_completions = process_location_completion_response(response.json())
+        location_completion_response = response.json()
+
+        # if the accuweather request is successful but the response object shape is not valid
+        if location_completion_response is None or not isinstance(
+            location_completion_response, list
+        ):
+            logger.warning(
+                f"Invalid location completion response from Accuweather: {location_completion_response}"
+            )
+            return None
+
+        processed_location_completions = process_location_completion_response(
+            location_completion_response
+        )
 
         location_completions = [
             LocationCompletion(**item) for item in processed_location_completions
@@ -837,7 +850,7 @@ def add_partner_code(
         return url
 
 
-def process_location_completion_response(response: Any) -> list[dict[str, Any]]:
+def process_location_completion_response(response: list) -> list[dict[str, Any]]:
     """Process the API response for location completion request."""
     return [
         {

--- a/merino/providers/weather/backends/accuweather.py
+++ b/merino/providers/weather/backends/accuweather.py
@@ -806,11 +806,7 @@ class AccuweatherBackend:
             location_completion_response
         )
 
-        location_completions = [
-            LocationCompletion(**item) for item in processed_location_completions
-        ]
-
-        return location_completions
+        return [LocationCompletion(**item) for item in processed_location_completions]
 
     async def check_cache_for_weather(self, cache_key) -> list[bytes | None]:
         """Get cached weather data."""


### PR DESCRIPTION
## References

JIRA: [DISCO-2914](https://mozilla-hub.atlassian.net/browse/DISCO-2914)

## Description
There was sudden spike in these [Sentry errors](https://mozilla.sentry.io/issues/5648007025/?environment=prod&project=6622434&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=24h&stream_index=0&utc=true) last week. This is due to Accuweather returning a successful response for location completion but with an _**invalid shape**_. We are adding some defensive logic here to handle it gracefully.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2914]: https://mozilla-hub.atlassian.net/browse/DISCO-2914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ