### PR TITLE
[MC-1473] fix flaky test due to Thompson sampling

### DIFF
--- a/merino/configs/testing.toml
+++ b/merino/configs/testing.toml
@@ -68,6 +68,18 @@ backend = "test"
 bucket_name = "test-bucket"
 gcp_project = "test-project"
 
+[testing.curated_recommendations.rankers.thompson_sampling]
+# MERINO__CURATED_RECOMMENDATIONS__RANKERS__THOMPSON_SAMPLING__TEST_REPEAT_COUNT
+# The number of times that Thompson sampling tests are repeated. When you change how recommendations
+# are ranked, put the config below in configs/testing.local.toml to ensure that tests pass reliably:
+#     ```
+#    [testing]
+#    dynaconf_merge = true
+#
+#    [testing.curated_recommendations.rankers.thompson_sampling]
+#    test_repeat_count = 100
+#    ```
+test_repeat_count = 1
 
 [testing.curated_recommendations.corpus_api]
 


### PR DESCRIPTION
## References

JIRA: [MC-1473](https://mozilla-hub.atlassian.net/browse/MC-1473)

## Description
Fix a flaky test that failed in 3% of cases, due to Thompson sampling not ranking an item on top.

Also adds a config setting to make it easier to repeat tests which can be affected by Thompson sampling.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[MC-1473]: https://mozilla-hub.atlassian.net/browse/MC-1473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ