### PR TITLE
[HNT-258] fix: layouts match design

### DIFF
--- a/merino/curated_recommendations/layouts.py
+++ b/merino/curated_recommendations/layouts.py
@@ -1,5 +1,8 @@
 """The layouts below control how tiles are displayed in the sections experiment.
 
+Tile order should be based on horizontal stacking. You can try this our in the Mozilla Playground:
+https://developer.mozilla.org/en-US/play?id=zWYUe3xC5v60fEuN8USHE24l7Q7tR2Vghi08O6KT9DAZz9cv%2B%2F0s0H8F7vJBWRVCnQgSHYWR%2BadDY4zA
+
 TODO: HNT-252 will document the QA process for layout changes. PR review suffices while we're in nightly.
 """
 
@@ -59,27 +62,27 @@ layout_4_large = Layout(
             columnCount=4,
             tiles=[
                 Tile(size=TileSize.LARGE, position=0, hasAd=False, hasExcerpt=True),
-                Tile(size=TileSize.SMALL, position=1, hasAd=False, hasExcerpt=False),
                 Tile(size=TileSize.SMALL, position=2, hasAd=False, hasExcerpt=False),
-                Tile(size=TileSize.MEDIUM, position=3, hasAd=True, hasExcerpt=True),
+                Tile(size=TileSize.MEDIUM, position=1, hasAd=True, hasExcerpt=True),
+                Tile(size=TileSize.SMALL, position=3, hasAd=False, hasExcerpt=False),
             ],
         ),
         ResponsiveLayout(
             columnCount=3,
             tiles=[
                 Tile(size=TileSize.MEDIUM, position=0, hasAd=False, hasExcerpt=True),
-                Tile(size=TileSize.SMALL, position=1, hasAd=False, hasExcerpt=False),
                 Tile(size=TileSize.SMALL, position=2, hasAd=False, hasExcerpt=False),
-                Tile(size=TileSize.MEDIUM, position=3, hasAd=True, hasExcerpt=True),
+                Tile(size=TileSize.MEDIUM, position=1, hasAd=True, hasExcerpt=True),
+                Tile(size=TileSize.SMALL, position=3, hasAd=False, hasExcerpt=False),
             ],
         ),
         ResponsiveLayout(
             columnCount=2,
             tiles=[
                 Tile(size=TileSize.LARGE, position=0, hasAd=False, hasExcerpt=True),
-                Tile(size=TileSize.SMALL, position=1, hasAd=False, hasExcerpt=False),
                 Tile(size=TileSize.SMALL, position=2, hasAd=False, hasExcerpt=False),
-                Tile(size=TileSize.MEDIUM, position=3, hasAd=True, hasExcerpt=True),
+                Tile(size=TileSize.MEDIUM, position=1, hasAd=True, hasExcerpt=True),
+                Tile(size=TileSize.SMALL, position=3, hasAd=False, hasExcerpt=False),
             ],
         ),
         ResponsiveLayout(
@@ -101,10 +104,10 @@ layout_6_tiles = Layout(
         ResponsiveLayout(
             columnCount=4,
             tiles=[
-                Tile(size=TileSize.SMALL, position=0, hasAd=False, hasExcerpt=False),
-                Tile(size=TileSize.SMALL, position=1, hasAd=False, hasExcerpt=False),
-                Tile(size=TileSize.MEDIUM, position=2, hasAd=False, hasExcerpt=True),
-                Tile(size=TileSize.MEDIUM, position=3, hasAd=True, hasExcerpt=True),
+                Tile(size=TileSize.SMALL, position=2, hasAd=False, hasExcerpt=False),
+                Tile(size=TileSize.MEDIUM, position=0, hasAd=False, hasExcerpt=True),
+                Tile(size=TileSize.MEDIUM, position=1, hasAd=True, hasExcerpt=True),
+                Tile(size=TileSize.SMALL, position=3, hasAd=False, hasExcerpt=False),
                 Tile(size=TileSize.SMALL, position=4, hasAd=False, hasExcerpt=False),
                 Tile(size=TileSize.SMALL, position=5, hasAd=False, hasExcerpt=False),
             ],

--- a/merino/curated_recommendations/layouts.py
+++ b/merino/curated_recommendations/layouts.py
@@ -8,9 +8,9 @@ from merino.curated_recommendations.protocol import Layout, ResponsiveLayout, Ti
 # The following layouts are based on work-in-progress designs. The goal is to get some mock data to
 # FE developers. Names and layouts will likely be changed.
 
-# layout with 4 medium tiles, an ad in 2nd position, and an excerpt in all tiles
+# Layout 1: 4 medium tiles on 4 columns. Small tiles are used on fewer columns to display all items.
 layout_4_medium = Layout(
-    name="4-medium-tiles-ad-position-1",
+    name="4-medium-small-1-ad",
     responsiveLayouts=[
         ResponsiveLayout(
             columnCount=4,
@@ -22,35 +22,10 @@ layout_4_medium = Layout(
             ],
         ),
         ResponsiveLayout(
-            columnCount=2,
+            columnCount=3,
             tiles=[
                 Tile(size=TileSize.MEDIUM, position=0, hasAd=False, hasExcerpt=True),
                 Tile(size=TileSize.MEDIUM, position=1, hasAd=True, hasExcerpt=True),
-                Tile(size=TileSize.MEDIUM, position=2, hasAd=False, hasExcerpt=True),
-                Tile(size=TileSize.MEDIUM, position=3, hasAd=False, hasExcerpt=True),
-            ],
-        ),
-        ResponsiveLayout(
-            columnCount=1,
-            tiles=[
-                Tile(size=TileSize.MEDIUM, position=0, hasAd=False, hasExcerpt=True),
-                Tile(size=TileSize.MEDIUM, position=1, hasAd=True, hasExcerpt=True),
-                Tile(size=TileSize.MEDIUM, position=2, hasAd=False, hasExcerpt=True),
-                Tile(size=TileSize.MEDIUM, position=3, hasAd=False, hasExcerpt=True),
-            ],
-        ),
-    ],
-)
-
-# layout with 4 small tiles, no ads and no excerpts
-layout_4_small = Layout(
-    name="4-small-tiles-no-ads",
-    responsiveLayouts=[
-        ResponsiveLayout(
-            columnCount=4,
-            tiles=[
-                Tile(size=TileSize.SMALL, position=0, hasAd=False, hasExcerpt=False),
-                Tile(size=TileSize.SMALL, position=1, hasAd=False, hasExcerpt=False),
                 Tile(size=TileSize.SMALL, position=2, hasAd=False, hasExcerpt=False),
                 Tile(size=TileSize.SMALL, position=3, hasAd=False, hasExcerpt=False),
             ],
@@ -58,8 +33,8 @@ layout_4_small = Layout(
         ResponsiveLayout(
             columnCount=2,
             tiles=[
-                Tile(size=TileSize.SMALL, position=0, hasAd=False, hasExcerpt=False),
-                Tile(size=TileSize.SMALL, position=1, hasAd=False, hasExcerpt=False),
+                Tile(size=TileSize.MEDIUM, position=0, hasAd=False, hasExcerpt=True),
+                Tile(size=TileSize.MEDIUM, position=1, hasAd=True, hasExcerpt=True),
                 Tile(size=TileSize.SMALL, position=2, hasAd=False, hasExcerpt=False),
                 Tile(size=TileSize.SMALL, position=3, hasAd=False, hasExcerpt=False),
             ],
@@ -67,8 +42,8 @@ layout_4_small = Layout(
         ResponsiveLayout(
             columnCount=1,
             tiles=[
-                Tile(size=TileSize.SMALL, position=0, hasAd=False, hasExcerpt=False),
-                Tile(size=TileSize.SMALL, position=1, hasAd=False, hasExcerpt=False),
+                Tile(size=TileSize.MEDIUM, position=0, hasAd=False, hasExcerpt=True),
+                Tile(size=TileSize.MEDIUM, position=1, hasAd=True, hasExcerpt=True),
                 Tile(size=TileSize.SMALL, position=2, hasAd=False, hasExcerpt=False),
                 Tile(size=TileSize.SMALL, position=3, hasAd=False, hasExcerpt=False),
             ],
@@ -76,14 +51,23 @@ layout_4_small = Layout(
     ],
 )
 
-# layout with large-medium-small tiles, an ad in medium tile, and an excerpt in a large tile and medium tile
-layout_large_medium_small = Layout(
-    name="1-large-2-small-1-medium-ad-position-3",
+# Layout 2: Lead with a large tile.
+layout_4_large = Layout(
+    name="4-large-small-medium-1-ad",
     responsiveLayouts=[
         ResponsiveLayout(
             columnCount=4,
             tiles=[
                 Tile(size=TileSize.LARGE, position=0, hasAd=False, hasExcerpt=True),
+                Tile(size=TileSize.SMALL, position=1, hasAd=False, hasExcerpt=False),
+                Tile(size=TileSize.SMALL, position=2, hasAd=False, hasExcerpt=False),
+                Tile(size=TileSize.MEDIUM, position=3, hasAd=True, hasExcerpt=True),
+            ],
+        ),
+        ResponsiveLayout(
+            columnCount=3,
+            tiles=[
+                Tile(size=TileSize.MEDIUM, position=0, hasAd=False, hasExcerpt=True),
                 Tile(size=TileSize.SMALL, position=1, hasAd=False, hasExcerpt=False),
                 Tile(size=TileSize.SMALL, position=2, hasAd=False, hasExcerpt=False),
                 Tile(size=TileSize.MEDIUM, position=3, hasAd=True, hasExcerpt=True),
@@ -105,6 +89,57 @@ layout_large_medium_small = Layout(
                 Tile(size=TileSize.MEDIUM, position=1, hasAd=True, hasExcerpt=True),
                 Tile(size=TileSize.SMALL, position=2, hasAd=False, hasExcerpt=False),
                 Tile(size=TileSize.SMALL, position=3, hasAd=False, hasExcerpt=False),
+            ],
+        ),
+    ],
+)
+
+# Layout 3: Layout with 6 tiles, ranging from small to medium.
+layout_6_tiles = Layout(
+    name="6-small-medium-1-ad",
+    responsiveLayouts=[
+        ResponsiveLayout(
+            columnCount=4,
+            tiles=[
+                Tile(size=TileSize.SMALL, position=0, hasAd=False, hasExcerpt=False),
+                Tile(size=TileSize.SMALL, position=1, hasAd=False, hasExcerpt=False),
+                Tile(size=TileSize.MEDIUM, position=2, hasAd=False, hasExcerpt=True),
+                Tile(size=TileSize.MEDIUM, position=3, hasAd=True, hasExcerpt=True),
+                Tile(size=TileSize.SMALL, position=4, hasAd=False, hasExcerpt=False),
+                Tile(size=TileSize.SMALL, position=5, hasAd=False, hasExcerpt=False),
+            ],
+        ),
+        ResponsiveLayout(
+            columnCount=3,
+            tiles=[
+                Tile(size=TileSize.MEDIUM, position=0, hasAd=False, hasExcerpt=True),
+                Tile(size=TileSize.MEDIUM, position=1, hasAd=False, hasExcerpt=True),
+                Tile(size=TileSize.MEDIUM, position=2, hasAd=False, hasExcerpt=True),
+                Tile(size=TileSize.MEDIUM, position=3, hasAd=True, hasExcerpt=True),
+                Tile(size=TileSize.MEDIUM, position=4, hasAd=False, hasExcerpt=True),
+                Tile(size=TileSize.MEDIUM, position=5, hasAd=False, hasExcerpt=True),
+            ],
+        ),
+        ResponsiveLayout(
+            columnCount=2,
+            tiles=[
+                Tile(size=TileSize.MEDIUM, position=0, hasAd=False, hasExcerpt=True),
+                Tile(size=TileSize.MEDIUM, position=1, hasAd=True, hasExcerpt=True),
+                Tile(size=TileSize.SMALL, position=2, hasAd=False, hasExcerpt=False),
+                Tile(size=TileSize.SMALL, position=3, hasAd=False, hasExcerpt=False),
+                Tile(size=TileSize.SMALL, position=4, hasAd=False, hasExcerpt=False),
+                Tile(size=TileSize.SMALL, position=5, hasAd=False, hasExcerpt=False),
+            ],
+        ),
+        ResponsiveLayout(
+            columnCount=1,
+            tiles=[
+                Tile(size=TileSize.MEDIUM, position=0, hasAd=False, hasExcerpt=True),
+                Tile(size=TileSize.MEDIUM, position=1, hasAd=True, hasExcerpt=True),
+                Tile(size=TileSize.SMALL, position=2, hasAd=False, hasExcerpt=False),
+                Tile(size=TileSize.SMALL, position=3, hasAd=False, hasExcerpt=False),
+                Tile(size=TileSize.SMALL, position=4, hasAd=False, hasExcerpt=False),
+                Tile(size=TileSize.SMALL, position=5, hasAd=False, hasExcerpt=False),
             ],
         ),
     ],


### PR DESCRIPTION
## References

JIRA: [HNT-258](https://mozilla-hub.atlassian.net/browse/HNT-258)

## Description
Update the layouts to match the first 3 layouts from [the latest design](https://www.figma.com/design/VdghooQZTLiXYO8hF5pAuS/Feed?node-id=6259-53439&node-type=canvas&t=c3sqxcbdFWLfnN6B-0).

Additional changes:
- add validation on `hasAd`, `hasExcerpt`, `position`, and `columnCount`
- change the minimum number of recommendations to be 1 more than the number of tiles

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[HNT-258]: https://mozilla-hub.atlassian.net/browse/HNT-258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ