### PR TITLE
[DISCO-3005] Pass Language to weather report logic

### DIFF
--- a/merino/providers/weather/backends/accuweather/backend.py
+++ b/merino/providers/weather/backends/accuweather/backend.py
@@ -280,9 +280,9 @@ class AccuweatherBackend:
                     hasher.update(key.encode("utf-8") + value.encode("utf-8"))
             extra_identifiers = hasher.hexdigest()
 
-            return f"{self.__class__.__name__}:v4:{url}:{extra_identifiers}"
+            return f"{self.__class__.__name__}:v5:{url}:{extra_identifiers}"
 
-        return f"{self.__class__.__name__}:v4:{url}"
+        return f"{self.__class__.__name__}:v5:{url}"
 
     @functools.cache
     def cache_key_template(self, dt: WeatherDataType, language: str) -> str:

--- a/merino/providers/weather/backends/accuweather/backend.py
+++ b/merino/providers/weather/backends/accuweather/backend.py
@@ -835,13 +835,13 @@ class AccuweatherBackend:
         )
 
     async def get_location_completion(
-        self, geolocation: Location, languages: list[str], search_term: str
+        self, weather_context: WeatherContext, search_term: str
     ) -> list[LocationCompletion] | None:
         """Fetch a list of locations from the Accuweather API given a search term and location."""
         if not search_term:
             return None
-
-        language = get_language(languages)
+        geolocation = weather_context.geolocation
+        language = get_language(weather_context.languages)
 
         url_path = self.url_location_completion_path
 

--- a/merino/providers/weather/backends/accuweather/backend.py
+++ b/merino/providers/weather/backends/accuweather/backend.py
@@ -284,9 +284,12 @@ class AccuweatherBackend:
         return f"{self.__class__.__name__}:v4:{url}"
 
     @functools.cache
-    def cache_key_template(self, dt: WeatherDataType) -> str:
+    def cache_key_template(self, dt: WeatherDataType, language: str) -> str:
         """Get the cache key template for weather data."""
-        query_params: dict[str, str] = {self.url_param_api_key: self.api_key}
+        query_params: dict[str, str] = {
+            self.url_param_api_key: self.api_key,
+            LANGUAGE_PARAM: language,
+        }
         match dt:
             case WeatherDataType.CURRENT_CONDITIONS:
                 return self.cache_key_for_accuweather_request(
@@ -473,15 +476,18 @@ class AccuweatherBackend:
         }
 
     async def get_weather_report(
-        self, geolocation: Location, location_key: str | None = None
+        self, geolocation: Location, languages: list[str], location_key: str | None = None
     ) -> WeatherReport | None:
         """Get weather report either via location key or geolocation."""
+        language = get_language(languages)
         if location_key:
-            return await self.get_weather_report_with_location_key(location_key)
+            return await self.get_weather_report_with_location_key(location_key, language)
 
-        return await self.get_weather_report_with_geolocation(geolocation)
+        return await self.get_weather_report_with_geolocation(geolocation, language)
 
-    async def get_weather_report_with_location_key(self, location_key) -> WeatherReport | None:
+    async def get_weather_report_with_location_key(
+        self, location_key: str, language: str
+    ) -> WeatherReport | None:
         """Get weather information from AccuWeather.
 
         Firstly, it will look up the Redis cache for the current condition,
@@ -509,10 +515,10 @@ class AccuweatherBackend:
                     # The order matters below.
                     # See `LUA_SCRIPT_CACHE_BULK_FETCH_VIA_LOCATION` for details.
                     args=[
-                        self.cache_key_template(WeatherDataType.CURRENT_CONDITIONS).format(
-                            location_key=location_key
-                        ),
-                        self.cache_key_template(WeatherDataType.FORECAST).format(
+                        self.cache_key_template(
+                            WeatherDataType.CURRENT_CONDITIONS, language
+                        ).format(location_key=location_key),
+                        self.cache_key_template(WeatherDataType.FORECAST, language).format(
                             location_key=location_key
                         ),
                     ],
@@ -527,10 +533,10 @@ class AccuweatherBackend:
         self.emit_cache_fetch_metrics(cached_data, skip_location_key=True)
         cached_report = self.parse_cached_data(cached_data)
         location = Location(key=location_key)
-        return await self.make_weather_report(cached_report, location)
+        return await self.make_weather_report(cached_report, language, location)
 
     async def _fetch_from_cache(
-        self, country: str | None, region: str | None, city: str | None
+        self, country: str | None, region: str | None, city: str | None, language: str
     ) -> list[bytes | None] | None:
         """Fetch weather data from cache."""
         if country is None or city is None:
@@ -556,15 +562,17 @@ class AccuweatherBackend:
                 keys=[cache_key],
                 # The order matters below. See `LUA_SCRIPT_CACHE_BULK_FETCH` for details.
                 args=[
-                    self.cache_key_template(WeatherDataType.CURRENT_CONDITIONS),
-                    self.cache_key_template(WeatherDataType.FORECAST),
+                    self.cache_key_template(WeatherDataType.CURRENT_CONDITIONS, language),
+                    self.cache_key_template(WeatherDataType.FORECAST, language),
                     self.url_location_key_placeholder,
                 ],
             )
             return cached_data if cached_data else None
 
     async def get_weather_report_with_geolocation(
-        self, geolocation: Location
+        self,
+        geolocation: Location,
+        language: str,
     ) -> WeatherReport | None:
         """Get weather information from AccuWeather.
         Firstly, it will look up the Redis cache for the location key, current condition,
@@ -589,7 +597,9 @@ class AccuweatherBackend:
             return None
 
         try:
-            cached_data = await pathfinder.explore(geolocation, self._fetch_from_cache)
+            cached_data = await pathfinder.explore(
+                geolocation, self._fetch_from_cache, language=language
+            )
         except CacheAdapterError as exc:
             logger.error(f"Failed to fetch weather report from Redis: {exc}")
             self.metrics_client.increment("accuweather.cache.fetch.error")
@@ -599,10 +609,10 @@ class AccuweatherBackend:
         self.emit_cache_fetch_metrics(cached_data)
         cached_report = self.parse_cached_data(cached_data)
 
-        return await self.make_weather_report(cached_report, geolocation)
+        return await self.make_weather_report(cached_report, language, geolocation)
 
     async def make_weather_report(
-        self, cached_report: WeatherData, geolocation: Location
+        self, cached_report: WeatherData, language: str, geolocation: Location
     ) -> WeatherReport | None:
         """Make a `WeatherReport` either using the cached data or fetching from AccuWeather.
 
@@ -648,7 +658,7 @@ class AccuweatherBackend:
         try:
             async with asyncio.TaskGroup() as tg:
                 task_current = tg.create_task(
-                    self.get_current_conditions(location.key)
+                    self.get_current_conditions(location.key, language)
                     if current_conditions is None
                     else as_awaitable(
                         CurrentConditionsWithTTL(
@@ -658,7 +668,7 @@ class AccuweatherBackend:
                     )
                 )
                 task_forecast = tg.create_task(
-                    self.get_forecast(location.key)
+                    self.get_forecast(location.key, language)
                     if forecast is None
                     else as_awaitable(
                         ForecastWithTTL(forecast=forecast, ttl=self.cached_forecast_ttl_sec)
@@ -735,7 +745,9 @@ class AccuweatherBackend:
             set_region_mapping(country, city, region)
         return AccuweatherLocation(**response) if response else None
 
-    async def get_current_conditions(self, location_key: str) -> CurrentConditionsWithTTL | None:
+    async def get_current_conditions(
+        self, location_key: str, language: str
+    ) -> CurrentConditionsWithTTL | None:
         """Return current conditions data for a specific location or None if current
         conditions data is not found.
 
@@ -747,9 +759,7 @@ class AccuweatherBackend:
         try:
             response: dict[str, Any] | None = await self.request_upstream(
                 self.url_current_conditions_path.format(location_key=location_key),
-                params={
-                    self.url_param_api_key: self.api_key,
-                },
+                params={self.url_param_api_key: self.api_key, LANGUAGE_PARAM: language},
                 request_type=RequestType.CURRENT_CONDITIONS,
                 process_api_response=process_current_condition_response,
                 cache_ttl_sec=self.cached_current_condition_ttl_sec,
@@ -781,7 +791,7 @@ class AccuweatherBackend:
             else None
         )
 
-    async def get_forecast(self, location_key: str) -> ForecastWithTTL | None:
+    async def get_forecast(self, location_key: str, language: str) -> ForecastWithTTL | None:
         """Return daily forecast data for a specific location or None if daily
         forecast data is not found.
 
@@ -793,9 +803,7 @@ class AccuweatherBackend:
         try:
             response: dict[str, Any] | None = await self.request_upstream(
                 self.url_forecasts_path.format(location_key=location_key),
-                params={
-                    self.url_param_api_key: self.api_key,
-                },
+                params={self.url_param_api_key: self.api_key, LANGUAGE_PARAM: language},
                 request_type=RequestType.FORECASTS,
                 process_api_response=process_forecast_response,
                 cache_ttl_sec=self.cached_forecast_ttl_sec,

--- a/merino/providers/weather/backends/accuweather/pathfinder.py
+++ b/merino/providers/weather/backends/accuweather/pathfinder.py
@@ -47,7 +47,9 @@ def compass(location: Location) -> Generator[Triplet, None, None]:
 
 
 async def explore(
-    location: Location, probe: Callable[[MaybeStr, MaybeStr, MaybeStr], Awaitable[Optional[Any]]]
+    location: Location,
+    probe: Callable[..., Awaitable[Optional[Any]]],
+    language: str | None = None,
 ) -> Optional[Any]:
     """Repeatedly executes an async function (prober) for each candidate until a valid result (path) is found.
 
@@ -67,7 +69,10 @@ async def explore(
       - Any exception raised from `probe`.
     """
     for country, region, city in compass(location):
-        res = await probe(country, region, city)
+        if language:
+            res = await probe(country, region, city, language)
+        else:
+            res = await probe(country, region, city)
         if res is not None:
             return res
 

--- a/merino/providers/weather/backends/protocol.py
+++ b/merino/providers/weather/backends/protocol.py
@@ -81,7 +81,7 @@ class WeatherBackend(Protocol):
     """
 
     async def get_weather_report(
-        self, geolocation: Location, location_key: str | None
+        self, geolocation: Location, languages: list[str], location_key: str | None
     ) -> WeatherReport | None:  # pragma: no cover
         """Get weather information from partner.
 

--- a/merino/providers/weather/backends/protocol.py
+++ b/merino/providers/weather/backends/protocol.py
@@ -72,6 +72,14 @@ class LocationCompletion(BaseModel):
     administrative_area: LocationCompletionGeoDetails
 
 
+class WeatherContext:
+    """Class that contains context needed to make weather reports."""
+
+    def __init__(self, geolocation: Location, languages: list[str]):
+        self.geolocation = geolocation
+        self.languages = languages
+
+
 class WeatherBackend(Protocol):
     """Protocol for a weather backend that this provider depends on.
 
@@ -81,7 +89,7 @@ class WeatherBackend(Protocol):
     """
 
     async def get_weather_report(
-        self, geolocation: Location, languages: list[str], location_key: str | None
+        self, weather_context: WeatherContext
     ) -> WeatherReport | None:  # pragma: no cover
         """Get weather information from partner.
 
@@ -91,7 +99,7 @@ class WeatherBackend(Protocol):
         ...
 
     async def get_location_completion(
-        self, geolocation: Location, languages: list[str], search_term: str
+        self, weather_context: WeatherContext, search_term: str
     ) -> list[LocationCompletion] | None:  # pragma: no cover
         """Get a list of locations (cities and country) from partner
         Raises:

--- a/merino/providers/weather/backends/protocol.py
+++ b/merino/providers/weather/backends/protocol.py
@@ -6,6 +6,8 @@ from pydantic import BaseModel, HttpUrl
 
 from merino.middleware.geolocation import Location
 
+from dataclasses import dataclass
+
 
 class Temperature(BaseModel):
     """Model for temperature with C and F values."""
@@ -72,12 +74,12 @@ class LocationCompletion(BaseModel):
     administrative_area: LocationCompletionGeoDetails
 
 
+@dataclass
 class WeatherContext:
     """Class that contains context needed to make weather reports."""
 
-    def __init__(self, geolocation: Location, languages: list[str]):
-        self.geolocation = geolocation
-        self.languages = languages
+    geolocation: Location
+    languages: list[str]
 
 
 class WeatherBackend(Protocol):

--- a/merino/providers/weather/provider.py
+++ b/merino/providers/weather/provider.py
@@ -118,7 +118,7 @@ class Provider(BaseProvider):
                     )
                 else:
                     weather_report = await self.backend.get_weather_report(
-                        geolocation, srequest.query
+                        geolocation, languages, srequest.query
                     )
 
         except BackendError as backend_error:

--- a/tests/unit/providers/weather/backends/test_accuweather.py
+++ b/tests/unit/providers/weather/backends/test_accuweather.py
@@ -280,7 +280,13 @@ def fixture_accuweather_location_key() -> str:
 @pytest.fixture(name="languages")
 def fixture_languages() -> list[str]:
     """Language list to get weather report."""
-    return ["en-US"]
+    return ["en-US", "fr"]
+
+
+@pytest.fixture(name="language")
+def fixture_language() -> str:
+    """Language list to get weather report."""
+    return "en-US"
 
 
 @pytest.fixture(name="expected_weather_report")
@@ -922,6 +928,7 @@ async def test_get_weather_report(
     accuweather: AccuweatherBackend,
     expected_weather_report: WeatherReport,
     geolocation: Location,
+    languages: list[str],
     accuweather_location_response: bytes,
     accuweather_current_conditions_response: bytes,
     accuweather_forecast_response_fahrenheit: bytes,
@@ -971,7 +978,7 @@ async def test_get_weather_report(
         ".store_request_into_cache"
     ).return_value = TEST_CACHE_TTL_SEC
 
-    report: Optional[WeatherReport] = await accuweather.get_weather_report(geolocation)
+    report: Optional[WeatherReport] = await accuweather.get_weather_report(geolocation, languages)
 
     assert report == expected_weather_report
 
@@ -982,6 +989,7 @@ async def test_get_weather_report_without_region(
     accuweather: AccuweatherBackend,
     expected_weather_report: WeatherReport,
     geolocation: Location,
+    languages: list[str],
     accuweather_location_response: bytes,
     accuweather_current_conditions_response: bytes,
     accuweather_forecast_response_fahrenheit: bytes,
@@ -1034,7 +1042,7 @@ async def test_get_weather_report_without_region(
 
     geolocation = geolocation.model_copy()
     geolocation.regions = None
-    report: Optional[WeatherReport] = await accuweather.get_weather_report(geolocation)
+    report: Optional[WeatherReport] = await accuweather.get_weather_report(geolocation, languages)
 
     assert report == expected_weather_report
 
@@ -1044,6 +1052,7 @@ async def test_get_weather_report_with_fallback_city_endpoint_returns_none(
     mocker: MockerFixture,
     accuweather: AccuweatherBackend,
     geolocation: Location,
+    languages: list[str],
     accuweather_location_response: bytes,
     accuweather_current_conditions_response: bytes,
     accuweather_forecast_response_fahrenheit: bytes,
@@ -1122,7 +1131,7 @@ async def test_get_weather_report_with_fallback_city_endpoint_returns_none(
         ".store_request_into_cache"
     ).return_value = TEST_CACHE_TTL_SEC
 
-    report: Optional[WeatherReport] = await accuweather.get_weather_report(geolocation)
+    report: Optional[WeatherReport] = await accuweather.get_weather_report(geolocation, languages)
 
     assert report is None
 
@@ -1138,6 +1147,7 @@ async def test_get_weather_report_with_fallback_city_endpoint_returns_none(
 async def test_get_weather_report_location_key_fetch_failed(
     accuweather: AccuweatherBackend,
     geolocation: Location,
+    languages: list[str],
     response_header: dict[str, str],
     caplog: LogCaptureFixture,
     filter_caplog: FilterCaplogFixture,
@@ -1167,7 +1177,7 @@ async def test_get_weather_report_location_key_fetch_failed(
         ),
     ]
 
-    report: Optional[WeatherReport] = await accuweather.get_weather_report(geolocation)
+    report: Optional[WeatherReport] = await accuweather.get_weather_report(geolocation, languages)
 
     assert report is None
 
@@ -1187,6 +1197,7 @@ async def test_get_weather_report_with_location_key(
     accuweather: AccuweatherBackend,
     expected_weather_report_via_location_key: WeatherReport,
     geolocation: Location,
+    languages: list[str],
     accuweather_location_key: str,
     accuweather_location_response: bytes,
     accuweather_current_conditions_response: bytes,
@@ -1225,7 +1236,9 @@ async def test_get_weather_report_with_location_key(
         ".store_request_into_cache"
     ).return_value = TEST_CACHE_TTL_SEC
     report: Optional[WeatherReport] = await accuweather.get_weather_report(
-        geolocation, accuweather_location_key
+        geolocation,
+        languages,
+        accuweather_location_key,
     )
 
     assert report == expected_weather_report_via_location_key
@@ -1235,6 +1248,7 @@ async def test_get_weather_report_with_location_key(
 async def test_get_weather_report_with_cache_fetch_error(
     mocker: MockerFixture,
     geolocation: Location,
+    languages: list[str],
     accuweather_parameters: dict[str, Any],
     statsd_mock: Any,
     caplog: LogCaptureFixture,
@@ -1258,7 +1272,7 @@ async def test_get_weather_report_with_cache_fetch_error(
     )
     client_mock: AsyncMock = cast(AsyncMock, accuweather.http_client)
 
-    report: Optional[WeatherReport] = await accuweather.get_weather_report(geolocation)
+    report: Optional[WeatherReport] = await accuweather.get_weather_report(geolocation, languages)
 
     assert report is None
     client_mock.get.assert_not_called()
@@ -1278,6 +1292,7 @@ async def test_get_weather_report_with_cache_fetch_error(
 async def test_get_weather_report_failed_location_query(
     accuweather: AccuweatherBackend,
     geolocation: Location,
+    languages: list[str],
     response_header: dict[str, str],
 ) -> None:
     """Test that the get_weather_report method returns None if the AccuWeather
@@ -1297,7 +1312,7 @@ async def test_get_weather_report_failed_location_query(
         ),
     )
 
-    report: Optional[WeatherReport] = await accuweather.get_weather_report(geolocation)
+    report: Optional[WeatherReport] = await accuweather.get_weather_report(geolocation, languages)
 
     assert report is None
 
@@ -1306,6 +1321,7 @@ async def test_get_weather_report_failed_location_query(
 async def test_get_weather_report_failed_current_conditions_query(
     accuweather: AccuweatherBackend,
     geolocation: Location,
+    languages: list[str],
     accuweather_location_response: bytes,
     accuweather_forecast_response_fahrenheit: bytes,
     response_header: dict[str, str],
@@ -1349,7 +1365,7 @@ async def test_get_weather_report_failed_current_conditions_query(
         ),
     ]
 
-    report: Optional[WeatherReport] = await accuweather.get_weather_report(geolocation)
+    report: Optional[WeatherReport] = await accuweather.get_weather_report(geolocation, languages)
 
     assert report is None
 
@@ -1358,6 +1374,7 @@ async def test_get_weather_report_failed_current_conditions_query(
 async def test_get_weather_report_handles_exception_group_properly(
     accuweather: AccuweatherBackend,
     geolocation: Location,
+    languages: list[str],
     accuweather_location_response: bytes,
     accuweather_forecast_response_fahrenheit: bytes,
     response_header: dict[str, str],
@@ -1390,7 +1407,7 @@ async def test_get_weather_report_handles_exception_group_properly(
     )
 
     with pytest.raises(AccuweatherError) as accuweather_error:
-        await accuweather.get_weather_report(geolocation)
+        await accuweather.get_weather_report(geolocation, languages)
 
     assert str(accuweather_error.value) == expected_error_value
 
@@ -1399,6 +1416,7 @@ async def test_get_weather_report_handles_exception_group_properly(
 async def test_get_weather_report_handles_non_http_exception_group_properly(
     accuweather: AccuweatherBackend,
     geolocation: Location,
+    languages: list[str],
     accuweather_location_response: bytes,
     accuweather_forecast_response_fahrenheit: bytes,
     response_header: dict[str, str],
@@ -1438,7 +1456,7 @@ async def test_get_weather_report_handles_non_http_exception_group_properly(
     )
 
     with pytest.raises(AccuweatherError) as accuweather_error:
-        await accuweather.get_weather_report(geolocation)
+        await accuweather.get_weather_report(geolocation, languages)
 
     assert str(accuweather_error_for_current_conditions) in str(accuweather_error.value)
     assert str(accuweather_error_for_forecast) in str(accuweather_error.value)
@@ -1448,6 +1466,7 @@ async def test_get_weather_report_handles_non_http_exception_group_properly(
 async def test_get_weather_report_failed_forecast_query(
     accuweather: AccuweatherBackend,
     geolocation: Location,
+    languages: list[str],
     accuweather_location_response: bytes,
     accuweather_current_conditions_response: bytes,
     response_header: dict[str, str],
@@ -1491,7 +1510,7 @@ async def test_get_weather_report_failed_forecast_query(
         ),
     ]
 
-    report: Optional[WeatherReport] = await accuweather.get_weather_report(geolocation)
+    report: Optional[WeatherReport] = await accuweather.get_weather_report(geolocation, languages)
 
     assert report is None
 
@@ -1517,6 +1536,7 @@ async def test_get_weather_report_failed_forecast_query(
 async def test_get_weather_report_invalid_location(
     accuweather: AccuweatherBackend,
     location: Location,
+    languages: list[str],
     statsd_mock: Any,
 ) -> None:
     """Test that the get_weather_report method raises an error if location information
@@ -1524,7 +1544,7 @@ async def test_get_weather_report_invalid_location(
     """
     expected_result = None
 
-    result = await accuweather.get_weather_report(location)
+    result = await accuweather.get_weather_report(location, languages)
 
     assert expected_result == result
 
@@ -1698,6 +1718,7 @@ async def test_get_current_conditions(
     accuweather_current_conditions_response: bytes,
     expected_current_conditions_url: str,
     response_header: dict[str, str],
+    language: str,
 ) -> None:
     """Test that the get_current_conditions method returns CurrentConditionsWithTTL."""
     # This request flow hits the store_request_into_cache method that returns the ttl. Mocking
@@ -1730,7 +1751,7 @@ async def test_get_current_conditions(
     )
 
     conditions: Optional[CurrentConditionsWithTTL] = await accuweather.get_current_conditions(
-        location_key
+        location_key, language
     )
 
     assert conditions == expected_conditions
@@ -1738,7 +1759,9 @@ async def test_get_current_conditions(
 
 @pytest.mark.asyncio
 async def test_get_current_conditions_no_current_conditions_returned(
-    accuweather: AccuweatherBackend, response_header: dict[str, str]
+    accuweather: AccuweatherBackend,
+    response_header: dict[str, str],
+    language: str,
 ) -> None:
     """Test that the get_current_conditions method returns None if the response content
     is not as expected.
@@ -1756,7 +1779,7 @@ async def test_get_current_conditions_no_current_conditions_returned(
     )
 
     conditions: Optional[CurrentConditionsWithTTL] = await accuweather.get_current_conditions(
-        location_key
+        location_key, language
     )
 
     assert conditions is None
@@ -1764,7 +1787,9 @@ async def test_get_current_conditions_no_current_conditions_returned(
 
 @pytest.mark.asyncio
 async def test_get_current_conditions_error(
-    accuweather: AccuweatherBackend, response_header: dict[str, str]
+    accuweather: AccuweatherBackend,
+    response_header: dict[str, str],
+    language: str,
 ) -> None:
     """Test that the get_current_conditions method raises an appropriate exception in
     the event of an AccuWeather API error.
@@ -1791,7 +1816,7 @@ async def test_get_current_conditions_error(
     )
 
     with pytest.raises(AccuweatherError) as accuweather_error:
-        await accuweather.get_current_conditions(location_key)
+        await accuweather.get_current_conditions(location_key, language)
 
     assert str(accuweather_error.value) == expected_error_value
 
@@ -1819,6 +1844,7 @@ async def test_get_current_conditions_error(
 async def test_get_forecast(
     mocker: MockerFixture,
     request: FixtureRequest,
+    language: str,
     accuweather_fixture: str,
     forecast_response_fixture: str,
     expected_forecast_url: str,
@@ -1856,7 +1882,7 @@ async def test_get_forecast(
         ),
     )
 
-    forecast: Optional[ForecastWithTTL] = await accuweather.get_forecast(location_key)
+    forecast: Optional[ForecastWithTTL] = await accuweather.get_forecast(location_key, language)
 
     assert forecast == expected_forecast
 
@@ -1864,6 +1890,7 @@ async def test_get_forecast(
 @pytest.mark.asyncio
 async def test_get_forecast_no_forecast_returned(
     accuweather: AccuweatherBackend,
+    language: str,
     response_header: dict[str, str],
 ) -> None:
     """Test that the get_forecast method returns None if the response content is not as
@@ -1881,13 +1908,13 @@ async def test_get_forecast_no_forecast_returned(
         ),
     )
 
-    forecast: Optional[ForecastWithTTL] = await accuweather.get_forecast(location_key)
+    forecast: Optional[ForecastWithTTL] = await accuweather.get_forecast(location_key, language)
 
     assert forecast is None
 
 
 @pytest.mark.asyncio
-async def test_get_forecast_error(accuweather: AccuweatherBackend) -> None:
+async def test_get_forecast_error(accuweather: AccuweatherBackend, language: str) -> None:
     """Test that the get_forecast method raises an appropriate exception in the event
     of an AccuWeather API error.
     """
@@ -1912,7 +1939,7 @@ async def test_get_forecast_error(accuweather: AccuweatherBackend) -> None:
     )
 
     with pytest.raises(AccuweatherError) as accuweather_error:
-        await accuweather.get_forecast(location_key)
+        await accuweather.get_forecast(location_key, language)
 
     assert str(accuweather_error.value) == expected_error_value
 
@@ -2464,14 +2491,14 @@ async def test_get_location_completion_with_no_geolocation_country_code(
 
 @pytest.mark.asyncio
 async def test_fetch_from_cache_without_country_city(
-    accuweather: AccuweatherBackend,
+    accuweather: AccuweatherBackend, language: str
 ) -> None:
     """Test that `_fetch_from_cache` returns None if country or city is missing."""
-    cached_data = await accuweather._fetch_from_cache("US", None, None)
+    cached_data = await accuweather._fetch_from_cache("US", None, None, language)
 
     assert cached_data is None
 
-    cached_data = await accuweather._fetch_from_cache(None, None, None)
+    cached_data = await accuweather._fetch_from_cache(None, None, None, language)
 
     assert cached_data is None
 

--- a/tests/unit/providers/weather/backends/test_accuweather.py
+++ b/tests/unit/providers/weather/backends/test_accuweather.py
@@ -1989,16 +1989,16 @@ async def test_get_forecast_error(accuweather: AccuweatherBackend, language: str
     [
         (
             {"q": "asdfg", "apikey": "filter_me_out"},
-            f"AccuweatherBackend:v4:localhost:"
+            f"AccuweatherBackend:v5:localhost:"
             f"{hashlib.blake2s('q'.encode('utf-8') + 'asdfg'.encode('utf-8')).hexdigest()}",
         ),
         (
             {},
-            "AccuweatherBackend:v4:localhost",
+            "AccuweatherBackend:v5:localhost",
         ),
         (
             {"q": "asdfg"},
-            f"AccuweatherBackend:v4:localhost:"
+            f"AccuweatherBackend:v5:localhost:"
             f"{hashlib.blake2s('q'.encode('utf-8') + 'asdfg'.encode('utf-8')).hexdigest()}",
         ),
     ],


### PR DESCRIPTION
## References

JIRA: [DISCO-3005](https://mozilla-hub.atlassian.net/browse/DISCO-3005)

## Description
Passed along the language header to weather report logic to be able to retrieve, current conditions and forecast in different languages.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3005]: https://mozilla-hub.atlassian.net/browse/DISCO-3005?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ