### PR TITLE
feat: add geonames uploader SNG-1848

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -600,3 +600,34 @@ min_favicon_width = 48
 # MERINO_JOBS__AMO_RS_UPLOADER__RECORD_TYPE
 # The "type" of each remote settings record
 record_type = "amo-suggestions"
+
+
+[default.jobs.geonames_uploader]
+# MERINO_JOBS__GEONAMES_UPLOADER__BASE_URL
+# Base URL of the GeoNames server.
+base_url = "https://download.geonames.org"
+# MERINO_JOBS__GEONAMES_UPLOADER__GEONAMES_PATH
+# Full path on the GeoNames server of country-specific geonames files. Expected
+# to be an f-string with a `country_code` variable.
+geonames_path = "/export/dump/{country_code}.zip"
+# MERINO_JOBS__GEONAMES_UPLOADER__ALTERNATES_PATH
+# Full path on the GeoNames server of country-specific alternates files.
+# Expected to be an f-string with a `country_code` variable.
+alternates_path = "/export/dump/alternatenames/{country_code}.zip"
+# MERINO_JOBS__GEONAMES_UPLOADER__POPULATION_THRESHOLD
+# How large a geoname's population must be for it to be included in the output.
+# Geonames with populations at least this large will be included.
+population_threshold = 50_000
+# MERINO_JOBS__GEONAMES_UPLOADER__ALTERNATES_ISO_LANGUAGES
+# Which alternates of selected geonames to include in the output. Alternates are
+# categorized by language, like "en" and "en-US", plus a few other categories
+# like abbreviations ("abbr") and airport codes ("iata", "icao", "faac").
+alternates_iso_languages  = ["en", "en-US", "iata", "icao", "faac", "abbr"]
+# MERINO_JOBS__GEONAMES_UPLOADER__COUNTRY_CODE
+# Which country's geonames to upload. If we expand to more countries, we should
+# probably remove this from the config and instead require `--country-code` to
+# be passed on the command line when running the job.
+country_code = "US"
+# MERINO_JOBS__GEONAMES_UPLOADER__RECORD_TYPE
+# The "type" of each geonames remote settings record.
+record_type = "geonames"

--- a/merino/jobs/amo_rs_uploader/__init__.py
+++ b/merino/jobs/amo_rs_uploader/__init__.py
@@ -130,7 +130,7 @@ async def _upload(
         record_type=record_type,
         server=server,
         suggestion_score_fallback=score,
-        total_data_count=len(backend.dynamic_data),
+        total_item_count=len(backend.dynamic_data),
     ) as uploader:
         if not keep_existing_records:
             uploader.delete_records()

--- a/merino/jobs/cli.py
+++ b/merino/jobs/cli.py
@@ -5,6 +5,7 @@ import typer
 from merino.config_logging import configure_logging
 from merino.jobs.amo_rs_uploader import amo_rs_uploader_cmd
 from merino.jobs.csv_rs_uploader import csv_rs_uploader_cmd
+from merino.jobs.geonames_uploader import geonames_uploader_cmd
 from merino.jobs.navigational_suggestions import navigational_suggestions_cmd
 from merino.jobs.relevancy_uploader import relevancy_csv_rs_uploader_cmd
 from merino.jobs.wikipedia_indexer import indexer_cmd
@@ -23,6 +24,8 @@ cli.add_typer(amo_rs_uploader_cmd, no_args_is_help=True)
 cli.add_typer(csv_rs_uploader_cmd, no_args_is_help=True)
 
 cli.add_typer(relevancy_csv_rs_uploader_cmd, no_args_is_help=True)
+
+cli.add_typer(geonames_uploader_cmd, no_args_is_help=True)
 
 
 @cli.callback("setup")

--- a/merino/jobs/csv_rs_uploader/__init__.py
+++ b/merino/jobs/csv_rs_uploader/__init__.py
@@ -235,7 +235,7 @@ async def _upload_file_object(
         record_type=record_type,
         server=server,
         suggestion_score_fallback=score,
-        total_data_count=len(suggestions),
+        total_item_count=len(suggestions),
     ) as uploader:
         if not keep_existing_records:
             uploader.delete_records()

--- a/merino/jobs/csv_rs_uploader/chunked_rs_uploader.py
+++ b/merino/jobs/csv_rs_uploader/chunked_rs_uploader.py
@@ -19,7 +19,7 @@ class ChunkedRemoteSettingsSuggestionUploader(ChunkedRemoteSettingsUploader):
     kinto: kinto_http.Client
     record_type: str
     suggestion_score_fallback: float | None
-    total_data_count: int | None
+    total_item_count: int | None
 
     def __init__(
         self,
@@ -32,7 +32,7 @@ class ChunkedRemoteSettingsSuggestionUploader(ChunkedRemoteSettingsUploader):
         allow_delete: bool = False,
         dry_run: bool = False,
         suggestion_score_fallback: float | None = None,
-        total_data_count: int | None = None,
+        total_item_count: int | None = None,
     ):
         """Initialize the uploader."""
         super(ChunkedRemoteSettingsSuggestionUploader, self).__init__(
@@ -44,10 +44,10 @@ class ChunkedRemoteSettingsSuggestionUploader(ChunkedRemoteSettingsUploader):
             server,
             allow_delete,
             dry_run,
-            total_data_count,
+            total_item_count,
         )
         self.suggestion_score_fallback = suggestion_score_fallback
-        self.total_data_count = total_data_count
+        self.total_item_count = total_item_count
 
     def add_suggestion(self, suggestion: dict[str, Any]) -> None:
         """Add a suggestion. If the current chunk becomes full as a result, it
@@ -55,6 +55,6 @@ class ChunkedRemoteSettingsSuggestionUploader(ChunkedRemoteSettingsUploader):
         """
         if self.suggestion_score_fallback and "score" not in suggestion:
             suggestion |= {"score": self.suggestion_score_fallback}
-        self.current_chunk.add_data(suggestion)
+        self.current_chunk.add_item(suggestion)
         if self.current_chunk.size == self.chunk_size:
             self._finish_current_chunk()

--- a/merino/jobs/geonames_uploader/__init__.py
+++ b/merino/jobs/geonames_uploader/__init__.py
@@ -1,0 +1,207 @@
+"""CLI commands for the geonames_uploader module. See downloader.py for
+documentation on GeoNames.
+
+"""
+
+import asyncio
+import importlib
+import io
+import logging
+from zipfile import ZipFile
+from typing import Any, Callable
+
+import csv
+import requests
+import typer
+from urllib.parse import urljoin
+from tempfile import NamedTemporaryFile, TemporaryDirectory, TemporaryFile
+
+from merino.config import settings as config
+from merino.jobs.csv_rs_uploader.chunked_rs_uploader import (
+    ChunkedRemoteSettingsSuggestionUploader,
+)
+from merino.jobs.utils.chunked_rs_uploader import Chunk, ChunkedRemoteSettingsUploader
+from merino.jobs.geonames_uploader.downloader import Geoname, GeonamesDownloader
+
+logger = logging.getLogger(__name__)
+
+rs_settings = config.remote_settings
+job_settings = config.jobs.geonames_uploader
+
+# Options
+alternates_iso_languages_option = typer.Option(
+    job_settings.alternates_iso_languages,
+    "--alternates-iso-languages",
+    help="Alternate name languages and types to select",
+)
+
+alternates_path_option = typer.Option(
+    job_settings.alternates_path,
+    "--alternates-path",
+    help="Path of alternate names on the GeoNames server",
+)
+
+auth_option = typer.Option(
+    rs_settings.auth,
+    "--auth",
+    help="Remote settings authorization token",
+)
+
+base_url_option = typer.Option(
+    job_settings.base_url,
+    "--base-url",
+    help="Base URL of the GeoNames server",
+)
+
+bucket_option = typer.Option(
+    rs_settings.bucket,
+    "--bucket",
+    help="Remote settings bucket",
+)
+
+chunk_size_option = typer.Option(
+    rs_settings.chunk_size,
+    "--chunk-size",
+    help="The number of geonames to store in each attachment",
+)
+
+collection_option = typer.Option(
+    rs_settings.collection,
+    "--collection",
+    help="Remote settings collection ID",
+)
+
+country_code_option = typer.Option(
+    job_settings.country_code,
+    "--country-code",
+    help="Country code of geonames to select",
+)
+
+dry_run_option = typer.Option(
+    rs_settings.dry_run,
+    "--dry-run",
+    help="Log the records that would be uploaded but don't upload them",
+)
+
+geonames_path_option = typer.Option(
+    job_settings.geonames_path,
+    "--geonames-path",
+    help="Path of geonames on the GeoNames server",
+)
+
+keep_existing_records_option = typer.Option(
+    False,
+    "--keep-existing-records",
+    help="Keep existing records not present in the new data",
+)
+
+population_threshold_option = typer.Option(
+    job_settings.population_threshold,
+    "--population-threshold",
+    help="Population threshold of geonames to select",
+)
+
+record_type_option = typer.Option(
+    job_settings.record_type,
+    "--record-type",
+    help="The `type` of each remote settings record",
+)
+
+server_option = typer.Option(
+    rs_settings.server,
+    "--server",
+    help="Remote settings server",
+)
+
+geonames_uploader_cmd = typer.Typer(
+    name="geonames-uploader",
+    help="Command for uploading GeoNames data from geonames.org to remote settings",
+)
+
+
+class GeonamesChunk(Chunk):
+    """A chunk of geonames to be uploaded in a single attachment."""
+
+    max_alternate_name_length: int
+    max_alternate_name_word_count: int
+
+    @staticmethod
+    def item_to_json_serializable(geoname: Geoname) -> Any:
+        """Convert the geoname to a JSON serializable object."""
+        return geoname.to_json_serializable()
+
+    def __init__(self, start_index: int):
+        super().__init__(start_index)
+        self.max_alternate_name_length = 0
+        self.max_alternate_name_word_count = 0
+
+    def add_item(self, geoname: Geoname) -> None:
+        """Add a geoname to the chunk."""
+        super().add_item(geoname)
+        for name in geoname.alternate_names:
+            if len(name) > self.max_alternate_name_length:
+                self.max_alternate_name_length = len(name)
+            word_count = len(name.split())
+            if word_count > self.max_alternate_name_word_count:
+                self.max_alternate_name_word_count = word_count
+
+    def to_json_serializable(self) -> Any:
+        """Convert the chunk to a JSON serializable object that will be stored
+        in the chunk's attachment.
+
+        """
+        return {
+            "max_alternate_name_length": self.max_alternate_name_length,
+            "max_alternate_name_word_count": self.max_alternate_name_word_count,
+            "geonames": self.items,
+        }
+
+
+@geonames_uploader_cmd.command()
+def upload(
+    alternates_path: str = alternates_path_option,
+    auth: str = auth_option,
+    base_url: str = base_url_option,
+    bucket: str = bucket_option,
+    chunk_size: int = chunk_size_option,
+    collection: str = collection_option,
+    country_code: str = country_code_option,
+    dry_run: bool = dry_run_option,
+    geonames_path: str = geonames_path_option,
+    alternates_iso_languages: list[str] = alternates_iso_languages_option,
+    keep_existing_records: bool = keep_existing_records_option,
+    population_threshold: int = population_threshold_option,
+    record_type: str = record_type_option,
+    server: str = server_option,
+):
+    """Download GeoNames data from the GeoNames server, apply some processing
+    and selection, and upload it to remote settings.
+
+    """
+    downloader = GeonamesDownloader(
+        alternates_path=alternates_path,
+        base_url=base_url,
+        country_code=country_code,
+        geonames_path=geonames_path,
+        alternates_iso_languages=alternates_iso_languages,
+        population_threshold=population_threshold,
+    )
+    state = downloader.download()
+
+    with ChunkedRemoteSettingsUploader(
+        allow_delete=True,
+        auth=auth,
+        bucket=bucket,
+        chunk_cls=GeonamesChunk,
+        chunk_size=chunk_size,
+        collection=collection,
+        dry_run=dry_run,
+        record_type=record_type,
+        server=server,
+        total_item_count=len(state.geonames),
+    ) as uploader:
+        if not keep_existing_records:
+            uploader.delete_records()
+
+        for g in state.geonames:
+            uploader.add_item(g)

--- a/merino/jobs/geonames_uploader/downloader.py
+++ b/merino/jobs/geonames_uploader/downloader.py
@@ -1,0 +1,290 @@
+"""Utilities for downloading and processing data from GeoNames. GeoNames is an
+open-source geographical database of place names worldwide, including cities,
+regions, and countries [1]. See technical documentation at [2].
+
+[1] https://www.geonames.org/
+[2] https://download.geonames.org/export/dump/readme.txt
+
+"""
+
+import logging
+from typing import Any, Callable
+
+import csv
+import requests
+from urllib.parse import urljoin
+
+from merino.jobs.geonames_uploader.tempzipfile import TempZipFile
+
+logger = logging.getLogger(__name__)
+
+
+# Column indexes in the `geoname` table described in the GeoNames documentation.
+GEONAME_COL_ID = 0
+GEONAME_COL_NAME = 1
+GEONAME_COL_FEATURE_CLASS = 6
+GEONAME_COL_FEATURE_CODE = 7
+GEONAME_COL_COUNTRY_CODE = 8
+GEONAME_COL_ADMIN1_CODE = 10
+GEONAME_COL_POPULATION = 14
+MAX_GEONAME_COL = GEONAME_COL_POPULATION
+
+# Column indexes in the `alternate names` table described in the GeoNames
+# documentation.
+ALTERNATES_COL_GEONAME_ID = 1
+ALTERNATES_COL_ISO_LANGUAGE = 2
+ALTERNATES_COL_NAME = 3
+MAX_ALTERNATES_COL = ALTERNATES_COL_NAME
+
+FEATURE_CLASS_CITY = "P"
+FEATURE_CLASS_REGION = "A"
+FEATURE_CODE_REGION = "ADM1"
+
+
+class Geoname:
+    """A geoname is a representation of a single place like a city, state, or
+    region. An instance of this class corresponds to a single row in the
+    `geoname` table described in the GeoNames documentation (see link above).
+
+    This class also includes a set of `alternate_names` containing lowercased
+    versions of all the geoname's alternate names selected during the download
+    process. A single geoname can have many alternate names since a place can
+    have many different variations of its name. Alternate names can also include
+    translations of the geoname's name into different languages.
+
+    """
+
+    id: str
+    name: str
+    feature_class: str
+    feature_code: str
+    country_code: str
+    admin1_code: str
+    population: int
+    alternate_names: set[str]
+
+    def __init__(
+        self,
+        id: str,
+        name: str,
+        feature_class: str,
+        feature_code: str,
+        country_code: str,
+        admin1_code: str,
+        population: int,
+        alternate_names: set[str] | None = None,
+    ):
+        """Initialize the geoname."""
+        self.id = id
+        self.name = name
+        self.feature_class = feature_class
+        self.feature_code = feature_code
+        self.country_code = country_code
+        self.admin1_code = admin1_code
+        self.population = population
+        self.alternate_names = alternate_names or set([])
+        # Always make sure `name` is present as an alternate name. The client
+        # implementation relies on this.
+        self.alternate_names.add(name.casefold())
+
+    def to_json_serializable(self) -> dict[str, Any]:
+        """Return a `dict` version of the geoname that is JSON serializable."""
+        self_dict = vars(self)
+        for k, v in self_dict.items():
+            if isinstance(v, set):
+                self_dict[k] = list(v)
+        return self_dict
+
+    def __repr__(self) -> str:
+        return str(vars(self))
+
+    def __eq__(self, other) -> bool:
+        return isinstance(other, Geoname) and vars(self) == vars(other)
+
+
+class DownloadMetrics:
+    """Download metrics useful for logging."""
+
+    excluded_geonames_count: int
+    included_alternates_count: int
+
+    def __init__(
+        self,
+        excluded_geonames_count: int = 0,
+        included_alternates_count: int = 0,
+    ):
+        self.excluded_geonames_count = excluded_geonames_count
+        self.included_alternates_count = included_alternates_count
+
+    def __repr__(self) -> str:
+        return str(vars(self))
+
+    def __eq__(self, other) -> bool:
+        return isinstance(other, DownloadMetrics) and vars(self) == vars(other)
+
+
+class DownloadState:
+    """The result of a successful GeoNames download."""
+
+    geonames: list[Geoname]
+    geonames_by_id: dict[str, Geoname]
+    metrics: DownloadMetrics
+
+    def __init__(
+        self,
+        geonames: list[Geoname] | None = None,
+        geonames_by_id: dict[str, Geoname] | None = None,
+        metrics: DownloadMetrics | None = None,
+    ) -> None:
+        """Initialize the state."""
+        self.geonames = geonames or []
+        self.geonames_by_id = geonames_by_id or {}
+        self.metrics = metrics or DownloadMetrics()
+
+    def __repr__(self) -> str:
+        return str(vars(self))
+
+    def __eq__(self, other) -> bool:
+        return isinstance(other, DownloadState) and vars(self) == vars(other)
+
+
+class GeonamesDownloader:
+    """Downloads geonames and alternates for the cities and regions of a given
+    country from the GeoNames server.
+
+    Usage:
+
+    downloader = GeonamesDownloader(
+        base_url="https://download.geonames.org/",
+        geonames_path="/export/dump/{country_code}.zip",
+        alternates_path="/export/dump/alternatenames/{country_code}.zip",
+        country_code="US",
+        alternates_iso_languages=["en", "en-US", "iata", "icao", "faac", "abbr"],
+        population_threshold=100_000,
+    )
+    state = downloader.download()
+    for geoname in state.geonames:
+        print(geoname)
+
+    """
+
+    base_url: str
+    geonames_path: str
+    alternates_path: str
+    country_code: str
+    population_threshold: int
+    alternates_iso_languages: set[str]
+
+    def __init__(
+        self,
+        base_url: str,
+        geonames_path: str,
+        alternates_path: str,
+        country_code: str,
+        population_threshold: int,
+        alternates_iso_languages: list[str],
+    ):
+        """Initialize the downloader for a given country.
+
+        `base_url` is the base URL of the GeoNames server.
+
+        `geonames_path` and `alternates_path` are the full paths on the server
+        of country-specific geonames and alternates. It's assumed that both
+        paths are format strings that include a `country_code` variable.
+
+        `country_code` is an ISO-3166 uppercase two-letter code that indicates
+        the country of the geonames to download, e.g., "US".
+
+        `population_threshold` specifies how large a geoname's population must
+        be for it to be included in the output. Geonames with populations at
+        least this large will be included.
+
+        `alternates_iso_languages` specifies which alternates of selected
+        geonames to include in the output. Alternates are categorized by
+        language, like "en" and "en-US", plus a few other categories like
+        abbreviations ("abbr") and airport codes ("iata", "icao", "faac") (see
+        documentation link above). `alternates_iso_languages` should contain all
+        such categories you want to include in the output.
+
+        """
+        self.base_url = base_url
+        self.geonames_path = geonames_path
+        self.alternates_path = alternates_path
+        self.country_code = country_code
+        self.population_threshold = population_threshold
+        self.geonames = None
+        self.geonames_ids = None
+        self.alternates_iso_languages = set(alternates_iso_languages)
+
+    def download(self) -> DownloadState:
+        """Download selected geonames and alternates."""
+        state = self.download_geonames()
+        total_geonames_count = len(state.geonames) + state.metrics.excluded_geonames_count
+        logger.info(f"{len(state.geonames)} of {total_geonames_count} eligible geonames selected")
+        self.download_alternates(state)
+        logger.info(f"{state.metrics.included_alternates_count} alternates selected")
+        return state
+
+    def download_geonames(self) -> DownloadState:
+        """Download geonames only."""
+        url = urljoin(self.base_url, self.geonames_path.format(country_code=self.country_code))
+        return self._download(url, DownloadState(), self._process_geoname)
+
+    def download_alternates(self, state: DownloadState) -> DownloadState:
+        """Download alternates only."""
+        url = urljoin(self.base_url, self.alternates_path.format(country_code=self.country_code))
+        return self._download(url, state, self._process_alternate)
+
+    def _process_geoname(self, line: list[str], state: DownloadState) -> None:
+        geoname_id = line[GEONAME_COL_ID]
+        feature_class = line[GEONAME_COL_FEATURE_CLASS]
+        feature_code = line[GEONAME_COL_FEATURE_CODE]
+        population = int(line[GEONAME_COL_POPULATION])
+        is_city = feature_class == FEATURE_CLASS_CITY
+        is_region = feature_class == FEATURE_CLASS_REGION and feature_code == FEATURE_CODE_REGION
+        if is_city or is_region:
+            if population >= self.population_threshold:
+                geoname = Geoname(
+                    id=geoname_id,
+                    name=line[GEONAME_COL_NAME],
+                    feature_class=feature_class,
+                    feature_code=feature_code,
+                    country_code=line[GEONAME_COL_COUNTRY_CODE],
+                    admin1_code=line[GEONAME_COL_ADMIN1_CODE],
+                    population=population,
+                )
+                state.geonames.append(geoname)
+                state.geonames_by_id[geoname_id] = geoname
+            else:
+                state.metrics.excluded_geonames_count += 1
+
+    def _process_alternate(self, line: list[str], state: DownloadState) -> None:
+        geoname_id = line[ALTERNATES_COL_GEONAME_ID]
+        iso_language = line[ALTERNATES_COL_ISO_LANGUAGE]
+        name = line[ALTERNATES_COL_NAME]
+        geoname = state.geonames_by_id.get(geoname_id, None)
+        if geoname and iso_language in self.alternates_iso_languages:
+            geoname.alternate_names.add(name.casefold())
+            state.metrics.included_alternates_count += 1
+
+    def _download(
+        self,
+        url: str,
+        state: DownloadState,
+        process_item: Callable[[list[str], DownloadState], None],
+    ) -> DownloadState:
+        logger.info(f"Sending request: {url}")
+        resp = requests.get(url, stream=True)  # nosec
+        resp.raise_for_status()
+        content_len = resp.headers.get("content-length", "???")
+        logger.info(f"Downloading {url} ({content_len} bytes)...")
+        with TempZipFile(resp.raw) as zip_file:
+            txt_filename = f"{self.country_code}.txt"
+            logger.info(f"Extracting {txt_filename} from {url}...")
+            txt_path = zip_file.extract(txt_filename)
+            logger.info(f"Opening {txt_filename} from {url}...")
+            with open(txt_path, newline="", encoding="utf-8-sig") as txt_file:
+                reader = csv.reader(txt_file, dialect="excel-tab")
+                for line in reader:
+                    process_item(line, state)
+        return state

--- a/merino/jobs/geonames_uploader/tempzipfile.py
+++ b/merino/jobs/geonames_uploader/tempzipfile.py
@@ -1,0 +1,61 @@
+"""Utilities for writing zip files to a temporary directory and extracting
+items from them.
+"""
+
+from io import BufferedRandom
+from tempfile import TemporaryDirectory, TemporaryFile
+from typing import Any
+from zipfile import ZipFile
+
+
+class TempZipFile:
+    """This class writes a zip file to a temporary directory and extracts its
+    items to the directory. This is useful when streaming large zip files from
+    the web, for example, that you don't want to keep in memory all at once.
+
+    Usage:
+
+    # `file_like_obj` might be a streaming HTTP response.
+    with TempZipFile(file_like_obj) as zip_file:
+        txt_path = zip_file.extract("foo.txt")
+        with open(txt_path) as txt_file:
+            print(txt_file.read())
+
+    """
+
+    tmp_dir: TemporaryDirectory
+    tmp_file: BufferedRandom
+    zip_file: ZipFile
+
+    def __init__(self, file_obj: Any) -> None:
+        """Write `file_obj` to a temporary directory and initialize the zip
+        file.
+
+        """
+        self.tmp_dir = TemporaryDirectory()
+        self.tmp_file = TemporaryFile(dir=self.tmp_dir.name)
+        read_len = -1
+        while read_len != 0:
+            chunk = file_obj.read()
+            read_len = len(chunk)
+            self.tmp_file.write(chunk)
+        self.zip_file = ZipFile(self.tmp_file)
+
+    def extract(self, item_name: str) -> str:
+        """Extract an item named `item_name` to the temporary directory and
+        return the path to it.
+
+        """
+        return self.zip_file.extract(item_name, path=self.tmp_dir.name)
+
+    def close(self) -> None:
+        """Clean up."""
+        self.zip_file.close()
+        self.tmp_file.close()
+        self.tmp_dir.cleanup()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()

--- a/merino/jobs/relevancy_uploader/__init__.py
+++ b/merino/jobs/relevancy_uploader/__init__.py
@@ -290,13 +290,13 @@ async def _upload_file_object(
             dry_run=dry_run,
             record_type=RELEVANCY_RECORD_TYPE,
             server=server,
-            total_data_count=len(data[category]),
+            total_item_count=len(data[category]),
             category_name=category.name,
             category_code=category.value,
             version=version,
         ) as uploader:
             for domain in domains:
-                uploader.add_data(domain)
+                uploader.add_item(domain)
 
 
 def _read_categories_data(file_path) -> dict:

--- a/merino/jobs/relevancy_uploader/chunked_rs_uploader.py
+++ b/merino/jobs/relevancy_uploader/chunked_rs_uploader.py
@@ -27,7 +27,7 @@ class ChunkedRemoteSettingsRelevancyUploader(ChunkedRemoteSettingsUploader):
         version: int,
         allow_delete: bool = True,
         dry_run: bool = False,
-        total_data_count: int | None = None,
+        total_item_count: int | None = None,
     ):
         """Initialize the uploader."""
         super().__init__(
@@ -39,7 +39,7 @@ class ChunkedRemoteSettingsRelevancyUploader(ChunkedRemoteSettingsUploader):
             server,
             allow_delete,
             dry_run,
-            total_data_count,
+            total_item_count,
         )
         self.category_name = category_name
         self.category_code = category_code
@@ -65,7 +65,7 @@ class ChunkedRemoteSettingsRelevancyUploader(ChunkedRemoteSettingsUploader):
         """Create a record and attachment for a chunk."""
         # The record ID will be "{record_type}-{start}-{end}", where `start` and
         # `end` are zero-padded based on the total suggestion count.
-        places = 0 if not self.total_data_count else len(str(self.total_data_count))
+        places = 0 if not self.total_item_count else len(str(self.total_item_count))
         start = f"{chunk.start_index:0{places}}"
         end = f"{chunk.start_index + chunk.size:0{places}}"
         record_id = "-".join([self.category_name, start, end])
@@ -80,7 +80,7 @@ class ChunkedRemoteSettingsRelevancyUploader(ChunkedRemoteSettingsUploader):
                 }
             },
         }
-        attachment_json = json.dumps(chunk.data)
+        attachment_json = json.dumps(chunk.to_json_serializable())
 
         logger.info(f"Uploading record: {record}")
         if not self.dry_run:

--- a/merino/jobs/utils/chunked_rs_uploader.py
+++ b/merino/jobs/utils/chunked_rs_uploader.py
@@ -12,23 +12,38 @@ logger = logging.getLogger(__name__)
 
 
 class Chunk:
-    """A chunk of suggestions to be uploaded in a single attachment."""
+    """A chunk of items to be uploaded in a single attachment. Can be subclassed
+    to support specialized chunk types and handling.
+
+    """
 
     start_index: int
-    data: list[dict[str, Any]]
+    items: list[Any]
+
+    @staticmethod
+    def item_to_json_serializable(item: Any) -> Any:
+        """Convert the item to a JSON serializable object."""
+        return item
 
     def __init__(self, start_index: int):
         self.start_index = start_index
-        self.data = []
-
-    def add_data(self, data: dict[str, Any]) -> None:
-        """Add data to the chunk."""
-        self.data.append(data)
+        self.items = []
 
     @property
     def size(self) -> int:
-        """Return the length of the data."""
-        return len(self.data)
+        """Return the number of items in the chunk."""
+        return len(self.items)
+
+    def add_item(self, item: Any) -> None:
+        """Add an item to the chunk."""
+        self.items.append(self.item_to_json_serializable(item))
+
+    def to_json_serializable(self) -> Any:
+        """Convert the chunk to a JSON serializable object that will be stored
+        in the chunk's attachment.
+
+        """
+        return self.items
 
 
 @dataclass
@@ -47,10 +62,10 @@ class DeletionNotAllowed(Exception):
 
 
 class ChunkedRemoteSettingsUploader:
-    """A class that uploads data (e.g. suggestions of relevancy inputs) to remote
-    settings. Data is uploaded and stored in chunks. Chunking is handled
-    automatically, and the caller only needs to specify a chunk size and call
-    `add_data()` until all data has been added:
+    """A class that uploads items to remote settings. Items are uploaded and
+    stored in chunks. Chunking is handled automatically, and the caller only
+    needs to specify a chunk size and call `add_item()` until all items haveq
+    been added:
 
         with ChunkedRemoteSettingsUploader(
             chunk_size=200,
@@ -61,25 +76,25 @@ class ChunkedRemoteSettingsUploader:
             server="http://example.com/",
             total_suggestion_count=1234
         ) as uploader:
-            for s in my_data:
-                uploader.add_data(s)
+            for i in my_items:
+                uploader.add_item(i)
 
     This class can be used with any type of data regardless of schema. The
-    values passed to `add_data()` are dictionaries that can contain
+    values passed to `add_item()` are dictionaries that can contain
     anything. However, the dictionaries must be JSON serializable, i.e., they
     must be able to be passed to `json.dumps()`. It's the consumer's
     responsibility to convert unserializable dicts to serializable dicts before
     passing them to the uploader.
 
     For each chunk, the uploader will create a record with an attachment. The
-    record represents the chunk and the attachment contains the chunk's
-    data as JSON. All chunks will contain the number of data
-    specified by the uploader's `chunk_size` except possibly the final chunk,
-    which may contain fewer suggestions.
+    record represents the chunk and the attachment contains the chunk's data as
+    JSON. All chunks will contain the number of items specified by the
+    uploader's `chunk_size` except possibly the final chunk, which may contain
+    fewer items.
 
     Each record's "id" will encode the uploader's `record_type` and the range of
-    data contained in the record's chunk, and its "type" will be the
-    uploader's `record_type`, like this:
+    items contained in the record's chunk, and its "type" will be the uploader's
+    `record_type`, like this:
 
         {
             "id": f"{uploader.record_type}-{chunk.start_index}-{chunk.start_index + chunk.size}",
@@ -91,8 +106,8 @@ class ChunkedRemoteSettingsUploader:
 
         { "id": "my-record-type-400-600", "type": "my-record-type" }
 
-    The record's attachment will be the list of data in the chunk as JSON
-    (MIME type "application/json").
+    The record's attachment will be the list of items in the chunk as JSON (MIME
+    type "application/json").
 
     It's common to delete existing suggestions before uploading new ones, so as
     a convenience the uploader can also delete all records of its `record_type`:
@@ -101,12 +116,13 @@ class ChunkedRemoteSettingsUploader:
 
     """
 
+    chunk_cls: type[Chunk]
     chunk_size: int
     current_chunk: Chunk
     dry_run: bool
     kinto: kinto_http.Client
     record_type: str
-    total_data_count: int | None
+    total_item_count: int | None
     # Records to add/update/delete in Kinto.  Keyed by record ID.  None indicates deletion.
     _kinto_changes: dict[str, KintoRecordUpdate | None]
 
@@ -120,25 +136,31 @@ class ChunkedRemoteSettingsUploader:
         server: str,
         allow_delete: bool = False,
         dry_run: bool = False,
-        total_data_count: int | None = None,
+        total_item_count: int | None = None,
+        chunk_cls: type[Chunk] = Chunk,
     ):
         """Initialize the uploader."""
+        self.chunk_cls = chunk_cls
         self.chunk_size = chunk_size
-        self.current_chunk = Chunk(0)
+        self.current_chunk = chunk_cls(0)
         self.allow_delete = allow_delete
         self.dry_run = dry_run
         self.record_type = record_type
-        self.total_data_count = total_data_count
-        self.kinto = kinto_http.Client(
-            server_url=server, bucket=bucket, collection=collection, auth=auth
-        )
+        self.total_item_count = total_item_count
         self._kinto_changes = {}
+        if dry_run:
+            self.kinto = None
+        else:
+            self.kinto = kinto_http.Client(
+                server_url=server, bucket=bucket, collection=collection, auth=auth
+            )
 
-    def add_data(self, data: dict[str, Any]) -> None:
-        """Add data to the current_chunk. If the current chunk becomes full as a result, it
-        will be uploaded before this method returns.
+    def add_item(self, item: dict[str, Any]) -> None:
+        """Add an item to the current_chunk. If the chunk becomes full as a
+        result, it will be uploaded before this method returns.
+
         """
-        self.current_chunk.add_data(data)
+        self.current_chunk.add_item(item)
         if self.current_chunk.size == self.chunk_size:
             self._finish_current_chunk()
 
@@ -174,8 +196,14 @@ class ChunkedRemoteSettingsUploader:
             if not self.dry_run:
                 self.kinto.update_record(data=change.record_data)
 
-            logger.info(f"Uploading attachment json with {change.chunk_size} suggestions")
-            logger.debug(change.attachment_json)
+            # The logger apparently formats the message even when no args are
+            # passed, and if `attachment_json` is an object literal (as opposed
+            # to an array literal), the curly braces must confuse it because it
+            # ends up logging nothing at all. Adding a trailing space seems to
+            # prevent that.
+            logger.info(f"Uploading attachment json with {change.chunk_size} items")
+            logger.debug(change.attachment_json + " ")
+
             if not self.dry_run:
                 self.kinto.session.request(
                     "post",
@@ -202,9 +230,10 @@ class ChunkedRemoteSettingsUploader:
         `record_type`.
         """
         logger.info(f"Deleting records with type: {self.record_type}")
-        for record in self.kinto.get_records():
-            if record.get("type") == self.record_type:
-                self._kinto_changes[record["id"]] = None
+        if not self.dry_run:
+            for record in self.kinto.get_records():
+                if record.get("type") == self.record_type:
+                    self._kinto_changes[record["id"]] = None
 
     def _finish_current_chunk(self) -> None:
         """If the current chunk is not empty, upload it and create a new empty
@@ -212,13 +241,15 @@ class ChunkedRemoteSettingsUploader:
         """
         if self.current_chunk.size:
             self._upload_chunk(self.current_chunk)
-            self.current_chunk = Chunk(self.current_chunk.start_index + self.current_chunk.size)
+            self.current_chunk = self.chunk_cls(
+                self.current_chunk.start_index + self.current_chunk.size
+            )
 
     def _upload_chunk(self, chunk: Chunk) -> None:
         """Create a record and attachment for a chunk."""
         # The record ID will be "{record_type}-{start}-{end}", where `start` and
         # `end` are zero-padded based on the total suggestion count.
-        places = 0 if not self.total_data_count else len(str(self.total_data_count))
+        places = 0 if not self.total_item_count else len(str(self.total_item_count))
         start = f"{chunk.start_index:0{places}}"
         end = f"{chunk.start_index + chunk.size:0{places}}"
         record_id = "-".join([self.record_type, start, end])
@@ -226,7 +257,7 @@ class ChunkedRemoteSettingsUploader:
             "id": record_id,
             "type": self.record_type,
         }
-        attachment_json = json.dumps(chunk.data)
+        attachment_json = json.dumps(chunk.to_json_serializable())
 
         self._kinto_changes[record_id] = KintoRecordUpdate(
             record_data=record,

--- a/tests/unit/jobs/amo_rs_uploader/test_amo_rs_uploader.py
+++ b/tests/unit/jobs/amo_rs_uploader/test_amo_rs_uploader.py
@@ -119,7 +119,7 @@ def do_upload_test(
     mock_chunked_uploader_ctor.assert_called_once_with(
         **common_kwargs,
         suggestion_score_fallback=score,
-        total_data_count=TEST_ADDON_COUNT,
+        total_item_count=TEST_ADDON_COUNT,
     )
 
     if not keep_existing_records:

--- a/tests/unit/jobs/csv_rs_uploader/test_csv_rs_uploader.py
+++ b/tests/unit/jobs/csv_rs_uploader/test_csv_rs_uploader.py
@@ -83,7 +83,7 @@ def test_upload_without_deleting(mocker):
 
 
 def test_delete_and_upload(mocker):
-    """upload(keep_existing_records=True) with the primary CSV test data"""
+    """upload(keep_existing_records=False) with the primary CSV test data"""
     do_csv_test(
         mocker=mocker,
         csv_path=PRIMARY_CSV_PATH,

--- a/tests/unit/jobs/csv_rs_uploader/utils.py
+++ b/tests/unit/jobs/csv_rs_uploader/utils.py
@@ -67,7 +67,7 @@ def _do_csv_test(
         **common_kwargs,
         record_type=expected_record_type,
         suggestion_score_fallback=score,
-        total_data_count=len(expected_suggestions),
+        total_item_count=len(expected_suggestions),
     )
 
     if not keep_existing_records:

--- a/tests/unit/jobs/geonames_uploader/test_downloader.py
+++ b/tests/unit/jobs/geonames_uploader/test_downloader.py
@@ -1,0 +1,507 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Unit tests for downloader.py module."""
+
+import csv
+import pytest
+
+from io import BufferedReader
+
+from tempfile import NamedTemporaryFile
+from zipfile import ZipFile
+
+from merino.jobs.geonames_uploader.downloader import (
+    GEONAME_COL_ID,
+    GEONAME_COL_NAME,
+    GEONAME_COL_FEATURE_CLASS,
+    GEONAME_COL_FEATURE_CODE,
+    GEONAME_COL_COUNTRY_CODE,
+    GEONAME_COL_ADMIN1_CODE,
+    GEONAME_COL_POPULATION,
+    MAX_GEONAME_COL,
+    ALTERNATES_COL_GEONAME_ID,
+    ALTERNATES_COL_ISO_LANGUAGE,
+    ALTERNATES_COL_NAME,
+    MAX_ALTERNATES_COL,
+    DownloadMetrics,
+    DownloadState,
+    Geoname,
+    GeonamesDownloader,
+)
+
+
+class GeonameAlternate:
+    """Geoname alternate"""
+
+    geoname_id: str
+    iso_language: str
+    name: str
+
+    def __init__(
+        self,
+        geoname_id: str,
+        iso_language: str,
+        name: str,
+    ):
+        self.geoname_id = geoname_id
+        self.iso_language = iso_language
+        self.name = name
+
+
+GEONAMES = [
+    # Waterloo, AL
+    Geoname(
+        id="1",
+        name="Waterloo",
+        feature_class="P",
+        feature_code="PPL",
+        country_code="US",
+        admin1_code="AL",
+        population=200,
+    ),
+    # AL
+    Geoname(
+        id="2",
+        name="Alabama",
+        feature_class="A",
+        feature_code="ADM1",
+        country_code="US",
+        admin1_code="AL",
+        population=4530315,
+    ),
+    # Waterloo, IA
+    Geoname(
+        id="3",
+        name="Waterloo",
+        feature_class="P",
+        feature_code="PPLA2",
+        country_code="US",
+        admin1_code="IA",
+        population=68460,
+    ),
+    # IA
+    Geoname(
+        id="4",
+        name="Iowa",
+        feature_class="A",
+        feature_code="ADM1",
+        country_code="US",
+        admin1_code="IA",
+        population=2955010,
+    ),
+    # Waterloo Lake (not a city or region)
+    Geoname(
+        id="5",
+        name="Waterloo Lake",
+        feature_class="H",
+        feature_code="LK",
+        country_code="US",
+        admin1_code="TX",
+        population=0,
+    ),
+    # New York City
+    Geoname(
+        id="6",
+        name="New York City",
+        feature_class="P",
+        feature_code="PPL",
+        country_code="US",
+        admin1_code="NY",
+        population=8804190,
+    ),
+    # NY State
+    Geoname(
+        id="7",
+        name="New York",
+        feature_class="A",
+        feature_code="ADM1",
+        country_code="US",
+        admin1_code="NY",
+        population=19274244,
+    ),
+]
+
+ALTERNATES = [
+    # Waterloo, AL
+    GeonameAlternate(
+        geoname_id="1",
+        name="Waterloo",
+        iso_language="en",
+    ),
+    # AL
+    GeonameAlternate(
+        geoname_id="2",
+        name="AL",
+        iso_language="abbr",
+    ),
+    # Waterloo, IA
+    GeonameAlternate(
+        geoname_id="3",
+        name="Waterloo",
+        iso_language="en",
+    ),
+    # IA
+    GeonameAlternate(
+        geoname_id="4",
+        name="IA",
+        iso_language="abbr",
+    ),
+    # Waterloo Lake
+    GeonameAlternate(
+        geoname_id="5",
+        name="Waterloo",
+        iso_language="en",
+    ),
+    GeonameAlternate(
+        geoname_id="5",
+        name="W. Lake",
+        iso_language="en-US",
+    ),
+    # New York City
+    GeonameAlternate(
+        geoname_id="6",
+        name="New York",
+        iso_language="en",
+    ),
+    GeonameAlternate(
+        geoname_id="6",
+        name="NY",
+        iso_language="abbr",
+    ),
+    GeonameAlternate(
+        geoname_id="6",
+        name="NYC",
+        iso_language="abbr",
+    ),
+    GeonameAlternate(
+        geoname_id="6",
+        name="LGA",
+        iso_language="iata",
+    ),
+    GeonameAlternate(
+        geoname_id="6",
+        name="Nueva York",
+        iso_language="es",
+    ),
+    # NY State
+    GeonameAlternate(
+        geoname_id="7",
+        name="NY",
+        iso_language="abbr",
+    ),
+    GeonameAlternate(
+        geoname_id="7",
+        name="Nueva York",
+        iso_language="es",
+    ),
+]
+
+
+class DownloaderTest:
+    """Downloader test fixture"""
+
+    geonames: BufferedReader
+    alternates: BufferedReader
+
+    def __init__(self) -> None:
+        """Initialize test"""
+        self.geonames = self.make_geonames_zip(GEONAMES)
+        self.alternates = self.make_alternates_zip(ALTERNATES)
+
+    def run(
+        self,
+        requests_mock,
+        population_threshold: int,
+        alternates_iso_languages: list[str],
+        expected_geonames: list[Geoname],
+        expected_metrics: DownloadMetrics,
+    ) -> None:
+        """Run test"""
+        requests_mock.get("https://localhost/US.zip", body=self.geonames)
+        requests_mock.get("https://localhost/alternates/US.zip", body=self.alternates)
+
+        downloader = GeonamesDownloader(
+            base_url="https://localhost",
+            geonames_path="/{country_code}.zip",
+            alternates_path="/alternates/{country_code}.zip",
+            country_code="US",
+            alternates_iso_languages=alternates_iso_languages,
+            population_threshold=population_threshold,
+        )
+        state = downloader.download()
+
+        self.assert_state(state, expected_geonames, expected_metrics)
+        self.clean_up()
+
+    def assert_state(
+        self,
+        actual_state: DownloadState,
+        expected_geonames: list[Geoname],
+        expected_metrics: DownloadMetrics,
+    ) -> None:
+        """Assert download state is equal to expected state"""
+        state = DownloadState()
+        state.geonames = expected_geonames
+        state.geonames_by_id = {g.id: g for g in expected_geonames}
+        state.metrics = expected_metrics
+        assert actual_state == state
+
+    def make_geonames_zip(self, geonames: list[Geoname]) -> BufferedReader:
+        """Create a geonames zip file"""
+        rows = []
+        for g in geonames:
+            row = [""] * (MAX_GEONAME_COL + 1)
+            row[GEONAME_COL_ID] = g.id
+            row[GEONAME_COL_NAME] = g.name
+            row[GEONAME_COL_FEATURE_CLASS] = g.feature_class
+            row[GEONAME_COL_FEATURE_CODE] = g.feature_code
+            row[GEONAME_COL_COUNTRY_CODE] = g.country_code
+            row[GEONAME_COL_ADMIN1_CODE] = g.admin1_code
+            row[GEONAME_COL_POPULATION] = str(g.population)
+            rows.append(row)
+        return self.make_zip(rows, "US.txt")
+
+    def make_alternates_zip(self, alternates: list[GeonameAlternate]) -> BufferedReader:
+        """Create a geonames alternates zip file"""
+        rows = []
+        for a in alternates:
+            row = [""] * (MAX_ALTERNATES_COL + 1)
+            row[ALTERNATES_COL_GEONAME_ID] = a.geoname_id
+            row[ALTERNATES_COL_ISO_LANGUAGE] = a.iso_language
+            row[ALTERNATES_COL_NAME] = a.name
+            rows.append(row)
+        return self.make_zip(rows, "US.txt")
+
+    def make_zip(self, tsv_rows: list[list[str]], arcname: str) -> BufferedReader:
+        """Create a zip file in a temporary directory with a single tsv item"""
+        # Open a temporary tsv file and write the rows to it.
+        tmp_tsv_file = NamedTemporaryFile(mode="wt", encoding="utf-8", delete_on_close=False)
+        writer = csv.writer(tmp_tsv_file, dialect="excel-tab")
+        for row in tsv_rows:
+            writer.writerow(row)
+        tmp_tsv_file.close()
+        # Create a new zip file and add the tsv file to it.
+        tmp_zip_file = NamedTemporaryFile(delete_on_close=False)
+        zip_file = ZipFile(tmp_zip_file, mode="w")
+        zip_file.write(tmp_tsv_file.name, arcname)
+        # Close the zip file, reopen it, and return it.
+        zip_file.close()
+        return open(tmp_zip_file.name, mode="rb")
+
+    def clean_up(self) -> None:
+        """Tear down the test"""
+        self.geonames.close()
+        self.alternates.close()
+
+
+@pytest.fixture()
+def downloader_test() -> DownloaderTest:
+    """Return downloader test fixture"""
+    return DownloaderTest()
+
+
+def test_all_populations_and_iso_languages(
+    requests_mock,
+    downloader_test: DownloaderTest,
+):
+    """Request geonames with populations > 0 and alternates of all ISO languages
+    in the datset
+
+    """
+    downloader_test.run(
+        requests_mock,
+        population_threshold=1,
+        alternates_iso_languages=["en", "abbr", "iata"],
+        expected_geonames=[
+            Geoname(
+                id="1",
+                name="Waterloo",
+                feature_class="P",
+                feature_code="PPL",
+                country_code="US",
+                admin1_code="AL",
+                population=200,
+                alternate_names=set(["waterloo"]),
+            ),
+            Geoname(
+                id="2",
+                name="Alabama",
+                feature_class="A",
+                feature_code="ADM1",
+                country_code="US",
+                admin1_code="AL",
+                population=4530315,
+                alternate_names=set(["alabama", "al"]),
+            ),
+            Geoname(
+                id="3",
+                name="Waterloo",
+                feature_class="P",
+                feature_code="PPLA2",
+                country_code="US",
+                admin1_code="IA",
+                population=68460,
+                alternate_names=set(["waterloo"]),
+            ),
+            Geoname(
+                id="4",
+                name="Iowa",
+                feature_class="A",
+                feature_code="ADM1",
+                country_code="US",
+                admin1_code="IA",
+                population=2955010,
+                alternate_names=set(["iowa", "ia"]),
+            ),
+            Geoname(
+                id="6",
+                name="New York City",
+                feature_class="P",
+                feature_code="PPL",
+                country_code="US",
+                admin1_code="NY",
+                population=8804190,
+                alternate_names=set(["new york city", "new york", "ny", "nyc", "lga"]),
+            ),
+            Geoname(
+                id="7",
+                name="New York",
+                feature_class="A",
+                feature_code="ADM1",
+                country_code="US",
+                admin1_code="NY",
+                population=19274244,
+                alternate_names=set(["new york", "ny"]),
+            ),
+        ],
+        expected_metrics=DownloadMetrics(
+            # No excluded cities or regions
+            excluded_geonames_count=0,
+            included_alternates_count=9,
+        ),
+    )
+
+
+def test_one_million_population_and_all_iso_languages(
+    requests_mock,
+    downloader_test: DownloaderTest,
+):
+    """Request geonames with populations > one million and alternates of all ISO
+    languages in the datset
+
+    """
+    downloader_test.run(
+        requests_mock,
+        population_threshold=1_000_000,
+        alternates_iso_languages=["en", "abbr", "iata"],
+        expected_geonames=[
+            Geoname(
+                id="2",
+                name="Alabama",
+                feature_class="A",
+                feature_code="ADM1",
+                country_code="US",
+                admin1_code="AL",
+                population=4530315,
+                alternate_names=set(["alabama", "al"]),
+            ),
+            Geoname(
+                id="4",
+                name="Iowa",
+                feature_class="A",
+                feature_code="ADM1",
+                country_code="US",
+                admin1_code="IA",
+                population=2955010,
+                alternate_names=set(["iowa", "ia"]),
+            ),
+            Geoname(
+                id="6",
+                name="New York City",
+                feature_class="P",
+                feature_code="PPL",
+                country_code="US",
+                admin1_code="NY",
+                population=8804190,
+                alternate_names=set(["new york city", "new york", "ny", "nyc", "lga"]),
+            ),
+            Geoname(
+                id="7",
+                name="New York",
+                feature_class="A",
+                feature_code="ADM1",
+                country_code="US",
+                admin1_code="NY",
+                population=19274244,
+                alternate_names=set(["new york", "ny"]),
+            ),
+        ],
+        expected_metrics=DownloadMetrics(
+            # No Waterloo, AL or Waterloo, IA
+            excluded_geonames_count=2,
+            included_alternates_count=7,
+        ),
+    )
+
+
+def test_one_million_population_and_en_only(
+    requests_mock,
+    downloader_test: DownloaderTest,
+):
+    """Request geonames with populations > one million and "en" alternates only"""
+    downloader_test.run(
+        requests_mock,
+        population_threshold=1_000_000,
+        alternates_iso_languages=["en"],
+        expected_geonames=[
+            Geoname(
+                id="2",
+                name="Alabama",
+                feature_class="A",
+                feature_code="ADM1",
+                country_code="US",
+                admin1_code="AL",
+                population=4530315,
+                alternate_names=set(["alabama"]),
+            ),
+            Geoname(
+                id="4",
+                name="Iowa",
+                feature_class="A",
+                feature_code="ADM1",
+                country_code="US",
+                admin1_code="IA",
+                population=2955010,
+                alternate_names=set(["iowa"]),
+            ),
+            Geoname(
+                id="6",
+                name="New York City",
+                feature_class="P",
+                feature_code="PPL",
+                country_code="US",
+                admin1_code="NY",
+                population=8804190,
+                alternate_names=set(["new york city", "new york"]),
+            ),
+            Geoname(
+                id="7",
+                name="New York",
+                feature_class="A",
+                feature_code="ADM1",
+                country_code="US",
+                admin1_code="NY",
+                population=19274244,
+                alternate_names=set(["new york"]),
+            ),
+        ],
+        expected_metrics=DownloadMetrics(
+            # No Waterloo, AL or Waterloo, IA
+            excluded_geonames_count=2,
+            # Only "new york" for New York City, other values in
+            # `altername_names` are lowercased versions of `name`
+            included_alternates_count=1,
+        ),
+    )

--- a/tests/unit/jobs/geonames_uploader/test_geonames_uploader.py
+++ b/tests/unit/jobs/geonames_uploader/test_geonames_uploader.py
@@ -1,0 +1,123 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Unit tests for __init__.py module."""
+
+from typing import Any
+
+from merino.jobs.geonames_uploader.downloader import (
+    DownloadMetrics,
+    DownloadState,
+    Geoname,
+)
+from merino.jobs.geonames_uploader import GeonamesChunk, upload
+
+
+def do_uploader_test(
+    mocker,
+    geonames: list[Geoname],
+    keep_existing_records: bool = True,
+) -> None:
+    """Perform a geonames upload test."""
+    # Mock the geonames downloader.
+    mock_downloader_ctor = mocker.patch("merino.jobs.geonames_uploader.GeonamesDownloader")
+    mock_downloader = mock_downloader_ctor.return_value
+    mock_downloader.download.return_value = DownloadState(
+        geonames=geonames,
+        geonames_by_id={g.id: g for g in geonames},
+        metrics=DownloadMetrics(
+            excluded_geonames_count=0,
+            included_alternates_count=0,
+        ),
+    )
+
+    # Mock the chunked uploader.
+    mock_chunked_uploader_ctor = mocker.patch(
+        "merino.jobs.geonames_uploader.ChunkedRemoteSettingsUploader"
+    )
+    mock_chunked_uploader = mock_chunked_uploader_ctor.return_value.__enter__.return_value
+
+    # Do the upload.
+    upload_kwargs: dict[str, Any] = {
+        "auth": "auth",
+        "bucket": "bucket",
+        "chunk_size": 99,
+        "collection": "collection",
+        "dry_run": False,
+        "record_type": "geonames",
+        "server": "server",
+    }
+    downloader_kwargs: dict[str, Any] = {
+        "alternates_path": "/alternates/{country_code}.zip",
+        "base_url": "https://localhost",
+        "country_code": "US",
+        "geonames_path": "/{country_code}.zip",
+        "alternates_iso_languages": ["en", "abbr", "iata"],
+        "population_threshold": 12345,
+    }
+
+    upload(
+        **upload_kwargs,
+        **downloader_kwargs,
+        keep_existing_records=keep_existing_records,
+    )
+
+    # Check geonames downloader calls.
+    mock_downloader_ctor.assert_called_once_with(**downloader_kwargs)
+    mock_downloader.download.assert_called_once()
+
+    # Check chunked uploader calls.
+    mock_chunked_uploader_ctor.assert_called_once_with(
+        **upload_kwargs,
+        allow_delete=True,
+        chunk_cls=GeonamesChunk,
+        total_item_count=len(geonames),
+    )
+
+    if not keep_existing_records:
+        mock_chunked_uploader.delete_records.assert_called_once()
+    else:
+        mock_chunked_uploader.delete_records.assert_not_called()
+
+    mock_chunked_uploader.add_item.assert_has_calls([*map(mocker.call, geonames)])
+
+
+def test_upload_without_deleting(mocker):
+    """upload(keep_existing_records=True)"""
+    do_uploader_test(
+        mocker=mocker,
+        geonames=[
+            Geoname(
+                id="1",
+                name="Waterloo",
+                feature_class="P",
+                feature_code="PPL",
+                country_code="US",
+                admin1_code="AL",
+                population=200,
+                alternate_names=set(["waterloo"]),
+            ),
+        ],
+        keep_existing_records=True,
+    )
+
+
+def test_delete_and_upload(mocker):
+    """upload(keep_existing_records=False)"""
+    do_uploader_test(
+        mocker=mocker,
+        geonames=[
+            Geoname(
+                id="1",
+                name="Waterloo",
+                feature_class="P",
+                feature_code="PPL",
+                country_code="US",
+                admin1_code="AL",
+                population=200,
+                alternate_names=set(["waterloo"]),
+            ),
+        ],
+        keep_existing_records=False,
+    )

--- a/tests/unit/jobs/relevancy_uploader/test_chunked_relevancy_rs_uploader.py
+++ b/tests/unit/jobs/relevancy_uploader/test_chunked_relevancy_rs_uploader.py
@@ -166,7 +166,7 @@ def do_upload_test(
     ) as uploader:
         for i in range(data_count):
             data: dict[str, Any] = {"i": i}
-            uploader.add_data(data)
+            uploader.add_item(data)
 
     check_upload_requests(requests_mock.request_history, expected_records)
 

--- a/tests/unit/jobs/relevancy_uploader/utils.py
+++ b/tests/unit/jobs/relevancy_uploader/utils.py
@@ -78,7 +78,7 @@ def _do_csv_test(
     mock_chunked_uploader_ctor.assert_any_call(
         **common_kwargs,
         record_type="category_to_domains",
-        total_data_count=len(primary_category_data),
+        total_item_count=len(primary_category_data),
         category_name="Sports",
         category_code=17,
     )
@@ -86,7 +86,7 @@ def _do_csv_test(
     mock_chunked_uploader_ctor.assert_any_call(
         **common_kwargs,
         record_type="category_to_domains",
-        total_data_count=len(secondary_category_data),
+        total_item_count=len(secondary_category_data),
         category_name="News",
         category_code=14,
     )
@@ -94,7 +94,7 @@ def _do_csv_test(
     mock_chunked_uploader_ctor.assert_any_call(
         **common_kwargs,
         record_type="category_to_domains",
-        total_data_count=len(inconclusive_category_data),
+        total_item_count=len(inconclusive_category_data),
         category_name="Inconclusive",
         category_code=0,
     )
@@ -104,7 +104,7 @@ def _do_csv_test(
     else:
         mock_chunked_uploader.delete_records.assert_not_called()
 
-    mock_chunked_uploader.add_data.assert_has_calls(
+    mock_chunked_uploader.add_item.assert_has_calls(
         [
             *map(
                 mocker.call,

--- a/tests/unit/jobs/utils/test_chunked_rs_uploader.py
+++ b/tests/unit/jobs/utils/test_chunked_rs_uploader.py
@@ -306,7 +306,7 @@ def test_suggestion_score_fallback_overridden(requests_mock):
     )
 
 
-def test_total_data_count(requests_mock):
+def test_total_item_count(requests_mock):
     """Tests passing a total suggestion count so record IDs contain zero-padded
     start and end indexes.
     """
@@ -316,7 +316,7 @@ def test_total_data_count(requests_mock):
         chunk_size=500,
         suggestion_count=1999,
         uploader_kwargs={
-            "total_data_count": 1999,
+            "total_item_count": 1999,
         },
         expected_records=[
             Record(0, 500, id=f"{record_type}-0000-0500"),


### PR DESCRIPTION
Add a `geonames_uploader` job that downloads data from GeoNames, selects a set of geonames based on the config (like population size), and uploads the selected geonames to remote settings. This supports city-based weather queries on the client and lets the client recognize city and state names.

GeoNames is an open-source geographical database of place names worldwide, including cities, regions, and countries [1]. Technical documentation at [2].

This commit sets the population threshold to 50,000. That results in 1,013 geonames (U.S. cities and states) in the output, which results in 6 records when using the usual 200-items-per-attachment count. That seems reasonable.

[1] https://www.geonames.org/
[2] https://download.geonames.org/export/dump/readme.txt

## References

JIRA: https://mozilla-hub.atlassian.net/browse/SNG-1848

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
