### PR TITLE
feat: replace Canadian admin1_codes - bug 1929362

### DIFF
--- a/tests/unit/jobs/geonames_uploader/test_downloader.py
+++ b/tests/unit/jobs/geonames_uploader/test_downloader.py
@@ -34,7 +34,7 @@ from merino.jobs.geonames_uploader.downloader import (
     GeonamesDownloader,
 )
 
-
+# Geonames that will populate the mock GeoNames files
 GEONAMES = [
     # Waterloo, AL
     Geoname(
@@ -120,7 +120,7 @@ GEONAMES = [
         admin1_code="NY",
         population=19274244,
     ),
-    # A made-up city with diacritics in its name
+    # A made-up Canadian city with diacritics in its name
     Geoname(
         id=8,
         name="Àęí",
@@ -134,6 +134,7 @@ GEONAMES = [
     ),
 ]
 
+# Alternates that will populate the mock GeoNames files
 ALTERNATES = [
     # Waterloo, AL
     GeonameAlternate(
@@ -465,7 +466,9 @@ def test_all_populations_and_iso_languages(
                 feature_class="P",
                 feature_code="PPLA2",
                 country_code="CA",
-                admin1_code="10",
+                # The raw `admin1_code` value of "10" in the dataset should be
+                # converted to "QC" in the returned geoname.
+                admin1_code="QC",
                 population=1,
                 # Versions both with and without diacritics should be included.
                 alternates=[


### PR DESCRIPTION
## References

[Bug 1929362 - Convert Canadian province admin1_code values to postal abbreviations in the Merino geonames uploader job](https://bugzilla.mozilla.org/show_bug.cgi?id=1929362)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
