### PR TITLE
[DISCO-3049] Fix isolation issues in unit tests

### DIFF
--- a/tests/unit/jobs/navigational_suggestions/test_navigational_suggestions_utils.py
+++ b/tests/unit/jobs/navigational_suggestions/test_navigational_suggestions_utils.py
@@ -4,6 +4,8 @@
 
 """Unit tests for utils.py module."""
 
+import logging
+
 from pytest import LogCaptureFixture
 from pytest_mock import MockerFixture
 
@@ -104,6 +106,8 @@ def test_favicon_downloader_handles_exception(
     requests_mock, mocker: MockerFixture, caplog: LogCaptureFixture
 ):
     """Test FaviconDownloader using requests_mock"""
+    caplog.set_level(logging.INFO)
+
     requests_mock.register_uri(
         "GET",
         "http://icon",

--- a/tests/unit/middleware/test_featureflags.py
+++ b/tests/unit/middleware/test_featureflags.py
@@ -61,4 +61,4 @@ async def test_featureflags_invalid_scope_type(
 
     await featureflags_middleware(scope, receive_mock, send_mock)
 
-    assert session_id_context.get() == "fff"
+    assert session_id_context.get() is None

--- a/tests/unit/providers/adm/test_provider.py
+++ b/tests/unit/providers/adm/test_provider.py
@@ -47,7 +47,7 @@ async def test_initialize(adm: Provider, adm_suggestion_content: SuggestionConte
         ("example   ", "example"),
         ("   example   ", "example"),
     ],
-    ids={
+    ids=[
         "normalized",
         "uppercase",
         "mixed-case",
@@ -56,7 +56,7 @@ async def test_initialize(adm: Provider, adm_suggestion_content: SuggestionConte
         "multi-leading space",
         "multi-tail space",
         "leading and trailing space",
-    },
+    ],
 )
 def test_normalize_query(adm: Provider, query: str, expected: str) -> None:
     """Test for the query normalization method to strip trailing space and

--- a/tests/unit/providers/amo/test_provider.py
+++ b/tests/unit/providers/amo/test_provider.py
@@ -2,6 +2,7 @@
 
 import datetime
 import time
+from logging import ERROR, INFO
 from typing import Any
 
 import freezegun
@@ -151,6 +152,7 @@ async def test_query_return_match(
 @pytest.mark.asyncio
 async def test_query_error(caplog: LogCaptureFixture, keywords: dict[SupportedAddon, set[str]]):
     """Test that provider can handle query error."""
+    caplog.set_level(ERROR)
     provider = AddonsProvider(
         backend=AmoErrorBackend(),
         keywords=keywords,
@@ -173,6 +175,7 @@ async def test_fetch_addon_info_error(
     caplog: LogCaptureFixture, keywords: dict[SupportedAddon, set[str]]
 ):
     """Test that provider can handle fetch errors."""
+    caplog.set_level(INFO)
     provider = AddonsProvider(
         backend=AmoInitErrorBackend(),
         keywords=keywords,

--- a/tests/unit/providers/top_picks/test_provider.py
+++ b/tests/unit/providers/top_picks/test_provider.py
@@ -187,7 +187,7 @@ async def test_fetch_top_picks_data_fail(
         ("example   ", "example"),
         ("   example   ", "example"),
     ],
-    ids={
+    ids=[
         "normalized",
         "uppercase",
         "mixed-case",
@@ -196,7 +196,7 @@ async def test_fetch_top_picks_data_fail(
         "multi-leading space",
         "multi-tail space",
         "leading and trailing space",
-    },
+    ],
 )
 def test_normalize_query(top_picks: Provider, query: str, expected: str) -> None:
     """Test for the query normalization method to strip trailing space and

--- a/tests/unit/test_featureflags.py
+++ b/tests/unit/test_featureflags.py
@@ -13,6 +13,13 @@ from pydantic import ValidationError
 from merino.featureflags import FeatureFlags, session_id_context
 
 
+@pytest.fixture(autouse=True)
+def reset_session_id_context():
+    """Automatically reset session_id_context after each test."""
+    yield
+    session_id_context.set(None)
+
+
 def test_missing():
     """Test that is_enabled will return False if a flag is undefined."""
     flags = FeatureFlags()


### PR DESCRIPTION
## References

JIRA: [DISCO-3049](https://mozilla-hub.atlassian.net/browse/DISCO-3049)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->

- ~add pytest-xdist in order to run unit tests in parallel~
- fix isolation issue in `test_favicon_downloader_handles_exception` by setting the logging level
- fix isolation issues in `test_normalize_query` by fixing parameterize syntax
- fix isolation issues in feature flag tests by resetting `session_id_context` between tests

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3049]: https://mozilla-hub.atlassian.net/browse/DISCO-3049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ