### PR TITLE
[DISCO-2939] fix(load-tests): revert CMD to ENTRYPOINT change in the Dockerfile [load test: warn]

### DIFF
--- a/tests/load/Dockerfile
+++ b/tests/load/Dockerfile
@@ -41,4 +41,4 @@ COPY ./tests/load/locustfiles ./tests/load/locustfiles
 EXPOSE 8089 5557
 
 USER locust
-CMD ["locust", "-f", "tests/load/locustfiles/locustfile.py,tests/load/locustfiles/smoke_load.py,tests/load/locustfiles/average_load.py"]
+ENTRYPOINT ["locust", "-f", "tests/load/locustfiles/locustfile.py,tests/load/locustfiles/smoke_load.py"]


### PR DESCRIPTION
## References

JIRA: [DISCO-2939](https://mozilla-hub.atlassian.net/browse/DISCO-2939)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->

The load tests aren't executing as expected in CI with the changes made in DISCO-2904. This reverts the Dockerfile change.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2939]: https://mozilla-hub.atlassian.net/browse/DISCO-2939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ