### PR TITLE
[DISCO-2962] - Add cron job to gauge size of the region look up map

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -218,6 +218,8 @@ connect_timeout_sec = 3.0
 # Global Redis settings. The weather provider optionally uses Redis to cache weather suggestions.
 # In the form of `redis://localhost:6379`.
 
+# MERINO_PROVIDERS__ACCUWEATHER__CRON_INTERVAL_SEC
+cron_interval_sec = 21600 # 6 hours
 
 [default.providers.accuweather.cache_ttls]
 # Cache TTLs for weather data.

--- a/merino/providers/manager.py
+++ b/merino/providers/manager.py
@@ -95,6 +95,7 @@ def _create_provider(provider_id: str, setting: Settings) -> BaseProvider:
                 name=provider_id,
                 query_timeout_sec=setting.query_timeout_sec,
                 enabled_by_default=setting.enabled_by_default,
+                cron_interval_sec=setting.cron_interval_sec,
             )
         case ProviderType.AMO:
             return AmoProvider(

--- a/merino/providers/weather/backends/accuweather/pathfinder.py
+++ b/merino/providers/weather/backends/accuweather/pathfinder.py
@@ -87,9 +87,9 @@ def set_region_mapping(country: str, city: str, region: str | None):
         SUCCESSFUL_REGIONS_MAPPING[(country, city)] = region
 
 
-def get_region_mapping() -> dict:
-    """Get SUCCESSFUL_REGIONS_MAPPING"""
-    return SUCCESSFUL_REGIONS_MAPPING
+def get_region_mapping_size() -> int:
+    """Get SUCCESSFUL_REGIONS_MAPPING size"""
+    return len(SUCCESSFUL_REGIONS_MAPPING)
 
 
 def clear_region_mapping() -> None:

--- a/merino/providers/weather/backends/accuweather/pathfinder.py
+++ b/merino/providers/weather/backends/accuweather/pathfinder.py
@@ -87,6 +87,11 @@ def set_region_mapping(country: str, city: str, region: str | None):
         SUCCESSFUL_REGIONS_MAPPING[(country, city)] = region
 
 
+def get_region_mapping() -> dict:
+    """Get SUCCESSFUL_REGIONS_MAPPING"""
+    return SUCCESSFUL_REGIONS_MAPPING
+
+
 def clear_region_mapping() -> None:
     """Clear SUCCESSFUL_REGIONS_MAPPING."""
     SUCCESSFUL_REGIONS_MAPPING.clear()

--- a/merino/providers/weather/provider.py
+++ b/merino/providers/weather/provider.py
@@ -76,7 +76,7 @@ class Provider(BaseProvider):
             name="fetch_pathfinder_size",
             interval=self.cron_interval_sec,
             condition=self._should_fetch,
-            task=self._fetch_mapping,
+            task=self._fetch_mapping_size,
         )
         self.cron_task = asyncio.create_task(cron_job())
 
@@ -86,7 +86,7 @@ class Provider(BaseProvider):
     def _should_fetch(self) -> bool:
         return True
 
-    async def _fetch_mapping(self) -> None:
+    async def _fetch_mapping_size(self) -> None:
         self.metrics_client.gauge(
             name=f"providers.{self.name}.pathfinder.size", value=len(get_region_mapping())
         )

--- a/merino/providers/weather/provider.py
+++ b/merino/providers/weather/provider.py
@@ -1,15 +1,18 @@
 """Weather integration."""
 
+import asyncio
 import logging
 from typing import Any
 
 import aiodogstatsd
 from pydantic import HttpUrl
 
+from merino import cron
 from merino.exceptions import BackendError
 from merino.middleware.geolocation import Location
 from merino.providers.base import BaseProvider, BaseSuggestion, SuggestionRequest
 from merino.providers.custom_details import CustomDetails, WeatherDetails
+from merino.providers.weather.backends.accuweather.pathfinder import get_region_mapping
 from merino.providers.weather.backends.protocol import (
     CurrentConditions,
     Forecast,
@@ -42,6 +45,8 @@ class Provider(BaseProvider):
     metrics_client: aiodogstatsd.Client
     score: float
     dummy_url: HttpUrl
+    cron_task: asyncio.Task
+    cron_interval_sec: float
 
     def __init__(
         self,
@@ -50,6 +55,7 @@ class Provider(BaseProvider):
         score: float,
         name: str,
         query_timeout_sec: float,
+        cron_interval_sec: float,
         enabled_by_default: bool = False,
         dummy_url: str = "https://merino.services.mozilla.com/",
         **kwargs: Any,
@@ -61,14 +67,29 @@ class Provider(BaseProvider):
         self._query_timeout_sec = query_timeout_sec
         self._enabled_by_default = enabled_by_default
         self.dummy_url = HttpUrl(dummy_url)
+        self.cron_interval_sec = cron_interval_sec
         super().__init__(**kwargs)
 
     async def initialize(self) -> None:
         """Initialize the provider."""
-        ...
+        cron_job = cron.Job(
+            name="fetch_pathfinder_size",
+            interval=self.cron_interval_sec,
+            condition=self._should_fetch,
+            task=self._fetch_mapping,
+        )
+        self.cron_task = asyncio.create_task(cron_job())
 
     def hidden(self) -> bool:  # noqa: D102
         return False
+
+    def _should_fetch(self) -> bool:
+        return True
+
+    async def _fetch_mapping(self) -> None:
+        self.metrics_client.gauge(
+            name=f"providers.{self.name}.pathfinder.size", value=len(get_region_mapping())
+        )
 
     async def query(self, srequest: SuggestionRequest) -> list[BaseSuggestion]:
         """Provide weather suggestions."""

--- a/merino/providers/weather/provider.py
+++ b/merino/providers/weather/provider.py
@@ -12,7 +12,7 @@ from merino.exceptions import BackendError
 from merino.middleware.geolocation import Location
 from merino.providers.base import BaseProvider, BaseSuggestion, SuggestionRequest
 from merino.providers.custom_details import CustomDetails, WeatherDetails
-from merino.providers.weather.backends.accuweather.pathfinder import get_region_mapping
+from merino.providers.weather.backends.accuweather.pathfinder import get_region_mapping_size
 from merino.providers.weather.backends.protocol import (
     CurrentConditions,
     Forecast,
@@ -88,7 +88,7 @@ class Provider(BaseProvider):
 
     async def _fetch_mapping_size(self) -> None:
         self.metrics_client.gauge(
-            name=f"providers.{self.name}.pathfinder.size", value=len(get_region_mapping())
+            name=f"providers.{self.name}.pathfinder.mapping.size", value=get_region_mapping_size()
         )
 
     async def query(self, srequest: SuggestionRequest) -> list[BaseSuggestion]:

--- a/tests/integration/api/v1/suggest/test_suggest_weather.py
+++ b/tests/integration/api/v1/suggest/test_suggest_weather.py
@@ -58,6 +58,7 @@ def fixture_providers(backend_mock: Any, statsd_mock: Any) -> Providers:
             name="weather",
             query_timeout_sec=0.2,
             enabled_by_default=True,
+            cron_interval_sec=100,
         )
     }
 

--- a/tests/unit/providers/weather/test_provider.py
+++ b/tests/unit/providers/weather/test_provider.py
@@ -149,5 +149,5 @@ async def test_fetch_mapping(statsd_mock: Any, provider: Provider):
 
     assert len(statsd_mock.gauge.call_args_list) == 1
     assert statsd_mock.gauge.call_args_list == [
-        call(name="providers.weather.pathfinder.size", value=1)
+        call(name="providers.weather.pathfinder.mapping.size", value=1)
     ]

--- a/tests/unit/providers/weather/test_provider.py
+++ b/tests/unit/providers/weather/test_provider.py
@@ -145,7 +145,7 @@ async def test_fetch_mapping(statsd_mock: Any, provider: Provider):
     assert len(statsd_mock.gauge.call_args_list) == 0
 
     set_region_mapping("Canada", "Vancouver", "BC")
-    await provider._fetch_mapping()
+    await provider._fetch_mapping_size()
 
     assert len(statsd_mock.gauge.call_args_list) == 1
     assert statsd_mock.gauge.call_args_list == [

--- a/tests/unit/providers/weather/test_provider.py
+++ b/tests/unit/providers/weather/test_provider.py
@@ -5,6 +5,7 @@
 """Unit tests for the weather provider module."""
 
 from typing import Any
+from unittest.mock import call
 
 import pytest
 from pydantic import HttpUrl
@@ -14,6 +15,7 @@ from merino.config import settings
 from merino.middleware.geolocation import Location
 from merino.providers.base import BaseSuggestion, SuggestionRequest
 from merino.providers.custom_details import CustomDetails, WeatherDetails
+from merino.providers.weather.backends.accuweather.pathfinder import set_region_mapping
 from merino.providers.weather.backends.protocol import (
     CurrentConditions,
     Forecast,
@@ -53,6 +55,7 @@ def fixture_provider(backend_mock: Any, statsd_mock: Any) -> Provider:
         name="weather",
         score=0.3,
         query_timeout_sec=0.2,
+        cron_interval_sec=6000,
     )
 
 
@@ -134,3 +137,17 @@ async def test_query_no_weather_report_returned(
     )
 
     assert suggestions == expected_suggestions
+
+
+@pytest.mark.asyncio
+async def test_fetch_mapping(statsd_mock: Any, provider: Provider):
+    """Test that pathfinder metric is recorded properly."""
+    assert len(statsd_mock.gauge.call_args_list) == 0
+
+    set_region_mapping("Canada", "Vancouver", "BC")
+    await provider._fetch_mapping()
+
+    assert len(statsd_mock.gauge.call_args_list) == 1
+    assert statsd_mock.gauge.call_args_list == [
+        call(name="providers.weather.pathfinder.size", value=1)
+    ]


### PR DESCRIPTION
## References

JIRA: [DISCO-2962](https://mozilla-hub.atlassian.net/browse/DISCO-2962)

## Description
We have a look up map to help with retrieving the correct region for a given city, made changes so we can see the size of the map periodically. Debated whether we should log the contents of the map, but decided to hold off, until we look at the size?


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2962]: https://mozilla-hub.atlassian.net/browse/DISCO-2962?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ