### PR TITLE
[MC-1571] add defaultCategoryName to Fakespot feed

### DIFF
--- a/merino/curated_recommendations/protocol.py
+++ b/merino/curated_recommendations/protocol.py
@@ -139,7 +139,8 @@ class CuratedRecommendationsRequest(BaseModel):
         return []
 
 
-# Fakespot header/footer cta copy hardcoded strings for now.
+# Fakespot UI copy - hardcoded strings for now.
+FAKESPOT_DEFAULT_CATEGORY_NAME = "Holiday Gift Guide"
 FAKESPOT_HEADER_COPY = (
     "Fakespot by Mozilla curates the chaos of online shopping into gift guides you can trust."
 )
@@ -169,6 +170,7 @@ class FakespotFeed(BaseModel):
     """Fakespot product recommendations"""
 
     products: list[FakespotProduct]
+    defaultCategoryName: str
     headerCopy: str
     footerCopy: str
     cta: FakespotCTA

--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -22,6 +22,7 @@ from merino.curated_recommendations.protocol import (
     CuratedRecommendationsBucket,
     FakespotFeed,
     FakespotProduct,
+    FAKESPOT_DEFAULT_CATEGORY_NAME,
     FAKESPOT_HEADER_COPY,
     FAKESPOT_FOOTER_COPY,
     FAKESPOT_CTA_COPY,
@@ -191,6 +192,7 @@ class CuratedRecommendationsProvider:
                 )
         return FakespotFeed(
             products=fakespot_products,
+            defaultCategoryName=FAKESPOT_DEFAULT_CATEGORY_NAME,
             headerCopy=FAKESPOT_HEADER_COPY,
             footerCopy=FAKESPOT_FOOTER_COPY,
             cta=FakespotCTA(ctaCopy=FAKESPOT_CTA_COPY, url=FAKESPOT_CTA_URL),

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -28,6 +28,7 @@ from merino.curated_recommendations.engagement_backends.protocol import (
 from merino.curated_recommendations.prior_backends.protocol import PriorBackend
 from merino.curated_recommendations.protocol import (
     ExperimentName,
+    FAKESPOT_DEFAULT_CATEGORY_NAME,
     FAKESPOT_HEADER_COPY,
     FAKESPOT_FOOTER_COPY,
     FAKESPOT_CTA_COPY,
@@ -700,7 +701,8 @@ class TestCuratedRecommendationsRequestFeeds:
         required_fields = ["id", "title", "category", "imageUrl", "url"]
         for product in fakespot_products:
             assert all(product.get(field) for field in required_fields)
-        # Assert the header, footer, cta copy are present
+        # Assert the default category name, header, footer, cta copy are present
+        assert fakespot_feed["defaultCategoryName"] == FAKESPOT_DEFAULT_CATEGORY_NAME
         assert fakespot_feed["headerCopy"] == FAKESPOT_HEADER_COPY
         assert fakespot_feed["footerCopy"] == FAKESPOT_FOOTER_COPY
         assert fakespot_feed["cta"]["ctaCopy"] == FAKESPOT_CTA_COPY


### PR DESCRIPTION
## References

JIRA: [MC-1571](https://mozilla-hub.atlassian.net/browse/MC-1571)

waiting on final string...

## Description

Adds another UI string for the Fakespot feed - this one to denote the name displayed when all categories are shown (which is the default state).

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [X] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)

[MC-1571]: https://mozilla-hub.atlassian.net/browse/MC-1571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ