### PR TITLE
[DISCO-2967] deleting records error + CLI flag

### DIFF
--- a/merino/jobs/csv_rs_uploader/__init__.py
+++ b/merino/jobs/csv_rs_uploader/__init__.py
@@ -43,7 +43,13 @@ collection_option = typer.Option(
 keep_existing_records_option = typer.Option(
     False,
     "--keep-existing-records",
-    help="Keep existing records before uploading new records",
+    help="Keep existing records not present in the new CSV data",
+)
+
+allow_delete_option = typer.Option(
+    False,
+    "--allow-deletion",
+    help="Allow record deletion (see https://bugzilla.mozilla.org/show_bug.cgi?id=1908802 before enabling this)",
 )
 
 dry_run_option = typer.Option(
@@ -108,6 +114,7 @@ def upload(
     collection: str = collection_option,
     csv_path: str = csv_path_option,
     keep_existing_records: bool = keep_existing_records_option,
+    allow_delete: bool = allow_delete_option,
     dry_run: bool = dry_run_option,
     model_name: str = model_name_option,
     model_package: str = model_package_option,
@@ -129,6 +136,7 @@ def upload(
             collection=collection,
             csv_path=csv_path,
             keep_existing_records=keep_existing_records,
+            allow_delete=allow_delete,
             dry_run=dry_run,
             model_name=model_name,
             model_package=model_package,
@@ -146,6 +154,7 @@ async def _upload(
     collection: str,
     csv_path: str,
     keep_existing_records: bool,
+    allow_delete: bool,
     dry_run: bool,
     model_name: str,
     model_package: str,
@@ -160,6 +169,7 @@ async def _upload(
             chunk_size=chunk_size,
             collection=collection,
             keep_existing_records=keep_existing_records,
+            allow_delete=allow_delete,
             dry_run=dry_run,
             file_object=csv_file,
             model_name=model_name,
@@ -177,6 +187,7 @@ async def _upload_file_object(
     collection: str,
     file_object: io.TextIOWrapper,
     keep_existing_records: bool,
+    allow_delete: bool,
     dry_run: bool,
     model_name: str,
     model_package: str,
@@ -219,6 +230,7 @@ async def _upload_file_object(
         bucket=bucket,
         chunk_size=chunk_size,
         collection=collection,
+        allow_delete=allow_delete,
         dry_run=dry_run,
         record_type=record_type,
         server=server,

--- a/merino/jobs/csv_rs_uploader/chunked_rs_uploader.py
+++ b/merino/jobs/csv_rs_uploader/chunked_rs_uploader.py
@@ -29,6 +29,7 @@ class ChunkedRemoteSettingsSuggestionUploader(ChunkedRemoteSettingsUploader):
         collection: str,
         record_type: str,
         server: str,
+        allow_delete: bool = False,
         dry_run: bool = False,
         suggestion_score_fallback: float | None = None,
         total_data_count: int | None = None,
@@ -41,6 +42,7 @@ class ChunkedRemoteSettingsSuggestionUploader(ChunkedRemoteSettingsUploader):
             collection,
             record_type,
             server,
+            allow_delete,
             dry_run,
             total_data_count,
         )

--- a/merino/jobs/relevancy_uploader/chunked_rs_uploader.py
+++ b/merino/jobs/relevancy_uploader/chunked_rs_uploader.py
@@ -25,6 +25,7 @@ class ChunkedRemoteSettingsRelevancyUploader(ChunkedRemoteSettingsUploader):
         category_name: str,
         category_code: int,
         version: int,
+        allow_delete: bool = True,
         dry_run: bool = False,
         total_data_count: int | None = None,
     ):
@@ -36,6 +37,7 @@ class ChunkedRemoteSettingsRelevancyUploader(ChunkedRemoteSettingsUploader):
             collection,
             record_type,
             server,
+            allow_delete,
             dry_run,
             total_data_count,
         )

--- a/tests/unit/jobs/csv_rs_uploader/utils.py
+++ b/tests/unit/jobs/csv_rs_uploader/utils.py
@@ -26,6 +26,7 @@ def _do_csv_test(
     model_name: str,
     model_package: str,
     upload_callable: Callable[[dict[str, Any]], None],
+    allow_delete: bool,
     keep_existing_records: bool,
     record_type: str,
     score: float,
@@ -48,6 +49,7 @@ def _do_csv_test(
         "dry_run": False,
         "record_type": record_type,
         "server": "server",
+        "allow_delete": allow_delete,
     }
     upload_callable(
         {
@@ -84,6 +86,7 @@ def do_csv_test(
     expected_suggestions: list[dict[str, Any]],
     csv_path: str | None = None,
     csv_rows: list[dict[str, str]] | None = None,
+    allow_delete: bool = True,
     keep_existing_records: bool = True,
     record_type: str = "record_type",
     expected_record_type: str = "record_type",
@@ -106,6 +109,7 @@ def do_csv_test(
         model_name=model_name,
         model_package=model_package,
         upload_callable=uploader,
+        allow_delete=allow_delete,
         keep_existing_records=keep_existing_records,
         record_type=record_type,
         score=score,
@@ -134,6 +138,7 @@ def do_error_test(
                 chunk_size=99,
                 collection="collection",
                 keep_existing_records=True,
+                allow_delete=True,
                 dry_run=False,
                 file_object=file_object,
                 model_name=model_name,


### PR DESCRIPTION
## References

JIRA: [DISCO-2967](https://mozilla-hub.atlassian.net/browse/DISCO-2967)

## Description

Added the `--allow-delete` flag.  If it's not present, don't allow records to be deleted.  See
https://bugzilla.mozilla.org/show_bug.cgi?id=1908802 for details.  I turned off the flag for relevancy updates, because the bug only affects Suggest.

Refactored the CSV uploader so that it records changes it's going to make and executes them at the end.  This is needed to correctly determine if there's a deletion. The current pattern is to delete all records, then update ones from the CSV data -- undoing the delete.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2967]: https://mozilla-hub.atlassian.net/browse/DISCO-2967?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ