### PR TITLE
[DISCO-3062] Fix merino-locust docker image isn't publishing when load tests are triggered by default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,7 +236,7 @@ jobs:
       - run:
           name: Check for load test directive
           command: |
-            if ! git log -1 "$CIRCLE_SHA1" | grep -q '\[load test: abort\|warn\]'; then
+            if git log -1 "$CIRCLE_SHA1" | grep -q '\[load test: skip\]'; then
               echo "Skipping remaining steps in this job: load test not required."
               circleci-agent step halt
             fi


### PR DESCRIPTION
## References

JIRA: [DISCO-3062](https://mozilla-hub.atlassian.net/browse/DISCO-3062)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->

- update the `docker-image-publish-locust` job to skip only if the `[load test: skip]` substring is provided in the latest commit message

I tested this by modifying the PR build, adding the `docker-image-publish-locust` job temporarily:

Case 1: No Skip --> [CI](https://app.circleci.com/pipelines/github/mozilla-services/merino-py/3695/workflows/1bc8431c-b0a3-4d3d-a5ba-5fa967d78ba0) & [Dockerhub](https://hub.docker.com/r/mozilla/merino-py/tags)
Case 2: Skip --> [CI](https://app.circleci.com/pipelines/github/mozilla-services/merino-py/3696/workflows/80716e02-271a-4167-a785-f79f247b1930)

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3062]: https://mozilla-hub.atlassian.net/browse/DISCO-3062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ