### PR TITLE
[MC-1518] Rank using region engagement in experiment

### DIFF
--- a/merino/curated_recommendations/protocol.py
+++ b/merino/curated_recommendations/protocol.py
@@ -47,6 +47,16 @@ class Locale(str, Enum):
         return Locale._value2member_map_
 
 
+@unique
+class ExperimentName(str, Enum):
+    """List of Nimbus experiment names on New Tab. This list is NOT meant to be exhaustive.
+    This is simply intended to make it easier to reference experiment names in this codebase,
+    when Merino needs to change behavior depending on the experimentName request parameter.
+    """
+
+    REGION_SPECIFIC_CONTENT_EXPANSION = "new-tab-region-specific-content-expansion"
+
+
 # Maximum tileId that Firefox can support. Firefox uses Javascript to store this value. The max
 # value of a Javascript number can be found using `Number.MAX_SAFE_INTEGER`. which is 2^53 - 1
 # because it uses a 64-bit IEEE 754 float.
@@ -93,6 +103,11 @@ class CuratedRecommendationsRequest(BaseModel):
     region: str | None = None
     count: int = 100
     topics: list[Topic | str] | None = None
+    # Firefox sends the name and branch for Nimbus experiments on the "pocketNewtab" feature:
+    # https://searchfox.org/mozilla-central/source/browser/components/newtab/lib/DiscoveryStreamFeed.sys.mjs
+    # Allow any string value or null, because ExperimentName is not meant to be an exhaustive list.
+    experimentName: ExperimentName | str | None = None
+    experimentBranch: str | None = None
 
     @field_validator("topics", mode="before")
     def validate_topics(cls, values):

--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -112,6 +112,14 @@ class CuratedRecommendationsProvider:
         else:
             return None
 
+    @staticmethod
+    def is_enrolled_in_regional_engagement(request: CuratedRecommendationsRequest) -> bool:
+        """Return True if Thompson sampling should use regional engagement (treatment)"""
+        return (
+            request.experimentName == ExperimentName.REGION_SPECIFIC_CONTENT_EXPANSION.value
+            and request.experimentBranch == "treatment"
+        )
+
     def process_recommendations(
         self,
         recommendations: list[CuratedRecommendation],
@@ -126,9 +134,7 @@ class CuratedRecommendationsProvider:
             recommendations,
             self.engagement_backend,
             region=self.derive_region(request.locale, request.region),
-            enable_region_engagement=request.experimentName
-            == ExperimentName.REGION_SPECIFIC_CONTENT_EXPANSION.value
-            and request.experimentBranch == "treatment",
+            enable_region_engagement=self.is_enrolled_in_regional_engagement(request),
         )
 
         # 2. Perform publisher spread on the recommendation set

--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -113,9 +113,7 @@ class CuratedRecommendationsProvider:
     ) -> CuratedRecommendationsResponse:
         """Provide curated recommendations."""
         # Get the recommendation surface ID based on passed locale & region
-        surface_id = CuratedRecommendationsProvider.get_recommendation_surface_id(
-            request.locale, request.region
-        )
+        surface_id = self.get_recommendation_surface_id(request.locale, request.region)
 
         corpus_items = await self.corpus_backend.fetch(surface_id)
 
@@ -132,7 +130,7 @@ class CuratedRecommendationsProvider:
         recommendations = thompson_sampling(
             recommendations,
             self.engagement_backend,
-            region=request.region,
+            region=self.derive_region(request.locale, request.region),
             enable_region_engagement=request.experimentName
             == ExperimentName.REGION_SPECIFIC_CONTENT_EXPANSION.value
             and request.experimentBranch == "treatment",

--- a/merino/curated_recommendations/rankers.py
+++ b/merino/curated_recommendations/rankers.py
@@ -11,6 +11,13 @@ DEFAULT_ALPHA_PRIOR = 188  # beta * P99 German NewTab CTR for 2023-03-28 to 2023
 DEFAULT_BETA_PRIOR = (
     12500  # 0.5% of median German NewTab item impressions for 2023-03-28 to 2023-04-05.
 )
+# In a weighted average, how much to weigh the metrics from the requested region. 0.95 was chosen
+# somewhat arbitrarily in the new-tab-region-specific-content experiment that only targeted Canada.
+# CA has about 9x fewer impressions than the total for NEW_TAB_EN_US. A value close to 1 boosts
+# regional engagement enough to let it significantly impact the final ranking, while still giving
+# some influence to global engagement. It might work equally well for other regions than Canada.
+# We could decide later to derive this value dynamically per region.
+REGION_ENGAGEMENT_WEIGHT = 0.95
 
 MAX_TOP_REC_SLOTS = 10
 NUM_RECS_PER_TOPIC = 2
@@ -19,8 +26,11 @@ NUM_RECS_PER_TOPIC = 2
 def thompson_sampling(
     recs: list[CuratedRecommendation],
     engagement_backend: EngagementBackend,
-    alpha_prior=DEFAULT_ALPHA_PRIOR,
-    beta_prior=DEFAULT_BETA_PRIOR,
+    alpha_prior: float = DEFAULT_ALPHA_PRIOR,
+    beta_prior: float = DEFAULT_BETA_PRIOR,
+    enable_region_engagement: bool = False,
+    region: str | None = None,
+    region_weight: float = REGION_ENGAGEMENT_WEIGHT,
 ) -> list[CuratedRecommendation]:
     """Re-rank items using [Thompson sampling][thompson-sampling], combining exploitation of known item
     CTR with exploration of new items using a prior.
@@ -29,24 +39,43 @@ def thompson_sampling(
     :param engagement_backend: Provides aggregate click and impression engagement by scheduledCorpusItemId.
     :param alpha_prior: Prior successes (e.g., clicks). Must be > 0.
     :param beta_prior: Prior failures (e.g., non-click impressions). Must be > 0.
+    :param enable_region_engagement: If True, regional engagement weighs higher. False by default.
+    :param region: Optionally, the client's region, e.g. 'US'.
+    :param region_weight: In a weighted average, how much to weigh regional engagement.
 
     :return: A re-ordered version of recs, ranked according to the Thompson sampling score.
 
     [thompson-sampling]: https://en.wikipedia.org/wiki/Thompson_sampling
     """
 
-    def get_score(rec: CuratedRecommendation) -> float:
-        opens = alpha_prior
-        no_opens = beta_prior
-
-        engagement = engagement_backend.get(rec.scheduledCorpusItemId)
+    def get_opens_no_opens(
+        rec: CuratedRecommendation, region_query: str | None = None
+    ) -> tuple[float, float]:
+        """Get opens and no-opens counts for a recommendation, optionally in a region."""
+        engagement = engagement_backend.get(rec.scheduledCorpusItemId, region_query)
         if engagement:
-            opens += engagement.click_count
-            no_opens += engagement.impression_count - engagement.click_count
+            return engagement.click_count, engagement.impression_count - engagement.click_count
+        else:
+            return 0, 0
+
+    def sample_score(rec: CuratedRecommendation) -> float:
+        """Sample beta distributed from weighted regional/global engagement for a recommendation."""
+        opens, no_opens = get_opens_no_opens(rec)
+
+        # Use a weighted average of regional and global engagement, if that's enabled and available.
+        if enable_region_engagement:
+            region_opens, region_no_opens = get_opens_no_opens(rec, region)
+            if region_no_opens:
+                opens = (region_weight * region_opens) + ((1 - region_weight) * opens)
+                no_opens = (region_weight * region_no_opens) + ((1 - region_weight) * no_opens)
+
+        opens += alpha_prior
+        no_opens += beta_prior
 
         return float(beta.rvs(opens, no_opens))
 
-    return sorted(recs, key=get_score, reverse=True)
+    # Sort the recommendations from best to worst sampled score.
+    return sorted(recs, key=sample_score, reverse=True)
 
 
 def spread_publishers(

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -337,6 +337,13 @@ async def curated_content(
         then region is extracted from the `locale` parameter if it contains two parts (e.g. en-US).
     - `count`: [Optional] The maximum number of recommendations to return. Defaults to 100.
     - `topics`: [Optional] A list of preferred [topics][curated-topics-doc].
+    - `experimentName`: [Optional] The Nimbus New Tab experiment name that the user is enrolled in.
+        When an experiment _only_ requires backend changes, this allows us to run the experiments
+        without waiting on the Firefox release cycle. When an experiment _does_ require changes in
+        Firefox, other parameters can be changed, such as we did for topic preferences. The API
+        schema does not list all New Tab experiments; only those which the backend uses to change
+        its behavior. Any string or null is accepted.
+    - `experimentBranch`: [Optional] The branch name of the Nimbus experiment that the user is in.
 
     [curated-topics-doc]: https://mozilla-hub.atlassian.net/wiki/x/LQDaMg
     """

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -952,6 +952,14 @@ class TestCorpusApiRanking:
         ],
     )
     @pytest.mark.parametrize(
+        "locale,region,derived_region",
+        [
+            ("en-US", None, "US"),
+            ("en-US", "IN", "IN"),
+            ("fr-FR", "FR", "FR"),
+        ],
+    )
+    @pytest.mark.parametrize(
         "experiment_name, experiment_branch",
         [
             (None, None),  # No experiment
@@ -960,7 +968,14 @@ class TestCorpusApiRanking:
         ],
     )
     async def test_thompson_sampling_behavior(
-        self, topics, engagement_backend, experiment_name, experiment_branch
+        self,
+        topics,
+        engagement_backend,
+        experiment_name,
+        experiment_branch,
+        locale,
+        region,
+        derived_region,
     ):
         """Test that Thompson sampling produces different orders and favors higher CTRs."""
         n_iterations = 20  # Increase to 2000 when changing Thompson sampling to ensure reliability
@@ -971,7 +986,8 @@ class TestCorpusApiRanking:
                 response = await ac.post(
                     "/api/v1/curated-recommendations",
                     json={
-                        "locale": "en-US",
+                        "locale": locale,
+                        "region": region,
                         "topics": topics,
                         "experimentName": experiment_name,
                         "experimentBranch": experiment_branch,
@@ -986,7 +1002,7 @@ class TestCorpusApiRanking:
                 past_id_orders.append(id_order)  # a list of lists with all orders
 
                 engagement_region = (
-                    "US"
+                    derived_region
                     if experiment_name == ExperimentName.REGION_SPECIFIC_CONTENT_EXPANSION.value
                     and experiment_branch == "treatment"
                     else None

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -26,7 +26,7 @@ from merino.curated_recommendations.engagement_backends.protocol import (
     EngagementBackend,
     Engagement,
 )
-from merino.curated_recommendations.protocol import CuratedRecommendation
+from merino.curated_recommendations.protocol import CuratedRecommendation, ExperimentName
 from merino.main import app
 from merino.metrics import get_metrics_client
 
@@ -98,8 +98,9 @@ class MockEngagementBackend(EngagementBackend):
     """Mock class implementing the protocol for EngagementBackend."""
 
     def get(self, scheduled_corpus_item_id: str, region: str | None = None) -> Engagement | None:
-        """Return random click and impression counts based on the scheduled corpus id."""
-        rng = np.random.default_rng(seed=int.from_bytes(scheduled_corpus_item_id.encode()))
+        """Return random click and impression counts based on the scheduled corpus id and region."""
+        seed_input = "_".join(filter(None, [scheduled_corpus_item_id, region]))
+        rng = np.random.default_rng(seed=int.from_bytes(seed_input.encode()))
 
         if scheduled_corpus_item_id == "50f86ebe-3f25-41d8-bd84-53ead7bdc76e":
             # Give the first item 100% click-through rate to put it on top with high certainty.
@@ -950,7 +951,17 @@ class TestCorpusApiRanking:
             None,
         ],
     )
-    async def test_thompson_sampling_behavior(self, topics, engagement_backend):
+    @pytest.mark.parametrize(
+        "experiment_name, experiment_branch",
+        [
+            (None, None),  # No experiment
+            (ExperimentName.REGION_SPECIFIC_CONTENT_EXPANSION.value, "control"),
+            (ExperimentName.REGION_SPECIFIC_CONTENT_EXPANSION.value, "treatment"),
+        ],
+    )
+    async def test_thompson_sampling_behavior(
+        self, topics, engagement_backend, experiment_name, experiment_branch
+    ):
         """Test that Thompson sampling produces different orders and favors higher CTRs."""
         n_iterations = 20  # Increase to 2000 when changing Thompson sampling to ensure reliability
         past_id_orders = []
@@ -959,7 +970,12 @@ class TestCorpusApiRanking:
             for i in range(n_iterations):
                 response = await ac.post(
                     "/api/v1/curated-recommendations",
-                    json={"locale": "en-US", "topics": topics},
+                    json={
+                        "locale": "en-US",
+                        "topics": topics,
+                        "experimentName": experiment_name,
+                        "experimentBranch": experiment_branch,
+                    },
                 )
                 data = response.json()
                 corpus_items = data["data"]
@@ -969,8 +985,15 @@ class TestCorpusApiRanking:
                 assert id_order not in past_id_orders, f"Duplicate order at iteration {i}."
                 past_id_orders.append(id_order)  # a list of lists with all orders
 
+                engagement_region = (
+                    "US"
+                    if experiment_name == ExperimentName.REGION_SPECIFIC_CONTENT_EXPANSION.value
+                    and experiment_branch == "treatment"
+                    else None
+                )
                 engagements = [
-                    engagement_backend.get(item["scheduledCorpusItemId"]) for item in corpus_items
+                    engagement_backend.get(item["scheduledCorpusItemId"], region=engagement_region)
+                    for item in corpus_items
                 ]
                 ctr_by_rank = [
                     (rank, e.click_count / e.impression_count)


### PR DESCRIPTION
## References

JIRA: [MC-1518](https://mozilla-hub.atlassian.net/browse/MC-1518)
[Experiment brief](https://docs.google.com/document/d/1YaZYPZ-ZR06_9XdNcm27KUDSvGi9hl_51G0vp6ol-Uk/edit) (in progress of being drafted)

## Description
Building on https://github.com/mozilla-services/merino-py/pull/633, this PR uses regional engagement in Thompson sampling in the treatment branch of an experiment.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[MC-1518]: https://mozilla-hub.atlassian.net/browse/MC-1518?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ