### PR TITLE
feat: include Canadian cities in geonames uploader SNG-1904

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -647,11 +647,13 @@ city_alternates_iso_languages  = ["en", "en-US", "iata", "icao", "faac", "abbr"]
 # interfere with prefix matching, so we only include "abbr". Note that full
 # names like "California" are always included in the output.
 region_alternates_iso_languages  = ["abbr"]
-# MERINO_JOBS__GEONAMES_UPLOADER__COUNTRY_CODE
-# Which country's geonames to upload. If we expand to more countries, we should
-# probably remove this from the config and instead require `--country-code` to
-# be passed on the command line when running the job.
-country_code = "US"
+# MERINO_JOBS__GEONAMES_UPLOADER__COUNTRY_CODES
+# List of countries whose geonames will be uploaded. All countries' data will be
+# uploaded together without any separation into different records, attachments,
+# collections, etc. This is only a short-term hack to opportunistically include
+# Canadian cities, since there are many Canadians Mozillians and relatively few
+# Canadian cities over the population threshold.
+country_codes = ["US", "CA"]
 # MERINO_JOBS__GEONAMES_UPLOADER__RECORD_TYPE
 # The "type" of each geonames remote settings record.
 record_type = "geonames"

--- a/tests/unit/jobs/geonames_uploader/test_downloader.py
+++ b/tests/unit/jobs/geonames_uploader/test_downloader.py
@@ -137,6 +137,18 @@ GEONAMES = [
         admin1_code="NY",
         population=19274244,
     ),
+    # A made-up city with diacritics in its name
+    Geoname(
+        id=8,
+        name="Àęí",
+        latitude="45.50884",
+        longitude="-73.58781",
+        feature_class="P",
+        feature_code="PPLA2",
+        country_code="CA",
+        admin1_code="10",
+        population=1,
+    ),
 ]
 
 ALTERNATES = [
@@ -226,6 +238,12 @@ ALTERNATES = [
         geoname_id=7,
         name="Nueva York",
         iso_language="es",
+    ),
+    # A made-up city with diacritics in its name
+    GeonameAlternate(
+        geoname_id=8,
+        name="Öũ",
+        iso_language="en",
     ),
 ]
 
@@ -425,11 +443,24 @@ def test_all_populations_and_iso_languages(
                 population=19274244,
                 alternate_names=set(["new york", "state of new york", "nueva york", "ny"]),
             ),
+            Geoname(
+                id=8,
+                name="Àęí",
+                latitude="45.50884",
+                longitude="-73.58781",
+                feature_class="P",
+                feature_code="PPLA2",
+                country_code="CA",
+                admin1_code="10",
+                population=1,
+                # Versions both with and without diacritics should be included.
+                alternate_names=set(["àęí", "öũ", "aei", "ou"]),
+            ),
         ],
         expected_metrics=DownloadMetrics(
             # No excluded cities or regions
             excluded_geonames_count=0,
-            included_alternates_count=14,
+            included_alternates_count=15,
         ),
     )
 
@@ -500,8 +531,8 @@ def test_one_million_population_and_all_iso_languages(
             ),
         ],
         expected_metrics=DownloadMetrics(
-            # No Waterloo, AL or Waterloo, IA
-            excluded_geonames_count=2,
+            # No Waterloo AL, Waterloo IA, or city with diacritics
+            excluded_geonames_count=3,
             included_alternates_count=12,
         ),
     )
@@ -568,8 +599,8 @@ def test_one_million_population_and_en_only(
             ),
         ],
         expected_metrics=DownloadMetrics(
-            # No Waterloo, AL or Waterloo, IA
-            excluded_geonames_count=2,
+            # No Waterloo AL, Waterloo IA, or city with diacritics
+            excluded_geonames_count=3,
             # Only "al", "ia", "new york" (city), and "ny" (state). Other
             # values in `altername_names` are lowercased versions of `name`.
             included_alternates_count=4,


### PR DESCRIPTION
## References

JIRA: https://mozilla-hub.atlassian.net/browse/SNG-1904

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->

There are only 116 Canadian cities above our population threshold of 50k.
Currently the final geonames record in RS only contains 13 items, so including
the CA cities doesn't even add another record to our dataset. Since there are
many Canadian Mozillians and there's little cost to including these cities, I'd
like to do that.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
