### PR TITLE
feat: add alternate_names_2 to geonames uploader

### DIFF
--- a/merino/jobs/geonames_uploader/__init__.py
+++ b/merino/jobs/geonames_uploader/__init__.py
@@ -144,10 +144,10 @@ class GeonamesChunk(Chunk):
     def add_item(self, geoname: Geoname) -> None:
         """Add a geoname to the chunk."""
         super().add_item(geoname)
-        for name in geoname.alternate_names:
-            if len(name) > self.max_alternate_name_length:
-                self.max_alternate_name_length = len(name)
-            word_count = len(name.split())
+        for alt in geoname.alternates:
+            if len(alt.name) > self.max_alternate_name_length:
+                self.max_alternate_name_length = len(alt.name)
+            word_count = len(alt.name.split())
             if word_count > self.max_alternate_name_word_count:
                 self.max_alternate_name_word_count = word_count
 


### PR DESCRIPTION
## References

[bug 1929167](https://bugzilla.mozilla.org/show_bug.cgi?id=1929167)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->

The Rust change in bug 1928544 (vendored today in bug 1929082) expects `alternate_names_2` to be present in each geoname object in the remote settings data. We need to modify the uploader to include it.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
