### PR TITLE
[HNT-249] fix content duration Nimbus slug

### DIFF
--- a/merino/curated_recommendations/protocol.py
+++ b/merino/curated_recommendations/protocol.py
@@ -60,7 +60,7 @@ class ExperimentName(str, Enum):
     # Same as the above, but targeting small countries, which need a higher enrollment %.
     REGION_SPECIFIC_CONTENT_EXPANSION_SMALL = "new-tab-region-specific-content-expansion-small"
     # Experiment where high-engaging items scheduled for past dates are included.
-    EXTENDED_EXPIRATION_EXPERIMENT = "new-tab-extended-expiration-experiment"
+    EXTENDED_EXPIRATION_EXPERIMENT = "new-tab-extend-content-duration"
 
 
 # Maximum tileId that Firefox can support. Firefox uses Javascript to store this value. The max


### PR DESCRIPTION
## References

JIRA: [HNT-249](https://mozilla-hub.atlassian.net/browse/HNT-249)

## Description
Set the slug to the one chosen in the [Nimbus experiment](https://experimenter.services.mozilla.com/nimbus/new-tab-extend-content-duration/summary): `new-tab-extend-content-duration`.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[HNT-249]: https://mozilla-hub.atlassian.net/browse/HNT-249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ