### PR TITLE
[DISCO-2940]: Implement sampling for accuweather metrics

### DIFF
--- a/docs/data.md
+++ b/docs/data.md
@@ -137,19 +137,19 @@ log inspection interfaces.
 
 The weather provider records additional metrics.
 
-- `accuweather.request.location.not_provided` - A counter to measure the number of times a query was send without a location being provided, and therefore unable to process a weather request.
+- `accuweather.request.location.not_provided` - A counter to measure the number of times a query was send without a location being provided, and therefore unable to process a weather request. Sampled at 90%.
 - `merino.providers.accuweather.query.cache.fetch` - A timer to measure the duration (in ms) of
-  looking up a weather report in the cache.
-- `merino.providers.accuweather.query.cache.fetch.miss.locations` - A counter to measure the number of times weather location was not in the cache.
-- `merino.providers.accuweather.query.cache.fetch.miss.currentconditions` - A counter to measure the number of times a current conditions was not in the cache.
-- `merino.providers.accuweather.query.cache.fetch.miss.forecasts` - A counter to measure the number of times a forecast for a location was not in the cache.
-- `merino.providers.accuweather.query.cache.fetch.miss.ttl` - A counter to measure the number of times a weather report was available but expired or had an invalid TTL.
+  looking up a weather report in the cache. Sampled at 90%.
+- `merino.providers.accuweather.query.cache.fetch.miss.locations` - A counter to measure the number of times weather location was not in the cache. Sampled at 90%.
+- `merino.providers.accuweather.query.cache.fetch.miss.currentconditions` - A counter to measure the number of times a current conditions was not in the cache. Sampled at 90%.
+- `merino.providers.accuweather.query.cache.fetch.miss.forecasts` - A counter to measure the number of times a forecast for a location was not in the cache. Sampled at 90%.
+- `merino.providers.accuweather.query.cache.fetch.miss.ttl` - A counter to measure the number of times a weather report was available but expired or had an invalid TTL. Sampled at 90%.
 - `merino.providers.accuweather.query.cache.fetch.hit.{locations | currentconditions | forecasts}` - A counter to measure the number of times a
-  requested value like a location or forecast is in the cache. We don't count TTL hits explicitly, just misses.
+  requested value like a location or forecast is in the cache. We don't count TTL hits explicitly, just misses. Sampled at 90%.
 - `merino.providers.accuweather.query.backend.get` - A timer to measure the duration (in ms) of a
-  request for a weather report from the backend. This metric isn't recorded for cache hits.
+  request for a weather report from the backend. This metric isn't recorded for cache hits. Sampled at 90%.
 - `merino.providers.accuweather.query.cache.store` - A timer to measure the duration (in ms) of
-  saving a weather report from the backend to the cache. This metric isn't recorded for cache hits.
+  saving a weather report from the backend to the cache. This metric isn't recorded for cache hits. Sampled at 90%.
 - `merino.providers.accuweather.query.cache.error` - A counter to measure the number of times the
   cache store returned an error when fetching or storing a weather report. This should be 0 in
   normal operation. In case of an error, the logs will include a `WARNING` with the full error

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -281,6 +281,9 @@ url_cities_path = "/locations/v1/cities/{country_code}/search.json"
 # The query parameter for cities
 url_cities_param_query = "q"
 
+# Sampling rate (90%) used by some metrics, can be of int type as well.
+metrics_sampling_rate = 0.9
+
 # MERINO_ACCUWEATHER__PARTNER_CODE - partner_code (Not currently defined)
 # The partner code to append to URLs in the current conditions and forecast responses.
 

--- a/merino/metrics.py
+++ b/merino/metrics.py
@@ -159,9 +159,12 @@ def get_metrics_client_with_sample_rate(sample_rate: float | int) -> aiodogstats
 async def configure_metrics() -> None:
     """Configure metrics client. Used in application startup."""
     client = get_metrics_client()
+    client_with_sampling = get_metrics_client_with_sample_rate()
     if settings.metrics.dev_logger:
         client._protocol = _LocalDatagramLogger()
+        client_with_sampling._protocol = _LocalDatagramLogger()
     await client.connect()
+    await client_with_sampling.connect()
 
 
 class _LocalDatagramLogger(aiodogstatsd.client.DatagramProtocol):

--- a/merino/providers/manager.py
+++ b/merino/providers/manager.py
@@ -9,7 +9,7 @@ from merino.cache.none import NoCacheAdapter
 from merino.cache.redis import RedisAdapter
 from merino.config import settings
 from merino.exceptions import InvalidProviderError
-from merino.metrics import get_metrics_client
+from merino.metrics import get_metrics_client, get_metrics_client_with_sample_rate
 from merino.providers.adm.backends.fake_backends import FakeAdmBackend
 from merino.providers.adm.backends.remotesettings import RemoteSettingsBackend
 from merino.providers.adm.provider import Provider as AdmProvider
@@ -67,6 +67,9 @@ def _create_provider(provider_id: str, setting: Settings) -> BaseProvider:
                         ),
                         cached_forecast_ttl_sec=setting.cache_ttls.forecast_ttl_sec,
                         metrics_client=get_metrics_client(),
+                        metrics_client_with_sample_rate=get_metrics_client_with_sample_rate(
+                            sample_rate=settings.accuweather.metrics_sampling_rate
+                        ),
                         http_client=create_http_client(
                             base_url=settings.accuweather.url_base,
                             connect_timeout=settings.providers.accuweather.connect_timeout_sec,

--- a/merino/providers/manager.py
+++ b/merino/providers/manager.py
@@ -9,7 +9,7 @@ from merino.cache.none import NoCacheAdapter
 from merino.cache.redis import RedisAdapter
 from merino.config import settings
 from merino.exceptions import InvalidProviderError
-from merino.metrics import get_metrics_client, get_metrics_client_with_sample_rate
+from merino.metrics import get_metrics_client
 from merino.providers.adm.backends.fake_backends import FakeAdmBackend
 from merino.providers.adm.backends.remotesettings import RemoteSettingsBackend
 from merino.providers.adm.provider import Provider as AdmProvider
@@ -67,9 +67,7 @@ def _create_provider(provider_id: str, setting: Settings) -> BaseProvider:
                         ),
                         cached_forecast_ttl_sec=setting.cache_ttls.forecast_ttl_sec,
                         metrics_client=get_metrics_client(),
-                        metrics_client_with_sample_rate=get_metrics_client_with_sample_rate(
-                            sample_rate=settings.accuweather.metrics_sampling_rate
-                        ),
+                        metrics_sample_rate=settings.accuweather.metrics_sampling_rate,
                         http_client=create_http_client(
                             base_url=settings.accuweather.url_base,
                             connect_timeout=settings.providers.accuweather.connect_timeout_sec,

--- a/merino/providers/weather/backends/accuweather/backend.py
+++ b/merino/providers/weather/backends/accuweather/backend.py
@@ -185,6 +185,7 @@ class AccuweatherBackend:
     cached_current_condition_ttl_sec: int
     cached_forecast_ttl_sec: int
     metrics_client: aiodogstatsd.Client
+    metrics_client_with_sample_rate: aiodogstatsd.Client
     url_param_api_key: str
     url_cities_admin_path: str
     url_cities_path: str
@@ -204,6 +205,7 @@ class AccuweatherBackend:
         cached_current_condition_ttl_sec: int,
         cached_forecast_ttl_sec: int,
         metrics_client: aiodogstatsd.Client,
+        metrics_client_with_sample_rate: aiodogstatsd.Client,
         http_client: AsyncClient,
         url_param_api_key: str,
         url_cities_admin_path: str,
@@ -246,6 +248,7 @@ class AccuweatherBackend:
         self.cached_current_condition_ttl_sec = cached_current_condition_ttl_sec
         self.cached_forecast_ttl_sec = cached_forecast_ttl_sec
         self.metrics_client = metrics_client
+        self.metrics_client_with_sample_rate = metrics_client_with_sample_rate
         self.http_client = http_client
         self.url_param_api_key = url_param_api_key
         self.url_cities_admin_path = url_cities_admin_path
@@ -319,7 +322,9 @@ class AccuweatherBackend:
         """
         response_dict: dict[str, Any] | None
 
-        with self.metrics_client.timeit(f"accuweather.request.{request_type}.get"):
+        with self.metrics_client_with_sample_rate.timeit(
+            f"accuweather.request.{request_type}.get"
+        ):
             response: Response = await self.http_client.get(url_path, params=params)
             response.raise_for_status()
 
@@ -361,7 +366,7 @@ class AccuweatherBackend:
         """Store the request into cache. Also ensures that the cache ttl is
         at least `cached_ttl_sec`. Returns the cached request's ttl in seconds.
         """
-        with self.metrics_client.timeit("accuweather.cache.store"):
+        with self.metrics_client_with_sample_rate.timeit("accuweather.cache.store"):
             expiry_delta: datetime.timedelta = parser.parse(
                 response_expiry
             ) - datetime.datetime.now(datetime.timezone.utc)
@@ -400,18 +405,18 @@ class AccuweatherBackend:
                 pass
 
         if not skip_location_key:
-            self.metrics_client.increment(
+            self.metrics_client_with_sample_rate.increment(
                 "accuweather.cache.hit.locations"
                 if location
                 else "accuweather.cache.fetch.miss.locations"
             )
 
-        self.metrics_client.increment(
+        self.metrics_client_with_sample_rate.increment(
             "accuweather.cache.hit.currentconditions"
             if current
             else "accuweather.cache.fetch.miss.currentconditions"
         )
-        self.metrics_client.increment(
+        self.metrics_client_with_sample_rate.increment(
             "accuweather.cache.hit.forecasts"
             if forecast
             else "accuweather.cache.fetch.miss.forecasts"
@@ -421,7 +426,7 @@ class AccuweatherBackend:
         # check for the TTL for both keys. In a rare scenario, the TTL could have technically
         # run out by the time we fetch it We register this with this counter.
         if current and forecast and not ttl:
-            self.metrics_client.increment("accuweather.cache.fetch.miss.ttl")
+            self.metrics_client_with_sample_rate.increment("accuweather.cache.fetch.miss.ttl")
 
     def parse_cached_data(self, cached_data: list[bytes | None]) -> WeatherData:
         """Parse the weather data from cache.
@@ -496,7 +501,9 @@ class AccuweatherBackend:
         """
         # Look up for all the weather data from the cache.
         try:
-            with self.metrics_client.timeit("accuweather.cache.fetch-via-location-key"):
+            with self.metrics_client_with_sample_rate.timeit(
+                "accuweather.cache.fetch-via-location-key"
+            ):
                 cached_data: list[bytes | None] = await self.cache.run_script(
                     sid=SCRIPT_LOCATION_KEY_ID,
                     keys=[],
@@ -542,7 +549,7 @@ class AccuweatherBackend:
                 query_params=self.get_location_key_query_params(city),
             )
 
-        with self.metrics_client.timeit("accuweather.cache.fetch"):
+        with self.metrics_client_with_sample_rate.timeit("accuweather.cache.fetch"):
             cached_data: list = await self.cache.run_script(
                 sid=SCRIPT_ID_BULK_FETCH_VIA_GEOLOCATION,
                 keys=[cache_key],

--- a/merino/providers/weather/backends/accuweather/backend.py
+++ b/merino/providers/weather/backends/accuweather/backend.py
@@ -591,7 +591,9 @@ class AccuweatherBackend:
         city: str | None = geolocation.city
 
         if country is None or city is None:
-            self.metrics_client.increment("accuweather.request.location.not_provided")
+            self.metrics_client.increment(
+                "accuweather.request.location.not_provided", sample_rate=self.metrics_sample_rate
+            )
             return None
 
         try:

--- a/tests/integration/providers/weather/backends/test_accuweather.py
+++ b/tests/integration/providers/weather/backends/test_accuweather.py
@@ -39,6 +39,7 @@ from merino.providers.weather.backends.protocol import (
 
 ACCUWEATHER_CACHE_EXPIRY_DATE_FORMAT = "%a, %d %b %Y %H:%M:%S %Z"
 ACCUWEATHER_LOCATION_KEY = "39376"
+ACCUWEATHER_METRICS_SAMPLE_RATE = 0.9
 
 # these TTL values below are the same as the default accuweather config values
 WEATHER_REPORT_TTL_SEC = 1800
@@ -70,6 +71,7 @@ def fixture_accuweather_parameters(mocker: MockerFixture, statsd_mock: Any) -> d
         "url_forecasts_path": "/forecasts/v1/daily/1day/{location_key}.json",
         "url_location_completion_path": "/locations/v1/cities/{country_code}/autocomplete.json",
         "url_location_key_placeholder": "{location_key}",
+        "metrics_sample_rate": ACCUWEATHER_METRICS_SAMPLE_RATE,
     }
 
 

--- a/tests/unit/providers/weather/backends/test_accuweather.py
+++ b/tests/unit/providers/weather/backends/test_accuweather.py
@@ -48,6 +48,7 @@ from tests.types import FilterCaplogFixture
 ACCUWEATHER_CACHE_EXPIRY_DATE_FORMAT = "%a, %d %b %Y %H:%M:%S %Z"
 TEST_CACHE_TTL_SEC = 1800
 TEST_DEFAULT_WEATHER_REPORT_CACHE_TTL_SEC = 300
+ACCUWEATHER_METRICS_SAMPLE_RATE = 0.9
 
 
 @pytest.fixture(name="redis_mock_cache_miss")
@@ -264,6 +265,7 @@ def fixture_accuweather_parameters(mocker: MockerFixture, statsd_mock: Any) -> d
         "url_forecasts_path": "/forecasts/v1/daily/1day/{location_key}.json",
         "url_location_completion_path": "/locations/v1/cities/{country_code}/autocomplete.json",
         "url_location_key_placeholder": "{location_key}",
+        "metrics_sample_rate": ACCUWEATHER_METRICS_SAMPLE_RATE,
     }
 
 


### PR DESCRIPTION
## References

JIRA: [DISCO-2940](https://mozilla-hub.atlassian.net/browse/DISCO-2940)

## Description
Adding sampling for some of the accuweather metrics at 90% (0.9)

### Metrics log output
Verifying that metrics are being emitted with the correct sample rate value. Notice the `@0.9`
```
// location key exists but forecast and current conditions expired
merino.accuweather.cache.fetch:4|ms|@0.9|
merino.accuweather.cache.hit.locations:1|c|@0.9|
merino.accuweather.cache.fetch.miss.currentconditions:1|c|@0.9|
merino.accuweather.cache.fetch.miss.forecasts:1|c|@0.9|
merino.accuweather.request.forecasts.get:322|ms|@0.9|
merino.accuweather.cache.store:6|ms|@0.9|
merino.accuweather.request.currentconditions.get:780|ms|@0.9|
merino.accuweather.cache.store:6|ms|@0.9|

// location key, forecast and current conditions all exist
merino.accuweather.cache.fetch:0|ms|@0.9|
merino.accuweather.cache.hit.locations:1|c|@0.9|
merino.accuweather.cache.hit.currentconditions:1|c|@0.9|
merino.accuweather.cache.hit.forecasts:1|c|@0.9|
```

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2940]: https://mozilla-hub.atlassian.net/browse/DISCO-2940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ