### PR TITLE
[DISCO-3054] Update CI load test strategy to opt-out

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,7 +222,7 @@ jobs:
     # Pushing a new production Docker image to the Docker Hub registry triggers a
     # webhook that starts the Jenkins deployment workflow
     docker:
-      - image: cimg/base:2022.08
+      - image: cimg/base:2024.11
     steps:
       - checkout
       - attach_workspace:
@@ -236,16 +236,15 @@ jobs:
           name: Push to Docker Hub
           # The commit tag signals deployment and load test instructions to Jenkins by
           # modifying the Docker image tag name. The convention looks as follows:
-          #^(?P<environment>stage|prod)(?:-(?P<task>\w+)-(?P<onfailure>warn|abort))?-(?P<commit>[a-z0-9]+)$
+          #^(?P<environment>stage|prod)(?:-(?P<task>\w+)-(?P<action>abort|skip|warn))?-(?P<commit>[a-z0-9]+)$
           command: |
-            if git log -1 "$CIRCLE_SHA1" | grep -q '\[load test: warn\]'; then
-              echo "Load test requested. Slack warning will be output if test fails and deployment workflow for prod will proceed."
-              STAGE_DOCKER_TAG="stage-loadtest-warn-${CIRCLE_SHA1}"
-            elif git log -1 "$CIRCLE_SHA1" | grep -q '\[load test: abort\]'; then
-              echo "Load test requested. Deployment workflow for prod will abort if load test fails."
+            LOAD_TEST_ACTION=$(git log -1 "$CIRCLE_SHA1" | sed -n 's/.*\[load test: \([^]]*\)\].*/\1/p')
+            if [ "$LOAD_TEST_ACTION" = "abort" ]; then
               STAGE_DOCKER_TAG="stage-loadtest-abort-${CIRCLE_SHA1}"
-            else
+            elif [ "$LOAD_TEST_ACTION" = "skip" ]; then
               STAGE_DOCKER_TAG="stage-${CIRCLE_SHA1}"
+            else
+              STAGE_DOCKER_TAG="stage-loadtest-warn-${CIRCLE_SHA1}"
             fi
             echo "${DOCKERHUB_REPO}:${STAGE_DOCKER_TAG}"
             docker tag app:build "${DOCKERHUB_REPO}:${STAGE_DOCKER_TAG}"

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@ JIRA: [DISCO-TODO](https://mozilla-hub.atlassian.net/browse/DISCO-TODO)
 _Put an `x` in the boxes that apply_
 
 - [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
-- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
-- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
+- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
+- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
 - [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
 - [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)

--- a/docs/dev/release-process.md
+++ b/docs/dev/release-process.md
@@ -40,13 +40,22 @@ retrieved locally via `git rev-parse HEAD`.
 
 ## Load Testing
 
-Load testing can be run locally or as a part of the deployment process. Local execution does not
-require any labeling in commit messages. For deployment, you have to add a label to the message of
-the commit that you wish to deploy in the form of: `[load test: (abort|warn)]`. In most cases this
-will be the merge commit created by merging a GitHub pull request.
+Load testing can be performed either locally or during the deployment process. During deployment,
+load tests are run against the staging environment before Merino-py is promoted to production.
 
-`abort` will prevent deployment should the load testing fail while `warn` will warn via Slack and
-continue deployment. For detailed specifics on load testing and this convention, please see the
+Load tests in continuous deployment are controlled by adding a specific label to the commit message
+being deployed. The format for the label is `[load test: (abort|skip|warn)]`. Typically, this label
+is added to the merge commit created when a GitHub pull request is integrated.
+
+- `abort`: Stops the deployment if the load test fails.
+- `skip`: Skips load testing entirely during deployment.
+- `warn`: Proceeds with the deployment even if the load test fails, but sends a warning notification
+  through Slack.
+
+If no label is included in the commit message, the default behavior is to run the load test and
+issue a warning if it fails.
+
+For more detailed information about load testing procedures and conventions, please refer to the
 [Load Test README][load_test_readme].
 
 Logs from load tests executed in continuous deployment are available in the `/data` volume of the


### PR DESCRIPTION
**Follow-up to https://github.com/mozilla-services/merino-py/pull/681**

## References

JIRA: [DISCO-3054](https://mozilla-hub.atlassian.net/browse/DISCO-3054)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->

- update the CircleCI config to trigger load tests by default and support load test opt-out
- update documentation accordingly

I tested this logic by encapsulating it in the following script and executing the following test cases:

./test_stage_docker_tag.sh
```
#!/bin/bash

CIRCLE_SHA1="dummysha123456"
COMMIT_MESSAGE=$1

LOAD_TEST_ACTION=$(echo "$COMMIT_MESSAGE" | sed -n 's/.*\[load test: \([^]]*\)\].*/\1/p')

if [ "$LOAD_TEST_ACTION" = "abort" ]; then
  STAGE_DOCKER_TAG="stage-loadtest-abort-${CIRCLE_SHA1}"
elif [ "$LOAD_TEST_ACTION" = "skip" ]; then
  STAGE_DOCKER_TAG="stage-${CIRCLE_SHA1}"
else
  STAGE_DOCKER_TAG="stage-loadtest-warn-${CIRCLE_SHA1}"
fi

echo "COMPOSED DOCKER TAG: ${STAGE_DOCKER_TAG}"
```

Test Cases:
1. ./test_stage_docker_tag.sh "chore(load-test-opt-in): turning it on"
2. ./test_stage_docker_tag.sh "chore(load-test-opt-in): turning it on [load test: abort]"
3. ./test_stage_docker_tag.sh "chore(load-test-opt-in): turning it on [load test: skip]"
4. ./test_stage_docker_tag.sh "chore(load-test-opt-in): turning it on [load test: warn]"

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3054]: https://mozilla-hub.atlassian.net/browse/DISCO-3054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ