### PR TITLE
[DISCO-3086] weather: add city skip list

### DIFF
--- a/merino/providers/weather/backends/accuweather/backend.py
+++ b/merino/providers/weather/backends/accuweather/backend.py
@@ -611,7 +611,6 @@ class AccuweatherBackend:
             return None
 
         cached_data = cached_data if cached_data is not None else []
-
         self.emit_cache_fetch_metrics(cached_data)
         cached_report = self.parse_cached_data(cached_data)
 
@@ -656,15 +655,18 @@ class AccuweatherBackend:
 
         # The cached report is incomplete, now fetching from AccuWeather.
         if location is None:
+            skip_log = False
             try:
-                location, _ = await pathfinder.explore(
+                location, is_skipped = await pathfinder.explore(
                     geolocation, self.get_location_by_geolocation
                 )
+                skip_log = is_skipped
             except AccuweatherError as exc:
                 logger.warning(f"{exc}")
 
             if location is None:
-                logger.warning(f"Unable to find location for {country}/{city}")
+                if not skip_log:
+                    logger.warning(f"Unable to find location for {country}/{city}")
                 return None
 
         try:

--- a/merino/providers/weather/backends/accuweather/backend.py
+++ b/merino/providers/weather/backends/accuweather/backend.py
@@ -19,6 +19,7 @@ from merino.exceptions import CacheAdapterError
 from merino.middleware.geolocation import Location
 from merino.providers.weather.backends.accuweather.pathfinder import (
     set_region_mapping,
+    is_in_skip_cities_list,
 )
 from merino.providers.weather.backends.protocol import (
     CurrentConditions,
@@ -608,7 +609,8 @@ class AccuweatherBackend:
             return None
 
         cached_data = cached_data if cached_data is not None else []
-        self.emit_cache_fetch_metrics(cached_data)
+        if not is_in_skip_cities_list(country, city):
+            self.emit_cache_fetch_metrics(cached_data)
         cached_report = self.parse_cached_data(cached_data)
 
         return await self.make_weather_report(cached_report, weather_context)
@@ -658,7 +660,8 @@ class AccuweatherBackend:
                 logger.warning(f"{exc}")
 
             if location is None:
-                logger.warning(f"Unable to find location for {country}/{city}")
+                if not is_in_skip_cities_list(country, city):
+                    logger.warning(f"Unable to find location for {country}/{city}")
                 return None
 
         try:

--- a/merino/providers/weather/backends/accuweather/pathfinder.py
+++ b/merino/providers/weather/backends/accuweather/pathfinder.py
@@ -5,22 +5,22 @@ from typing import Any, Awaitable, Callable, Generator, Optional
 from merino.middleware.geolocation import Location
 
 MaybeStr = Optional[str]
-Triplet = tuple[MaybeStr, MaybeStr, MaybeStr]
+Quadtuplet = tuple[MaybeStr, MaybeStr, MaybeStr, bool]
 
 SUCCESSFUL_REGIONS_MAPPING: dict[tuple[str, str], str | None] = {}
 REGION_MAPPING_EXCLUSIONS: frozenset = frozenset(["CA", "ES", "GR", "IT", "US"])
 CITY_NAME_CORRECTION_MAPPING: dict[str, str] = {
     "La'ie": "Laie",
     "Mitchell/Ontario": "Mitchell",
+    "Montreal West": "Montreal",
+    "Kleinburg Station": "Kleinburg",
     "Middlebury (village)": "Middlebury",
     "TracadieSheila": "Tracadie Sheila",
 }
 SKIP_CITIES_LIST: frozenset = frozenset(
     [
         ("CA", "AB", "Sturgeon County"),
-        ("CA", "ON", "Kleinburg Station"),
         ("CA", "ON", "North Park"),
-        ("CA", "QC", "Montreal West"),
         ("US", "GA", "South Fulton"),
         ("US", "KY", "Fort Campbell North"),
         ("US", "TX", "Fort Cavazos"),
@@ -29,7 +29,7 @@ SKIP_CITIES_LIST: frozenset = frozenset(
 )
 
 
-def compass(location: Location) -> Generator[Triplet, None, None]:
+def compass(location: Location) -> Generator[Quadtuplet, None, None]:
     """Generate all the "country, region, city" triplets based on a `Location`.
 
     It will generate ones that are more likely to produce a valid result based on heuristics.
@@ -44,37 +44,36 @@ def compass(location: Location) -> Generator[Triplet, None, None]:
     country = location.country
     regions = location.regions
     city = location.city
+    is_skipped = False
 
     if regions and country and city:
         city = CITY_NAME_CORRECTION_MAPPING.get(city, city)
         match (country, city):
+            case ("US" | "CA", _) if (country, regions[0], city) not in SKIP_CITIES_LIST:
+                yield country, regions[0], city, is_skipped
             case ("US" | "CA", _):
-                yield (
-                    (country, regions[0], city)
-                    if (country, regions[0], city) not in SKIP_CITIES_LIST
-                    else (None, None, None)
-                )
+                yield None, None, None, True
                 # use the most specific region
             case ("IT" | "ES" | "GR", _):
-                yield country, regions[-1], city  # use the least specific region
+                yield country, regions[-1], city, is_skipped  # use the least specific region
             case (country, city) if (
                 country,
                 city,
             ) in SUCCESSFUL_REGIONS_MAPPING:  # dynamic rules we've learned
-                yield country, SUCCESSFUL_REGIONS_MAPPING[(country, city)], city
+                yield country, SUCCESSFUL_REGIONS_MAPPING[(country, city)], city, is_skipped
             case _:  # Fall back to try all triplets
                 regions_to_try = [*regions, None]
                 for region in regions_to_try:
-                    yield country, region, city
+                    yield country, region, city, is_skipped
     else:
-        yield country, None, city
+        yield country, None, city, is_skipped
 
 
 async def explore(
     location: Location,
     probe: Callable[..., Awaitable[Optional[Any]]],
     language: str | None = None,
-) -> Optional[Any]:
+) -> tuple[Optional[Any], bool]:
     """Repeatedly executes an async function (prober) for each candidate until a valid result (path) is found.
 
     This can be used to find a result from various sources (cache or upstream API) for all possible location combinations.
@@ -92,16 +91,17 @@ async def explore(
     Raises:
       - Any exception raised from `probe`.
     """
-    for country, region, city in compass(location):
-        if any((country, region, city)):
-            if language:
-                res = await probe(country, region, city, language)
-            else:
-                res = await probe(country, region, city)
-            if res is not None:
-                return res
+    for country, region, city, is_skipped in compass(location):
+        if is_skipped:
+            return None, True
+        if language:
+            res = await probe(country, region, city, language)
+        else:
+            res = await probe(country, region, city)
+        if res is not None:
+            return res, is_skipped
 
-    return None
+    return None, False
 
 
 def set_region_mapping(country: str, city: str, region: str | None):

--- a/tests/unit/providers/weather/backends/test_accuweather.py
+++ b/tests/unit/providers/weather/backends/test_accuweather.py
@@ -1601,6 +1601,37 @@ async def test_get_weather_report_invalid_location(
 
 
 @pytest.mark.asyncio
+async def test_get_weather_report_with_city_in_skip_list(
+    accuweather: AccuweatherBackend,
+    statsd_mock: Any,
+) -> None:
+    """Test that the get_weather_report method raises an error if location information
+    is missing.
+    """
+    expected_result = None
+
+    weather_context = WeatherContext(
+        Location(
+            regions=["ON"],
+            city="North Park",
+            country="CA",
+            dma=807,
+            postal_code="94105",
+        ),
+        ["en-US"],
+    )
+    result = await accuweather.get_weather_report(weather_context)
+
+    assert expected_result == result
+
+    metrics_called = [
+        (call_arg[0][0], call_arg[1]["sample_rate"])
+        for call_arg in statsd_mock.increment.call_args_list
+    ]
+    assert metrics_called == []
+
+
+@pytest.mark.asyncio
 async def test_get_location_by_geolocation(
     accuweather: AccuweatherBackend,
     accuweather_location_response: bytes,

--- a/tests/unit/providers/weather/backends/test_accuweather.py
+++ b/tests/unit/providers/weather/backends/test_accuweather.py
@@ -1624,10 +1624,7 @@ async def test_get_weather_report_with_city_in_skip_list(
 
     assert expected_result == result
 
-    metrics_called = [
-        (call_arg[0][0], call_arg[1]["sample_rate"])
-        for call_arg in statsd_mock.increment.call_args_list
-    ]
+    metrics_called = [call_arg for call_arg in statsd_mock.increment.call_args_list]
     assert metrics_called == []
 
 

--- a/tests/unit/providers/weather/backends/test_pathfinder.py
+++ b/tests/unit/providers/weather/backends/test_pathfinder.py
@@ -28,6 +28,7 @@ from merino.providers.weather.backends.accuweather.pathfinder import (
             Location(country="CA", regions=["ON"], city="Mitchell/Ontario"),
             ("CA", "ON", "Mitchell"),
         ),
+        (Location(country="CA", regions=["ON"], city="North Park"), (None, None, None)),
     ],
     ids=[
         "Specific Region Country",
@@ -36,6 +37,7 @@ from merino.providers.weather.backends.accuweather.pathfinder import (
         "Fallback with Region",
         "Fallback No Region",
         "Corrected City Name",
+        "Tuple in Skip List",
     ],
 )
 def test_compass(location: Location, expected_tuple: Tuple) -> None:

--- a/tests/unit/providers/weather/backends/test_pathfinder.py
+++ b/tests/unit/providers/weather/backends/test_pathfinder.py
@@ -21,23 +21,22 @@ from merino.providers.weather.backends.accuweather.pathfinder import (
     [
         (
             Location(country="CA", regions=["BC"], city="Vancouver"),
-            ("CA", "BC", "Vancouver", False),
+            ("CA", "BC", "Vancouver"),
         ),
         (
             Location(country="IT", regions=["MT", "77"], city="Matera"),
-            ("IT", "77", "Matera", False),
+            ("IT", "77", "Matera"),
         ),
         (
             Location(country="GB", regions=["ENG", "HWT"], city="London"),
-            ("GB", "LND", "London", False),
+            ("GB", "LND", "London"),
         ),
-        (Location(country="BR", regions=["DF"], city="Brasilia"), ("BR", "DF", "Brasilia", False)),
-        (Location(country="IE", regions=None, city="Dublin"), ("IE", None, "Dublin", False)),
+        (Location(country="BR", regions=["DF"], city="Brasilia"), ("BR", "DF", "Brasilia")),
+        (Location(country="IE", regions=None, city="Dublin"), ("IE", None, "Dublin")),
         (
             Location(country="CA", regions=["ON"], city="Mitchell/Ontario"),
-            ("CA", "ON", "Mitchell", False),
+            ("CA", "ON", "Mitchell"),
         ),
-        (Location(country="CA", regions=["ON"], city="North Park"), (None, None, None, True)),
     ],
     ids=[
         "Specific Region Country",
@@ -46,7 +45,6 @@ from merino.providers.weather.backends.accuweather.pathfinder import (
         "Fallback with Region",
         "Fallback No Region",
         "Corrected City Name",
-        "City in Skip List",
     ],
 )
 def test_compass(location: Location, expected_tuple: Tuple) -> None:

--- a/tests/unit/providers/weather/backends/test_pathfinder.py
+++ b/tests/unit/providers/weather/backends/test_pathfinder.py
@@ -19,16 +19,25 @@ from merino.providers.weather.backends.accuweather.pathfinder import (
 @pytest.mark.parametrize(
     ("location", "expected_tuple"),
     [
-        (Location(country="CA", regions=["BC"], city="Vancouver"), ("CA", "BC", "Vancouver")),
-        (Location(country="IT", regions=["MT", "77"], city="Matera"), ("IT", "77", "Matera")),
-        (Location(country="GB", regions=["ENG", "HWT"], city="London"), ("GB", "LND", "London")),
-        (Location(country="BR", regions=["DF"], city="Brasilia"), ("BR", "DF", "Brasilia")),
-        (Location(country="IE", regions=None, city="Dublin"), ("IE", None, "Dublin")),
+        (
+            Location(country="CA", regions=["BC"], city="Vancouver"),
+            ("CA", "BC", "Vancouver", False),
+        ),
+        (
+            Location(country="IT", regions=["MT", "77"], city="Matera"),
+            ("IT", "77", "Matera", False),
+        ),
+        (
+            Location(country="GB", regions=["ENG", "HWT"], city="London"),
+            ("GB", "LND", "London", False),
+        ),
+        (Location(country="BR", regions=["DF"], city="Brasilia"), ("BR", "DF", "Brasilia", False)),
+        (Location(country="IE", regions=None, city="Dublin"), ("IE", None, "Dublin", False)),
         (
             Location(country="CA", regions=["ON"], city="Mitchell/Ontario"),
-            ("CA", "ON", "Mitchell"),
+            ("CA", "ON", "Mitchell", False),
         ),
-        (Location(country="CA", regions=["ON"], city="North Park"), (None, None, None)),
+        (Location(country="CA", regions=["ON"], city="North Park"), (None, None, None, True)),
     ],
     ids=[
         "Specific Region Country",
@@ -37,7 +46,7 @@ from merino.providers.weather.backends.accuweather.pathfinder import (
         "Fallback with Region",
         "Fallback No Region",
         "Corrected City Name",
-        "Tuple in Skip List",
+        "City in Skip List",
     ],
 )
 def test_compass(location: Location, expected_tuple: Tuple) -> None:


### PR DESCRIPTION
## References

JIRA: [DISCO-3086](https://mozilla-hub.atlassian.net/browse/DISCO-3086)

## Description
There are cities that accuweather does not provide weather for. Instead of constantly requesting them, we should skip them. Cities are from taken from logs.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3086]: https://mozilla-hub.atlassian.net/browse/DISCO-3086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ