### PR TITLE
change average load test duration to 2 hours

### DIFF
--- a/tests/load/locustfiles/average_load.py
+++ b/tests/load/locustfiles/average_load.py
@@ -56,7 +56,7 @@ class MerinoAverageLoadTestShape(LoadTestShape):
     the WORKERS_COUNT and USERS_PER_WORKER values must be changed respectively.
     """
 
-    MAX_RUN_TIME: int = int(os.environ.get("MAX_RUN_TIME", 86400))  # 24 hours
+    MAX_RUN_TIME: int = int(os.environ.get("MAX_RUN_TIME", 7200))  # 2 hours
     # Must match value defined in setup_k8s.sh
     WORKER_COUNT: int = int(os.environ.get("WORKER_COUNT", 25))
     # Number of users supported on a worker running on a n1-standard-2


### PR DESCRIPTION
## References

JIRA: [DISCO-TODO](https://mozilla-hub.atlassian.net/browse/DISCO-TODO)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
