### PR TITLE
[MC-1522] Update 'In the news' copy for German New Tab surface

### DIFF
--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -214,7 +214,7 @@ class CuratedRecommendationsProvider:
         localized_titles = {
             ScheduledSurfaceId.NEW_TAB_EN_US: "In the news",
             ScheduledSurfaceId.NEW_TAB_EN_GB: "In the news",
-            ScheduledSurfaceId.NEW_TAB_DE_DE: "In den news",
+            ScheduledSurfaceId.NEW_TAB_DE_DE: "In den News",
         }
         title = localized_titles[surface_id]
 

--- a/tests/unit/curated_recommendations/test_provider.py
+++ b/tests/unit/curated_recommendations/test_provider.py
@@ -389,4 +389,4 @@ class TestCuratedRecommendationsProviderRankNeedToKnowRecommendations:
         )
 
         # Verify that the title is correct for the German New Tab surface
-        assert title == "In den news"
+        assert title == "In den News"


### PR DESCRIPTION
## References

JIRA: https://mozilla-hub.atlassian.net/browse/MC-1522

## Description

A very small update to capitalize the word "News" for the German copy of the "Big Rectangle" heading.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
