### PR TITLE
[DISCO-3011] Migrate Load Test Images From Container Registry to Artifact Registry

### DIFF
--- a/docs/testing/load-tests.md
+++ b/docs/testing/load-tests.md
@@ -157,7 +157,7 @@ a GKE cluster
 * To apply new changes to an existing GCP Cluster, execute the `setup_k8s.sh` file and select the
   **setup** option.
     * This option will consider the local commit history, creating new containers and
-      deploying them (see [Container Registry][container_registry])
+      deploying them (see [Artifact Registry][artifact_registry])
 
 ### Run Test Session
 
@@ -507,11 +507,11 @@ updating the following:
 5. Documentation
     * [ ] [load test docs][load_test_docs]
 
+[artifact_registry]: https://console.cloud.google.com/artifacts/docker/spheric-keel-331521/us-west1/locust-merino?project=spheric-keel-331521
 [circle_ci]: https://circleci.com/docs/
 [circle_config_yml]: https://github.com/mozilla-services/merino-py/blob/main/.circleci/config.yml
 [cloud]: https://console.cloud.google.com/home/dashboard?q=search&referrer=search&project=spheric-keel-331521&cloudshell=false
 [conserv]: https://drive.google.com/drive/folders/1rvCpmwGuLt4COH6Zw6vSyu_019_sB3Ux
-[container_registry]: https://console.cloud.google.com/gcr/images/spheric-keel-331521/global/locust-merino?project=spheric-keel-331521
 [docker]: https://docs.docker.com/
 [docker_compose]:https://github.com/mozilla-services/merino-py/blob/main/tests/load/docker-compose.yml
 [dockerfile]: https://github.com/mozilla-services/merino-py/blob/main/tests/load/Dockerfile

--- a/tests/load/cloudbuild.yaml
+++ b/tests/load/cloudbuild.yaml
@@ -1,4 +1,4 @@
 steps:
 - name: "gcr.io/cloud-builders/docker"
-  args: ["build", "-t", "gcr.io/$PROJECT_ID/locust-merino:$TAG_NAME", "-f", "./tests/load/Dockerfile", "."]
-images: ["gcr.io/$PROJECT_ID/locust-merino:$TAG_NAME"]
+  args: ["build", "-t", "us-west1-docker.pkg.dev/$PROJECT_ID/merino/locust-merino:$TAG_NAME", "-f", "./tests/load/Dockerfile", "."]
+images: ["us-west1-docker.pkg.dev/$PROJECT_ID/merino/locust-merino:$TAG_NAME"]

--- a/tests/load/kubernetes-config/locust-master-controller.yml
+++ b/tests/load/kubernetes-config/locust-master-controller.yml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: locust-master
-          image: gcr.io/[PROJECT_ID]/locust-merino:[LOCUST_IMAGE_TAG]
+          image: us-west1-docker.pkg.dev/[PROJECT_ID]/merino/locust-merino:[LOCUST_IMAGE_TAG]
           env:
             - name: LOCUST_MODE_MASTER
               value: "true"

--- a/tests/load/kubernetes-config/locust-worker-controller.yml
+++ b/tests/load/kubernetes-config/locust-worker-controller.yml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: locust-worker
-          image: gcr.io/[PROJECT_ID]/locust-merino:[LOCUST_IMAGE_TAG]
+          image: us-west1-docker.pkg.dev/[PROJECT_ID]/merino/locust-merino:[LOCUST_IMAGE_TAG]
           env:
             - name: LOCUST_MODE_WORKER
               value: "true"


### PR DESCRIPTION
## References

JIRA: [DISCO-3011](https://mozilla-hub.atlassian.net/browse/DISCO-3011)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->

The GCP container registry has been [deprecated](https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr) in favor of the artifact registry. This PR updated the load test scripts to use a new artifact registry when creating [merino-locust](https://console.cloud.google.com/artifacts/docker/spheric-keel-331521/us-west1/merino/locust-merino?cloudshell=true&project=spheric-keel-331521) images.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3011]: https://mozilla-hub.atlassian.net/browse/DISCO-3011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ