### PR TITLE
[HNT-266] Fix curated recommendation count

### DIFF
--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -176,7 +176,7 @@ class CuratedRecommendationsProvider:
             ):
                 rec.topic = None
 
-        return recommendations
+        return recommendations[: request.count]
 
     def rank_need_to_know_recommendations(
         self,

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -410,13 +410,16 @@ class TestCuratedRecommendationsRequestParameters:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("count", [10, 50, 100])
-    async def test_curated_recommendations_count(self, count):
+    async def test_curated_recommendations_count(self, count, fixture_response_data):
         """Test the curated recommendations endpoint accepts valid count."""
         async with AsyncClient(app=app, base_url="http://test") as ac:
             response = await ac.post(
                 "/api/v1/curated-recommendations", json={"locale": "en-US", "count": count}
             )
             assert response.status_code == 200
+            data = response.json()
+            schedule_count = len(fixture_response_data["data"]["scheduledSurface"]["items"])
+            assert len(data["data"]) == min(count, schedule_count)
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("count", [None, 100.5])


### PR DESCRIPTION
## References

JIRA: [HNT-226](https://mozilla-hub.atlassian.net/browse/HNT-226)

## Description
The client should not get more recommendations back than it requests.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[HNT-226]: https://mozilla-hub.atlassian.net/browse/HNT-226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ