### PR TITLE
[DISCO-3090] weather: added city name correction mapping

### DIFF
--- a/merino/providers/weather/backends/accuweather/pathfinder.py
+++ b/merino/providers/weather/backends/accuweather/pathfinder.py
@@ -9,6 +9,12 @@ Triplet = tuple[MaybeStr, MaybeStr, MaybeStr]
 
 SUCCESSFUL_REGIONS_MAPPING: dict[tuple[str, str], str | None] = {}
 REGION_MAPPING_EXCLUSIONS: frozenset = frozenset(["CA", "ES", "GR", "IT", "US"])
+CITY_NAME_CORRECTION_MAPPING: dict[str, str] = {
+    "La'ie": "Laie",
+    "Mitchell/Ontario": "Mitchell",
+    "Middlebury (village)": "Middlebury",
+    "TracadieSheila": "Tracadie Sheila",
+}
 
 
 def compass(location: Location) -> Generator[Triplet, None, None]:
@@ -28,6 +34,7 @@ def compass(location: Location) -> Generator[Triplet, None, None]:
     city = location.city
 
     if regions and country and city:
+        city = CITY_NAME_CORRECTION_MAPPING.get(city, city)
         match (country, city):
             case ("US" | "CA", _):
                 yield country, regions[0], city  # use the most specific region

--- a/tests/unit/providers/weather/backends/test_pathfinder.py
+++ b/tests/unit/providers/weather/backends/test_pathfinder.py
@@ -24,6 +24,10 @@ from merino.providers.weather.backends.accuweather.pathfinder import (
         (Location(country="GB", regions=["ENG", "HWT"], city="London"), ("GB", "LND", "London")),
         (Location(country="BR", regions=["DF"], city="Brasilia"), ("BR", "DF", "Brasilia")),
         (Location(country="IE", regions=None, city="Dublin"), ("IE", None, "Dublin")),
+        (
+            Location(country="CA", regions=["ON"], city="Mitchell/Ontario"),
+            ("CA", "ON", "Mitchell"),
+        ),
     ],
     ids=[
         "Specific Region Country",
@@ -31,6 +35,7 @@ from merino.providers.weather.backends.accuweather.pathfinder import (
         "Successful Region Mapping Pair",
         "Fallback with Region",
         "Fallback No Region",
+        "Corrected City Name",
     ],
 )
 def test_compass(location: Location, expected_tuple: Tuple) -> None:


### PR DESCRIPTION
## References

JIRA: [DISCO-3090](https://mozilla-hub.atlassian.net/browse/DISCO-3090)

## Description
Some city names that maxminddb returns aren't spelled/formatted how accuweather expects it. With these corrections, those cities should not be creating warning logs anymore.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3090]: https://mozilla-hub.atlassian.net/browse/DISCO-3090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ