### PR TITLE
[DISCO-3008] remove unused accuweather metric emission

### DIFF
--- a/docs/data.md
+++ b/docs/data.md
@@ -144,7 +144,6 @@ The weather provider records additional metrics.
 - `merino.providers.accuweather.query.cache.fetch.miss.locations` - A counter to measure the number of times weather location was not in the cache. Sampled at 75%.
 - `merino.providers.accuweather.query.cache.fetch.miss.currentconditions` - A counter to measure the number of times a current conditions was not in the cache. Sampled at 75%.
 - `merino.providers.accuweather.query.cache.fetch.miss.forecasts` - A counter to measure the number of times a forecast for a location was not in the cache. Sampled at 75%.
-- `merino.providers.accuweather.query.cache.fetch.miss.ttl` - A counter to measure the number of times a weather report was available but expired or had an invalid TTL. Sampled at 75%.
 - `merino.providers.accuweather.query.cache.fetch.hit.{locations | currentconditions | forecasts}` - A counter to measure the number of times a
   requested value like a location or forecast is in the cache. We don't count TTL hits explicitly, just misses. Sampled at 75%.
 - `merino.providers.accuweather.query.backend.get` - A timer to measure the duration (in ms) of a

--- a/merino/providers/weather/backends/accuweather/backend.py
+++ b/merino/providers/weather/backends/accuweather/backend.py
@@ -390,18 +390,17 @@ class AccuweatherBackend:
               current_condition, forecast
             -  `skip_location_key` A boolean to determine whether location was looked up.
         """
-        location, current, forecast, ttl = False, False, False, False
+        location, current, forecast = False, False, False
         match cached_data:
             case []:
                 pass
             # the last variable is ttl but is omitted here since we don't need to use but need
             # it to satisfy this match case
-            case [location_cached, current_cached, forecast_cached, ttl_cached]:
-                location, current, forecast, ttl = (
+            case [location_cached, current_cached, forecast_cached, _]:
+                location, current, forecast = (
                     location_cached is not None,
                     current_cached is not None,
                     forecast_cached is not None,
-                    ttl_cached is not None,
                 )
             case _:  # pragma: no cover
                 pass

--- a/merino/providers/weather/backends/accuweather/backend.py
+++ b/merino/providers/weather/backends/accuweather/backend.py
@@ -427,14 +427,6 @@ class AccuweatherBackend:
             sample_rate=self.metrics_sample_rate,
         )
 
-        # We do a two-trip lookup on Redis. We first fetch the keys, and then, in a second lookup,
-        # check for the TTL for both keys. In a rare scenario, the TTL could have technically
-        # run out by the time we fetch it We register this with this counter.
-        if current and forecast and not ttl:
-            self.metrics_client.increment(
-                "accuweather.cache.fetch.miss.ttl", sample_rate=self.metrics_sample_rate
-            )
-
     def parse_cached_data(self, cached_data: list[bytes | None]) -> WeatherData:
         """Parse the weather data from cache.
 

--- a/tests/unit/providers/weather/backends/test_accuweather.py
+++ b/tests/unit/providers/weather/backends/test_accuweather.py
@@ -2122,10 +2122,6 @@ def test_add_partner_code(
             ("hit.locations", "fetch.miss.currentconditions", "fetch.miss.forecasts"),
         ),
         (
-            ["location", "current", "forecast", None],
-            ("hit.locations", "hit.currentconditions", "hit.forecasts", "fetch.miss.ttl"),
-        ),
-        (
             [None, None, None, None],
             (
                 "fetch.miss.locations",
@@ -2139,7 +2135,6 @@ def test_add_partner_code(
         "partial-hits-left",
         "partial-hits-right",
         "partial-hits-one",
-        "partial-miss-ttl",
         "cache-misses",
     ],
 )


### PR DESCRIPTION
## References

JIRA: [DISCO-3008](https://mozilla-hub.atlassian.net/browse/DISCO-3008)

## Description
We no longer use the `accuweather.cache.fetch.miss.ttl` metric on Grafana so we are removing the emission



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3008]: https://mozilla-hub.atlassian.net/browse/DISCO-3008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ