### PR TITLE
feat(curated recommendations): [MC-1498] Prototype support for contextual content experiments [load test: warn]

### DIFF
--- a/merino/curated_recommendations/protocol.py
+++ b/merino/curated_recommendations/protocol.py
@@ -93,7 +93,7 @@ class CuratedRecommendationsRequest(BaseModel):
     region: str | None = None
     count: int = 100
     topics: list[Topic | str] | None = None
-    feeds: str | None = None
+    feeds: list[str] | None = None
 
     @field_validator("topics", mode="before")
     def validate_topics(cls, values):
@@ -121,29 +121,22 @@ class CuratedRecommendationsRequest(BaseModel):
         return []
 
 
-class LocalizedString(BaseModel):
-    """A string value for a given locale"""
-
-    value: str
-    locale: Locale
-
-
 class CuratedRecommendationsBucket(BaseModel):
     """A ranked list of curated recommendations"""
 
     recommendations: list[CuratedRecommendation]
-    title: LocalizedString | None = None
+    title: str | None = None
 
 
 class CuratedRecommendationsFeed(BaseModel):
     """Multiple lists of curated recommendations for the main New Tab feed and also for experiments"""
 
-    general: CuratedRecommendationsBucket
-    experimental: CuratedRecommendationsBucket
+    need_to_know: CuratedRecommendationsBucket
 
 
 class CuratedRecommendationsResponse(BaseModel):
     """Response schema for a list of curated recommendations"""
 
     recommendedAt: int
-    data: CuratedRecommendationsFeed | list[CuratedRecommendation]
+    data: list[CuratedRecommendation]
+    feeds: CuratedRecommendationsFeed | None = None

--- a/merino/curated_recommendations/protocol.py
+++ b/merino/curated_recommendations/protocol.py
@@ -121,10 +121,18 @@ class CuratedRecommendationsRequest(BaseModel):
         return []
 
 
+class LocalizedString(BaseModel):
+    """A string value for a given locale"""
+
+    value: str
+    locale: Locale
+
+
 class CuratedRecommendationsBucket(BaseModel):
     """A ranked list of curated recommendations"""
 
     recommendations: list[CuratedRecommendation]
+    title: LocalizedString | None = None
 
 
 class CuratedRecommendationsFeed(BaseModel):

--- a/merino/curated_recommendations/protocol.py
+++ b/merino/curated_recommendations/protocol.py
@@ -93,6 +93,7 @@ class CuratedRecommendationsRequest(BaseModel):
     region: str | None = None
     count: int = 100
     topics: list[Topic | str] | None = None
+    include_experimental: bool | None = None
 
     @field_validator("topics", mode="before")
     def validate_topics(cls, values):
@@ -120,8 +121,21 @@ class CuratedRecommendationsRequest(BaseModel):
         return []
 
 
+class CuratedRecommendationsBucket(BaseModel):
+    """A ranked list of curated recommendations"""
+
+    recommendations: list[CuratedRecommendation]
+
+
+class CuratedRecommendationsFeed(BaseModel):
+    """Multiple lists of curated recommendations for the main New Tab feed and also for experiments"""
+
+    general: CuratedRecommendationsBucket
+    experimental: CuratedRecommendationsBucket
+
+
 class CuratedRecommendationsResponse(BaseModel):
     """Response schema for a list of curated recommendations"""
 
     recommendedAt: int
-    data: list[CuratedRecommendation]
+    data: CuratedRecommendationsFeed | list[CuratedRecommendation]

--- a/merino/curated_recommendations/protocol.py
+++ b/merino/curated_recommendations/protocol.py
@@ -129,7 +129,9 @@ class CuratedRecommendationsBucket(BaseModel):
 
 
 class CuratedRecommendationsFeed(BaseModel):
-    """Multiple lists of curated recommendations for the main New Tab feed and also for experiments"""
+    """Multiple lists of curated recommendations for experiments.
+    Currently limited to the 'need_to_know' feed only.
+    """
 
     need_to_know: CuratedRecommendationsBucket
 

--- a/merino/curated_recommendations/protocol.py
+++ b/merino/curated_recommendations/protocol.py
@@ -93,7 +93,7 @@ class CuratedRecommendationsRequest(BaseModel):
     region: str | None = None
     count: int = 100
     topics: list[Topic | str] | None = None
-    include_experimental: bool | None = None
+    feeds: str | None = None
 
     @field_validator("topics", mode="before")
     def validate_topics(cls, values):

--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -158,11 +158,23 @@ class CuratedRecommendationsProvider:
             ):
                 rec.topic = None
 
-        # TODO: this will need to return feeds specified in the `feeds` parameter and not just anything
-        if curated_recommendations_request.feeds:
-            # TODO: while a filter on stories is being decided on, return all stories that have the word
-            # "Why" in the story title
-            experimental_feed = [r for r in recommendations if "Why" in r.title]
+        # TODO: this will need to return feeds specified in the `feeds` parameter
+        if (
+            surface_id
+            in (
+                ScheduledSurfaceId.NEW_TAB_EN_US,
+                ScheduledSurfaceId.NEW_TAB_EN_GB,
+                ScheduledSurfaceId.NEW_TAB_DE_DE,
+            )
+            and curated_recommendations_request.feeds
+        ):
+            # TODO: the single feed of stories needs to be split into the general feed and extra feed(s).
+            #  This will be filtered on a corpus item property, most likely `isTimeSensitive`.
+            #  While a filter on stories is being decided on, the extra feed contains all stories
+            #  that have the word "Why" or "Warum" in the story title
+            experimental_feed = [
+                r for r in recommendations if ("Why" in r.title or "Warum" in r.title)
+            ]
             general_feed = [r for r in recommendations if r not in experimental_feed]
 
             return CuratedRecommendationsResponse(

--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -158,14 +158,18 @@ class CuratedRecommendationsProvider:
             ):
                 rec.topic = None
 
-        if curated_recommendations_request.include_experimental:
+        # TODO: this will need to return feeds specified in the `feeds` parameter and not just anything
+        if curated_recommendations_request.feeds:
+            # TODO: while a filter on stories is being decided on, return all stories that have the word
+            # "Why" in the story title
+            experimental_feed = [r for r in recommendations if "Why" in r.title]
+            general_feed = [r for r in recommendations if r not in experimental_feed]
+
             return CuratedRecommendationsResponse(
                 recommendedAt=self.time_ms(),
                 data=CuratedRecommendationsFeed(
-                    general=CuratedRecommendationsBucket(recommendations=recommendations),
-                    experimental=CuratedRecommendationsBucket(
-                        recommendations=list(reversed(recommendations))
-                    ),
+                    general=CuratedRecommendationsBucket(recommendations=general_feed),
+                    experimental=CuratedRecommendationsBucket(recommendations=experimental_feed),
                 ),
             )
         else:

--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -19,6 +19,7 @@ from merino.curated_recommendations.protocol import (
     CuratedRecommendationsResponse,
     CuratedRecommendationsFeed,
     CuratedRecommendationsBucket,
+    LocalizedString,
 )
 from merino.curated_recommendations.rankers import (
     boost_preferred_topic,
@@ -177,11 +178,17 @@ class CuratedRecommendationsProvider:
             ]
             general_feed = [r for r in recommendations if r not in experimental_feed]
 
+            title = LocalizedString(
+                value="Read this now!", locale=curated_recommendations_request.locale
+            )
+
             return CuratedRecommendationsResponse(
                 recommendedAt=self.time_ms(),
                 data=CuratedRecommendationsFeed(
                     general=CuratedRecommendationsBucket(recommendations=general_feed),
-                    experimental=CuratedRecommendationsBucket(recommendations=experimental_feed),
+                    experimental=CuratedRecommendationsBucket(
+                        recommendations=experimental_feed, title=title
+                    ),
                 ),
             )
         else:

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -337,6 +337,7 @@ async def curated_content(
         then region is extracted from the `locale` parameter if it contains two parts (e.g. en-US).
     - `count`: [Optional] The maximum number of recommendations to return. Defaults to 100.
     - `topics`: [Optional] A list of preferred [topics][curated-topics-doc].
+    - `feeds`: [Optional] A comma-separated list of additional data feeds.
 
     [curated-topics-doc]: https://mozilla-hub.atlassian.net/wiki/x/LQDaMg
     """

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -337,7 +337,8 @@ async def curated_content(
         then region is extracted from the `locale` parameter if it contains two parts (e.g. en-US).
     - `count`: [Optional] The maximum number of recommendations to return. Defaults to 100.
     - `topics`: [Optional] A list of preferred [topics][curated-topics-doc].
-    - `feeds`: [Optional] A comma-separated list of additional data feeds.
+    - `feeds`: [Optional] A list of additional data feeds. Currently, accepts
+       only one value: 'need_to_know'.
 
     [curated-topics-doc]: https://mozilla-hub.atlassian.net/wiki/x/LQDaMg
     """


### PR DESCRIPTION
## References

JIRA: https://mozilla-hub.atlassian.net/browse/MC-1498

## Description

This is a prototype of an additional feed of curated corpus recommendations alongside the one already being sent to New Tab surfaces. If an optional parameter (`"feeds": ["need_to_know"]`) is requested with the API call, the new feed of 5-10 items (10 for the current prototype with semi-mocked data) is returned. 

The shape of the API response becomes the following:

```
{
  recommendedAt: int
  data: recommendation[]
  feeds: {
    need_to_know: {
      recommendations: recommendation[],
      title: string // localized based on locale value sent in request
    }
  }
}
```

The full spec is available at https://mozilla-hub.atlassian.net/wiki/spaces/FPS/pages/975110262/API+Technical+Specification.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
