### PR TITLE
[DISCO-2964]: Lower accuweather metrics sampling to 75 percent

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -282,7 +282,7 @@ url_cities_path = "/locations/v1/cities/{country_code}/search.json"
 url_cities_param_query = "q"
 
 # Sampling rate (90%) used by some metrics, can be of int type as well.
-metrics_sampling_rate = 0.9
+metrics_sampling_rate = 0.75
 
 # MERINO_ACCUWEATHER__PARTNER_CODE - partner_code (Not currently defined)
 # The partner code to append to URLs in the current conditions and forecast responses.

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -281,7 +281,7 @@ url_cities_path = "/locations/v1/cities/{country_code}/search.json"
 # The query parameter for cities
 url_cities_param_query = "q"
 
-# Sampling rate (90%) used by some metrics, can be of int type as well.
+# Sampling rate (75%) used by some metrics, can be of int type as well.
 metrics_sampling_rate = 0.75
 
 # MERINO_ACCUWEATHER__PARTNER_CODE - partner_code (Not currently defined)


### PR DESCRIPTION
## References

JIRA: [DISCO-2964]https://mozilla-hub.atlassian.net/browse/DISCO-2964)

## Description
Lowering sampling rate to 75%

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2964]: https://mozilla-hub.atlassian.net/browse/DISCO-2964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ