### PR TITLE
[HNT-242] Mock section feeds

### DIFF
--- a/merino/curated_recommendations/protocol.py
+++ b/merino/curated_recommendations/protocol.py
@@ -157,9 +157,7 @@ class Section(BaseModel):
 
 
 class CuratedRecommendationsFeed(BaseModel):
-    """Multiple lists of curated recommendations for experiments.
-    Currently limited to the 'need_to_know' & fakespot feed only.
-    """
+    """Multiple lists of curated recommendations, that are currently in an experimental phase."""
 
     need_to_know: CuratedRecommendationsBucket | None = None
     fakespot: FakespotFeed | None = None

--- a/merino/curated_recommendations/protocol.py
+++ b/merino/curated_recommendations/protocol.py
@@ -147,6 +147,15 @@ class CuratedRecommendationsBucket(BaseModel):
     title: str | None = None
 
 
+class Section(BaseModel):
+    """A ranked list of curated recommendations"""
+
+    receivedRank: int
+    recommendations: list[CuratedRecommendation]
+    title: str
+    subtitle: str | None = None
+
+
 class CuratedRecommendationsFeed(BaseModel):
     """Multiple lists of curated recommendations for experiments.
     Currently limited to the 'need_to_know' & fakespot feed only.
@@ -154,6 +163,26 @@ class CuratedRecommendationsFeed(BaseModel):
 
     need_to_know: CuratedRecommendationsBucket | None = None
     fakespot: FakespotFeed | None = None
+
+    # The following feeds are used as mock data for the 'sections' experiment.
+    # They should be removed when the sections are implemented that we'll actually launch with.
+    business: Section | None = None
+    career: Section | None = None
+    arts: Section | None = None
+    food: Section | None = None
+    health_fitness: Section | None = None
+    home: Section | None = None
+    personal_finance: Section | None = None
+    politics: Section | None = None
+    sports: Section | None = None
+    technology: Section | None = None
+    travel: Section | None = None
+    education: Section | None = None
+    gaming: Section | None = None
+    parenting: Section | None = None
+    science: Section | None = None
+    self_improvement: Section | None = None
+    top_stories_section: Section | None = None
 
 
 class CuratedRecommendationsResponse(BaseModel):

--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -360,10 +360,9 @@ class CuratedRecommendationsProvider:
         need_to_know_feed = None
         # Fakespot products for the Fakespot experiment
         fakespot_feed = None
+        # The sections experiment organizes recommendations in many feeds
         sections_feeds = None
 
-        # For users in the "Need to Know" experiment, separate recommendations into
-        # two different feeds: the "general" feed and the "need to know" feed.
         if self.is_need_to_know_experiment(curated_recommendations_request, surface_id):
             # this applies ranking to the general_feed!
             general_feed, need_to_know_recs, title = await self.rank_need_to_know_recommendations(
@@ -375,7 +374,7 @@ class CuratedRecommendationsProvider:
             )
         elif self.is_sections_experiment(curated_recommendations_request):
             sections_feeds = self.get_sections(recommendations, curated_recommendations_request)
-            general_feed = []
+            general_feed = []  # Everything is organized into sections. There's no 'general' feed.
         else:
             # Default ranking for general feed
             general_feed = self.rank_recommendations(

--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -2,6 +2,7 @@
 
 import time
 import re
+from datetime import datetime
 from typing import cast
 
 from merino.curated_recommendations.corpus_backends.protocol import (
@@ -23,6 +24,7 @@ from merino.curated_recommendations.protocol import (
     CuratedRecommendationsFeed,
     CuratedRecommendationsBucket,
     FakespotFeed,
+    Section,
 )
 from merino.curated_recommendations.rankers import (
     boost_preferred_topic,
@@ -159,6 +161,11 @@ class CuratedRecommendationsProvider:
         )
 
     @staticmethod
+    def is_sections_experiment(request) -> bool:
+        """Check if the 'sections' experiment is enabled."""
+        return request.feeds and "sections" in request.feeds
+
+    @staticmethod
     def is_fakespot_experiment(request, surface_id) -> bool:
         """Check if the 'Fakespot' experiment is enabled."""
         return (
@@ -270,6 +277,64 @@ class CuratedRecommendationsProvider:
 
         return general_feed, need_to_know_feed, title
 
+    def get_sections(
+        self,
+        recommendations: list[CuratedRecommendation],
+        request: CuratedRecommendationsRequest,
+    ) -> CuratedRecommendationsFeed:
+        """Return a CuratedRecommendationsFeed with recommendations mapped to their topic."""
+        # Apply Thompson sampling to rank all recommendations by engagement
+        recommendations = thompson_sampling(
+            recommendations,
+            engagement_backend=self.engagement_backend,
+            prior_backend=self.prior_backend,
+            region=self.derive_region(request.locale, request.region),
+            enable_region_engagement=self.is_enrolled_in_regional_engagement(request),
+        )
+
+        # HNT-243 will iron out schema changes. The following should probably become request params:
+        max_recs_per_section = 30
+        min_recs_per_section = 3
+        top_stories_count = 6
+
+        # Create "Today's top stories" section with the first 6 recommendations
+        top_stories = recommendations[:top_stories_count]
+        feeds = CuratedRecommendationsFeed(
+            top_stories_section=Section(
+                receivedRank=0,
+                recommendations=top_stories,
+                title="Today's top stories",
+                subtitle=datetime.now().strftime("%B %d, %Y"),  # e.g., "October 24, 2024"
+            )
+        )
+
+        # Group the remaining recommendations by topic, while preserving the Thompson sampling order
+        sections_by_topic: dict[str, Section] = dict()
+        remaining_recs = recommendations[top_stories_count:]
+        for rec in remaining_recs:
+            if rec.topic and rec.topic.value in CuratedRecommendationsFeed.model_fields:
+                topic = rec.topic
+                if topic in sections_by_topic:
+                    section = sections_by_topic[topic]
+                else:
+                    section = sections_by_topic[topic] = Section(
+                        receivedRank=len(sections_by_topic) + 1,  # add 1 for top_stories_section
+                        recommendations=[],
+                        title=rec.topic.replace("_", " ").capitalize(),
+                    )
+
+                if len(section.recommendations) < max_recs_per_section:
+                    rec.receivedRank = len(section.recommendations)
+                    section.recommendations.append(rec)
+
+        for topic_id, section in sections_by_topic.items():
+            # Only add sections that meet the minimum number of recommendations.
+            if len(section.recommendations) >= min_recs_per_section:
+                setattr(feeds, topic_id, section)
+
+        # Construct and return CuratedRecommendationsFeed with valid sections
+        return feeds
+
     async def fetch(
         self, curated_recommendations_request: CuratedRecommendationsRequest
     ) -> CuratedRecommendationsResponse:
@@ -295,6 +360,7 @@ class CuratedRecommendationsProvider:
         need_to_know_feed = None
         # Fakespot products for the Fakespot experiment
         fakespot_feed = None
+        sections_feeds = None
 
         # For users in the "Need to Know" experiment, separate recommendations into
         # two different feeds: the "general" feed and the "need to know" feed.
@@ -307,6 +373,9 @@ class CuratedRecommendationsProvider:
             need_to_know_feed = CuratedRecommendationsBucket(
                 recommendations=need_to_know_recs, title=title
             )
+        elif self.is_sections_experiment(curated_recommendations_request):
+            sections_feeds = self.get_sections(recommendations, curated_recommendations_request)
+            general_feed = []
         else:
             # Default ranking for general feed
             general_feed = self.rank_recommendations(
@@ -321,10 +390,12 @@ class CuratedRecommendationsProvider:
         response = CuratedRecommendationsResponse(recommendedAt=self.time_ms(), data=general_feed)
 
         # If we have feeds to return, add those to the response
-        if need_to_know_feed is not None or fakespot_feed is not None:
+        if need_to_know_feed or fakespot_feed:
             response.feeds = CuratedRecommendationsFeed(
                 need_to_know=need_to_know_feed, fakespot=fakespot_feed
             )
+        elif sections_feeds:
+            response.feeds = sections_feeds
 
         return response
 

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -365,7 +365,7 @@ async def curated_content(
     - `count`: [Optional] The maximum number of recommendations to return. Defaults to 100.
     - `topics`: [Optional] A list of preferred [topics][curated-topics-doc].
     - `feeds`: [Optional] A list of additional data feeds. Currently, accepts
-       only two values: 'need_to_know' & 'fakespot'.
+       only three values: 'need_to_know', 'fakespot', and 'sections'.
     - `experimentName`: [Optional] The Nimbus New Tab experiment name that the user is enrolled in.
         When an experiment _only_ requires backend changes, this allows us to run the experiments
         without waiting on the Firefox release cycle. When an experiment _does_ require changes in

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -1293,3 +1293,38 @@ class TestNeedToKnow:
             data = response.json()
             need_to_know = data["feeds"]["need_to_know"]["recommendations"]
             assert len(need_to_know) == 10  # The number of time-sensitive items in the fixture.
+
+
+class TestSections:
+    """Test the behavior of the sections feeds"""
+
+    @pytest.mark.asyncio
+    async def test_curated_recommendations_with_sections_feed(self):
+        """Test the curated recommendations endpoint response is as expected
+        when requesting the 'sections' feed for en-US locale.
+        """
+        async with AsyncClient(app=app, base_url="http://test") as ac:
+            # Mock the endpoint to request the sections feed
+            response = await ac.post(
+                "/api/v1/curated-recommendations",
+                json={"locale": "en-US", "feeds": ["sections"]},
+            )
+            data = response.json()
+
+            # Check if the response is valid
+            assert response.status_code == 200
+
+            # Assert that an empty data array is returned. All recommendations are under "feeds".
+            assert len(data["data"]) == 0
+
+            # Check that all sections are present
+            feeds = data["feeds"]
+            assert (
+                len(feeds) > 5
+            )  # fixture data contains enough recommendations for many sections.
+
+            # Ensure "Today's top stories" is present with a valid date subtitle
+            top_stories_section = data["feeds"].get("top_stories_section")
+            assert top_stories_section is not None
+            assert top_stories_section["title"] == "Today's top stories"
+            assert top_stories_section["subtitle"] is not None


### PR DESCRIPTION
## References

JIRA: [HNT-242](https://mozilla-hub.atlassian.net/browse/HNT-242)

## Description
Return mock data for section feeds, to unblock front-end developers from starting to integrate the API. I don't know what content we'll actually launch with exactly, so I roughly based this work on [the Figma design](https://www.figma.com/design/VdghooQZTLiXYO8hF5pAuS/Feed?node-id=5358-17426&node-type=canvas&t=PWBqFJ8XsRE8ifQT-0).

We have some API details to iron out, but the high-level concept is that we'll return sections as feeds.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[HNT-242]: https://mozilla-hub.atlassian.net/browse/HNT-242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ