### PR TITLE
[MC-1567] Fix initialization of GcsEngagement

### DIFF
--- a/merino/curated_recommendations/__init__.py
+++ b/merino/curated_recommendations/__init__.py
@@ -33,10 +33,10 @@ def init_engagement_backend() -> EngagementBackend:
     try:
         metrics_namespace = "recommendation.engagement"
         synced_gcs_blob = SyncedGcsBlob(
-            storage_client=Client(settings.curated_recommendations.gcs.engagement.gcp_project),
+            storage_client=Client(settings.curated_recommendations.gcs.gcp_project),
             metrics_client=get_metrics_client(),
             metrics_namespace=metrics_namespace,
-            bucket_name=settings.curated_recommendations.gcs.engagement.bucket_name,
+            bucket_name=settings.curated_recommendations.gcs.bucket_name,
             blob_name=settings.curated_recommendations.gcs.engagement.blob_name,
             max_size=settings.curated_recommendations.gcs.engagement.max_size,
             cron_interval_seconds=settings.curated_recommendations.gcs.engagement.cron_interval_seconds,


### PR DESCRIPTION
## References

JIRA: [MC-1567](https://mozilla-hub.atlassian.net/browse/MC-1567)

## Description
Fix GcsEngagement failing to initialize because the wrong config is used:

> Failed to initialize GCS Engagement Backend: "'DynaBox' object has no attribute 'gcp_project'"



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[MC-1567]: https://mozilla-hub.atlassian.net/browse/MC-1567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ