### PR TITLE
[DISCO-3010] Calibrate smoke and average tests for n2-highcpu-8 machine change and real-world network traffic data [load test: warn]

### DIFF
--- a/docs/testing/load-tests.md
+++ b/docs/testing/load-tests.md
@@ -29,7 +29,9 @@ Follow the steps bellow to execute the load tests locally:
 The following environment variables as well as
 [Locust environment variables][locust_environment_variables] can be set in
 `tests\load\docker-compose.yml`.
-Make sure any required API key is added but then not checked into source control (i.e. `WIKIPEDIA__ES_API_KEY`).
+Make sure any required API key is added but then not checked into source control.
+
+**WARNING**: if the `WIKIPEDIA__ES_API_KEY` is missing, the load tests will not execute.
 
 | Environment Variable                             | Node(s)         | Description                                                                               |
 |--------------------------------------------------|-----------------|-------------------------------------------------------------------------------------------|
@@ -168,7 +170,7 @@ a GKE cluster
   EXTERNAL_IP=$(kubectl get svc locust-master -o jsonpath="{.status.loadBalancer.ingress[0].ip}")
   echo http://$EXTERNAL_IP:8089
   ```
-* Select the `MerinoLoadTestShape`, this option has pre-defined settings and will last 10 minutes
+* Select the `MerinoSmokeLoadTestShape`, this option has pre-defined settings and will last 10 minutes
 * Select "Start Swarming"
 
 #### 2. Stop Load Test
@@ -309,10 +311,12 @@ the performance test.
 
 | Parameter          | Description                                                                                                                                                                                                      |
 |--------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [WAIT TIME][13]    | - Changing this cadence will increase or decrease the number of channel subscriptions and notifications sent by a MerinoUser. <br/>- The default is currently in use for the MerinoUser class.                   |
-| [TASK WEIGHT][14]  | - Changing this weight impacts the probability of a task being chosen for execution. <br/>- This value is hardcoded in the task decorators of the MerinoUser class.                                              |
+| `WAIT TIME`        | - Changing this cadence will increase or decrease the number of channel subscriptions and notifications sent by a MerinoUser. <br/>- The default is currently in use for the MerinoUser class.                   |
+| `TASK WEIGHT`      | - Changing this weight impacts the probability of a task being chosen for execution. <br/>- This value is hardcoded in the task decorators of the MerinoUser class.                                              |
 | `USERS_PER_WORKER` | - This value should be set to the maximum number of users a Locust worker can support given CPU and memory constraints. <br/>- This value is hardcoded in the LoadTestShape classes.                             |
 | `WORKER_COUNT`     | - This value is derived by dividing the total number of users needed for the performance test by the `USERS_PER_WORKER`. <br>- This value is hardcoded in the LoadTestShape classes and the setup_k8s.sh script. |
+
+* Locust documentation is available for [WAIT TIME][13] and [TASK WEIGHT][14]
 
 ## Calibrating for USERS_PER_WORKER
 

--- a/tests/load/locustfiles/locustfile.py
+++ b/tests/load/locustfiles/locustfile.py
@@ -399,7 +399,7 @@ class MerinoUser(HttpUser):
         for query in queries:
             self._request_suggestions(query, providers)
 
-    @task(weight=497)
+    @task(weight=642)
     def weather_suggestions(self) -> None:
         """Send multiple requests for Weather queries."""
         # Firefox will do local keyword matching to trigger weather suggestions
@@ -412,14 +412,14 @@ class MerinoUser(HttpUser):
 
         self._request_suggestions(query, providers, headers)
 
-    @task(weight=421)
+    @task(weight=298)
     def curated_recommendations_locale(self) -> None:
         """Send request to get curated recommendations, specifying random locale & 0 topics."""
         self._request_recommendations(
             CuratedRecommendationsRequest(locale=choice(list(Locale))), "locale"
         )
 
-    @task(weight=74)
+    @task(weight=52)
     def curated_recommendations_random_topics(self) -> None:
         """Send request to get curated recommendations with a random number of topics (between 1 & 4(max))."""
         num_topics = randint(1, 4)  # Randomly choose between 1 and 4 topics


### PR DESCRIPTION
## References

JIRA: [DISCO-3010](https://mozilla-hub.atlassian.net/browse/DISCO-3010)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->

- update network traffic end point distribution from 50% suggest and 50% recommendations to 65% suggest and 35% recommendations
- add corrections and clarifications to documentation

For the latest load test results, please see the [Merino Load Test Spreadsheet](https://docs.google.com/spreadsheets/d/1SAO3QYIrbxDRxzmYIab-ebZXA1dF06W1lT4I1h2R3a8/edit?gid=0#gid=0)

### Calibrating for n2-highcpu-8 machine change

In the end, no additional load was necessary, since scaling is still achieved with the configured load
<img width="589" alt="image" src="https://github.com/user-attachments/assets/c7513032-022d-428f-b3bd-ff39016433bf">


### Adjusting traffic distribution

The current load distribution between endpoints has proven to be slightly different than the original 50/50 estimate. So adjustments have been made as follows:

49.7% --> 64.2% weatherSuggestions
42.1% --> 29.8% curatedRecommendationsLocale
7.4% --> 5.2% curatedRecommendationsRandomTopics
0.2% --> 0.2% admSuggestions
0.2% --> 0.2% dynamicWikipediaSuggestions
0.2% --> 0.2% fakerSuggestions
0.2% --> 0.2% topPicksSuggestions

<img width="596" alt="image" src="https://github.com/user-attachments/assets/1b181a27-2bab-430c-93b2-559fe34b65f2">


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3010]: https://mozilla-hub.atlassian.net/browse/DISCO-3010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ