### PR TITLE
MC-1432: return 200 (ok) feed for unknown / invalid topics

### DIFF
--- a/merino/curated_recommendations/protocol.py
+++ b/merino/curated_recommendations/protocol.py
@@ -2,9 +2,9 @@
 
 import hashlib
 from enum import unique, Enum
-from typing import Annotated
+from typing import Annotated, Optional
 
-from pydantic import Field, model_validator, BaseModel
+from pydantic import Field, field_validator, model_validator, BaseModel
 
 from merino.curated_recommendations.corpus_backends.protocol import CorpusItem, Topic
 
@@ -89,7 +89,30 @@ class CuratedRecommendationsRequest(BaseModel):
     locale: Locale
     region: str | None = None
     count: int = 100
-    topics: list[Topic] | None = None
+    # # adding Optional as it gets rid of "Incompatible types in assignment
+    # (expression has type "None", variable has type "list[Topic | str]")"
+    topics: Optional[list[Topic | str]] = None
+
+    @field_validator("topics", mode="before")
+    def validate_topics(cls, values):
+        """Validate the topics param."""
+        if values:
+            if isinstance(values, list):
+                valid_topics = []
+                for value in values:
+                    # if value is a valid Topic, add it to valid_topics
+                    if isinstance(value, Topic):
+                        valid_topics.append(value)
+                    # if value is a string, check if its in enum Topic
+                    # skip if invalid topic
+                    elif isinstance(value, str):
+                        try:
+                            valid_topics.append(Topic(value))
+                        except ValueError:
+                            # Skip invalid topics
+                            continue
+                return valid_topics
+        return []
 
 
 class CuratedRecommendationsResponse(BaseModel):

--- a/merino/curated_recommendations/protocol.py
+++ b/merino/curated_recommendations/protocol.py
@@ -2,11 +2,14 @@
 
 import hashlib
 from enum import unique, Enum
-from typing import Annotated, Optional
+from typing import Annotated
+import logging
 
 from pydantic import Field, field_validator, model_validator, BaseModel
 
 from merino.curated_recommendations.corpus_backends.protocol import CorpusItem, Topic
+
+logger = logging.getLogger(__name__)
 
 
 @unique
@@ -89,9 +92,7 @@ class CuratedRecommendationsRequest(BaseModel):
     locale: Locale
     region: str | None = None
     count: int = 100
-    # # adding Optional as it gets rid of "Incompatible types in assignment
-    # (expression has type "None", variable has type "list[Topic | str]")"
-    topics: Optional[list[Topic | str]] = None
+    topics: list[Topic | str] | None = None
 
     @field_validator("topics", mode="before")
     def validate_topics(cls, values):
@@ -110,8 +111,12 @@ class CuratedRecommendationsRequest(BaseModel):
                             valid_topics.append(Topic(value))
                         except ValueError:
                             # Skip invalid topics
+                            logger.warning(f"Invalid topic: {value}")
                             continue
                 return valid_topics
+            else:
+                # Not wrapped in a list
+                logger.warning(f"Topics not wrapped in a list: {values}")
         return []
 
 

--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -2,10 +2,12 @@
 
 import time
 import re
+from typing import cast
 
 from merino.curated_recommendations.corpus_backends.protocol import (
     CorpusBackend,
     ScheduledSurfaceId,
+    Topic,
 )
 from merino.curated_recommendations.engagement_backends.protocol import EngagementBackend
 from merino.curated_recommendations.protocol import (
@@ -133,9 +135,10 @@ class CuratedRecommendationsProvider:
 
         # 1. Finally, perform preferred topics boosting if preferred topics are passed in the request
         if curated_recommendations_request.topics:
-            recommendations = boost_preferred_topic(
-                recommendations, curated_recommendations_request.topics
+            validated_topics: list[Topic] = cast(
+                list[Topic], curated_recommendations_request.topics
             )
+            recommendations = boost_preferred_topic(recommendations, validated_topics)
 
         for rank, rec in enumerate(recommendations):
             # Update received_rank now that recommendations have been ranked.

--- a/merino/curated_recommendations/rankers.py
+++ b/merino/curated_recommendations/rankers.py
@@ -80,7 +80,7 @@ def spread_publishers(
 
 def boost_preferred_topic(
     recs: list[CuratedRecommendation],
-    preferred_topics: list[Topic | str],
+    preferred_topics: list[Topic],
 ) -> list[CuratedRecommendation]:
     """Boost recommendations into top N slots based on preferred topics.
     2 recs per topic (for now).

--- a/merino/curated_recommendations/rankers.py
+++ b/merino/curated_recommendations/rankers.py
@@ -80,7 +80,7 @@ def spread_publishers(
 
 def boost_preferred_topic(
     recs: list[CuratedRecommendation],
-    preferred_topics: list[Topic],
+    preferred_topics: list[Topic | str],
 ) -> list[CuratedRecommendation]:
     """Boost recommendations into top N slots based on preferred topics.
     2 recs per topic (for now).

--- a/tests/data/scheduled_surface_short.json
+++ b/tests/data/scheduled_surface_short.json
@@ -45,6 +45,17 @@
             "publisher": "Culture Study",
             "imageUrl": "https://s3.amazonaws.com/pocket-curatedcorpusapi-prod-images/3a4a6ed6-a1df-497d-8d31-f777534806ac.jpeg"
           }
+        },
+        {
+          "id": "1134669c-3ab8-4f68-8514-4e2ec9c0b5b1",
+          "corpusItem": {
+            "url": "https://getpocket.com/explore/item/worried-about-sending-your-baby-to-daycare-our-research-shows-they-like-being-in-groups",
+            "title": "Worried About Sending Your Baby to Daycare? Research Shows They Like Being in Groups",
+            "excerpt": "Babies as young as six months respond to and enjoy being in groups with other babies.",
+            "topic": "PARENTING",
+            "publisher": "The Conversation",
+            "imageUrl": "https://s3.us-east-1.amazonaws.com/pocket-curatedcorpusapi-prod-images/b9182b66-5398-4fe2-a95d-8b9a46e5a05d.jpeg"
+          }
         }
       ]
     }

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -654,7 +654,6 @@ class TestCuratedRecommendationsRequestParameters:
             response = await ac.post(
                 "/api/v1/curated-recommendations", json={"locale": "en-US", "topics": topics}
             )
-            # response = await fetch_en_us(ac)
             data = response.json()
             corpus_items = data["data"]
             # assert 200 is returned even tho some invalid topics


### PR DESCRIPTION
## References

JIRA: https://mozilla-hub.atlassian.net/browse/MC-1432

## Description
Return a 200 OK content feed even if server receives an unknown or invalid preferred topics. If multiple preferred topics passed, ignore invalid ones (treat as blank) & return feed based on valid topics (if present). 

Set `topics` param to `Optional[list[Topic | str]] = None` to accommodate for invalid `str` topics. Using pydantics `@field_validator` to run a `validate_topics` on `topics`.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
