### PR TITLE
[HNT-205] Allow content to be fetched by scheduled date

### DIFF
--- a/merino/curated_recommendations/corpus_backends/protocol.py
+++ b/merino/curated_recommendations/corpus_backends/protocol.py
@@ -59,6 +59,20 @@ class CorpusItem(BaseModel):
 class CorpusBackend(Protocol):
     """Protocol for Curated Recommendation backend that the provider depends on."""
 
-    async def fetch(self, surface_id: ScheduledSurfaceId) -> list[CorpusItem]:  # pragma: no cover
-        """Fetch Curated Recommendations"""
+    async def fetch(
+        self,
+        surface_id: ScheduledSurfaceId,
+        days_offset: int = 0,
+    ) -> list[CorpusItem]:
+        """Fetch corpus items.
+
+        Args:
+            surface_id: Identifies the scheduled surface, for example NEW_TAB_EN_US.
+            days_offset: Optionally, the number of days relative to today for which items were
+                scheduled. A positive value indicates a future day, negative value indicates a past
+                day, and 0 refers to today. Defaults to 0.
+
+        Returns:
+        list[CorpusItem]: A list of fetched corpus items.
+        """
         ...

--- a/tests/integration/api/v1/curated_recommendations/conftest.py
+++ b/tests/integration/api/v1/curated_recommendations/conftest.py
@@ -1,0 +1,6 @@
+"""Module for test configurations for the curated-recommendations integration tests."""
+
+# When the conftest plugin is loaded the following fixtures will be loaded as well.
+pytest_plugins = [
+    "tests.integration.api.v1.curated_recommendations.corpus_backends.fixtures",
+]

--- a/tests/integration/api/v1/curated_recommendations/conftest.py
+++ b/tests/integration/api/v1/curated_recommendations/conftest.py
@@ -1,6 +1,0 @@
-"""Module for test configurations for the curated-recommendations integration tests."""
-
-# When the conftest plugin is loaded the following fixtures will be loaded as well.
-pytest_plugins = [
-    "tests.integration.api.v1.curated_recommendations.corpus_backends.fixtures",
-]

--- a/tests/integration/api/v1/curated_recommendations/corpus_backends/fixtures.py
+++ b/tests/integration/api/v1/curated_recommendations/corpus_backends/fixtures.py
@@ -1,0 +1,75 @@
+"""Pytest fixtures for the Corpus API backend"""
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+from httpx import AsyncClient, Request, Response
+
+from merino.curated_recommendations.corpus_backends.corpus_api_backend import (
+    CorpusApiGraphConfig,
+    CorpusApiBackend,
+)
+from merino.metrics import get_metrics_client
+
+
+@pytest.fixture()
+def fixture_response_data():
+    """Load mock response data for the scheduledSurface query"""
+    with open("tests/data/scheduled_surface.json") as f:
+        return json.load(f)
+
+
+# This fixture is used in tests where recs order is important to check &
+# keeping the list short is easier to manipulate.
+@pytest.fixture()
+def fixture_response_data_short():
+    """Load mock response data (shortened) for the scheduledSurface query"""
+    with open("tests/data/scheduled_surface_short.json") as f:
+        return json.load(f)
+
+
+@pytest.fixture()
+def fixture_graphql_200ok_with_error_response():
+    """Load mock response data for a GraphQL error response"""
+    with open("tests/data/graphql_error.json") as f:
+        return json.load(f)
+
+
+@pytest.fixture()
+def fixture_request_data() -> Request:
+    """Load mock response data for the scheduledSurface query"""
+    graph_config = CorpusApiGraphConfig()
+
+    return Request(
+        method="POST",
+        url=graph_config.endpoint,
+        headers=graph_config.headers,
+        json={"locale": "en-US"},
+    )
+
+
+@pytest.fixture(name="corpus_http_client")
+def fixture_mock_corpus_http_client(fixture_response_data, fixture_request_data) -> AsyncMock:
+    """Mock curated corpus api HTTP client."""
+    # Create a mock HTTP client
+    mock_http_client = AsyncMock(spec=AsyncClient)
+    # Mock the POST request response with the loaded json mock data
+    mock_http_client.post.return_value = Response(
+        status_code=200,
+        json=fixture_response_data,
+        request=fixture_request_data,
+    )
+
+    return mock_http_client
+
+
+@pytest.fixture(name="corpus_backend")
+def fixture_mock_corpus_backend(corpus_http_client: AsyncMock) -> CorpusApiBackend:
+    """Mock corpus api backend."""
+    # Initialize the backend with the mock HTTP client
+    return CorpusApiBackend(
+        http_client=corpus_http_client,
+        graph_config=CorpusApiGraphConfig(),
+        metrics_client=get_metrics_client(),
+    )

--- a/tests/integration/api/v1/curated_recommendations/corpus_backends/fixtures.py
+++ b/tests/integration/api/v1/curated_recommendations/corpus_backends/fixtures.py
@@ -49,8 +49,8 @@ def fixture_request_data() -> Request:
     )
 
 
-@pytest.fixture(name="corpus_http_client")
-def fixture_mock_corpus_http_client(fixture_response_data, fixture_request_data) -> AsyncMock:
+@pytest.fixture()
+def corpus_http_client(fixture_response_data, fixture_request_data) -> AsyncMock:
     """Mock curated corpus api HTTP client."""
     # Create a mock HTTP client
     mock_http_client = AsyncMock(spec=AsyncClient)
@@ -64,8 +64,8 @@ def fixture_mock_corpus_http_client(fixture_response_data, fixture_request_data)
     return mock_http_client
 
 
-@pytest.fixture(name="corpus_backend")
-def fixture_mock_corpus_backend(corpus_http_client: AsyncMock) -> CorpusApiBackend:
+@pytest.fixture()
+def corpus_backend(corpus_http_client: AsyncMock) -> CorpusApiBackend:
     """Mock corpus api backend."""
     # Initialize the backend with the mock HTTP client
     return CorpusApiBackend(

--- a/tests/integration/api/v1/curated_recommendations/corpus_backends/test_corpus_api_backend.py
+++ b/tests/integration/api/v1/curated_recommendations/corpus_backends/test_corpus_api_backend.py
@@ -1,0 +1,105 @@
+"""Integration tests for merino/curated_recommendations/corpus_backends/corpus_api_backend.py"""
+
+from datetime import datetime
+
+import pytest
+from httpx import Response
+from pydantic import HttpUrl
+
+from merino.curated_recommendations.corpus_backends.corpus_api_backend import (
+    CorpusApiBackend,
+)
+from merino.curated_recommendations.corpus_backends.protocol import (
+    ScheduledSurfaceId,
+    CorpusItem,
+    Topic,
+)
+
+
+@pytest.mark.asyncio
+async def test_fetch(corpus_backend: CorpusApiBackend, fixture_response_data):
+    """Test if the fetch method returns data from cache if available."""
+    surface_id = ScheduledSurfaceId.NEW_TAB_EN_US
+
+    # Populate the cache by calling the fetch method
+    results = await corpus_backend.fetch(surface_id)
+
+    assert len(results) == 80
+    assert results[0] == CorpusItem(
+        url=HttpUrl(
+            "https://getpocket.com/explore/item/milk-powder-is-the-key-to-better-cookies-"
+            "brownies-and-cakes?utm_source=pocket-newtab-en-us"
+        ),
+        title="Milk Powder Is the Key to Better Cookies, Brownies, and Cakes",
+        excerpt="Consider this pantry staple your secret ingredient for making more flavorful "
+        "desserts.",
+        topic=Topic.FOOD,
+        publisher="Epicurious",
+        isTimeSensitive=False,
+        imageUrl=HttpUrl(
+            "https://s3.us-east-1.amazonaws.com/pocket-curatedcorpusapi-prod-images/"
+            "40e30ce2-a298-4b34-ab58-8f0f3910ee39.jpeg"
+        ),
+        scheduledCorpusItemId="de614b6b-6df6-470a-97f2-30344c56c1b3",
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "test_input,expected_title",
+    [
+        ({}, "Scheduled items from day 0"),  # Default value is 0
+        ({"days_offset": 0}, "Scheduled items from day 0"),
+        ({"days_offset": -1}, "Scheduled items from day -1"),
+        ({"days_offset": -2}, "Scheduled items from day -2"),
+        ({"days_offset": 1}, "Scheduled items from day 1"),
+    ],
+)
+async def test_fetch_days_since_today(
+    corpus_backend: CorpusApiBackend,
+    fixture_response_data,
+    fixture_response_data_short,
+    fixture_request_data,
+    corpus_http_client,
+    test_input,
+    expected_title,
+):
+    """Test fetch method with days_offset parameter."""
+    surface_id = ScheduledSurfaceId.NEW_TAB_EN_US
+
+    def mock_post_by_date(*args, **kwargs):
+        """Mock scheduledSurface response containing a single item with the schedule date."""
+        variables = kwargs["json"]["variables"]
+        surface_timezone = corpus_backend.get_surface_timezone(variables["scheduledSurfaceId"])
+        date_today = corpus_backend.get_scheduled_surface_date(surface_timezone).date()
+        days_ago = (datetime.strptime(variables.get("date"), "%Y-%m-%d").date() - date_today).days
+        return Response(
+            status_code=200,
+            json={
+                "data": {
+                    "scheduledSurface": {
+                        "items": [
+                            {
+                                "id": "de614b6b-6df6-470a-97f2-30344c56c1b3",
+                                "corpusItem": {
+                                    "url": "https://example.com",
+                                    "title": f"Scheduled items from day {days_ago}",
+                                    "excerpt": "",
+                                    "topic": "FOOD",
+                                    "publisher": "Mozilla",
+                                    "isTimeSensitive": True,
+                                    "imageUrl": "https://example.com/image.jpg",
+                                },
+                            },
+                        ]
+                    }
+                },
+            },
+            request=fixture_request_data,
+        )
+
+    corpus_http_client.post.side_effect = mock_post_by_date
+
+    results = await corpus_backend.fetch(surface_id, **test_input)
+    assert len(results) == 1
+    assert results[0].title == expected_title

--- a/tests/integration/api/v1/curated_recommendations/corpus_backends/test_corpus_api_backend.py
+++ b/tests/integration/api/v1/curated_recommendations/corpus_backends/test_corpus_api_backend.py
@@ -14,6 +14,13 @@ from merino.curated_recommendations.corpus_backends.protocol import (
     CorpusItem,
     Topic,
 )
+from tests.integration.api.v1.curated_recommendations.corpus_backends.fixtures import (
+    fixture_response_data,
+    fixture_response_data_short,
+    fixture_request_data,
+    corpus_http_client,
+    corpus_backend,
+)
 
 
 @pytest.mark.asyncio

--- a/tests/integration/api/v1/curated_recommendations/corpus_backends/test_corpus_api_backend.py
+++ b/tests/integration/api/v1/curated_recommendations/corpus_backends/test_corpus_api_backend.py
@@ -14,13 +14,6 @@ from merino.curated_recommendations.corpus_backends.protocol import (
     CorpusItem,
     Topic,
 )
-from tests.integration.api.v1.curated_recommendations.corpus_backends.fixtures import (
-    fixture_response_data,
-    fixture_response_data_short,
-    fixture_request_data,
-    corpus_http_client,
-    corpus_backend,
-)
 
 
 @pytest.mark.asyncio

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -1,7 +1,6 @@
 """Tests the curated recommendation endpoint /api/v1/curated-recommendations"""
 
 import asyncio
-import json
 from datetime import timedelta, datetime
 from unittest.mock import AsyncMock
 
@@ -9,7 +8,7 @@ import aiodogstatsd
 import freezegun
 import numpy as np
 import pytest
-from httpx import AsyncClient, Request, Response, HTTPStatusError
+from httpx import AsyncClient, Response, HTTPStatusError
 from pydantic import HttpUrl
 from pytest_mock import MockerFixture
 from scipy.stats import linregress
@@ -21,7 +20,6 @@ from merino.curated_recommendations import (
     get_provider,
     ConstantPrior,
 )
-from merino.curated_recommendations.corpus_backends.corpus_api_backend import CorpusApiGraphConfig
 from merino.curated_recommendations.corpus_backends.protocol import Topic
 from merino.curated_recommendations.engagement_backends.protocol import (
     EngagementBackend,
@@ -30,70 +28,6 @@ from merino.curated_recommendations.engagement_backends.protocol import (
 from merino.curated_recommendations.prior_backends.protocol import PriorBackend
 from merino.curated_recommendations.protocol import CuratedRecommendation, ExperimentName
 from merino.main import app
-from merino.metrics import get_metrics_client
-
-
-@pytest.fixture()
-def fixture_response_data():
-    """Load mock response data for the scheduledSurface query"""
-    with open("tests/data/scheduled_surface.json") as f:
-        return json.load(f)
-
-
-# This fixture is used in tests where recs order is important to check &
-# keeping the list short is easier to manipulate.
-@pytest.fixture()
-def fixture_response_data_short():
-    """Load mock response data (shortened) for the scheduledSurface query"""
-    with open("tests/data/scheduled_surface_short.json") as f:
-        return json.load(f)
-
-
-@pytest.fixture()
-def fixture_graphql_200ok_with_error_response():
-    """Load mock response data for a GraphQL error response"""
-    with open("tests/data/graphql_error.json") as f:
-        return json.load(f)
-
-
-@pytest.fixture()
-def fixture_request_data() -> Request:
-    """Load mock response data for the scheduledSurface query"""
-    graph_config = CorpusApiGraphConfig()
-
-    return Request(
-        method="POST",
-        url=graph_config.endpoint,
-        headers=graph_config.headers,
-        json={"locale": "en-US"},
-    )
-
-
-@pytest.fixture(name="corpus_http_client")
-def fixture_mock_corpus_http_client(fixture_response_data, fixture_request_data) -> AsyncMock:
-    """Mock curated corpus api HTTP client."""
-    # Create a mock HTTP client
-    mock_http_client = AsyncMock(spec=AsyncClient)
-
-    # Mock the POST request response with the loaded json mock data
-    mock_http_client.post.return_value = Response(
-        status_code=200,
-        json=fixture_response_data,
-        request=fixture_request_data,
-    )
-
-    return mock_http_client
-
-
-@pytest.fixture(name="corpus_backend")
-def fixture_mock_corpus_backend(corpus_http_client: AsyncMock) -> CorpusApiBackend:
-    """Mock corpus api backend."""
-    # Initialize the backend with the mock HTTP client
-    return CorpusApiBackend(
-        http_client=corpus_http_client,
-        graph_config=CorpusApiGraphConfig(),
-        metrics_client=get_metrics_client(),
-    )
 
 
 class MockEngagementBackend(EngagementBackend):

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -28,14 +28,6 @@ from merino.curated_recommendations.engagement_backends.protocol import (
 from merino.curated_recommendations.prior_backends.protocol import PriorBackend
 from merino.curated_recommendations.protocol import CuratedRecommendation, ExperimentName
 from merino.main import app
-from tests.integration.api.v1.curated_recommendations.corpus_backends.fixtures import (
-    fixture_response_data,
-    fixture_response_data_short,
-    fixture_request_data,
-    fixture_graphql_200ok_with_error_response,
-    corpus_http_client,
-    corpus_backend,
-)
 
 
 class MockEngagementBackend(EngagementBackend):

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -28,6 +28,14 @@ from merino.curated_recommendations.engagement_backends.protocol import (
 from merino.curated_recommendations.prior_backends.protocol import PriorBackend
 from merino.curated_recommendations.protocol import CuratedRecommendation, ExperimentName
 from merino.main import app
+from tests.integration.api.v1.curated_recommendations.corpus_backends.fixtures import (
+    fixture_response_data,
+    fixture_response_data_short,
+    fixture_request_data,
+    fixture_graphql_200ok_with_error_response,
+    corpus_http_client,
+    corpus_backend,
+)
 
 
 class MockEngagementBackend(EngagementBackend):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -4,4 +4,5 @@
 pytest_plugins = [
     "tests.integration.fixtures.gcs",
     "tests.integration.fixtures.metrics",
+    "tests.integration.api.v1.curated_recommendations.corpus_backends.fixtures",
 ]


### PR DESCRIPTION
## References

JIRA: [HNT-205](https://mozilla-hub.atlassian.net/browse/HNT-205)

## Description
Allow fetching of corpus items that were scheduled on previous days.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[HNT-205]: https://mozilla-hub.atlassian.net/browse/HNT-205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ