### PR TITLE
[DISCO-2886] disable AMO provider

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -37,7 +37,7 @@ query_timeout_sec = 0.2
 # MERINO_RUNTIME__DISABLED_PROVIDERS
 # List containing providers to disable at startup.
 # Prevents a provider from being instantiated.
-disabled_providers = []
+disabled_providers = ["amo"]
 
 # MERINO_RUNTIME__DEFAULT_SUGGESTIONS_RESPONSE_TTL_SEC
 default_suggestions_response_ttl_sec = 300 # 5 mins

--- a/merino/configs/testing.toml
+++ b/merino/configs/testing.toml
@@ -10,7 +10,7 @@ dynaconf_merge = true
 [testing.runtime]
 # Use a larger timeout for testing
 query_timeout_sec = 0.5
-disabled_providers = ["disabled_provider"]
+disabled_providers = ["disabled_provider", "amo"]
 
 
 [testing.metrics]

--- a/merino/providers/amo/provider.py
+++ b/merino/providers/amo/provider.py
@@ -65,7 +65,7 @@ class Provider(BaseProvider):
         backend: AmoBackend,
         keywords: dict[SupportedAddon, set[str]],
         name: str = "amo",
-        enabled_by_default: bool = True,
+        enabled_by_default: bool = False,
         min_chars=settings.providers.amo.min_chars,
         score=settings.providers.amo.score,
         resync_interval_sec=settings.providers.amo.resync_interval_sec,

--- a/tests/integration/api/v1/suggest/test_suggest_amo.py
+++ b/tests/integration/api/v1/suggest/test_suggest_amo.py
@@ -50,11 +50,5 @@ def test_suggest_addons(client: TestClient, query: str, expected_title: dict[str
 
     result = response.json()
 
-    if expected_title:
-        assert len(result["suggestions"]) == 1
-        addon_suggestion = result["suggestions"][0]
-        assert addon_suggestion["title"] == expected_title
-        assert "amo" in addon_suggestion["custom_details"]
-        assert "rating" in addon_suggestion["custom_details"]["amo"]
-    else:
-        assert len(result["suggestions"]) == 0
+    # since amo provider is disabled, we shouldn't be getting any addons suggestions
+    assert len(result["suggestions"]) == 0

--- a/tests/load/locustfiles/locustfile.py
+++ b/tests/load/locustfiles/locustfile.py
@@ -354,7 +354,7 @@ class MerinoUser(HttpUser):
         for query in queries:
             self._request_suggestions(query, providers)
 
-    @task(weight=2)
+    @task(weight=0)
     def amo_suggestions(self) -> None:
         """Send a request for AMO. AMO matches work with matching the first keyword
         and then prefix on subsequent words.
@@ -399,7 +399,7 @@ class MerinoUser(HttpUser):
         for query in queries:
             self._request_suggestions(query, providers)
 
-    @task(weight=495)
+    @task(weight=497)
     def weather_suggestions(self) -> None:
         """Send multiple requests for Weather queries."""
         # Firefox will do local keyword matching to trigger weather suggestions

--- a/tests/unit/providers/test_init_providers.py
+++ b/tests/unit/providers/test_init_providers.py
@@ -23,6 +23,7 @@ from tests.types import FilterCaplogFixture
 
 DISABLED_PROVIDERS = settings.runtime.disabled_providers
 
+
 @pytest.mark.asyncio
 async def test_init_providers() -> None:
     """Test for the `init_providers` method of the Merino providers module."""
@@ -30,8 +31,10 @@ async def test_init_providers() -> None:
 
     providers, default_providers = get_providers()
 
-    # a disabled provider should not be initialized 
-    assert providers.keys() == {provider.value for provider in ProviderType if provider.value not in DISABLED_PROVIDERS}
+    # a disabled provider should not be initialized
+    assert providers.keys() == {
+        provider.value for provider in ProviderType if provider.value not in DISABLED_PROVIDERS
+    }
 
     assert {provider.name for provider in default_providers} == {
         provider.name for provider in providers.values() if provider.enabled_by_default
@@ -84,4 +87,6 @@ async def test_shutdown_providers(
 
     providers = records[1].__dict__["providers"]
 
-    assert set(providers) == {provider.value for provider in ProviderType if provider.value not in DISABLED_PROVIDERS}
+    assert set(providers) == {
+        provider.value for provider in ProviderType if provider.value not in DISABLED_PROVIDERS
+    }

--- a/tests/unit/providers/test_init_providers.py
+++ b/tests/unit/providers/test_init_providers.py
@@ -21,6 +21,7 @@ from merino.providers import (
 from merino.providers.manager import ProviderType
 from tests.types import FilterCaplogFixture
 
+DISABLED_PROVIDERS = settings.runtime.disabled_providers
 
 @pytest.mark.asyncio
 async def test_init_providers() -> None:
@@ -29,7 +30,8 @@ async def test_init_providers() -> None:
 
     providers, default_providers = get_providers()
 
-    assert providers.keys() == {provider.value for provider in ProviderType}
+    # a disabled provider should not be initialized 
+    assert providers.keys() == {provider.value for provider in ProviderType if provider.value not in DISABLED_PROVIDERS}
 
     assert {provider.name for provider in default_providers} == {
         provider.name for provider in providers.values() if provider.enabled_by_default
@@ -82,4 +84,4 @@ async def test_shutdown_providers(
 
     providers = records[1].__dict__["providers"]
 
-    assert set(providers) == {provider.value for provider in ProviderType}
+    assert set(providers) == {provider.value for provider in ProviderType if provider.value not in DISABLED_PROVIDERS}


### PR DESCRIPTION
## References

JIRA: [DISCO-2886](https://mozilla-hub.atlassian.net/browse/DISCO-2886)

## Description
We are disabling this provider (`amo`) since online users are not using it. Disabling this would also minimize Sentry errors.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2886]: https://mozilla-hub.atlassian.net/browse/DISCO-2886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ