### PR TITLE
fix(load-tests): entrypoint to include all locustfiles and Makefile docker compose commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,14 +118,14 @@ contract-tests-clean:  ##  Stop and remove containers and networks for contract 
 
 .PHONY: load-tests
 load-tests:  ##  Run local execution of (Locust) load tests
-	docker-compose \
+	docker compose \
       -f $(LOAD_TEST_DIR)/docker-compose.yml \
       -p merino-py-load-tests \
       up --scale locust_worker=1
 
 .PHONY: load-tests-clean
 load-tests-clean:  ##  Stop and remove containers and networks for load tests
-	docker-compose \
+	docker compose \
       -f $(LOAD_TEST_DIR)/docker-compose.yml \
       -p merino-py-load-tests \
       down
@@ -150,15 +150,15 @@ profile:  ## Profile Merino with Scalene
 
 .PHONY: docker-compose-up
 docker-compose-up:  ## Run `docker-compose up` in `./dev`
-	docker-compose -f dev/docker-compose.yaml up
+	docker compose -f dev/docker-compose.yaml up
 
 .PHONY: docker-compose-up-daemon
 docker-compose-up-daemon:  ## Run `docker-compose up -d` in `./dev`
-	docker-compose -f dev/docker-compose.yaml up -d
+	docker compose -f dev/docker-compose.yaml up -d
 
 .PHONY: docker-compose-down
 docker-compose-down:  ## Run `docker-compose down` in `./dev`
-	docker-compose -f dev/docker-compose.yaml down
+	docker compose -f dev/docker-compose.yaml down
 
 .PHONY: help
 help:

--- a/docs/testing/load-tests.md
+++ b/docs/testing/load-tests.md
@@ -75,10 +75,10 @@ repository root:
 
 * In a browser navigate to `http://localhost:8089/`
 * Set up the load test parameters:
-    * Option 1: Select the `MerinoLoadTestShape`
-      * This option has pre-defined settings and will last 10 minutes
+    * Option 1: Select the `MerinoSmokeLoadTestShape` or `MerinoAverageLoadTestShape`
+      * These options have pre-defined settings
     * Option 2: Select the `Default` load test shape with the following recommended settings:
-      * Number of users: 35
+      * Number of users: 25
       * Spawn rate: 1
       * Host: 'https://stagepy.merino.nonprod.cloudops.mozgcp.net'
         * Set host to 'http://host.docker.internal:8000' to test against a local instance of Merino
@@ -241,6 +241,9 @@ Execute the `setup_k8s.sh` file and select the **delete** option
 ```
 
 ## Distributed GCP Execution - CI Trigger
+
+The load tests are triggered in CI via [Jenkins][jenkins_load_test], which has a command overriding
+the load test Dockerfile entrypoint.
 
 Follow the steps bellow to execute the distributed load tests on GCP with a CI trigger:
 
@@ -509,6 +512,7 @@ updating the following:
 [docker_compose]:https://github.com/mozilla-services/merino-py/blob/main/tests/load/docker-compose.yml
 [dockerfile]: https://github.com/mozilla-services/merino-py/blob/main/tests/load/Dockerfile
 [grafana]: https://earthangel-b40313e5.influxcloud.net/d/rQAfYKIVk/merino-py-application-and-infrastructure?orgId=1&refresh=1m&var-environment=stagepy
+[jenkins_load_test]: https://github.com/mozilla-services/cloudops-infra/blob/master/projects/merino/Jenkinsfile-stage-py
 [kubernetes_panel]: https://console.cloud.google.com/kubernetes/list/overview?cloudshell=false&project=spheric-keel-331521
 [locust_environment_variables]: https://docs.locust.io/en/stable/configuration.html#environment-variables
 [locust_master_controller]: https://github.com/mozilla-services/merino-py/blob/main/tests/load/kubernetes-config/locust-master-controller.yml

--- a/tests/load/Dockerfile
+++ b/tests/load/Dockerfile
@@ -41,4 +41,4 @@ COPY ./tests/load/locustfiles ./tests/load/locustfiles
 EXPOSE 8089 5557
 
 USER locust
-ENTRYPOINT ["locust", "-f", "tests/load/locustfiles/locustfile.py,tests/load/locustfiles/smoke_load.py"]
+ENTRYPOINT ["locust", "-f", "tests/load/locustfiles/"]

--- a/tests/load/locustfiles/average_load.py
+++ b/tests/load/locustfiles/average_load.py
@@ -60,7 +60,7 @@ class MerinoAverageLoadTestShape(LoadTestShape):
     # Must match value defined in setup_k8s.sh
     WORKER_COUNT: int = int(os.environ.get("WORKER_COUNT", 25))
     # Number of users supported on a worker running on a n1-standard-2
-    USERS_PER_WORKER: int = int(os.environ.get("USERS_PER_WORKER", 6))
+    USERS_PER_WORKER: int = int(os.environ.get("USERS_PER_WORKER", 5))
     MAX_USERS: int = WORKER_COUNT * USERS_PER_WORKER
     trend: QuadraticTrend
     user_classes: list[Type[User]] = [MerinoUser]

--- a/tests/load/locustfiles/smoke_load.py
+++ b/tests/load/locustfiles/smoke_load.py
@@ -25,7 +25,7 @@ class ShapeStage(BaseModel):
 
 
 class MerinoSmokeLoadTestShape(LoadTestShape):
-    """A load test shape class for Merino (Duration: 10 minutes, Users: 35).
+    """A load test shape class for Merino (Duration: 10 minutes, Users: 25).
 
     The smoke load test verifies the system's performance under minimal load.
     The test is run for a short period, possibly in CD, to ensure the system is working correctly.
@@ -39,7 +39,7 @@ class MerinoSmokeLoadTestShape(LoadTestShape):
     # Must match value defined in setup_k8s.sh
     WORKER_COUNT: int = int(os.environ.get("WORKER_COUNT", 5))
     # Number of users supported on a worker running on a n1-standard-2
-    USERS_PER_WORKER: int = int(os.environ.get("USERS_PER_WORKER", 6))
+    USERS_PER_WORKER: int = int(os.environ.get("USERS_PER_WORKER", 5))
     USERS: int = WORKER_COUNT * USERS_PER_WORKER
 
     stages: list[ShapeStage]


### PR DESCRIPTION
## References

JIRA: [DISCO-2939](https://mozilla-hub.atlassian.net/browse/DISCO-2939)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->

- Have the load test Docker image entrypoint include all locust files
- Update the Makefile to use 'docker compose' instead of 'docker-compose'
- Add documentation for location of CD load test command
- Update load test shapes to use 5 users per worker (6 was causing some CPU warnings)

Note the command was changed in the Jenkins file here: https://github.com/mozilla-services/cloudops-infra/pull/5835 

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2939]: https://mozilla-hub.atlassian.net/browse/DISCO-2939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ