### PR TITLE
[DISCO-2824] R2D2 job: Remove fallback categorization logic

### DIFF
--- a/merino/jobs/relevancy_uploader/__init__.py
+++ b/merino/jobs/relevancy_uploader/__init__.py
@@ -46,39 +46,6 @@ class Category(Enum):
     Travel = 19
 
 
-# Mapping to unify categories across the sources
-UPLOAD_CATEGORY_TO_R2D2_CATEGORY: dict[str, Category] = {
-    "Sports": Category.Sports,
-    "Economy & Finance": Category.Finance,
-    "Ecommerce": Category.Inconclusive,
-    "Travel": Category.Travel,
-    "Information Technology": Category.Tech,
-    "News & Media": Category.News,
-    "Chat": Category.Inconclusive,
-    "Photography": Category.Hobbies,
-    "Social Networks": Category.Inconclusive,
-    "Instant Messengers": Category.Inconclusive,
-    "Business": Category.Business,
-    "Health & Fitness": Category.Inconclusive,
-    "Music": Category.Hobbies,
-    "Home & Garden": Category.Home,
-    "Science": Category.Education,
-    "Fashion": Category.Fashion,
-    "Technology": Category.Tech,
-    "Food & Drink": Category.Food,
-    "Video Streaming": Category.Hobbies,
-    "Education": Category.Education,
-    "Lifestyle": Category.Inconclusive,
-    "Cartoons & Anime": Category.Inconclusive,
-    "Gaming": Category.Hobbies,
-    "Magazines": Category.Inconclusive,
-    "Forums": Category.Inconclusive,
-    "Entertainment": Category.Inconclusive,
-    "Clothing": Category.Fashion,
-    "Weather": Category.Inconclusive,
-    "Government": Category.Government,
-}
-
 RELEVANCY_RECORD_TYPE = "category_to_domains"
 
 
@@ -111,7 +78,7 @@ class RelevancyData:
         for domain, csv_categories in domain_categories.items():
             classified = classify_domain(domain, upload_categories, data)
             if not classified:
-                classify_domain_with_fallback(domain, csv_categories, data)
+                classify_domain_with_inconclusive(domain, data)
         return data
 
 
@@ -132,17 +99,10 @@ def classify_domain(domain, upload_categories, data) -> bool:
     return classified
 
 
-def classify_domain_with_fallback(domain, categories, data) -> None:
-    """Classify the domain using UPLOAD_CATEGORY_TO_R2D2 mapping."""
-    classified = False
+def classify_domain_with_inconclusive(domain, data) -> None:
+    """Classify the domain to inconclusive"""
     md5_hash = md5(domain.encode(), usedforsecurity=False).digest()
-    for category in set(categories):
-        category_mapped = UPLOAD_CATEGORY_TO_R2D2_CATEGORY.get(category, Category.Inconclusive)
-        if category_mapped != Category.Inconclusive:
-            data[category_mapped].append({"domain": base64.b64encode(md5_hash).decode()})
-            classified = True
-    if not classified:
-        data[Category.Inconclusive].append({"domain": base64.b64encode(md5_hash).decode()})
+    data[Category.Inconclusive].append({"domain": base64.b64encode(md5_hash).decode()})
 
 
 rs_settings = config.remote_settings

--- a/tests/unit/jobs/relevancy_uploader/test_relevancy_csv_uploader.py
+++ b/tests/unit/jobs/relevancy_uploader/test_relevancy_csv_uploader.py
@@ -39,10 +39,8 @@ def expected_secondary_category_data() -> list[dict[str, Any]]:
     `PRIMARY_CSV_PATH` related to the 'News' Category.
     """
     sportsnews_hash = md5("sportsnnews.com".encode(), usedforsecurity=False).digest()
-    fallback_hash = md5("fallback.com".encode(), usedforsecurity=False).digest()
     return [
         {"domain": base64.b64encode(sportsnews_hash).decode()},
-        {"domain": base64.b64encode(fallback_hash).decode()},
     ]
 
 

--- a/tests/unit/jobs/relevancy_uploader/test_relevancy_data.csv
+++ b/tests/unit/jobs/relevancy_uploader/test_relevancy_data.csv
@@ -3,5 +3,4 @@ rank,domain,host,origin,suffix,categories
 1,sports.com,sports1.sports.com,https://sports1.sports.com,com,"[Sports]"
 2,sports.com,sports2.sports.com,https://sports2.sports.com,com,"[Sports]"
 3,sportsnnews.com,hi.sportsnnews.com,https://hi.sportsnnews.com,com,"[Sports,News & Media]"
-4,fallback.com,cat.fallback.com,https://cat.fallback.com,com,"[News & Media]"
-5,inconclusive.com,inconclusive.inconclusive.com,https://inconclusive.inconclusive.com,com,"[Hello]"
+4,inconclusive.com,inconclusive.inconclusive.com,https://inconclusive.inconclusive.com,com,"[Hello]"


### PR DESCRIPTION
## References

JIRA: [DISCO-2824](https://mozilla-hub.atlassian.net/browse/DISCO-2824)

## Description
Remove fallback categorization logic for r2d2 upload job, as the number of domains it categorized is minimal and the categorization isn't accurate


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2824]: https://mozilla-hub.atlassian.net/browse/DISCO-2824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ