### PR TITLE
[DISCO-2896] Suggest endpoint query param validation

### DIFF
--- a/tests/integration/api/v1/suggest/test_suggest_weather.py
+++ b/tests/integration/api/v1/suggest/test_suggest_weather.py
@@ -207,7 +207,7 @@ def test_suggest_with_weather_report(client: TestClient, backend_mock: Any) -> N
     ]
     backend_mock.get_weather_report.return_value = weather_report
 
-    response = client.get("/api/v1/suggest?q=weather")
+    response = client.get("/api/v1/suggest?q=weather&request_type=weather")
 
     assert response.status_code == 200
     assert response.headers["Cache-Control"] == "private, max-age=500"
@@ -224,7 +224,7 @@ def test_suggest_without_weather_report(client: TestClient, backend_mock: Any) -
     expected_suggestion: list[Suggestion] = []
     backend_mock.get_weather_report.return_value = None
 
-    response = client.get("/api/v1/suggest?q=weather")
+    response = client.get("/api/v1/suggest?q=weather&request_type=weather")
 
     assert response.status_code == 200
     assert (
@@ -233,6 +233,17 @@ def test_suggest_without_weather_report(client: TestClient, backend_mock: Any) -
     )
     result = response.json()
     assert result["suggestions"] == expected_suggestion
+
+
+def test_suggest_weather_with_missing_request_type_query_parameter(
+    client: TestClient, backend_mock: Any
+) -> None:
+    """Test that the suggest endpoint response for accuweather provider returns a 400 when `q`
+    is present but `request_type is missing
+    """
+    response = client.get("/api/v1/suggest?q=weather&providers=weather")
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Invalid query parameters: `request_type` is missing"
 
 
 @freeze_time("1998-03-31")

--- a/tests/integration/api/v1/suggest/test_suggest_weather.py
+++ b/tests/integration/api/v1/suggest/test_suggest_weather.py
@@ -235,9 +235,7 @@ def test_suggest_without_weather_report(client: TestClient, backend_mock: Any) -
     assert result["suggestions"] == expected_suggestion
 
 
-def test_suggest_weather_with_missing_request_type_query_parameter(
-    client: TestClient, backend_mock: Any
-) -> None:
+def test_suggest_weather_with_missing_request_type_query_parameter(client: TestClient) -> None:
     """Test that the suggest endpoint response for accuweather provider returns a 400 when `q`
     is present but `request_type is missing
     """

--- a/tests/unit/providers/weather/test_provider.py
+++ b/tests/unit/providers/weather/test_provider.py
@@ -142,13 +142,11 @@ async def test_query_no_weather_report_returned(
 
 @pytest.mark.asyncio
 async def test_query_with_no_request_type_param_returns_http_400(
-    backend_mock: Any, provider: Provider, geolocation: Location
+    provider: Provider, geolocation: Location
 ) -> None:
     """Test that the query method throws a http 400 error when `q` param is provided but no
     `request_type` param is provided
     """
-    backend_mock.get_weather_report.return_value = None
-
     with pytest.raises(HTTPException) as accuweather_error:
         await provider.query(SuggestionRequest(query="weather", geolocation=geolocation))
 

--- a/tests/unit/providers/weather/test_provider.py
+++ b/tests/unit/providers/weather/test_provider.py
@@ -6,6 +6,7 @@
 
 from typing import Any
 from unittest.mock import call
+from fastapi import HTTPException
 
 import pytest
 from pydantic import HttpUrl
@@ -137,6 +138,23 @@ async def test_query_no_weather_report_returned(
     )
 
     assert suggestions == expected_suggestions
+
+
+@pytest.mark.asyncio
+async def test_query_with_no_request_type_param_returns_http_400(
+    backend_mock: Any, provider: Provider, geolocation: Location
+) -> None:
+    """Test that the query method throws a http 400 error when `q` param is provided but no
+    `request_type` param is provided
+    """
+    backend_mock.get_weather_report.return_value = None
+
+    with pytest.raises(HTTPException) as accuweather_error:
+        await provider.query(SuggestionRequest(query="weather", geolocation=geolocation))
+
+    expected_error_message = "400: Invalid query parameters: `request_type` is missing"
+
+    assert expected_error_message == str(accuweather_error.value)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## References

JIRA: [DISCO-2896](https://mozilla-hub.atlassian.net/browse/DISCO-2896)
related PR: https://github.com/mozilla-services/merino-py/pull/569 

## Description
For the suggest endpoint,  we need to return a http 400 error when `q` query param has a value but `request_type` query param is missing. 

### Testing locally
These query param combinations work (as expected)
`... suggest?q=&providers=accuweather`
`... suggest?q=&providers=accuweather&request_type=weather`
`... suggest?q=&providers=accuweather&request_type=location`
`... suggest?q=new&providers=accuweather&request_type=location`

This query param combination does not work (as expected)
`... suggest?q=weather&providers=accuweather`

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2896]: https://mozilla-hub.atlassian.net/browse/DISCO-2896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ