### PR TITLE
fix: exclude verbose region names in geonames uploader SNG-1902

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -635,11 +635,18 @@ alternates_path = "/export/dump/alternatenames/{country_code}.zip"
 # How large a geoname's population must be for it to be included in the output.
 # Geonames with populations at least this large will be included.
 population_threshold = 50_000
-# MERINO_JOBS__GEONAMES_UPLOADER__ALTERNATES_ISO_LANGUAGES
-# Which alternates of selected geonames to include in the output. Alternates are
-# categorized by language, like "en" and "en-US", plus a few other categories
-# like abbreviations ("abbr") and airport codes ("iata", "icao", "faac").
-alternates_iso_languages  = ["en", "en-US", "iata", "icao", "faac", "abbr"]
+# MERINO_JOBS__GEONAMES_UPLOADER__CITY_ALTERNATES_ISO_LANGUAGES
+# Which alternates of selected cities to include in the output. Alternates are
+# categorized by language, like "en", plus a few other categories like
+# abbreviations ("abbr") and airport codes ("iata", "icao", "faac").
+city_alternates_iso_languages  = ["en", "en-US", "iata", "icao", "faac", "abbr"]
+# MERINO_JOBS__GEONAMES_UPLOADER__REGION_ALTERNATES_ISO_LANGUAGES
+# Which alternates of selected regions to include in the output. Takes the same
+# values as city alternates. For U.S. states, "en" alternates include verbose
+# names like "State of California" that people are unlikely type and that
+# interfere with prefix matching, so we only include "abbr". Note that full
+# names like "California" are always included in the output.
+region_alternates_iso_languages  = ["abbr"]
 # MERINO_JOBS__GEONAMES_UPLOADER__COUNTRY_CODE
 # Which country's geonames to upload. If we expand to more countries, we should
 # probably remove this from the config and instead require `--country-code` to

--- a/merino/jobs/geonames_uploader/__init__.py
+++ b/merino/jobs/geonames_uploader/__init__.py
@@ -29,12 +29,6 @@ rs_settings = config.remote_settings
 job_settings = config.jobs.geonames_uploader
 
 # Options
-alternates_iso_languages_option = typer.Option(
-    job_settings.alternates_iso_languages,
-    "--alternates-iso-languages",
-    help="Alternate name languages and types to select",
-)
-
 alternates_path_option = typer.Option(
     job_settings.alternates_path,
     "--alternates-path",
@@ -63,6 +57,12 @@ chunk_size_option = typer.Option(
     rs_settings.chunk_size,
     "--chunk-size",
     help="The number of geonames to store in each attachment",
+)
+
+city_alternates_iso_languages_option = typer.Option(
+    job_settings.city_alternates_iso_languages,
+    "--city-alternates-iso-languages",
+    help="Alternate city name languages and types to select",
 )
 
 collection_option = typer.Option(
@@ -105,6 +105,12 @@ record_type_option = typer.Option(
     job_settings.record_type,
     "--record-type",
     help="The `type` of each remote settings record",
+)
+
+region_alternates_iso_languages_option = typer.Option(
+    job_settings.region_alternates_iso_languages,
+    "--region-alternates-iso-languages",
+    help="Alternate region name languages and types to select",
 )
 
 server_option = typer.Option(
@@ -168,10 +174,11 @@ def upload(
     country_code: str = country_code_option,
     dry_run: bool = dry_run_option,
     geonames_path: str = geonames_path_option,
-    alternates_iso_languages: list[str] = alternates_iso_languages_option,
+    city_alternates_iso_languages: list[str] = city_alternates_iso_languages_option,
     keep_existing_records: bool = keep_existing_records_option,
     population_threshold: int = population_threshold_option,
     record_type: str = record_type_option,
+    region_alternates_iso_languages: list[str] = region_alternates_iso_languages_option,
     server: str = server_option,
 ):
     """Download GeoNames data from the GeoNames server, apply some processing
@@ -181,10 +188,11 @@ def upload(
     downloader = GeonamesDownloader(
         alternates_path=alternates_path,
         base_url=base_url,
+        city_alternates_iso_languages=city_alternates_iso_languages,
         country_code=country_code,
         geonames_path=geonames_path,
-        alternates_iso_languages=alternates_iso_languages,
         population_threshold=population_threshold,
+        region_alternates_iso_languages=region_alternates_iso_languages,
     )
     state = downloader.download()
 

--- a/tests/unit/jobs/geonames_uploader/test_geonames_uploader.py
+++ b/tests/unit/jobs/geonames_uploader/test_geonames_uploader.py
@@ -50,11 +50,12 @@ def do_uploader_test(
     }
     downloader_kwargs: dict[str, Any] = {
         "alternates_path": "/alternates/{country_code}.zip",
+        "city_alternates_iso_languages": ["en", "iata"],
         "base_url": "https://localhost",
         "country_code": "US",
         "geonames_path": "/{country_code}.zip",
-        "alternates_iso_languages": ["en", "abbr", "iata"],
         "population_threshold": 12345,
+        "region_alternates_iso_languages": ["abbr"],
     }
 
     upload(


### PR DESCRIPTION
## References

JIRA: https://mozilla-hub.atlassian.net/browse/SNG-1902

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->

In the GeoNames data, U.S. states have verbose alternate names like "State of
California" that people are unlikely to type and that interfere with prefix
matching. The Merino uploader job should filter them out.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
