### PR TITLE
[MC-1506] fix: don't log missing blob error on stage

### DIFF
--- a/merino/utils/synced_gcs_blob.py
+++ b/merino/utils/synced_gcs_blob.py
@@ -107,7 +107,7 @@ class SyncedGcsBlob:
 
         if not blob.exists():
             # The staging bucket is not expected to have data. We don't want to emit a Sentry error.
-            level = logging.INFO if settings.current_env.lower() == "staging" else logging.ERROR
+            level = logging.INFO if settings.current_env.lower() == "stage" else logging.ERROR
             logger.log(level, f"Blob '{self.blob_name}' not found.")
             return
 


### PR DESCRIPTION
## References

JIRA: [MC-1506](https://mozilla-hub.atlassian.net/browse/MC-1506)
Previous attempt: https://github.com/mozilla-services/merino-py/pull/692

## Description
Don't log an error if engagement data does not exist on staging. In the Kubernetes console, I confirmed that the [environment string is "stage"](https://console.cloud.google.com/kubernetes/configmap/us-west1/merino-nonprod-v1/stagepy-merino/merinopy-stagepy-merino-app-1/details?project=moz-fx-merino-nonprod-ee93) as opposed to "staging".

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[MC-1506]: https://mozilla-hub.atlassian.net/browse/MC-1506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ