### PR TITLE
feat: [MC-1459] Load engagement by region

### DIFF
--- a/merino/curated_recommendations/engagement_backends/fake_engagement.py
+++ b/merino/curated_recommendations/engagement_backends/fake_engagement.py
@@ -9,7 +9,7 @@ from merino.curated_recommendations.engagement_backends.protocol import (
 class FakeEngagement(EngagementBackend):
     """Fallback backend that returns None for any engagement data."""
 
-    def get(self, scheduled_corpus_item_id: str) -> Engagement | None:
+    def get(self, scheduled_corpus_item_id: str, region: str | None = None) -> Engagement | None:
         """No-op for getting engagement data."""
         return None
 

--- a/merino/curated_recommendations/engagement_backends/protocol.py
+++ b/merino/curated_recommendations/engagement_backends/protocol.py
@@ -10,9 +10,12 @@ class Engagement(BaseModel):
     Engagement is aggregated over a rolling 24-hour window by scheduled_corpus_item_id, a unique ID
      for the URL, scheduled date, and surface (e.g., "New Tab en-US"). It's expected to be updated
      periodically with a delay of < 30 minutes from when clicks or impressions happen in the client.
+    Additionally, engagement data is aggregated for the regions US, CA, IE, GB, DE, AU, and CH.
+     If region is None this means engagement data is aggregated across all regions.
     """
 
     scheduled_corpus_item_id: str
+    region: str | None = None  # If region is None, then engagement is across all regions.
     click_count: int
     impression_count: int
 
@@ -20,8 +23,8 @@ class Engagement(BaseModel):
 class EngagementBackend(Protocol):
     """Protocol for Engagement backend that the provider depends on."""
 
-    def get(self, scheduled_corpus_item_id: str) -> Engagement | None:
-        """Fetch engagement data for the given scheduled corpus item id"""
+    def get(self, scheduled_corpus_item_id: str, region: str | None = None) -> Engagement | None:
+        """Fetch engagement data for the given scheduled corpus item id and optionally region"""
         ...
 
     def initialize(self) -> None:

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -97,7 +97,7 @@ def fixture_mock_corpus_backend(corpus_http_client: AsyncMock) -> CorpusApiBacke
 class MockEngagementBackend(EngagementBackend):
     """Mock class implementing the protocol for EngagementBackend."""
 
-    def get(self, scheduled_corpus_item_id: str) -> Engagement | None:
+    def get(self, scheduled_corpus_item_id: str, region: str | None = None) -> Engagement | None:
         """Return random click and impression counts based on the scheduled corpus id."""
         rng = np.random.default_rng(seed=int.from_bytes(scheduled_corpus_item_id.encode()))
 


### PR DESCRIPTION
## References

JIRA: [MC-1459](https://mozilla-hub.atlassian.net/browse/MC-1459)

## Description
We want to experiment with ranking New Tab recommendations differently by region, after a successful experiment in Canada in recommendation-api.

This PR takes the first step, by allowing engagement to be loaded from different regions. This data does not exist yet, so the code can to read data _with_ and _without_ the `region` field present.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[MC-1459]: https://mozilla-hub.atlassian.net/browse/MC-1459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ