### PR TITLE
[MC-1569] fix regional ranking experiment names

### DIFF
--- a/merino/curated_recommendations/protocol.py
+++ b/merino/curated_recommendations/protocol.py
@@ -54,7 +54,10 @@ class ExperimentName(str, Enum):
     when Merino needs to change behavior depending on the experimentName request parameter.
     """
 
+    # Experiment where large countries receive region-specific ranking.
     REGION_SPECIFIC_CONTENT_EXPANSION = "new-tab-region-specific-content-expansion"
+    # Same as the above, but targeting small countries, which need a higher enrollment %.
+    REGION_SPECIFIC_CONTENT_EXPANSION_SMALL = "new-tab-region-specific-content-expansion-small"
 
 
 # Maximum tileId that Firefox can support. Firefox uses Javascript to store this value. The max

--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -137,8 +137,13 @@ class CuratedRecommendationsProvider:
     @staticmethod
     def is_enrolled_in_regional_engagement(request: CuratedRecommendationsRequest) -> bool:
         """Return True if Thompson sampling should use regional engagement (treatment)."""
+        # Large and small countries need a different enrollment %, thus require separate experiments
         return CuratedRecommendationsProvider.is_enrolled_in_experiment(
             request, ExperimentName.REGION_SPECIFIC_CONTENT_EXPANSION.value, "treatment"
+        ) or CuratedRecommendationsProvider.is_enrolled_in_experiment(
+            request,
+            ExperimentName.REGION_SPECIFIC_CONTENT_EXPANSION_SMALL.value,
+            "treatment",
         )
 
     @staticmethod

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -1214,6 +1214,13 @@ class TestCorpusApiRanking:
             (ExperimentName.REGION_SPECIFIC_CONTENT_EXPANSION.value, "control", False),
             (ExperimentName.REGION_SPECIFIC_CONTENT_EXPANSION.value, "treatment", True),
             (f"optin-{ExperimentName.REGION_SPECIFIC_CONTENT_EXPANSION.value}", "treatment", True),
+            (ExperimentName.REGION_SPECIFIC_CONTENT_EXPANSION_SMALL.value, "control", False),
+            (ExperimentName.REGION_SPECIFIC_CONTENT_EXPANSION_SMALL.value, "treatment", True),
+            (
+                f"optin-{ExperimentName.REGION_SPECIFIC_CONTENT_EXPANSION_SMALL.value}",
+                "treatment",
+                True,
+            ),
         ],
     )
     @pytest.mark.parametrize(


### PR DESCRIPTION
## References

JIRA: [MC-1569](https://mozilla-hub.atlassian.net/browse/MC-1569)

## Description
When Data Science sized the regional ranking experiment, it was decided that we need separate experiments for small and large countries, to allow us to set a different enrollment %. This PR adds the experiment for smaller countries.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[MC-1569]: https://mozilla-hub.atlassian.net/browse/MC-1569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ