### PR TITLE
[DISCO-2951]: Investigate ttl cache miss high count

### DIFF
--- a/merino/providers/weather/backends/accuweather.py
+++ b/merino/providers/weather/backends/accuweather.py
@@ -386,7 +386,9 @@ class AccuweatherBackend:
             else "accuweather.cache.fetch.miss.forecasts"
         )
 
-        # register a ttl cache miss if we get current and forecast but no ttl
+        # We do a two-trip lookup on Redis. We first fetch the keys, and then, in a second lookup,
+        # check for the TTL for both keys. In a rare scenario, the TTL could have technically
+        # run out by the time we fetch it We register this with this counter.
         if current and forecast and not ttl:
             self.metrics_client.increment("accuweather.cache.fetch.miss.ttl")
 

--- a/merino/providers/weather/backends/accuweather.py
+++ b/merino/providers/weather/backends/accuweather.py
@@ -367,14 +367,14 @@ class AccuweatherBackend:
                 )
             case _:  # pragma: no cover
                 pass
+
         if not skip_location_key:
             self.metrics_client.increment(
                 "accuweather.cache.hit.locations"
                 if location
                 else "accuweather.cache.fetch.miss.locations"
             )
-        if not ttl:
-            self.metrics_client.increment("accuweather.cache.fetch.miss.ttl")
+
         self.metrics_client.increment(
             "accuweather.cache.hit.currentconditions"
             if current
@@ -385,6 +385,10 @@ class AccuweatherBackend:
             if forecast
             else "accuweather.cache.fetch.miss.forecasts"
         )
+
+        # register a ttl cache miss if we get current and forecast but no ttl
+        if current and forecast and not ttl:
+            self.metrics_client.increment("accuweather.cache.fetch.miss.ttl")
 
     def parse_cached_data(self, cached_data: list[bytes | None]) -> WeatherData:
         """Parse the weather data from cache.

--- a/tests/unit/providers/weather/backends/test_accuweather.py
+++ b/tests/unit/providers/weather/backends/test_accuweather.py
@@ -2141,13 +2141,12 @@ def test_add_partner_code(
         ),
         (
             ["location", "current", "forecast", None],
-            ("hit.locations", "fetch.miss.ttl", "hit.currentconditions", "hit.forecasts"),
+            ("hit.locations", "hit.currentconditions", "hit.forecasts", "fetch.miss.ttl"),
         ),
         (
             [None, None, None, None],
             (
                 "fetch.miss.locations",
-                "fetch.miss.ttl",
                 "fetch.miss.currentconditions",
                 "fetch.miss.forecasts",
             ),


### PR DESCRIPTION
## References

JIRA: [DISCO-2951](https://mozilla-hub.atlassian.net/browse/DISCO-2951)

## Description
Fix the `emit_cache_fetch_metrics` function to emit ttl cache miss metric only when `current conditions` and `forecast` are not None but `ttl` is `None`



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2951]: https://mozilla-hub.atlassian.net/browse/DISCO-2951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ