### PR TITLE
[HNT-248] Adjust recommendation beta prior

### DIFF
--- a/merino/curated_recommendations/prior_backends/gcs_prior.py
+++ b/merino/curated_recommendations/prior_backends/gcs_prior.py
@@ -40,7 +40,7 @@ class GcsPrior(PriorBackend):
         # To maintain this proportion, we've chosen a weight of 0.1. A higher weight increases
         # exploration. Since having more items reduces the number of impressions available per item,
         # beta scales with the average impressions per item to adjust the level of exploration.
-        beta = 0.1 * prior_stats.impressions_per_item
+        beta = 0.05 * prior_stats.impressions_per_item
         # Set alpha to create an optimistic prior, so every item is explored to discover its CTR.
         alpha = beta * prior_stats.average_ctr_top2_items
 


### PR DESCRIPTION
## References

JIRA: [DISCO-TODO](https://mozilla-hub.atlassian.net/browse/DISCO-TODO)

## Description
Matt has done some analysis showing that exploration takes most of the day. One concern is that this would prevent the [content expiration experiment](https://docs.google.com/document/d/1Lybqo3uG0fIp2EgHdCYsxEAIUzSlDvXcdhpbL_NtQwo/edit?tab=t.0) from showing older items until late in the day. It might also prevent good items from being shown to more users.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
