### PR TITLE
[MC-1506] don't error when blob is missing in staging

### DIFF
--- a/merino/utils/synced_gcs_blob.py
+++ b/merino/utils/synced_gcs_blob.py
@@ -14,6 +14,7 @@ from google.cloud.storage import Client
 from aiodogstatsd import Client as StatsdClient
 
 from merino import cron
+from merino.config import settings
 
 logger = logging.getLogger(__name__)
 
@@ -105,7 +106,9 @@ class SyncedGcsBlob:
         blob = bucket.blob(self.blob_name)
 
         if not blob.exists():
-            logger.error(f"Blob '{self.blob_name}' not found.")
+            # The staging bucket is not expected to have data. We don't want to emit a Sentry error.
+            level = logging.INFO if settings.current_env.lower() == "staging" else logging.ERROR
+            logger.log(level, f"Blob '{self.blob_name}' not found.")
             return
 
         # reload() populates blob.size and blob.updated.


### PR DESCRIPTION
## References

JIRA: [MC-1506](https://mozilla-hub.atlassian.net/browse/MC-1506)
[Slack thread](https://mozilla.slack.com/archives/G01M6ALKVL4/p1730747515881179)

## Description
Sentry errors get emitted in the staging environment, because there's no engagement data there. This is actually expected because bigquery-etl doesn't have a staging environment, and therefore only writes to production.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[MC-1506]: https://mozilla-hub.atlassian.net/browse/MC-1506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ