### PR TITLE
[MC-1439][MC-1474] fix(curated-recommendations): fix topic and receivedRank

### DIFF
--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -137,6 +137,16 @@ class CuratedRecommendationsProvider:
                 recommendations, curated_recommendations_request.topics
             )
 
+        for rank, rec in enumerate(recommendations):
+            # Update received_rank now that recommendations have been ranked.
+            rec.receivedRank = rank
+
+            # Topic labels are enabled only for en-US in Fx130. We are unsure about the quality of
+            # localized topic strings in Firefox. As a workaround, we decided to only send topics
+            # for New Tab en-US. This workaround should be removed once Fx131 is released on Oct 1.
+            if surface_id != ScheduledSurfaceId.NEW_TAB_EN_US:
+                rec.topic = None
+
         return CuratedRecommendationsResponse(
             recommendedAt=self.time_ms(),
             data=recommendations,

--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -144,7 +144,10 @@ class CuratedRecommendationsProvider:
             # Topic labels are enabled only for en-US in Fx130. We are unsure about the quality of
             # localized topic strings in Firefox. As a workaround, we decided to only send topics
             # for New Tab en-US. This workaround should be removed once Fx131 is released on Oct 1.
-            if surface_id != ScheduledSurfaceId.NEW_TAB_EN_US:
+            if surface_id not in (
+                ScheduledSurfaceId.NEW_TAB_EN_US,
+                ScheduledSurfaceId.NEW_TAB_EN_GB,
+            ):
                 rec.topic = None
 
         return CuratedRecommendationsResponse(

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -244,17 +244,38 @@ async def test_curated_recommendations_locales(locale):
     "locale",
     ["fr", "fr-FR", "es", "es-ES", "it", "it-IT", "de", "de-DE", "de-AT", "de-CH"],
 )
-async def test_curated_recommendations_non_en_us_topic(locale):
+@pytest.mark.parametrize("topics", [None, ["arts", "finance"]])
+async def test_curated_recommendations_non_en_topic_is_null(locale, topics):
     """Test that topic is missing/null for non-en-US locales."""
     async with AsyncClient(app=app, base_url="http://test") as ac:
-        response = await ac.post("/api/v1/curated-recommendations", json={"locale": locale})
+        response = await ac.post(
+            "/api/v1/curated-recommendations", json={"locale": locale, "topics": topics}
+        )
         data = response.json()
         corpus_items = data["data"]
 
-        assert response.status_code == 200
         assert len(corpus_items) > 0
         # Assert that the topic is None for all items in non-en-US locales.
         assert all(item["topic"] is None for item in corpus_items)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "locale",
+    ["en-US", "en-GB"],
+)
+@pytest.mark.parametrize("topics", [None, ["arts", "finance"]])
+async def test_curated_recommendations_en_topic(locale, topics):
+    """Test that topic is missing/null for non-en-US locales."""
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        response = await ac.post(
+            "/api/v1/curated-recommendations", json={"locale": locale, "topics": topics}
+        )
+        data = response.json()
+        corpus_items = data["data"]
+
+        assert len(corpus_items) > 0
+        assert all(item["topic"] is not None for item in corpus_items)
 
 
 class TestCuratedRecommendationsRequestParameters:

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -246,7 +246,7 @@ async def test_curated_recommendations_locales(locale):
 )
 @pytest.mark.parametrize("topics", [None, ["arts", "finance"]])
 async def test_curated_recommendations_non_en_topic_is_null(locale, topics):
-    """Test that topic is missing/null for non-en-US locales."""
+    """Test that topic is missing/null for non-English locales."""
     async with AsyncClient(app=app, base_url="http://test") as ac:
         response = await ac.post(
             "/api/v1/curated-recommendations", json={"locale": locale, "topics": topics}
@@ -266,7 +266,7 @@ async def test_curated_recommendations_non_en_topic_is_null(locale, topics):
 )
 @pytest.mark.parametrize("topics", [None, ["arts", "finance"]])
 async def test_curated_recommendations_en_topic(locale, topics):
-    """Test that topic is missing/null for non-en-US locales."""
+    """Test that topic is present for English locales."""
     async with AsyncClient(app=app, base_url="http://test") as ac:
         response = await ac.post(
             "/api/v1/curated-recommendations", json={"locale": locale, "topics": topics}

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -242,7 +242,7 @@ async def test_curated_recommendations_locales(locale):
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "locale",
-    ["fr", "fr-FR", "es", "es-ES", "it", "it-IT", "de", "de-DE", "de-AT", "de-CH", "en-GB"],
+    ["fr", "fr-FR", "es", "es-ES", "it", "it-IT", "de", "de-DE", "de-AT", "de-CH"],
 )
 async def test_curated_recommendations_non_en_us_topic(locale):
     """Test that topic is missing/null for non-en-US locales."""


### PR DESCRIPTION
## References

- [MC-1439](https://mozilla-hub.atlassian.net/browse/MC-1439): As [a workaround](https://mozilla.slack.com/archives/C06TBL1E1PD/p1724768971239179), we agreed with Firefox FE (Scott) that we will not emit topics for markets other than New Tab en-US, because we are not confident topic labels are localized correctly in Fx130, and we only need to experiment with them in English locales. I believe there was a concern about feature whiplash if this were to be solved in Nimbus through audience targeting, and that the underlying issue causing feature whiplash has been solved starting from Fx131. (But I have to admit it's a bit out of my wheelhouse.)
- [MC-1474](https://mozilla-hub.atlassian.net/browse/MC-1474): receivedRank must be 0, 1, 2, ... in the response. This was a bug.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[MC-1439]: https://mozilla-hub.atlassian.net/browse/MC-1439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MC-1474]: https://mozilla-hub.atlassian.net/browse/MC-1474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ