### PR TITLE
[DISCO-3036] refactor: r2d2 job to use domain mapping file

### DIFF
--- a/merino/jobs/navigational_suggestions/__init__.py
+++ b/merino/jobs/navigational_suggestions/__init__.py
@@ -11,7 +11,7 @@ from httpx import URL
 
 from merino.config import settings as config
 from merino.content_handler.gcp_uploader import GcsUploader
-from merino.jobs.navigational_suggestions.domain_category_mapping import DOMAIN_MAPPING
+from merino.jobs.utils.domain_category_mapping import DOMAIN_MAPPING
 from merino.jobs.navigational_suggestions.domain_data_downloader import (
     DomainDataDownloader,
 )

--- a/merino/jobs/utils/domain_category_mapping.py
+++ b/merino/jobs/utils/domain_category_mapping.py
@@ -4,7 +4,11 @@ from merino.config import settings
 from merino.providers.base import Category
 
 if settings.env_for_dynaconf in ["testing", "ci"]:
-    DOMAIN_MAPPING = {}
+    DOMAIN_MAPPING = {
+        "mqzeM3Cm0XLuAd0kKwCttg==": [Category.Sports],
+        "g01iNP2/b7ehY5hQXQRP1g==": [Category.Sports, Category.News],
+        "uQX8/1Xq/Q9wZOXXGogCaQ==": [Category.Inconclusive],
+    }
 else:
     DOMAIN_MAPPING = {
         "BPNrX9JDOSGaN/1l4qozIg==": [Category.Home],


### PR DESCRIPTION
## References

JIRA: [DISCO-3036](https://mozilla-hub.atlassian.net/browse/DISCO-3036)

## Description
Since we have the mapping file in merino already, there's no need to have the job ask for a category mapping file. It also simplifies the logic as well.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3036]: https://mozilla-hub.atlassian.net/browse/DISCO-3036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ