### PR TITLE
MC-1462: remove repeat param to run gcs tests 20 times

### DIFF
--- a/tests/integration/api/v1/curated_recommendations/engagement_backends/test_gcs_engagement.py
+++ b/tests/integration/api/v1/curated_recommendations/engagement_backends/test_gcs_engagement.py
@@ -149,9 +149,7 @@ async def test_gcs_engagement_returns_zero_for_missing_keys(gcs_engagement):
 
 
 @pytest.mark.asyncio
-async def test_gcs_engagement_fetches_data(
-    gcs_engagement, blob_20min_ago, blob_5min_ago
-):
+async def test_gcs_engagement_fetches_data(gcs_engagement, blob_20min_ago, blob_5min_ago):
     """Test that the backend fetches data from GCS and returns engagement data."""
     gcs_engagement.initialize()
     await wait_until_engagement_is_updated(gcs_engagement)
@@ -178,9 +176,7 @@ async def test_gcs_engagement_logs_error_for_large_blob(
 
 
 @pytest.mark.asyncio
-async def test_gcs_engagement_metrics(
-    gcs_engagement, mock_metrics_client, blob_5min_ago
-):
+async def test_gcs_engagement_metrics(gcs_engagement, mock_metrics_client, blob_5min_ago):
     """Test that the backend records the correct metrics."""
     gcs_engagement.initialize()
     await wait_until_engagement_is_updated(gcs_engagement)

--- a/tests/integration/api/v1/curated_recommendations/engagement_backends/test_gcs_engagement.py
+++ b/tests/integration/api/v1/curated_recommendations/engagement_backends/test_gcs_engagement.py
@@ -150,7 +150,7 @@ async def test_gcs_engagement_returns_zero_for_missing_keys(gcs_engagement):
 
 @pytest.mark.asyncio
 async def test_gcs_engagement_fetches_data(
-    gcs_engagement, blob_20min_ago, blob_5min_ago, execution_number
+    gcs_engagement, blob_20min_ago, blob_5min_ago
 ):
     """Test that the backend fetches data from GCS and returns engagement data."""
     gcs_engagement.initialize()
@@ -179,7 +179,7 @@ async def test_gcs_engagement_logs_error_for_large_blob(
 
 @pytest.mark.asyncio
 async def test_gcs_engagement_metrics(
-    gcs_engagement, mock_metrics_client, blob_5min_ago, execution_number
+    gcs_engagement, mock_metrics_client, blob_5min_ago
 ):
     """Test that the backend records the correct metrics."""
     gcs_engagement.initialize()

--- a/tests/integration/api/v1/curated_recommendations/engagement_backends/test_gcs_engagement.py
+++ b/tests/integration/api/v1/curated_recommendations/engagement_backends/test_gcs_engagement.py
@@ -149,7 +149,6 @@ async def test_gcs_engagement_returns_zero_for_missing_keys(gcs_engagement):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("execution_number", range(20))
 async def test_gcs_engagement_fetches_data(
     gcs_engagement, blob_20min_ago, blob_5min_ago, execution_number
 ):
@@ -179,7 +178,6 @@ async def test_gcs_engagement_logs_error_for_large_blob(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("execution_number", range(20))
 async def test_gcs_engagement_metrics(
     gcs_engagement, mock_metrics_client, blob_5min_ago, execution_number
 ):


### PR DESCRIPTION
## References

## Description
Forgot to remove the repeat param to run a test 20 times in this recent PR: https://github.com/mozilla-services/merino-py/pull/619


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
