### PR TITLE
[DISCO-2963] Fix type KeyErrors

### DIFF
--- a/merino/jobs/utils/chunked_rs_uploader.py
+++ b/merino/jobs/utils/chunked_rs_uploader.py
@@ -136,7 +136,7 @@ class ChunkedRemoteSettingsUploader:
         logger.info(f"Deleting records with type: {self.record_type}")
         count = 0
         for record in self.kinto.get_records():
-            if record["type"] == self.record_type:
+            if record.get("type") == self.record_type:
                 logger.info(f"Deleting record: {record['id']}")
                 if not self.dry_run:
                     self.kinto.delete_record(id=record["id"])


### PR DESCRIPTION
Avoid crashing when an existing record does not have a `type` field.

## References

JIRA: [DISCO-2963](https://mozilla-hub.atlassian.net/browse/DISCO-2963)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2963]: https://mozilla-hub.atlassian.net/browse/DISCO-2963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ