### PR TITLE
[MC-1545] fix: allow optin- prefix before experiment name

### DIFF
--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -113,11 +113,21 @@ class CuratedRecommendationsProvider:
             return None
 
     @staticmethod
-    def is_enrolled_in_regional_engagement(request: CuratedRecommendationsRequest) -> bool:
-        """Return True if Thompson sampling should use regional engagement (treatment)"""
+    def is_enrolled_in_experiment(
+        request: CuratedRecommendationsRequest, name: str, branch: str
+    ) -> bool:
+        """Return True if the request's experimentName matches name or "optin-" + name, and the
+        experimentBranch matches the given branch. The optin- prefix signifies a forced enrollment.
+        """
         return (
-            request.experimentName == ExperimentName.REGION_SPECIFIC_CONTENT_EXPANSION.value
-            and request.experimentBranch == "treatment"
+            request.experimentName == name or request.experimentName == f"optin-{name}"
+        ) and request.experimentBranch == branch
+
+    @staticmethod
+    def is_enrolled_in_regional_engagement(request: CuratedRecommendationsRequest) -> bool:
+        """Return True if Thompson sampling should use regional engagement (treatment)."""
+        return CuratedRecommendationsProvider.is_enrolled_in_experiment(
+            request, ExperimentName.REGION_SPECIFIC_CONTENT_EXPANSION.value, "treatment"
         )
 
     def rank_recommendations(

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -1050,11 +1050,12 @@ class TestCorpusApiRanking:
         ],
     )
     @pytest.mark.parametrize(
-        "experiment_name, experiment_branch",
+        "experiment_name, experiment_branch, regional_ranking_is_expected",
         [
-            (None, None),  # No experiment
-            (ExperimentName.REGION_SPECIFIC_CONTENT_EXPANSION.value, "control"),
-            (ExperimentName.REGION_SPECIFIC_CONTENT_EXPANSION.value, "treatment"),
+            (None, None, False),  # No experiment
+            (ExperimentName.REGION_SPECIFIC_CONTENT_EXPANSION.value, "control", False),
+            (ExperimentName.REGION_SPECIFIC_CONTENT_EXPANSION.value, "treatment", True),
+            (f"optin-{ExperimentName.REGION_SPECIFIC_CONTENT_EXPANSION.value}", "treatment", True),
         ],
     )
     @pytest.mark.parametrize(
@@ -1070,6 +1071,7 @@ class TestCorpusApiRanking:
         locale,
         region,
         derived_region,
+        regional_ranking_is_expected,
         repeat,
     ):
         """Test that Thompson sampling produces different orders and favors higher CTRs."""
@@ -1096,12 +1098,7 @@ class TestCorpusApiRanking:
                 assert id_order not in past_id_orders, f"Duplicate order at iteration {i}."
                 past_id_orders.append(id_order)  # a list of lists with all orders
 
-                engagement_region = (
-                    derived_region
-                    if experiment_name == ExperimentName.REGION_SPECIFIC_CONTENT_EXPANSION.value
-                    and experiment_branch == "treatment"
-                    else None
-                )
+                engagement_region = derived_region if regional_ranking_is_expected else None
                 engagements = [
                     engagement_backend.get(item["scheduledCorpusItemId"], region=engagement_region)
                     for item in corpus_items


### PR DESCRIPTION
## References

JIRA: [MC-1545](https://mozilla-hub.atlassian.net/browse/MC-1545)
[Slack thread](https://mozilla.slack.com/archives/CF94YGE03/p1727462074174769?thread_ts=1727457879.892819&cid=CF94YGE03) in #ask-experimenter, where I asked about the optin- prefix

## Description
Allow team members to force enroll in the region-specific ranking experiment, by accepting an 'optin-' prefix for the experiment name.

```
about:studies?optin_slug=new-tab-region-specific-content-expansion&optin_branch=treatment&optin_collection=nimbus-preview
```

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[MC-1545]: https://mozilla-hub.atlassian.net/browse/MC-1545?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ