### PR TITLE
[MC-1521] Use isTimeSensitive to populate Need to Know feed

### DIFF
--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -186,11 +186,15 @@ class CuratedRecommendationsProvider:
         @return: A tuple with two re-ranked lists of curated recommendations and a localised
         title for the "Need to Know" heading
         """
-        # TODO: the "need_to_know" items will be filtered by a corpus item property `isTimeSensitive`.
-        #  While data is being prepared, take the bottom ten items from the original recommendations
-        #  list and use them instead for the prototype.
-        general_feed = recommendations[:-10]
-        need_to_know_feed = recommendations[-10:]
+        # Filter out all time-sensitive recommendations into the need_to_know feed
+        need_to_know_feed = [r for r in recommendations if r.isTimeSensitive]
+
+        # Update received_rank for need_to_know recommendations
+        for rank, rec in enumerate(need_to_know_feed):
+            rec.receivedRank = rank
+
+        # Place the remaining recommendations in the general feed
+        general_feed = [r for r in recommendations if r not in need_to_know_feed]
 
         # Apply all the additional re-ranking and processing steps
         # to the main recommendations feed

--- a/tests/data/scheduled_surface.json
+++ b/tests/data/scheduled_surface.json
@@ -22,7 +22,7 @@
             "excerpt": "A rigorous experiment revealed that on a hot, dry day, drinking a hot beverage can help your body stay cool.",
             "topic": "FOOD",
             "publisher": "Smithsonian Magazine",
-            "isTimeSensitive": false,
+            "isTimeSensitive": true,
             "imageUrl": "https://s3.amazonaws.com/pocket-curatedcorpusapi-prod-images/968a6566-df7a-4f7d-aefd-8678853544b1.jpeg"
           }
         },
@@ -46,7 +46,7 @@
             "excerpt": "Anne Helen Petersen and Jessica Calarco discuss how mothers are experiencing and responding to pandemic-related disruptions in their normal routines.",
             "topic": "PARENTING",
             "publisher": "Culture Study",
-            "isTimeSensitive": false,
+            "isTimeSensitive": true,
             "imageUrl": "https://s3.amazonaws.com/pocket-curatedcorpusapi-prod-images/3a4a6ed6-a1df-497d-8d31-f777534806ac.jpeg"
           }
         },
@@ -82,7 +82,7 @@
             "excerpt": "We explain the biological changes that begin with your morning tea or coffee.",
             "topic": "HEALTH_FITNESS",
             "publisher": "The Telegraph",
-            "isTimeSensitive": false,
+            "isTimeSensitive": true,
             "imageUrl": "https://s3.us-east-1.amazonaws.com/pocket-curatedcorpusapi-prod-images/2aaffb04-80e0-4008-95af-7c65a213d191.jpeg"
           }
         },
@@ -94,7 +94,7 @@
             "excerpt": "These aren’t your run-of-the-mill skin-care tricks. Here, the experts share the rules they’ve learned and recommended throughout their careers.",
             "topic": "HEALTH_FITNESS",
             "publisher": "Allure",
-            "isTimeSensitive": false,
+            "isTimeSensitive": true,
             "imageUrl": "https://s3.us-east-1.amazonaws.com/pocket-curatedcorpusapi-prod-images/27386d38-3513-485c-8872-6f3d2c0ec5c8.jpeg"
           }
         },
@@ -130,7 +130,7 @@
             "excerpt": "In the age of Amazon and e-books, these bookstores have faced more challenges than ever, but many have been able to persevere and remain treasured parts of their communities.",
             "topic": "TRAVEL",
             "publisher": "Architectural Digest",
-            "isTimeSensitive": false,
+            "isTimeSensitive": true,
             "imageUrl": "https://s3.us-east-1.amazonaws.com/pocket-curatedcorpusapi-prod-images/52ebb1c9-3834-4378-812f-0bfcd2529357.jpeg"
           }
         },
@@ -154,7 +154,7 @@
             "excerpt": "We’ve gone from denying Botox to celebrating our face-lifts. Welcome to the new era of living out loud.",
             "topic": "HEALTH_FITNESS",
             "publisher": "Town & Country Magazine",
-            "isTimeSensitive": false,
+            "isTimeSensitive": true,
             "imageUrl": "https://s3.us-east-1.amazonaws.com/pocket-curatedcorpusapi-prod-images/da9b38c6-2e48-4938-bf87-85a60bf85190.jpeg"
           }
         },
@@ -190,7 +190,7 @@
             "excerpt": "Here’s how we’ve defined adolescence throughout history - and why it’s time for a new category.",
             "topic": "EDUCATION",
             "publisher": "BBC Future",
-            "isTimeSensitive": false,
+            "isTimeSensitive": true,
             "imageUrl": "https://s3.us-east-1.amazonaws.com/pocket-curatedcorpusapi-prod-images/1f11fb0d-3f0c-46a7-a667-cc2fcea6334e.jpeg"
           }
         },
@@ -466,7 +466,7 @@
             "excerpt": "Getting philosophical with the menswear’s favorite Instagram and TikTok star, Albert Muzquiz.",
             "topic": "ENTERTAINMENT",
             "publisher": "Esquire",
-            "isTimeSensitive": false,
+            "isTimeSensitive": true,
             "imageUrl": "https://hips.hearstapps.com/hmg-prod/images/jm-esquire-edgy-albert-11-001-664fbbbeca45e.jpg?crop=1.00xw:0.334xh;0,0.0326xh&resize=640:*"
           }
         },
@@ -862,7 +862,7 @@
             "excerpt": "Fuel up on coffee at artist Takashi Murakami’s retro cafe, immerse yourself in a new digital art museum, and take a meditative walk in the heart of a forest.",
             "topic": "TRAVEL",
             "publisher": "Afar",
-            "isTimeSensitive": false,
+            "isTimeSensitive": true,
             "imageUrl": "https://afar.brightspotcdn.com/dims4/default/4e20695/2147483647/strip/true/crop/3000x1500+0+0/resize/1440x720!/quality/90/?url=https%3A%2F%2Fk3-prod-afar-media.s3.us-west-2.amazonaws.com%2Fbrightspot%2Fe4%2F9f%2F3e7a0c934fa8aca7da05146bc497%2Fgeoff-haggray-tokyo-lede.jpg"
           }
         },
@@ -946,7 +946,7 @@
             "excerpt": "The baffling, contradictory demands of being female in the party of Donald Trump.",
             "topic": "POLITICS",
             "publisher": "New York Magazine",
-            "isTimeSensitive": false,
+            "isTimeSensitive": true,
             "imageUrl": "https://s3.us-east-1.amazonaws.com/pocket-curatedcorpusapi-prod-images/f0069eea-68dd-4536-be2e-bda6f1d87102.jpeg"
           }
         },

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -231,9 +231,10 @@ async def test_curated_recommendations_with_need_to_know_feed():
         assert response.status_code == 200
 
         corpus_items = data["data"]
-        # assert total of 70 items returned (minus the 10 bottom ones from the original result
-        # list that are sent off to the need_to_know feed
+
+        # Assert total of 70 items returned (minus the ten items marked as `isTimeSensitive` in the data
         assert len(corpus_items) == 70
+
         # Assert all corpus_items have expected fields populated.
         assert all(item["url"] for item in corpus_items)
         assert all(item["publisher"] for item in corpus_items)
@@ -259,15 +260,8 @@ async def test_curated_recommendations_with_need_to_know_feed():
         assert all(item["tileId"] for item in feed)
 
         # Make sure the top item in the `need_to_know` feed is the one we expect
-        # (Currently, #71 in the test data. Once `isTimeSensitive` prop is in use,
-        # this should be the top item in the list with `isTimeSensitive`=true)
-        assert feed[0]["title"] == "How Does a Therapist Stay Neutral?"
-
-        # Assert `need_to_know` stories have the correct rank.
-        # Currently, these stories keep their original rank (70+).
-        # Should this change, this assertion will need an update.
-        for i, item in enumerate(feed, 70):
-            assert item["receivedRank"] == i
+        # (the top item in the list with `isTimeSensitive`=true)
+        assert feed[0]["title"] == "A Hot Drink on a Hot Day Can Cool You Down"
 
 
 @freezegun.freeze_time("2012-01-14 03:25:34", tz_offset=0)


### PR DESCRIPTION

## References

JIRA: https://mozilla-hub.atlassian.net/browse/MC-1521

## Description
Replace the current prototype code that builds the “need to know” feed with logic using isTimeSensitive.

- The `need_to_know` feed is now populated with time-sensitive items instead of the bottom 10 items from the general feed.
- The `receivedRank` values for items in the `need_to_know` feed now start at zero and are consecutive numbers - essentially these are array indexes, similar to the general feed with or without the new feed.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
