### PR TITLE
[DISCO-3023] Refactor out and centralize accuweather error strings

### DIFF
--- a/merino/providers/weather/backends/accuweather/backend.py
+++ b/merino/providers/weather/backends/accuweather/backend.py
@@ -666,7 +666,7 @@ class AccuweatherBackend:
                 )
         except ExceptionGroup as e:
             raise AccuweatherError(
-                AccuweatherErrorMessages.FAILED_WEATHER_REPORT, exceptions={e.exceptions}
+                AccuweatherErrorMessages.FAILED_WEATHER_REPORT, exceptions=e.exceptions
             )
 
         if (current_conditions_response := await task_current) is not None and (

--- a/merino/providers/weather/backends/accuweather/backend.py
+++ b/merino/providers/weather/backends/accuweather/backend.py
@@ -15,7 +15,7 @@ from httpx import AsyncClient, HTTPError, Response
 from pydantic import BaseModel, ValidationError
 
 from merino.cache.protocol import CacheAdapter
-from merino.exceptions import BackendError, CacheAdapterError
+from merino.exceptions import CacheAdapterError
 from merino.middleware.geolocation import Location
 from merino.providers.weather.backends.accuweather.pathfinder import (
     set_region_mapping,
@@ -36,6 +36,11 @@ from merino.providers.weather.backends.accuweather.utils import (
     process_location_response_with_country,
     process_location_response_with_country_and_region,
     get_language,
+)
+
+from merino.providers.weather.backends.accuweather.errors import (
+    AccuweatherError,
+    AccuweatherErrorMessages,
 )
 
 
@@ -168,10 +173,6 @@ class ForecastWithTTL(NamedTuple):
 
     forecast: Forecast
     ttl: int
-
-
-class AccuweatherError(BackendError):
-    """Error during interaction with the AccuWeather API."""
 
 
 class WeatherDataType(Enum):
@@ -352,9 +353,7 @@ class AccuweatherBackend:
                     "set_error" if isinstance(exc, CacheAdapterError) else "ttl_date_error"
                 )
                 self.metrics_client.increment(f"accuweather.cache.store.{error_type}")
-                raise AccuweatherError(
-                    "Something went wrong with storing to cache. Did not update cache."
-                )
+                raise AccuweatherError(AccuweatherErrorMessages.CACHE_WRITE_ERROR)
 
         return response_dict
 
@@ -666,7 +665,9 @@ class AccuweatherBackend:
                     )
                 )
         except ExceptionGroup as e:
-            raise AccuweatherError(f"Failed to fetch weather report: {e.exceptions}")
+            raise AccuweatherError(
+                AccuweatherErrorMessages.FAILED_WEATHER_REPORT, exceptions={e.exceptions}
+            )
 
         if (current_conditions_response := await task_current) is not None and (
             forecast_response := await task_forecast
@@ -719,12 +720,12 @@ class AccuweatherBackend:
             )
         except HTTPError as error:
             raise AccuweatherError(
-                f"Unexpected location response from: {url_path}, city: {city}"
+                AccuweatherErrorMessages.UNEXPECTED_LOCATION_RESPONSE, url_path=url_path, city=city
             ) from error
         except Exception as exc:
             raise AccuweatherError(
-                f"Unexpected error occurred when requesting location by geolocation from "
-                f"Accuweather: {exc.__class__.__name__}"
+                AccuweatherErrorMessages.UNEXPECTED_GEOLOCATION_REQUEST_ERROR,
+                exception_class_name=exc.__class__.__name__,
             ) from exc
 
         # record the region that gave a location
@@ -753,12 +754,15 @@ class AccuweatherBackend:
             )
         except HTTPError as error:
             raise AccuweatherError(
-                f"Unexpected current conditions response, Url: {self.url_current_conditions_path.format(location_key=location_key)}"
+                AccuweatherErrorMessages.UNEXPECTED_CURRENT_CONDITIONS_RESPONSE,
+                current_conditions_url=self.url_current_conditions_path.format(
+                    location_key=location_key
+                ),
             ) from error
         except Exception as exc:
             raise AccuweatherError(
-                f"Unexpected error occurred when requesting current conditions from Accuweather:"
-                f" {exc.__class__.__name__}"
+                AccuweatherErrorMessages.UNEXPECTED_CURRENT_CONDITIONS_REQUEST_ERROR,
+                exception_class_name=exc.__class__.__name__,
             ) from exc
 
         return (
@@ -796,12 +800,13 @@ class AccuweatherBackend:
             )
         except HTTPError as error:
             raise AccuweatherError(
-                f"Unexpected forecast response, Url: {self.url_forecasts_path.format(location_key=location_key)}"
+                AccuweatherErrorMessages.UNEXPECTED_FORECAST_RESPONSE,
+                forecast_url=self.url_forecasts_path.format(location_key=location_key),
             ) from error
         except Exception as exc:
             raise AccuweatherError(
-                f"Unexpected error occurred when requesting forecast from Accuweather: "
-                f"{exc.__class__.__name__}"
+                AccuweatherErrorMessages.UNEXPECTED_FORECAST_REQUEST_ERROR,
+                exception_class_name=exc.__class__.__name__,
             ) from exc
 
         return (
@@ -852,13 +857,15 @@ class AccuweatherBackend:
             )
         except HTTPError as error:
             raise AccuweatherError(
-                f"Failed to get location completion from Accuweather, http error occurred. "
-                f"url path: {url_path}, query: {search_term}, language: {language}"
+                AccuweatherErrorMessages.FAILED_LOCATION_COMPLETION,
+                url_path=url_path,
+                search_term=search_term,
+                language=language,
             ) from error
         except Exception as exc:
             raise AccuweatherError(
-                f"Unexpected error occurred when requesting location completion from "
-                f"Accuweather: {exc.__class__.__name__}"
+                AccuweatherErrorMessages.UNEXPECTED_LOCATION_COMPLETION_REQUEST_ERROR,
+                exception_class_name=exc.__class__.__name__,
             ) from exc
 
         return (

--- a/merino/providers/weather/backends/accuweather/backend.py
+++ b/merino/providers/weather/backends/accuweather/backend.py
@@ -720,11 +720,13 @@ class AccuweatherBackend:
             )
         except HTTPError as error:
             raise AccuweatherError(
-                AccuweatherErrorMessages.UNEXPECTED_LOCATION_RESPONSE, url_path=url_path, city=city
+                AccuweatherErrorMessages.HTTP_UNEXPECTED_LOCATION_RESPONSE,
+                url_path=url_path,
+                city=city,
             ) from error
         except Exception as exc:
             raise AccuweatherError(
-                AccuweatherErrorMessages.UNEXPECTED_GEOLOCATION_REQUEST_ERROR,
+                AccuweatherErrorMessages.UNEXPECTED_GEOLOCATION_ERROR,
                 exception_class_name=exc.__class__.__name__,
             ) from exc
 
@@ -754,14 +756,14 @@ class AccuweatherBackend:
             )
         except HTTPError as error:
             raise AccuweatherError(
-                AccuweatherErrorMessages.UNEXPECTED_CURRENT_CONDITIONS_RESPONSE,
+                AccuweatherErrorMessages.HTTP_UNEXPECTED_CURRENT_CONDITIONS_RESPONSE,
                 current_conditions_url=self.url_current_conditions_path.format(
                     location_key=location_key
                 ),
             ) from error
         except Exception as exc:
             raise AccuweatherError(
-                AccuweatherErrorMessages.UNEXPECTED_CURRENT_CONDITIONS_REQUEST_ERROR,
+                AccuweatherErrorMessages.UNEXPECTED_CURRENT_CONDITIONS_ERROR,
                 exception_class_name=exc.__class__.__name__,
             ) from exc
 
@@ -800,12 +802,12 @@ class AccuweatherBackend:
             )
         except HTTPError as error:
             raise AccuweatherError(
-                AccuweatherErrorMessages.UNEXPECTED_FORECAST_RESPONSE,
+                AccuweatherErrorMessages.HTTP_UNEXPECTED_FORECAST_RESPONSE,
                 forecast_url=self.url_forecasts_path.format(location_key=location_key),
             ) from error
         except Exception as exc:
             raise AccuweatherError(
-                AccuweatherErrorMessages.UNEXPECTED_FORECAST_REQUEST_ERROR,
+                AccuweatherErrorMessages.UNEXPECTED_FORECAST_ERROR,
                 exception_class_name=exc.__class__.__name__,
             ) from exc
 
@@ -857,14 +859,14 @@ class AccuweatherBackend:
             )
         except HTTPError as error:
             raise AccuweatherError(
-                AccuweatherErrorMessages.FAILED_LOCATION_COMPLETION,
+                AccuweatherErrorMessages.HTTP_LOCATION_COMPLETION_ERROR,
                 url_path=url_path,
                 search_term=search_term,
                 language=language,
             ) from error
         except Exception as exc:
             raise AccuweatherError(
-                AccuweatherErrorMessages.UNEXPECTED_LOCATION_COMPLETION_REQUEST_ERROR,
+                AccuweatherErrorMessages.UNEXPECTED_LOCATION_COMPLETION_ERROR,
                 exception_class_name=exc.__class__.__name__,
             ) from exc
 

--- a/merino/providers/weather/backends/accuweather/errors.py
+++ b/merino/providers/weather/backends/accuweather/errors.py
@@ -11,7 +11,7 @@ class AccuweatherErrorMessages(Enum):
     CACHE_WRITE_ERROR = "Something went wrong with storing to cache. Did not update cache."
     FAILED_WEATHER_REPORT = "Failed to fetch weather report: {exceptions}"
     UNEXPECTED_LOCATION_RESPONSE = "Unexpected location response from: {url_path}, city: {city}"
-    UNEXPECTED_GEOLOCATION_REQUEST_ERROR = "Unexpected error occurred when requesting location byeolocation from Accuweather: {exception_class_name}"
+    UNEXPECTED_GEOLOCATION_REQUEST_ERROR = "Unexpected error occurred when requesting location by geolocation from Accuweather: {exception_class_name}"
     UNEXPECTED_CURRENT_CONDITIONS_RESPONSE = (
         "Unexpected current conditions response, Url: {current_conditions_url}"
     )

--- a/merino/providers/weather/backends/accuweather/errors.py
+++ b/merino/providers/weather/backends/accuweather/errors.py
@@ -1,0 +1,35 @@
+"""TODO"""
+
+from enum import Enum
+
+from merino.exceptions import BackendError
+
+
+class AccuweatherErrorMessages(Enum):
+    """TODO"""
+
+    CACHE_WRITE_ERROR = "Something went wrong with storing to cache. Did not update cache."
+    FAILED_WEATHER_REPORT = "Failed to fetch weather report: {exceptions}"
+    UNEXPECTED_LOCATION_RESPONSE = "Unexpected location response from: {url_path}, city: {city}"
+    UNEXPECTED_GEOLOCATION_REQUEST_ERROR = "Unexpected error occurred when requesting location byeolocation from Accuweather: {exception_class_name}"
+    UNEXPECTED_CURRENT_CONDITIONS_RESPONSE = (
+        "Unexpected current conditions response, Url: {current_conditions_url}"
+    )
+    UNEXPECTED_CURRENT_CONDITIONS_REQUEST_ERROR = "Unexpected error occurred when requesting current conditions from Accuweather: {exception_class_name}"
+    UNEXPECTED_FORECAST_RESPONSE = "Unexpected forecast response, Url: {forecast_url}"
+    UNEXPECTED_FORECAST_REQUEST_ERROR = "Unexpected error occurred when requesting forecast from Accuweather: {exception_class_name}"
+    FAILED_LOCATION_COMPLETION = "Failed to get location completion from Accuweather, http error occurred. Url path: {url_path}, query: {search_term}, language: {language}"
+    UNEXPECTED_LOCATION_COMPLETION_REQUEST_ERROR = "Unexpected error occurred when requesting location completion from Accuweather: {exception_class_name}"
+
+    def format_message(self, **kwargs) -> str:
+        """TODO"""
+        return self.value.format(**kwargs)
+
+
+class AccuweatherError(BackendError):
+    """Error during interaction with the AccuWeather API."""
+
+    def __init__(self, error_type: AccuweatherErrorMessages, **kwargs):
+        # Use the `format_message` method to get the formatted error message
+        message = error_type.format_message(**kwargs)
+        super().__init__(message)

--- a/merino/providers/weather/backends/accuweather/errors.py
+++ b/merino/providers/weather/backends/accuweather/errors.py
@@ -1,33 +1,38 @@
-"""TODO"""
+"""Errors module that maintains all the accuweather specific error strings and the
+AccuweatherError class to format and wrap them as a BackendError child object
+"""
 
 from enum import Enum
-
 from merino.exceptions import BackendError
 
 
 class AccuweatherErrorMessages(Enum):
-    """TODO"""
+    """Enum variables with string values representing error messages"""
 
     CACHE_WRITE_ERROR = "Something went wrong with storing to cache. Did not update cache."
     FAILED_WEATHER_REPORT = "Failed to fetch weather report: {exceptions}"
-    UNEXPECTED_LOCATION_RESPONSE = "Unexpected location response from: {url_path}, city: {city}"
-    UNEXPECTED_GEOLOCATION_REQUEST_ERROR = "Unexpected error occurred when requesting location by geolocation from Accuweather: {exception_class_name}"
-    UNEXPECTED_CURRENT_CONDITIONS_RESPONSE = (
+    HTTP_UNEXPECTED_LOCATION_RESPONSE = (
+        "Unexpected location response from: {url_path}, city: {city}"
+    )
+    HTTP_UNEXPECTED_CURRENT_CONDITIONS_RESPONSE = (
         "Unexpected current conditions response, Url: {current_conditions_url}"
     )
-    UNEXPECTED_CURRENT_CONDITIONS_REQUEST_ERROR = "Unexpected error occurred when requesting current conditions from Accuweather: {exception_class_name}"
-    UNEXPECTED_FORECAST_RESPONSE = "Unexpected forecast response, Url: {forecast_url}"
-    UNEXPECTED_FORECAST_REQUEST_ERROR = "Unexpected error occurred when requesting forecast from Accuweather: {exception_class_name}"
-    FAILED_LOCATION_COMPLETION = "Failed to get location completion from Accuweather, http error occurred. Url path: {url_path}, query: {search_term}, language: {language}"
-    UNEXPECTED_LOCATION_COMPLETION_REQUEST_ERROR = "Unexpected error occurred when requesting location completion from Accuweather: {exception_class_name}"
+    HTTP_UNEXPECTED_FORECAST_RESPONSE = "Unexpected forecast response, Url: {forecast_url}"
+    HTTP_LOCATION_COMPLETION_ERROR = "Failed to get location completion from Accuweather, http error occurred. Url path: {url_path}, query: {search_term}, language: {language}"
+    UNEXPECTED_GEOLOCATION_ERROR = "Unexpected error occurred when requesting location by geolocation from Accuweather: {exception_class_name}"
+    UNEXPECTED_CURRENT_CONDITIONS_ERROR = "Unexpected error occurred when requesting current conditions from Accuweather: {exception_class_name}"
+    UNEXPECTED_FORECAST_ERROR = "Unexpected error occurred when requesting forecast from Accuweather: {exception_class_name}"
+    UNEXPECTED_LOCATION_COMPLETION_ERROR = "Unexpected error occurred when requesting location completion from Accuweather: {exception_class_name}"
 
     def format_message(self, **kwargs) -> str:
-        """TODO"""
+        """Format the enum string value with the passed in keyword arguments"""
         return self.value.format(**kwargs)
 
 
 class AccuweatherError(BackendError):
-    """Error during interaction with the AccuWeather API."""
+    """Accuweather error type which inherits the BackendError parent class. On the provider
+    level, this is caught as a BackendError type and logged.
+    """
 
     def __init__(self, error_type: AccuweatherErrorMessages, **kwargs):
         # Use the `format_message` method to get the formatted error message

--- a/merino/providers/weather/backends/accuweather/errors.py
+++ b/merino/providers/weather/backends/accuweather/errors.py
@@ -30,8 +30,8 @@ class AccuweatherErrorMessages(Enum):
 
 
 class AccuweatherError(BackendError):
-    """Accuweather error type which inherits the BackendError parent class. On the provider
-    level, this is caught as a BackendError type and logged.
+    """Error during interaction with the Accuweather api. Inherits the BackendError parent
+    class. On the provider level, this is caught as a BackendError type and logged.
     """
 
     def __init__(self, error_type: AccuweatherErrorMessages, **kwargs):

--- a/tests/unit/providers/weather/backends/test_accuweather.py
+++ b/tests/unit/providers/weather/backends/test_accuweather.py
@@ -31,6 +31,7 @@ from merino.providers.weather.backends.accuweather import (
     CurrentConditionsWithTTL,
     ForecastWithTTL,
 )
+from merino.providers.weather.backends.accuweather.errors import AccuweatherErrorMessages
 from merino.providers.weather.backends.accuweather.utils import (
     RequestType,
     add_partner_code,
@@ -1428,12 +1429,12 @@ async def test_get_weather_report_handles_non_http_exception_group_properly(
         forecast_error,
     ]
     accuweather_error_for_current_conditions = AccuweatherError(
-        f"Unexpected error occurred when requesting current conditions from "
-        f"Accuweather: {current_conditions_error.__class__.__name__}"
+        AccuweatherErrorMessages.UNEXPECTED_CURRENT_CONDITIONS_REQUEST_ERROR,
+        exception_class_name=current_conditions_error.__class__.__name__,
     )
     accuweather_error_for_forecast = AccuweatherError(
-        f"Unexpected error occurred when requesting forecast from "
-        f"Accuweather: {forecast_error.__class__.__name__}"
+        AccuweatherErrorMessages.UNEXPECTED_FORECAST_REQUEST_ERROR,
+        exception_class_name=forecast_error.__class__.__name__,
     )
 
     with pytest.raises(AccuweatherError) as accuweather_error:

--- a/tests/unit/providers/weather/backends/test_accuweather.py
+++ b/tests/unit/providers/weather/backends/test_accuweather.py
@@ -1429,11 +1429,11 @@ async def test_get_weather_report_handles_non_http_exception_group_properly(
         forecast_error,
     ]
     accuweather_error_for_current_conditions = AccuweatherError(
-        AccuweatherErrorMessages.UNEXPECTED_CURRENT_CONDITIONS_REQUEST_ERROR,
+        AccuweatherErrorMessages.UNEXPECTED_CURRENT_CONDITIONS_ERROR,
         exception_class_name=current_conditions_error.__class__.__name__,
     )
     accuweather_error_for_forecast = AccuweatherError(
-        AccuweatherErrorMessages.UNEXPECTED_FORECAST_REQUEST_ERROR,
+        AccuweatherErrorMessages.UNEXPECTED_FORECAST_ERROR,
         exception_class_name=forecast_error.__class__.__name__,
     )
 
@@ -2385,7 +2385,7 @@ async def test_get_location_completion_raises_accuweather_error_on_catching_http
     url_path = f"/locations/v1/cities/{geolocation.country}/autocomplete.json"
     expected_error_message = (
         f"Failed to get location completion from Accuweather, http error occurred. "
-        f"url path: {url_path}, query: {search_term}, language: {languages[0]}"
+        f"Url path: {url_path}, query: {search_term}, language: {languages[0]}"
     )
 
     assert expected_error_message == str(accuweather_error.value)


### PR DESCRIPTION
## References

JIRA: [DISCO-3023](https://mozilla-hub.atlassian.net/browse/DISCO-3023)

## Description
Refactoring out the accuweather backend error strings into a separate module for clarity, maintainability and flexibility.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3023]: https://mozilla-hub.atlassian.net/browse/DISCO-3023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ