### PR TITLE
[DISCO-3080] fix: update domain mapping file path for bandit exclusion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ branch = true
 relative_files = true
 omit = [
   # Data file only
-  "merino/jobs/navigational_suggestions/domain_category_mapping.py"
+  "merino/jobs/utils/domain_category_mapping.py"
 ]
 
 [tool.coverage.report]
@@ -41,7 +41,7 @@ lint.pydocstyle = { convention = "pep257" }
 skips = ["B101", "B104", "B311"]
 exclude_dirs = [
   # Data file only
-  "merino/jobs/navigational_suggestions/domain_category_mapping.py"
+  "merino/jobs/utils/domain_category_mapping.py"
 ]
 
 [tool.mypy]


### PR DESCRIPTION
## References

JIRA: [DISCO-3080](https://mozilla-hub.atlassian.net/browse/DISCO-3080)

## Description
When [refactoring](https://github.com/mozilla-services/merino-py/pull/702), I forgot to update the paths in `pyproject.toml`


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3080]: https://mozilla-hub.atlassian.net/browse/DISCO-3080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ