### PR TITLE
[HNT-228] Validate curated recommendations configs

### DIFF
--- a/merino/config.py
+++ b/merino/config.py
@@ -24,6 +24,32 @@ _validators = [
     ),
     Validator("accuweather.partner_code", is_type_of=str),
     Validator("amo.dynamic.api_url", is_type_of=str),
+    Validator(
+        "curated_recommendations.corpus_api.retry_wait_initial_seconds",
+        "curated_recommendations.corpus_api.retry_wait_jitter_seconds",
+        is_type_of=float,
+        must_exist=True,
+        env=["production", "staging", "development"],
+    ),
+    Validator(
+        "curated_recommendations.corpus_api.retry_count",
+        "curated_recommendations.gcs.engagement.max_size",
+        "curated_recommendations.gcs.engagement.cron_interval_seconds",
+        "curated_recommendations.gcs.prior.max_size",
+        "curated_recommendations.gcs.prior.cron_interval_seconds",
+        is_type_of=int,
+        must_exist=True,
+        env=["production", "staging", "development"],
+    ),
+    Validator(
+        "curated_recommendations.gcs.bucket_name",
+        "curated_recommendations.gcs.gcp_project",
+        "curated_recommendations.gcs.engagement.blob_name",
+        "curated_recommendations.gcs.prior.blob_name",
+        is_type_of=str,
+        must_exist=True,
+        env=["production", "staging", "development"],
+    ),
     Validator("providers.accuweather.enabled_by_default", is_type_of=bool),
     # The Redis server URL is required when at least one provider wants to use Redis for caching.
     Validator(


### PR DESCRIPTION
## References

JIRA: [HNT-228](https://mozilla-hub.atlassian.net/browse/HNT-228)

## Description
Validate that required curated recommendations configs exist. This would have caught https://github.com/mozilla-services/merino-py/pull/656.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[HNT-228]: https://mozilla-hub.atlassian.net/browse/HNT-228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ