### PR TITLE
[HNT-251] add layouts to sections

### DIFF
--- a/merino/curated_recommendations/layouts.py
+++ b/merino/curated_recommendations/layouts.py
@@ -1,0 +1,111 @@
+"""The layouts below control how tiles are displayed in the sections experiment.
+
+TODO: HNT-252 will document the QA process for layout changes. PR review suffices while we're in nightly.
+"""
+
+from merino.curated_recommendations.protocol import Layout, ResponsiveLayout, Tile, TileSize
+
+# The following layouts are based on work-in-progress designs. The goal is to get some mock data to
+# FE developers. Names and layouts will likely be changed.
+
+# layout with 4 medium tiles, and an ad in 2nd position
+layout_4_medium = Layout(
+    name="4-medium-tiles-ad-position-1",
+    responsiveLayouts=[
+        ResponsiveLayout(
+            columnCount=4,
+            tiles=[
+                Tile(size=TileSize.MEDIUM, position=0, hasAd=False),
+                Tile(size=TileSize.MEDIUM, position=1, hasAd=True),
+                Tile(size=TileSize.MEDIUM, position=2, hasAd=False),
+                Tile(size=TileSize.MEDIUM, position=3, hasAd=False),
+            ],
+        ),
+        ResponsiveLayout(
+            columnCount=2,
+            tiles=[
+                Tile(size=TileSize.MEDIUM, position=0, hasAd=False),
+                Tile(size=TileSize.MEDIUM, position=1, hasAd=True),
+                Tile(size=TileSize.MEDIUM, position=2, hasAd=False),
+                Tile(size=TileSize.MEDIUM, position=3, hasAd=False),
+            ],
+        ),
+        ResponsiveLayout(
+            columnCount=1,
+            tiles=[
+                Tile(size=TileSize.MEDIUM, position=0, hasAd=False),
+                Tile(size=TileSize.MEDIUM, position=1, hasAd=True),
+                Tile(size=TileSize.MEDIUM, position=2, hasAd=False),
+                Tile(size=TileSize.MEDIUM, position=3, hasAd=False),
+            ],
+        ),
+    ],
+)
+
+# layout with 4 small tiles, and no ads
+layout_4_small = Layout(
+    name="4-small-tiles-no-ads",
+    responsiveLayouts=[
+        ResponsiveLayout(
+            columnCount=4,
+            tiles=[
+                Tile(size=TileSize.SMALL, position=0, hasAd=False),
+                Tile(size=TileSize.SMALL, position=1, hasAd=False),
+                Tile(size=TileSize.SMALL, position=2, hasAd=False),
+                Tile(size=TileSize.SMALL, position=3, hasAd=False),
+            ],
+        ),
+        ResponsiveLayout(
+            columnCount=2,
+            tiles=[
+                Tile(size=TileSize.SMALL, position=0, hasAd=False),
+                Tile(size=TileSize.SMALL, position=1, hasAd=False),
+                Tile(size=TileSize.SMALL, position=2, hasAd=False),
+                Tile(size=TileSize.SMALL, position=3, hasAd=False),
+            ],
+        ),
+        ResponsiveLayout(
+            columnCount=1,
+            tiles=[
+                Tile(size=TileSize.SMALL, position=0, hasAd=False),
+                Tile(size=TileSize.SMALL, position=1, hasAd=False),
+                Tile(size=TileSize.SMALL, position=2, hasAd=False),
+                Tile(size=TileSize.SMALL, position=3, hasAd=False),
+            ],
+        ),
+    ],
+)
+
+# layout with large-medium-small tiles, and an ad in medium tile
+layout_large_medium_small = Layout(
+    name="1-large-2-small-1-medium-ad-position-3",
+    responsiveLayouts=[
+        ResponsiveLayout(
+            columnCount=4,
+            tiles=[
+                Tile(size=TileSize.LARGE, position=0, hasAd=False),
+                Tile(size=TileSize.SMALL, position=1, hasAd=False),
+                Tile(size=TileSize.SMALL, position=2, hasAd=False),
+                Tile(size=TileSize.MEDIUM, position=3, hasAd=True),
+            ],
+        ),
+        ResponsiveLayout(
+            columnCount=2,
+            tiles=[
+                Tile(size=TileSize.LARGE, position=0, hasAd=False),
+                Tile(size=TileSize.SMALL, position=1, hasAd=False),
+                Tile(size=TileSize.SMALL, position=2, hasAd=False),
+                Tile(size=TileSize.MEDIUM, position=3, hasAd=True),
+            ],
+        ),
+        ResponsiveLayout(
+            columnCount=1,
+            tiles=[
+                Tile(size=TileSize.MEDIUM, position=0, hasAd=False),
+                Tile(size=TileSize.MEDIUM, position=1, hasAd=True),
+                Tile(size=TileSize.SMALL, position=2, hasAd=False),
+                Tile(size=TileSize.SMALL, position=3, hasAd=False),
+            ],
+        ),
+    ],
+)

--- a/merino/curated_recommendations/protocol.py
+++ b/merino/curated_recommendations/protocol.py
@@ -149,13 +149,45 @@ class CuratedRecommendationsBucket(BaseModel):
     title: str | None = None
 
 
-class Section(BaseModel):
-    """A ranked list of curated recommendations"""
+@unique
+class TileSize(str, Enum):
+    """Defines possible sizes for a tile in the layout."""
 
-    receivedRank: int
+    SMALL = "small"
+    MEDIUM = "medium"
+    LARGE = "large"
+
+
+class Tile(BaseModel):
+    """Defines properties for a single tile in a responsive layout."""
+
+    size: TileSize
+    position: int
+    hasAd: bool
+
+
+class ResponsiveLayout(BaseModel):
+    """Defines layout properties for a specific column count."""
+
+    columnCount: int
+    tiles: list[Tile]
+
+
+class Layout(BaseModel):
+    """Defines a responsive layout configuration with multiple column layouts."""
+
+    name: str
+    responsiveLayouts: list[ResponsiveLayout]
+
+
+class Section(BaseModel):
+    """A ranked list of curated recommendations with responsive layout configurations."""
+
+    receivedFeedRank: int
     recommendations: list[CuratedRecommendation]
     title: str
     subtitle: str | None = None
+    layout: Layout
 
 
 class CuratedRecommendationsFeed(BaseModel):

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -39,6 +39,7 @@ from merino.curated_recommendations.fakespot_backend.protocol import (
 from merino.curated_recommendations.prior_backends.protocol import PriorBackend
 from merino.curated_recommendations.protocol import (
     ExperimentName,
+    Layout,
 )
 from merino.curated_recommendations.protocol import CuratedRecommendation
 from merino.main import app
@@ -1336,6 +1337,9 @@ class TestSections:
             assert (
                 len(feeds) > 5
             )  # fixture data contains enough recommendations for many sections.
+
+            # All sections have a layout
+            assert all(Layout(**feed["layout"]) for feed in feeds.values() if feed)
 
             # Ensure "Today's top stories" is present with a valid date subtitle
             top_stories_section = data["feeds"].get("top_stories_section")


### PR DESCRIPTION
## References

- JIRA: [HNT-251](https://mozilla-hub.atlassian.net/browse/HNT-251)
- [API spec](https://mozilla-hub.atlassian.net/wiki/spaces/FPS/pages/1078231077/Sections+Phase+1+-+API+Technical+Specification)
- [the Figma designs](https://www.figma.com/design/VdghooQZTLiXYO8hF5pAuS/Feed?node-id=5358-17426&node-type=canvas&t=PWBqFJ8XsRE8ifQT-0)

## Description
Unblock front-end development by sending layout data for sections. Sections is under active development, so layouts and layout names are likely to change.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[HNT-251]: https://mozilla-hub.atlassian.net/browse/HNT-251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ