### PR TITLE
[DISCO-2975] Add count metric for upstream accuweather requests

### DIFF
--- a/merino/providers/weather/backends/accuweather/backend.py
+++ b/merino/providers/weather/backends/accuweather/backend.py
@@ -323,6 +323,8 @@ class AccuweatherBackend:
           - `HTTPError` upon HTTP request errors
           - `AccuweatherError` upon cache write errors
         """
+        # increment the upstream request stat counter
+        self.metrics_client.increment(f"accuweather.upstream.request.{request_type}.get")
         response_dict: dict[str, Any] | None
 
         with self.metrics_client.timeit(

--- a/merino/providers/weather/backends/accuweather/backend.py
+++ b/merino/providers/weather/backends/accuweather/backend.py
@@ -805,7 +805,7 @@ class AccuweatherBackend:
                 params={
                     self.url_param_api_key: self.api_key,
                 },
-                request_type=RequestType.FORCASTS,
+                request_type=RequestType.FORECASTS,
                 process_api_response=process_forecast_response,
                 cache_ttl_sec=self.cached_forecast_ttl_sec,
             )

--- a/merino/providers/weather/backends/accuweather/utils.py
+++ b/merino/providers/weather/backends/accuweather/utils.py
@@ -19,7 +19,7 @@ class RequestType(StrEnum):
 
     LOCATIONS = "locations"
     CURRENT_CONDITIONS = "currentconditions"
-    FORCASTS = "forecasts"
+    FORECASTS = "forecasts"
     AUTOCOMPLETE = "autocomplete"
 
 

--- a/tests/integration/api/v1/curated_recommendations/engagement_backends/test_gcs_engagement.py
+++ b/tests/integration/api/v1/curated_recommendations/engagement_backends/test_gcs_engagement.py
@@ -16,7 +16,6 @@ from testcontainers.core.waiting_utils import wait_for_logs
 
 from merino.config import settings
 from merino.curated_recommendations.engagement_backends.gcs_engagement import GcsEngagement
-from merino.curated_recommendations.engagement_backends.protocol import Engagement
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/api/v1/curated_recommendations/engagement_backends/test_gcs_engagement.py
+++ b/tests/integration/api/v1/curated_recommendations/engagement_backends/test_gcs_engagement.py
@@ -16,6 +16,7 @@ from testcontainers.core.waiting_utils import wait_for_logs
 
 from merino.config import settings
 from merino.curated_recommendations.engagement_backends.gcs_engagement import GcsEngagement
+from merino.curated_recommendations.engagement_backends.protocol import Engagement
 
 
 @pytest.fixture(scope="module")

--- a/tests/unit/providers/weather/backends/test_accuweather.py
+++ b/tests/unit/providers/weather/backends/test_accuweather.py
@@ -1943,7 +1943,7 @@ def test_cache_key_for_accuweather_request(
 @pytest.mark.parametrize(
     ("url", "expected_request_type"),
     [
-        ("/forecasts/v1/daily/1day/39376.json", RequestType.FORCASTS),
+        ("/forecasts/v1/daily/1day/39376.json", RequestType.FORECASTS),
         (
             "/currentconditions/v1/39376.json",
             RequestType.CURRENT_CONDITIONS,
@@ -2039,7 +2039,7 @@ async def test_get_request_cache_store_errors(
         await accuweather.request_upstream(
             url,
             params={"apikey": "test"},
-            request_type=RequestType.FORCASTS,
+            request_type=RequestType.FORECASTS,
             process_api_response=lambda a: cast(Optional[dict[str, Any]], a),
             cache_ttl_sec=TEST_CACHE_TTL_SEC,
         )
@@ -2055,7 +2055,7 @@ async def test_get_request_cache_store_errors(
 
     increment_called = [call_arg[0][0] for call_arg in statsd_mock.increment.call_args_list]
     assert [
-        f"accuweather.upstream.request.{RequestType.FORCASTS}.get",
+        f"accuweather.upstream.request.{RequestType.FORECASTS}.get",
         "accuweather.cache.store.set_error",
     ] == increment_called
 

--- a/tests/unit/providers/weather/backends/test_accuweather.py
+++ b/tests/unit/providers/weather/backends/test_accuweather.py
@@ -2055,6 +2055,7 @@ async def test_get_request_cache_store_errors(
 
     increment_called = [call_arg[0][0] for call_arg in statsd_mock.increment.call_args_list]
     assert [
+        f"accuweather.upstream.request.{RequestType.FORCASTS}.get",
         "accuweather.cache.store.set_error",
     ] == increment_called
 
@@ -2312,6 +2313,7 @@ async def test_get_location_completion_with_invalid_accuweather_response(
 
     metrics_called = [call_arg[0][0] for call_arg in statsd_mock.increment.call_args_list]
     assert [
+        f"accuweather.upstream.request.{RequestType.AUTOCOMPLETE}.get",
         f"accuweather.request.{RequestType.AUTOCOMPLETE}.processor.error",
     ] == metrics_called
 


### PR DESCRIPTION
## References

JIRA: [DISCO-2975](https://mozilla-hub.atlassian.net/browse/DISCO-2975)

## Description
Added a new and separate **count** metric to correctly represent and track upstream requests made to accuweather. Before that, we were piggy backing the `timeit()` metric for request latency to count the no. of requests but since we are sampling that metric, the count accuracy is also affected. This change fixes that.

Also tested locally and verified that the new metric is emitted.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2975]: https://mozilla-hub.atlassian.net/browse/DISCO-2975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ