### PR TITLE
fix: handle case where top picks domain does not have serp categories

### DIFF
--- a/dev/top_picks_for_ci.json
+++ b/dev/top_picks_for_ci.json
@@ -91,6 +91,21 @@
       "serp_categories": [
         0
       ]
+    },
+    {
+      "rank": 6,
+      "title": "Pineapple",
+      "domain": "pineapple",
+      "url": "https://pineapple.test",
+      "icon": "",
+      "categories": [
+        "web-browser"
+      ],
+      "similars": [
+        "pineappel",
+        "pinnapple",
+        "pineapple"
+      ]
     }
   ]
 }

--- a/merino/providers/top_picks/backends/top_picks.py
+++ b/merino/providers/top_picks/backends/top_picks.py
@@ -105,7 +105,7 @@ class TopPicksBackend:
                 "is_top_pick": True,
                 "is_sponsored": False,
                 "icon": record["icon"],
-                "categories": record["serp_categories"],
+                "categories": record.get("serp_categories"),
             }
 
             # Insertion of short keys between Firefox limit of 2 and self.query_char_limit - 1

--- a/tests/data/top_picks.json
+++ b/tests/data/top_picks.json
@@ -81,6 +81,21 @@
                 "bad",
                 "badd"
             ]
+        },
+        {
+            "rank": 6,
+            "title": "Pineapple",
+            "domain": "pineapple",
+            "url": "https://pineapple.test",
+            "icon": "",
+            "categories": [
+                "web-browser"
+            ],
+            "similars": [
+                "pineappel",
+                "pinnapple",
+                "pineapple"
+            ]
         }
     ]
 }

--- a/tests/unit/providers/top_picks/test_provider.py
+++ b/tests/unit/providers/top_picks/test_provider.py
@@ -262,6 +262,31 @@ async def test_query(
     ]
 
 
+@pytest.mark.asyncio
+async def test_query_with_top_pick_without_category(
+    srequest: SuggestionRequestFixture,
+    top_picks: Provider,
+) -> None:
+    """Test for the query method of the Top Pick provider. Includes testing for query
+    normalization, when uppercase or trailing whitespace in query string.
+    """
+    await top_picks.initialize()
+    query = "pine"
+    result: list[BaseSuggestion] = await top_picks.query(srequest(query))
+    assert result == [
+        Suggestion(
+            block_id=0,
+            title="Pineapple",
+            url=HttpUrl("https://pineapple.test"),
+            provider="top_picks",
+            is_top_pick=True,
+            is_sponsored=False,
+            icon="",
+            score=settings.providers.top_picks.score,
+        )
+    ]
+
+
 @pytest.mark.parametrize(
     "query",
     [


### PR DESCRIPTION
## References

## Description
Forgot to account for cases where a top pick does not have a serp category associated to it 🙈 


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
