### PR TITLE
[MC-1522] Provide localized titles for the Big Rectangle

### DIFF
--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -212,9 +212,9 @@ class CuratedRecommendationsProvider:
 
         # Provide a localized title string for the "Need to Know" feed.
         localized_titles = {
-            ScheduledSurfaceId.NEW_TAB_EN_US: "Need to Know",
-            ScheduledSurfaceId.NEW_TAB_EN_GB: "Need to Know in British English",
-            ScheduledSurfaceId.NEW_TAB_DE_DE: "Need to Know auf Deutsch",
+            ScheduledSurfaceId.NEW_TAB_EN_US: "In the news",
+            ScheduledSurfaceId.NEW_TAB_EN_GB: "In the news",
+            ScheduledSurfaceId.NEW_TAB_DE_DE: "In den news",
         }
         title = localized_titles[surface_id]
 

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -256,7 +256,7 @@ async def test_curated_recommendations_with_need_to_know_feed():
 
         # Assert that the `need_to_know` feed has a localized title returned
         title = data["feeds"]["need_to_know"]["title"]
-        assert title == "Need to Know"
+        assert title == "In the news"
 
         # Assert that the `need_to_know` feed has 10 items
         feed = data["feeds"]["need_to_know"]["recommendations"]

--- a/tests/unit/curated_recommendations/test_provider.py
+++ b/tests/unit/curated_recommendations/test_provider.py
@@ -366,7 +366,7 @@ class TestCuratedRecommendationsProviderRankNeedToKnowRecommendations:
             assert i == rec.receivedRank
 
         # Verify that the localized title is correct
-        assert title == "Need to Know"
+        assert title == "In the news"
 
     def test_rank_need_to_know_recommendations_different_surface(self, mocker: MockerFixture):
         """Test localization with a non-English New Tab surface
@@ -389,4 +389,4 @@ class TestCuratedRecommendationsProviderRankNeedToKnowRecommendations:
         )
 
         # Verify that the title is correct for the German New Tab surface
-        assert title == "Need to Know auf Deutsch"
+        assert title == "In den news"


### PR DESCRIPTION


## References

JIRA: https://mozilla-hub.atlassian.net/browse/MC-1522

## Description

- Update placeholder "need to know" titles to the final copy: sentence-case "In the news".
- Update tests.




## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
