### PR TITLE
[MC-1568] fix config error for curated_recommendations

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -476,7 +476,7 @@ query_timeout_sec = 5.0
 score = 0.23
 
 
-[production.curated_recommendations.gcs]
+[default.curated_recommendations.gcs]
 # MERINO__CURATED_RECOMMENDATIONS__GCS__BUCKET_NAME
 # GCS bucket that contains Airflow data for Merino
 bucket_name = ""


### PR DESCRIPTION
## References

JIRA: [MC-1516](https://mozilla-hub.atlassian.net/browse/MC-1516)

## Description
Fix unhandled exception during starting, causing deployment to fail:

> dynaconf.vendor.box.exceptions.BoxKeyError: "'DynaBox' object has no attribute 'corpus_api'"

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[MC-1516]: https://mozilla-hub.atlassian.net/browse/MC-1516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ