### PR TITLE
[DISCO-3072] bump accuweather cache key version

### DIFF
--- a/merino/providers/weather/backends/accuweather/backend.py
+++ b/merino/providers/weather/backends/accuweather/backend.py
@@ -283,9 +283,9 @@ class AccuweatherBackend:
                     hasher.update(key.encode("utf-8") + value.encode("utf-8"))
             extra_identifiers = hasher.hexdigest()
 
-            return f"{self.__class__.__name__}:v5:{url}:{extra_identifiers}"
+            return f"{self.__class__.__name__}:v6:{url}:{extra_identifiers}"
 
-        return f"{self.__class__.__name__}:v5:{url}"
+        return f"{self.__class__.__name__}:v6:{url}"
 
     @functools.cache
     def cache_key_template(self, dt: WeatherDataType, language: str) -> str:

--- a/tests/unit/providers/weather/backends/test_accuweather.py
+++ b/tests/unit/providers/weather/backends/test_accuweather.py
@@ -1992,16 +1992,16 @@ async def test_get_forecast_error(accuweather: AccuweatherBackend, language: str
     [
         (
             {"q": "asdfg", "apikey": "filter_me_out"},
-            f"AccuweatherBackend:v5:localhost:"
+            f"AccuweatherBackend:v6:localhost:"
             f"{hashlib.blake2s('q'.encode('utf-8') + 'asdfg'.encode('utf-8')).hexdigest()}",
         ),
         (
             {},
-            "AccuweatherBackend:v5:localhost",
+            "AccuweatherBackend:v6:localhost",
         ),
         (
             {"q": "asdfg"},
-            f"AccuweatherBackend:v5:localhost:"
+            f"AccuweatherBackend:v6:localhost:"
             f"{hashlib.blake2s('q'.encode('utf-8') + 'asdfg'.encode('utf-8')).hexdigest()}",
         ),
     ],


### PR DESCRIPTION
## References

JIRA: [DISCO-3072](https://mozilla-hub.atlassian.net/browse/DISCO-3072)

## Description
The structure of the accuweather cached data was updated in https://github.com/mozilla-services/merino-py/pull/708 to add a new field for the region code (`administrative_area_id`). This caused [validation errors](https://mozilla.sentry.io/issues/6065590782/?project=6622434&query=&referrer=issue-stream&statsPeriod=14d&stream_index=0) on sentry because the cache key version was not updated. This PR bumps the version so this should hopefully clear the error.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3072]: https://mozilla-hub.atlassian.net/browse/DISCO-3072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ