### PR TITLE
[DISCO-3045] add country and region code to geolocation resonse

### DIFF
--- a/merino/providers/custom_details.py
+++ b/merino/providers/custom_details.py
@@ -15,6 +15,8 @@ class GeolocationDetails(BaseModel):
     """Geolocation specific fields."""
 
     country: str | None = None
+    country_code: str | None = None
+    region_code: str | None = None
     region: str | None = None
     city: str | None = None
 

--- a/merino/providers/geolocation/provider.py
+++ b/merino/providers/geolocation/provider.py
@@ -57,9 +57,11 @@ class Provider(BaseProvider):
                 custom_details=CustomDetails(
                     geolocation=GeolocationDetails(
                         country=srequest.geolocation.country_name,
-                        region=srequest.geolocation.region_names[0]
-                        if srequest.geolocation.region_names
+                        region=srequest.geolocation.region_names[0] if srequest.geolocation.region_names
                         else None,
+                        region_code=srequest.geolocation.regions[0] if srequest.geolocation.regions else None,
+                        country_code=srequest.geolocation.country,
+
                         city=srequest.geolocation.city,
                     )
                 ),

--- a/tests/unit/providers/geolocation/test_provider.py
+++ b/tests/unit/providers/geolocation/test_provider.py
@@ -63,6 +63,8 @@ async def test_query_geolocation(provider: Provider, geolocation: Location) -> N
                 geolocation=GeolocationDetails(
                     country="United States",
                     region="California",
+                    region_code="CA",
+                    country_code="US",
                     city="San Francisco",
                 )
             ),
@@ -90,6 +92,7 @@ async def test_query_geolocation_empty_region(provider: Provider, empty_region: 
                 geolocation=GeolocationDetails(
                     country="United States",
                     city="San Francisco",
+                    country_code="US",
                 )
             ),
         )


### PR DESCRIPTION
## References

JIRA: [DISCO-3045](https://mozilla-hub.atlassian.net/browse/DISCO-3045)

## Description
This adds ISO country code and region code to the geolocation provider suggestion response to support city-based weather suggestions



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
