### PR TITLE
chore(curated recommendations): [MC-1519] Clean up need-to-know-prototype code

### DIFF
--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -111,14 +111,21 @@ class CuratedRecommendationsProvider:
         else:
             return None
 
-    def process_recommendations(
+    def rank_recommendations(
         self,
         recommendations: list[CuratedRecommendation],
         surface_id: str,
         topics: list[Topic | str] | None = None,
-    ):
+    ) -> list[CuratedRecommendation]:
         """Apply additional processing to the list of recommendations
         received from Curated Corpus API
+
+        @param recommendations: A list of CuratedRecommendation objects as they are received
+        from Curated Corpus API
+        @param surface_id: a string identifier for the New Tab surface these recommendations
+        are intended for
+        @param topics: Optionally, a list of user-preferred topics
+        @return: A re-ranked list of curated recommendations
         """
         # 3. Apply Thompson sampling to rank recommendations by engagement
         recommendations = thompson_sampling(recommendations, self.engagement_backend)
@@ -147,6 +154,44 @@ class CuratedRecommendationsProvider:
 
         return recommendations
 
+    def rank_need_to_know_recommendations(
+        self,
+        recommendations: list[CuratedRecommendation],
+        surface_id: str,
+        topics: list[Topic | str] | None = None,
+    ):
+        """Apply additional processing to the list of recommendations
+        received from Curated Corpus API, splitting the list in two:
+        the "general" feed and the "need to know" feed
+
+        @param recommendations: A list of CuratedRecommendation objects as they are received
+        from Curated Corpus API
+        @param surface_id: a string identifier for the New Tab surface these recommendations
+        are intended for
+        @param topics: Optionally, a list of user-preferred topics
+        @return: A tuple with two re-ranked lists of curated recommendations and a localised
+        title for the "Need to Know" heading
+        """
+        # TODO: the "need_to_know" items will be filtered by a corpus item property `isTimeSensitive`.
+        #  While data is being prepared, take the bottom ten items from the original recommendations
+        #  list and use them instead for the prototype.
+        general_feed = recommendations[:-10]
+        need_to_know_feed = recommendations[-10:]
+
+        # Apply all the additional re-ranking and processing steps
+        # to the main recommendations feed
+        general_feed = self.rank_recommendations(general_feed, surface_id, topics)
+
+        # Provide a localized title string for the "Need to Know" feed.
+        localized_titles = {
+            ScheduledSurfaceId.NEW_TAB_EN_US: "Need to Know",
+            ScheduledSurfaceId.NEW_TAB_EN_GB: "Need to Know in British English",
+            ScheduledSurfaceId.NEW_TAB_DE_DE: "Need to Know auf Deutsch",
+        }
+        title = localized_titles[surface_id]
+
+        return general_feed, need_to_know_feed, title
+
     async def fetch(
         self, curated_recommendations_request: CuratedRecommendationsRequest
     ) -> CuratedRecommendationsResponse:  # noqa
@@ -168,6 +213,8 @@ class CuratedRecommendationsProvider:
             for rank, item in enumerate(corpus_items)
         ]
 
+        # For users in the "Need to Know" experiment, separate recommendations into
+        # two different feeds: the "general" feed and the "need to know" feed.
         if (
             curated_recommendations_request.feeds
             and "need_to_know" in curated_recommendations_request.feeds
@@ -177,25 +224,10 @@ class CuratedRecommendationsProvider:
                 ScheduledSurfaceId.NEW_TAB_EN_GB,
                 ScheduledSurfaceId.NEW_TAB_DE_DE,
             )
-        ):  # TODO: the "need_to_know" items will be filtered by a corpus item property `isTimeSensitive`.
-            #  While data is being prepared, take the bottom ten items from the original recommendations
-            #  list and use them instead for the prototype.
-            general_feed = recommendations[:-10]
-            need_to_know_feed = recommendations[-10:]
-
-            # Apply all the additional re-ranking and processing steps
-            # to the main recommendations feed
-            general_feed = self.process_recommendations(
-                general_feed, surface_id, curated_recommendations_request.topics
+        ):
+            general_feed, need_to_know_feed, title = self.rank_need_to_know_recommendations(
+                recommendations, surface_id, curated_recommendations_request.topics
             )
-
-            # Provide a localized title string for the "Need to Know" feed.
-            localized_titles = {
-                ScheduledSurfaceId.NEW_TAB_EN_US: "Need to Know",
-                ScheduledSurfaceId.NEW_TAB_EN_GB: "Need to Know in British English",
-                ScheduledSurfaceId.NEW_TAB_DE_DE: "Need to Know auf Deutsch",
-            }
-            title = localized_titles[surface_id]
 
             return CuratedRecommendationsResponse(
                 recommendedAt=self.time_ms(),
@@ -206,10 +238,11 @@ class CuratedRecommendationsProvider:
                     ),
                 ),
             )
+        # For everyone else, return the "classic" New Tab list of recommendations
         else:
             # Apply all the additional re-ranking and processing steps
             # to the main recommendations feed
-            recommendations = self.process_recommendations(
+            recommendations = self.rank_recommendations(
                 recommendations, surface_id, curated_recommendations_request.topics
             )
 

--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -133,7 +133,7 @@ class CuratedRecommendationsProvider:
         from Curated Corpus API
         @param surface_id: a string identifier for the New Tab surface these recommendations
         are intended for
-        @param topics: Optionally, a list of user-preferred topics
+        @param request: The full API request with all the data
         @return: A re-ranked list of curated recommendations
         """
         # 3. Apply Thompson sampling to rank recommendations by engagement
@@ -172,7 +172,7 @@ class CuratedRecommendationsProvider:
         self,
         recommendations: list[CuratedRecommendation],
         surface_id: ScheduledSurfaceId,
-        topics: list[Topic | str] | None = None,
+        request: CuratedRecommendationsRequest,
     ):
         """Apply additional processing to the list of recommendations
         received from Curated Corpus API, splitting the list in two:
@@ -182,7 +182,7 @@ class CuratedRecommendationsProvider:
         from Curated Corpus API
         @param surface_id: a string identifier for the New Tab surface these recommendations
         are intended for
-        @param topics: Optionally, a list of user-preferred topics
+        @param request: The full API request with all the data
         @return: A tuple with two re-ranked lists of curated recommendations and a localised
         title for the "Need to Know" heading
         """
@@ -194,7 +194,7 @@ class CuratedRecommendationsProvider:
 
         # Apply all the additional re-ranking and processing steps
         # to the main recommendations feed
-        general_feed = self.rank_recommendations(general_feed, surface_id, topics)
+        general_feed = self.rank_recommendations(general_feed, surface_id, request)
 
         # Provide a localized title string for the "Need to Know" feed.
         localized_titles = {
@@ -240,7 +240,7 @@ class CuratedRecommendationsProvider:
             )
         ):
             general_feed, need_to_know_feed, title = self.rank_need_to_know_recommendations(
-                recommendations, surface_id, curated_recommendations_request.topics
+                recommendations, surface_id, curated_recommendations_request
             )
 
             return CuratedRecommendationsResponse(

--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -114,7 +114,7 @@ class CuratedRecommendationsProvider:
     def rank_recommendations(
         self,
         recommendations: list[CuratedRecommendation],
-        surface_id: str,
+        surface_id: ScheduledSurfaceId,
         topics: list[Topic | str] | None = None,
     ) -> list[CuratedRecommendation]:
         """Apply additional processing to the list of recommendations
@@ -157,7 +157,7 @@ class CuratedRecommendationsProvider:
     def rank_need_to_know_recommendations(
         self,
         recommendations: list[CuratedRecommendation],
-        surface_id: str,
+        surface_id: ScheduledSurfaceId,
         topics: list[Topic | str] | None = None,
     ):
         """Apply additional processing to the list of recommendations

--- a/tests/unit/curated_recommendations/test_provider.py
+++ b/tests/unit/curated_recommendations/test_provider.py
@@ -7,7 +7,12 @@ import uuid
 from pydantic import HttpUrl
 from pytest_mock import MockerFixture
 
-from merino.curated_recommendations.corpus_backends.protocol import ScheduledSurfaceId, Topic
+from merino.curated_recommendations import EngagementBackend
+from merino.curated_recommendations.corpus_backends.protocol import (
+    ScheduledSurfaceId,
+    Topic,
+    CorpusBackend,
+)
 from merino.curated_recommendations.provider import (
     CuratedRecommendationsProvider,
 )
@@ -295,7 +300,9 @@ class TestCuratedRecommendationsProviderRankNeedToKnowRecommendations:
         topics = ["business", "food"]
 
         # Call the method
-        provider = CuratedRecommendationsProvider()
+        provider = CuratedRecommendationsProvider(
+            mocker.patch.object(CorpusBackend), mocker.patch.object(EngagementBackend)
+        )
         general_feed, need_to_know_feed, title = provider.rank_need_to_know_recommendations(
             recommendations, surface_id, topics
         )
@@ -328,7 +335,9 @@ class TestCuratedRecommendationsProviderRankNeedToKnowRecommendations:
         topics = None
 
         # Call the method
-        provider = CuratedRecommendationsProvider()
+        provider = CuratedRecommendationsProvider(
+            mocker.patch.object(CorpusBackend), mocker.patch.object(EngagementBackend)
+        )
         general_feed, need_to_know_feed, title = provider.rank_need_to_know_recommendations(
             recommendations, surface_id, topics
         )

--- a/tests/unit/curated_recommendations/test_provider.py
+++ b/tests/unit/curated_recommendations/test_provider.py
@@ -258,8 +258,8 @@ class TestCuratedRecommendationsProviderRankNeedToKnowRecommendations:
     def generate_recommendations(length: int) -> list[CuratedRecommendation]:
         """Create dummy recommendations for the tests below.
 
-        @param length:
-        @return:
+        @param length: how many recommendations are needed for a test
+        @return: A list of curated recommendations
         """
         recs = []
         for i in range(length):
@@ -301,7 +301,8 @@ class TestCuratedRecommendationsProviderRankNeedToKnowRecommendations:
 
         # Call the method
         provider = CuratedRecommendationsProvider(
-            mocker.patch.object(CorpusBackend), mocker.patch.object(EngagementBackend)
+            mocker.patch.object(CorpusBackend, "__init__", return_value=None),
+            mocker.patch.object(EngagementBackend, "__init__", return_value=None),
         )
         general_feed, need_to_know_feed, title = provider.rank_need_to_know_recommendations(
             recommendations, surface_id, topics
@@ -336,7 +337,8 @@ class TestCuratedRecommendationsProviderRankNeedToKnowRecommendations:
 
         # Call the method
         provider = CuratedRecommendationsProvider(
-            mocker.patch.object(CorpusBackend), mocker.patch.object(EngagementBackend)
+            mocker.patch.object(CorpusBackend, "__init__", return_value=None),
+            mocker.patch.object(EngagementBackend, "__init__", return_value=None),
         )
         general_feed, need_to_know_feed, title = provider.rank_need_to_know_recommendations(
             recommendations, surface_id, topics

--- a/tests/unit/curated_recommendations/test_provider.py
+++ b/tests/unit/curated_recommendations/test_provider.py
@@ -279,6 +279,29 @@ class TestCuratedRecommendationsProviderRankNeedToKnowRecommendations:
 
         return recs
 
+    @staticmethod
+    def mock_curated_recommendations_provider(
+        mocker: MockerFixture,
+    ) -> CuratedRecommendationsProvider:
+        """Mock the necessary components of CuratedRecommendationsProvider.
+
+        @param mocker: MockerFixture
+        @return: A mocked CuratedRecommendationsProvider
+        """
+        # Mock the __init__ methods to prevent actual initialization
+        mocker.patch.object(CuratedRecommendationsProvider, "__init__", return_value=None)
+
+        # Mock the rank_recommendations method
+        mocker.patch.object(CuratedRecommendationsProvider, "rank_recommendations")
+
+        # Create and return the mocked provider instance
+        provider = CuratedRecommendationsProvider(
+            mocker.patch.object(CorpusBackend, "__init__", return_value=None),
+            mocker.patch.object(EngagementBackend, "__init__", return_value=None),
+        )
+
+        return provider
+
     def test_rank_need_to_know_recommendations(self, mocker: MockerFixture):
         """Test the main flow of logic in the function
 
@@ -287,23 +310,22 @@ class TestCuratedRecommendationsProviderRankNeedToKnowRecommendations:
         # Create mock recommendations
         recommendations = self.generate_recommendations(100)
 
-        # Mock bits and pieces of the provider class
-        mocker.patch.object(CuratedRecommendationsProvider, "__init__", return_value=None)
+        # Define the surface ID and topics
+        surface_id = ScheduledSurfaceId.NEW_TAB_EN_US
+        topics = ["business", "food"]
+
+        # Instantiate the mocked class
+        provider = self.mock_curated_recommendations_provider(mocker)
+
+        # Mock the rank_recommendations method separately to make sure it returns
+        # the correct number of results, and we can make sure it was called later
         rank_recommendations = mocker.patch.object(
             CuratedRecommendationsProvider,
             "rank_recommendations",
             return_value=recommendations[:-10],
         )
 
-        # Define the surface ID and topics
-        surface_id = ScheduledSurfaceId.NEW_TAB_EN_US
-        topics = ["business", "food"]
-
         # Call the method
-        provider = CuratedRecommendationsProvider(
-            mocker.patch.object(CorpusBackend, "__init__", return_value=None),
-            mocker.patch.object(EngagementBackend, "__init__", return_value=None),
-        )
         general_feed, need_to_know_feed, title = provider.rank_need_to_know_recommendations(
             recommendations, surface_id, topics
         )
@@ -327,19 +349,14 @@ class TestCuratedRecommendationsProviderRankNeedToKnowRecommendations:
         # Create mock recommendations
         recommendations = self.generate_recommendations(20)
 
-        # Mock bits and pieces of the provider class
-        mocker.patch.object(CuratedRecommendationsProvider, "__init__", return_value=None)
-        mocker.patch.object(CuratedRecommendationsProvider, "rank_recommendations")
-
         # Define the surface ID and topics
         surface_id = ScheduledSurfaceId.NEW_TAB_DE_DE
         topics = None
 
+        # Instantiate the mocked class
+        provider = self.mock_curated_recommendations_provider(mocker)
+
         # Call the method
-        provider = CuratedRecommendationsProvider(
-            mocker.patch.object(CorpusBackend, "__init__", return_value=None),
-            mocker.patch.object(EngagementBackend, "__init__", return_value=None),
-        )
         general_feed, need_to_know_feed, title = provider.rank_need_to_know_recommendations(
             recommendations, surface_id, topics
         )

--- a/tests/unit/curated_recommendations/test_provider.py
+++ b/tests/unit/curated_recommendations/test_provider.py
@@ -21,6 +21,7 @@ from merino.curated_recommendations.protocol import (
     MAX_TILE_ID,
     MIN_TILE_ID,
     CuratedRecommendation,
+    CuratedRecommendationsRequest,
 )
 
 
@@ -273,6 +274,7 @@ class TestCuratedRecommendationsProviderRankNeedToKnowRecommendations:
                 excerpt="is failing english",
                 topic=random.choice(list(Topic)),
                 publisher="cohens",
+                isTimeSensitive=False,
                 imageUrl=HttpUrl("https://placehold.co/600x400/"),
             )
 
@@ -303,6 +305,23 @@ class TestCuratedRecommendationsProviderRankNeedToKnowRecommendations:
 
         return provider
 
+    @staticmethod
+    def mock_curated_recommendations_request(
+        mocker: MockerFixture,
+    ) -> CuratedRecommendationsRequest:
+        """Mock the necessary components of CuratedRecommendationsRequest.
+
+        @param mocker: MockerFixture
+        @return: A mocked CuratedRecommendationsRequest
+        """
+        # Mock the __init__ methods to prevent actual initialization
+        mocker.patch.object(CuratedRecommendationsRequest, "__init__", return_value=None)
+
+        # Create and return the mocked provider instance
+        request = CuratedRecommendationsRequest(locale=Locale.EN_US)
+
+        return request
+
     def test_rank_need_to_know_recommendations(self, mocker: MockerFixture):
         """Test the main flow of logic in the function
 
@@ -311,12 +330,12 @@ class TestCuratedRecommendationsProviderRankNeedToKnowRecommendations:
         # Create mock recommendations
         recommendations = self.generate_recommendations(100)
 
-        # Define the surface ID and topics
+        # Define the surface ID
         surface_id = ScheduledSurfaceId.NEW_TAB_EN_US
-        topics = ["business", "food"]
 
-        # Instantiate the mocked class
+        # Instantiate the mocked classes
         provider = self.mock_curated_recommendations_provider(mocker)
+        request = self.mock_curated_recommendations_request(mocker)
 
         # Mock the rank_recommendations method separately to make sure it returns
         # the correct number of results, and we can make sure it was called later
@@ -328,7 +347,7 @@ class TestCuratedRecommendationsProviderRankNeedToKnowRecommendations:
 
         # Call the method
         general_feed, need_to_know_feed, title = provider.rank_need_to_know_recommendations(
-            recommendations, surface_id, topics
+            recommendations, surface_id, request
         )
 
         # Verify that the recommendations were split correctly
@@ -337,7 +356,7 @@ class TestCuratedRecommendationsProviderRankNeedToKnowRecommendations:
         assert len(need_to_know_feed) == 10  # The last 10 items
 
         # Verify that the rank_recommendations method was called with the correct arguments
-        rank_recommendations.assert_called_once_with(general_feed, surface_id, topics)
+        rank_recommendations.assert_called_once_with(general_feed, surface_id, request)
 
         # Verify that the localized title is correct
         assert title == "Need to Know"
@@ -350,16 +369,16 @@ class TestCuratedRecommendationsProviderRankNeedToKnowRecommendations:
         # Create mock recommendations
         recommendations = self.generate_recommendations(20)
 
-        # Define the surface ID and topics
+        # Define the surface ID
         surface_id = ScheduledSurfaceId.NEW_TAB_DE_DE
-        topics = None
 
-        # Instantiate the mocked class
+        # Instantiate the mocked classes
         provider = self.mock_curated_recommendations_provider(mocker)
+        request = self.mock_curated_recommendations_request(mocker)
 
         # Call the method
         general_feed, need_to_know_feed, title = provider.rank_need_to_know_recommendations(
-            recommendations, surface_id, topics
+            recommendations, surface_id, request
         )
 
         # Verify that the title is correct for the German New Tab surface


### PR DESCRIPTION
## References

JIRA: https://mozilla-hub.atlassian.net/browse/MC-1519

## Description

Implement review feedback from https://github.com/mozilla-services/merino-py/pull/629: 

- Split out processing for need-to-know recommendations into a separate method.

- Add unit tests for new `rank_need_to_know_recommendations` method.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
