### PR TITLE
chore: Update configs for pytest-cov

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,6 @@ unit-tests: $(INSTALL_STAMP)  ##  Run unit tests
 	COVERAGE_FILE=$(TEST_RESULTS_DIR)/.coverage.unit \
 	    MERINO_ENV=testing \
 	    $(POETRY) run pytest $(UNIT_TEST_DIR) \
-	    --cov $(APP_DIR) \
 	    --junit-xml=$(TEST_RESULTS_DIR)/unit_results.xml
 
 .PHONY: unit-test-fixtures
@@ -83,7 +82,6 @@ integration-tests: $(INSTALL_STAMP)  ##  Run integration tests
 	COVERAGE_FILE=$(TEST_RESULTS_DIR)/.coverage.integration \
 	    MERINO_ENV=testing \
 	    $(POETRY) run pytest $(INTEGRATION_TEST_DIR) \
-	    --cov $(APP_DIR) \
 	    --junit-xml=$(TEST_RESULTS_DIR)/integration_results.xml
 
 .PHONY: integration-test-fixtures

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.coverage.run]
-source = ["src"]
+source = ["merino"]
 branch = true
 relative_files = true
 
@@ -52,7 +52,7 @@ warn_unreachable = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "-v -r s"
+addopts = "-v -r s --cov=merino"
 
 [tool.poetry]
 name = "merino-py"


### PR DESCRIPTION
## References

JIRA: N/A

## Description
Noticed the `source` of `tool.coverage.run` was mis-configured (although it will always be overridden if `--cov=merino` is specified w/ pytest). Fixing it to avoid confusion. Also moved `--cov=merino` to `tool.pytest.ini_options` so that folks can do `MERINO_ENV=testing pytest tests/unit or integration` w/o those CLI options.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
