### PR TITLE
[HNT-273] response includes corpusItemId

### DIFF
--- a/merino/curated_recommendations/corpus_backends/corpus_api_backend.py
+++ b/merino/curated_recommendations/corpus_backends/corpus_api_backend.py
@@ -266,6 +266,7 @@ class CorpusApiBackend(CorpusBackend):
                 items: items(date: $date) {
                   id
                   corpusItem {
+                    id
                     url
                     title
                     excerpt
@@ -322,7 +323,11 @@ class CorpusApiBackend(CorpusBackend):
             )
 
         curated_recommendations = [
-            CorpusItem(**item["corpusItem"], scheduledCorpusItemId=item["id"])
+            CorpusItem(
+                **item["corpusItem"],
+                corpusItemId=item["corpusItem"]["id"],
+                scheduledCorpusItemId=item["id"],
+            )
             for item in data["data"]["scheduledSurface"]["items"]
         ]
 

--- a/merino/curated_recommendations/corpus_backends/protocol.py
+++ b/merino/curated_recommendations/corpus_backends/protocol.py
@@ -46,6 +46,7 @@ class CorpusItem(BaseModel):
     The corpus is the set of all curated items deemed recommendable.
     """
 
+    corpusItemId: str
     scheduledCorpusItemId: str
     url: HttpUrl
     title: str

--- a/tests/data/scheduled_surface.json
+++ b/tests/data/scheduled_surface.json
@@ -5,6 +5,7 @@
         {
           "id": "de614b6b-6df6-470a-97f2-30344c56c1b3",
           "corpusItem": {
+            "id": "4095b364-02ff-402c-b58a-792a067fccf2",
             "url": "https://getpocket.com/explore/item/milk-powder-is-the-key-to-better-cookies-brownies-and-cakes",
             "title": "Milk Powder Is the Key to Better Cookies, Brownies, and Cakes",
             "excerpt": "Consider this pantry staple your secret ingredient for making more flavorful desserts.",
@@ -17,6 +18,7 @@
         {
           "id": "886ce027-4e50-4b29-ba13-ad799e77e382",
           "corpusItem": {
+            "id": "22222222-4e50-4b29-ba13-ad799e77e382",
             "url": "https://getpocket.com/explore/item/a-hot-drink-on-a-hot-day-can-cool-you-down",
             "title": "A Hot Drink on a Hot Day Can Cool You Down",
             "excerpt": "A rigorous experiment revealed that on a hot, dry day, drinking a hot beverage can help your body stay cool.",
@@ -29,6 +31,7 @@
         {
           "id": "50f86ebe-3f25-41d8-bd84-53ead7bdc76e",
           "corpusItem": {
+            "id": "0d186d8b-9b81-4447-926c-0dcecbd6e95f",
             "url": "https://www.themarginalian.org/2024/05/28/passenger-pigeon/",
             "title": "Thunder, Bells, and Silence: the Eclipse That Went Extinct",
             "excerpt": "Juneteenth isn’t the “other” Independence Day, it is THE Independence Day.",
@@ -41,6 +44,7 @@
         {
           "id": "1452b7ea-7ba9-4da9-ba39-ab44e8147d5e",
           "corpusItem": {
+            "id": "edc41c85-1613-4be6-a4a1-fd495f07b875",
             "url": "https://getpocket.com/explore/item/other-countries-have-social-safety-nets-the-u-s-has-women?utm_source=old_source",
             "title": "Other Countries Have Social Safety Nets. The U.S. Has Women.",
             "excerpt": "Anne Helen Petersen and Jessica Calarco discuss how mothers are experiencing and responding to pandemic-related disruptions in their normal routines.",
@@ -53,6 +57,7 @@
         {
           "id": "8c9cfea8-8bb8-4197-bcfc-bbd574c5b796",
           "corpusItem": {
+            "id": "21bb198a-b328-4900-90db-645f10bde170",
             "url": "https://getpocket.com/explore/item/what-s-it-like-working-in-a-ghost-kitchen-we-couldn-t-get-close-enough-to-ask",
             "title": "What’s It Like Working in a Ghost Kitchen? We Couldn’t Get Close Enough to Ask.",
             "excerpt": "Your burger or tacos or pizza could be cooked anywhere by anyone — which is what makes the ghost kitchen concept so lucrative and appealing to owners and investors.",
@@ -65,6 +70,7 @@
         {
           "id": "3068efb0-1706-4fc0-bde3-955257069fcb",
           "corpusItem": {
+            "id": "5c49bce5-674b-4e52-a468-20a3f4b22c47",
             "url": "https://getpocket.com/explore/item/she-was-headed-to-a-locked-psych-ward-then-an-er-doctor-made-a-startling-discovery",
             "title": "She Was Headed to a Locked Psych Ward. Then an ER Doctor Made a Startling Discovery.",
             "excerpt": "A physician’s gut instinct about a young woman led to a diagnosis that had been overlooked for years.",
@@ -77,6 +83,7 @@
         {
           "id": "07cf47e4-f458-458b-87dc-7535e4b45315",
           "corpusItem": {
+            "id": "ef51ffcc-ce21-4a32-b7ca-9d813c40d770",
             "url": "https://getpocket.com/explore/item/what-happens-to-your-body-when-you-take-a-sip-of-caffeine",
             "title": "What Happens to Your Body When You Take a Sip of Caffeine",
             "excerpt": "We explain the biological changes that begin with your morning tea or coffee.",
@@ -89,6 +96,7 @@
         {
           "id": "08898f33-254f-4a33-84a2-8ff9c9d685a3",
           "corpusItem": {
+            "id": "cec59453-34e0-4092-ac17-35cff83d55b0",
             "url": "https://getpocket.com/explore/item/the-21-best-skin-care-tips-of-all-time-according-to-dermatologists",
             "title": "The 21 Best Skin-Care Tips of All Time, According to Dermatologists",
             "excerpt": "These aren’t your run-of-the-mill skin-care tricks. Here, the experts share the rules they’ve learned and recommended throughout their careers.",
@@ -101,6 +109,7 @@
         {
           "id": "c5a32bb6-0c16-438b-8bc8-5422f314326a",
           "corpusItem": {
+            "id": "cbbbbca9-76cd-4d74-b603-fa9047fe9705",
             "url": "https://getpocket.com/explore/item/29-flowers-that-are-sure-to-attract-butterflies-to-your-yard",
             "title": "29 Flowers That Are Sure to Attract Butterflies to Your Yard",
             "excerpt": "Plant these beautiful blooms and watch butterflies flock to your garden.",
@@ -113,6 +122,7 @@
         {
           "id": "5695fe90-9177-41d4-a778-e1e2d08a962b",
           "corpusItem": {
+            "id": "b500899e-7f93-49e8-b0b4-58d1aeeeafc8",
             "url": "https://getpocket.com/explore/item/stuffed-peppers",
             "title": "Stuffed Peppers",
             "excerpt": "It’s almost like peppers were made to be stuffed with meat and cheese.",
@@ -125,6 +135,7 @@
         {
           "id": "b9c59c9c-c51e-4614-8a3a-a0b116fe2368",
           "corpusItem": {
+            "id": "1caf9800-f430-4f9f-9485-854f7e9ce933",
             "url": "https://getpocket.com/explore/item/inside-the-world-s-most-beloved-independent-bookstores",
             "title": "Inside the World’s Most Beloved Independent Bookstores",
             "excerpt": "In the age of Amazon and e-books, these bookstores have faced more challenges than ever, but many have been able to persevere and remain treasured parts of their communities.",
@@ -137,6 +148,7 @@
         {
           "id": "20abed2a-4067-4c92-9970-887cb02959d8",
           "corpusItem": {
+            "id": "bf88c279-5fde-40c1-b7bd-a9c1582d9bc9",
             "url": "https://getpocket.com/explore/item/the-lesser-known-history-of-african-american-cowboys",
             "title": "The Lesser-Known History of African-American Cowboys",
             "excerpt": "One in four cowboys was black. So why aren’t they more present in popular culture?",
@@ -149,6 +161,7 @@
         {
           "id": "87100ddc-a391-4f93-8963-78b7bd91d811",
           "corpusItem": {
+            "id": "afab6fe3-898b-486e-b1c6-905f6a6ad4a4",
             "url": "https://getpocket.com/explore/item/would-you-go-public-with-your-plastic-surgery",
             "title": "Would You Go Public With Your Plastic Surgery?",
             "excerpt": "We’ve gone from denying Botox to celebrating our face-lifts. Welcome to the new era of living out loud.",
@@ -161,6 +174,7 @@
         {
           "id": "58306b4f-b3ba-4312-bf88-790de429b290",
           "corpusItem": {
+            "id": "2987be9d-785f-4993-a271-f96c17b60520",
             "url": "https://getpocket.com/explore/item/the-war-vet-the-dating-site-and-the-phone-call-from-hell",
             "title": "The War Vet, the Dating Site, and the Phone Call From Hell",
             "excerpt": "Jared Johns found out too late that swapping messages with the pretty girl from a dating site would mean serious trouble. If only he had known who she really was.",
@@ -173,6 +187,7 @@
         {
           "id": "61a5e774-cc55-416c-b0d5-505dbdf54a9a",
           "corpusItem": {
+            "id": "901faa8e-391b-4c7b-998e-4feca9d7cfba",
             "url": "https://getpocket.com/explore/item/6-myths-about-the-history-of-black-people-in-america",
             "title": "6 Myths About the History of Black People in America",
             "excerpt": "Six historians weigh in on the biggest misconceptions about Black history, including the Tuskegee experiment and enslaved people’s finances.",
@@ -185,6 +200,7 @@
         {
           "id": "6c9a5e6f-13f0-42f9-8b3e-2127a9db46a8",
           "corpusItem": {
+            "id": "a808bcba-1edd-4827-8b87-c7b11a28e567",
             "url": "https://getpocket.com/explore/item/why-teenagers-aren-t-what-they-used-to-be",
             "title": "Why Teenagers Aren’t What They Used to Be",
             "excerpt": "Here’s how we’ve defined adolescence throughout history - and why it’s time for a new category.",
@@ -197,6 +213,7 @@
         {
           "id": "3dc5ba73-4081-409f-b4de-bec89e879d5a",
           "corpusItem": {
+            "id": "f91c9f91-29dc-4e30-9cb8-ed9045215df3",
             "url": "https://getpocket.com/explore/item/why-rumination-is-keeping-you-up-at-night-and-how-to-beat-it-for-better-sleep",
             "title": "Why Rumination Is Keeping You Up at Night – And How to Beat It for Better Sleep",
             "excerpt": "Do you find yourself dwelling on the same worries, memories or regrets when you’re trying to drift off to sleep? Here’s how to break out of the rumination cycle.",
@@ -209,6 +226,7 @@
         {
           "id": "058336bf-40ed-4cf5-9edc-c56d42edcf0b",
           "corpusItem": {
+            "id": "9dc3addb-1495-4d83-a6bc-64cf7444f798",
             "url": "https://getpocket.com/explore/item/workout-motivation-the-overjustification-effect-might-explain-why-you-don-t-want-to-exercise",
             "title": "The Overjustification Effect Might Explain Why You Don’t Want to Exercise",
             "excerpt": "The psychological phenomenon known as the overjustification effect explains why extrinsic motivation isn’t getting you to the gym.",
@@ -221,6 +239,7 @@
         {
           "id": "5ce949bd-3bc9-4b07-9eb8-ffc42d2ef5b8",
           "corpusItem": {
+            "id": "91a2f35e-848b-4f2c-b3ad-56b595f7bcf8",
             "url": "https://getpocket.com/explore/item/the-first-self-proclaimed-drag-queen-was-a-formerly-enslaved-man",
             "title": "The First Self-Proclaimed Drag Queen Was a Formerly Enslaved Man",
             "excerpt": "In the late 19th century, William Dorsey Swann’s private parties attracted unwelcome attention from authorities and the press.",
@@ -233,6 +252,7 @@
         {
           "id": "5309b7dd-ae95-4fee-bc36-3b02aab6c7aa",
           "corpusItem": {
+            "id": "d4b8c7fa-06f3-46ac-8351-9f0842708d72",
             "url": "https://getpocket.com/explore/item/we-asked-experts-whether-cooling-bedding-works-here-s-what-they-said",
             "title": "We Asked Experts Whether Cooling Bedding Works. Here’s What They Said.",
             "excerpt": "A look at the dizzying array of mattresses, bedding and gadgets designed to keep you from overheating at night",
@@ -245,6 +265,7 @@
         {
           "id": "97e52d23-aac7-4d75-b20e-a76d8e5a297a",
           "corpusItem": {
+            "id": "32b3f771-8612-4a2c-92f0-aeaefe1990b6",
             "url": "https://getpocket.com/explore/item/biden-and-trump-may-forget-names-or-personal-details-but-here-is-what-really-matters-in-assessing",
             "title": "Here’s What Really Matters When Assessing Trump or Biden’s Cognitive Abilities",
             "excerpt": "Decision-making abilities are critical to a president’s performance.",
@@ -257,6 +278,7 @@
         {
           "id": "1134669c-3ab8-4f68-8514-4e2ec9c0b4b1",
           "corpusItem": {
+            "id": "a5430761-b82f-474b-9e40-54efa04d8551",
             "url": "https://getpocket.com/explore/item/worried-about-sending-your-baby-to-daycare-our-research-shows-they-like-being-in-groups",
             "title": "Worried About Sending Your Baby to Daycare? Research Shows They Like Being in Groups",
             "excerpt": "Babies as young as six months respond to and enjoy being in groups with other babies.",
@@ -269,6 +291,7 @@
         {
           "id": "1cdcbb73-8dfb-4747-af33-553305ed48b2",
           "corpusItem": {
+            "id": "c2052e1a-ac12-4159-a92b-0b0a43e8e96a",
             "url": "https://getpocket.com/explore/item/new-orleans-tree-survey-shows-ongoing-effects-of-hurricane-katrina",
             "title": "What’s Happening to the Trees in New Orleans?",
             "excerpt": "The Louisiana city has struggled to rebuild its tree canopy, devastated by storms and neglect. But an influx of federal aid and a new reforestation plan could offer hope.",
@@ -281,10 +304,11 @@
         {
           "id": "f8cd199d-9673-40cc-bf65-c5013d220335",
           "corpusItem": {
+            "id": "098f4faf-f590-4a69-9516-2df9acd1e1d0",
             "url": "https://getpocket.com/explore/item/car-ownership-maintenance-repairs-detailing-car-care",
             "title": "How to Repair, Maintain, and Care for Your Car",
             "excerpt": "Here are the repair, maintenance, and car-care tips you need to know to keep your ride in top shape for years to come.",
-            "topic": "PERSONAL_FINANCE",
+            "topic": "HOME",
             "publisher": "Car and Driver",
             "isTimeSensitive": false,
             "imageUrl": "https://s3.us-east-1.amazonaws.com/pocket-curatedcorpusapi-prod-images/c5f5b8db-3798-4460-8185-41b26eac7ce6.jpeg"
@@ -293,6 +317,7 @@
         {
           "id": "dda48992-ebc7-4f26-93b6-9d38ab2fbb3f",
           "corpusItem": {
+            "id": "5c94a00c-b070-4d3a-9f4b-a50913b13d92",
             "url": "https://getpocket.com/explore/item/advice-on-handling-a-toxic-co-worker",
             "title": "Advice on Handling a Toxic Co-worker",
             "excerpt": "What to do when there’s a toxic employee and the CEO or president is ignoring it.",
@@ -305,6 +330,7 @@
         {
           "id": "00a1e79e-5921-40d1-b4b8-8ae390dda552",
           "corpusItem": {
+            "id": "74761f37-2836-47bd-91bc-b7bfbfcb1c0b",
             "url": "https://getpocket.com/explore/item/why-is-it-so-hard-for-black-creators-to-get-their-due",
             "title": "Why Is It So Hard for Black Creators to Get Their Due?",
             "excerpt": "Ever since the TikTok “dance strike,” Black dancers looking for credit and compensation from social media face a complicated landscape.",
@@ -317,6 +343,7 @@
         {
           "id": "5d2cdda4-e4bf-48be-9eb4-dea33828b1f5",
           "corpusItem": {
+            "id": "eed2a6c3-19af-41c4-85f6-f09607987970",
             "url": "https://getpocket.com/explore/item/the-army-of-women-who-took-down-larry-nassar",
             "title": "The Army of Women Who Took Down Larry Nassar",
             "excerpt": "One woman spoke out, another listened. That helped put an end to the abuse that lasted for more than 20 years. Meet the survivors, detective, attorney, and judge who told the world: Believe women.",
@@ -329,6 +356,7 @@
         {
           "id": "cb1aced0-07f2-4cac-945b-a4cf8d69b390",
           "corpusItem": {
+            "id": "6e4a7bc7-0d0d-4f7f-bf96-96fcdd0f9130",
             "url": "https://getpocket.com/explore/item/true-kilts-debunking-the-myths-about-highlanders-and-clan-tartans",
             "title": "True Kilts: Debunking the Myths About Highlanders and Clan Tartans",
             "excerpt": "You might assume the clan tartans seen on kilts are several millennia old. You would be wrong.",
@@ -341,10 +369,11 @@
         {
           "id": "cc4bd2a0-af90-4b50-9eda-05d935960c62",
           "corpusItem": {
+            "id": "b169946a-5af6-4701-ab2b-6c7325119a21",
             "url": "https://getpocket.com/explore/item/here-s-how-to-jump-start-a-car-without-cables",
             "title": "Here’s How to Jump Start a Car Without Cables",
             "excerpt": "This is one instance you don’t want to channel Angus “Mac” MacGyver.",
-            "topic": "TECHNOLOGY",
+            "topic": "SELF_IMPROVEMENT",
             "publisher": "The Drive",
             "isTimeSensitive": false,
             "imageUrl": "https://s3.us-east-1.amazonaws.com/pocket-curatedcorpusapi-prod-images/fe2764c9-a3b1-47f4-bc30-2f2b22ef6304.jpeg"
@@ -353,6 +382,7 @@
         {
           "id": "be1c7b5f-f2f2-4827-b0b0-4e18160a6704",
           "corpusItem": {
+            "id": "c72bffd1-d5b8-4986-806f-ee511eb802b9",
             "url": "https://www.context.news/ai/african-techies-develop-ai-language-tools-from-swahili-to-zulu",
             "title": "From Swahili to Zulu, African Techies Develop AI Language Tools",
             "excerpt": "African techies pioneer AI tools in local languages to bridge the digital divide but data scarcity, ethical concerns are challenges",
@@ -365,6 +395,7 @@
         {
           "id": "f6717587-9db6-491c-ba44-3e090591c290",
           "corpusItem": {
+            "id": "181e32a1-db03-47bd-96cc-3cc6db5d6e67",
             "url": "https://www.axios.com/2024/06/16/parenting-father-time-nurture-book-sarah-hrdy",
             "title": "Dads’ Nurturing Nature",
             "excerpt": "Fathers are relatively new scientific subjects.",
@@ -377,6 +408,7 @@
         {
           "id": "2e7f5cdb-6eda-45ce-9fb9-eca7ab1114de",
           "corpusItem": {
+            "id": "4fe71bd0-c9c9-45d0-aea1-16b64e14f911",
             "url": "https://www.newyorker.com/sports/sporting-scene/the-mental-challenge-of-winning-the-nba-finals",
             "title": "The Mental Challenge of Winning the N.B.A. Finals",
             "excerpt": "Four games between the Boston Celtics and Dallas Mavericks have mostly come down to talent and strategy. But the mind-set of the players matters, too.",
@@ -389,6 +421,7 @@
         {
           "id": "aeeba41e-41df-44ac-9c6f-224bbb9b60e7",
           "corpusItem": {
+            "id": "7a15930f-9b68-4556-8a12-a36ad66c854c",
             "url": "https://www.sportico.com/feature/mlb-betting-gambling-rules-1234784194/",
             "title": "MLB’s Rules on Gambling: What Happens When Players Bet?",
             "excerpt": "Padres prospect Tucupita Marcano was recently given a lifetime ban by MLB for betting on baseball games when he was playing with the Pirates.",
@@ -401,6 +434,7 @@
         {
           "id": "4d271e4b-5207-4711-a341-6f792ce6e1c7",
           "corpusItem": {
+            "id": "c09dab1b-be22-4a44-a12d-92848de9d4e4",
             "url": "https://www.popsci.com/diy/how-to-share-eta-google-maps-apple-maps/",
             "title": "How to Share Your ETA in Google Maps or Apple Maps",
             "excerpt": "Let other people know when you’re going to show up while traveling. Whether you use Google, Apple, or another navigation app.",
@@ -413,6 +447,7 @@
         {
           "id": "d6a65829-3e17-4f10-a1e2-25051e081e56",
           "corpusItem": {
+            "id": "0cc1065b-3d50-497e-bb74-1f509321d47d",
             "url": "https://www.theguardian.com/music/article/2024/jun/16/john-cale-poptical-illusion-lou-reed-aaron-copland",
             "title": "‘Hip-hop is the new avant garde’: John Cale on Lou Reed, anger and continual reinvention",
             "excerpt": "He made rock history with the Velvet Underground and produced landmark albums for the likes of Patti Smith. At 82, his 18th solo outing proves he’s still at the bleeding edge",
@@ -425,6 +460,7 @@
         {
           "id": "deebdca8-6fae-41a9-89b7-673dfd99a30e",
           "corpusItem": {
+            "id": "f93b60c2-6e4c-419a-91e1-ca96240cedf6",
             "url": "https://www.billboard.com/pro/production-libraries-licensing-ai-companies-threaten-business/",
             "title": "Production Libraries Are Licensing to AI Companies. Could It Threaten Their Whole Business?",
             "excerpt": "The $1 billion production music business has begun licensing its works to AI companies. Could it spell the end of the business as a whole?",
@@ -437,6 +473,7 @@
         {
           "id": "b5b87f0d-30e9-41cd-8cc3-a885d303b9f1",
           "corpusItem": {
+            "id": "8ea51760-0d55-4e46-a5c0-e40c34a43ae8",
             "url": "https://www.si.com/olympics/colts-nfl-stadium-transformed-into-a-swimming-pool-for-us-olympic-trials",
             "title": "How an NFL Stadium Transformed Into a Swimming Pool for U.S. Olympic Trials",
             "excerpt": "It’s so huge you can’t smell the chlorine.",
@@ -449,6 +486,7 @@
         {
           "id": "e16545a8-7c83-49ad-80e1-ee8407721281",
           "corpusItem": {
+            "id": "9aa27f26-75d3-4b8a-97e1-967d846dbc4c",
             "url": "https://www.fastcompany.com/91139325/is-psychological-safety-being-weaponized",
             "title": "Is Psychological Safety Being Weaponized?",
             "excerpt": "How leaders can take actionable steps to turn psychological safety from a misguided weapon to a powerful tool.",
@@ -461,6 +499,7 @@
         {
           "id": "284f1e4f-c792-49db-9c66-bb7acd97106a",
           "corpusItem": {
+            "id": "d386e690-fd38-4bb0-8e36-457c126db6ca",
             "url": "https://www.esquire.com/style/big-black-book-summer-2024/a60873213/albert-muzquiz-edgy-mens-fashion-style-interview/",
             "title": "Edgy Albert Is the New Voice of Style on Social Media",
             "excerpt": "Getting philosophical with the menswear’s favorite Instagram and TikTok star, Albert Muzquiz.",
@@ -473,6 +512,7 @@
         {
           "id": "8f9001be-60d0-4d48-8875-06da18f0fc24",
           "corpusItem": {
+            "id": "6c127b10-caec-4ab1-90c5-510580e22796",
             "url": "https://www.newyorker.com/magazine/2024/06/24/the-era-of-the-line-cook",
             "title": "The Era of the Line Cook",
             "excerpt": "In a dinner series called the Line Up, line cooks, sous-chefs, and chefs de cuisine from buzzy New York restaurants get to be executive chefs for a night.",
@@ -485,6 +525,7 @@
         {
           "id": "ebe2bd62-3092-4237-829f-f2cf67ec6ee0",
           "corpusItem": {
+            "id": "8ca2f435-2910-476a-94d2-d8e1d702b803",
             "url": "https://www.newyorker.com/books/under-review/a-new-book-about-plant-intelligence-highlights-the-messiness-of-scientific-change",
             "title": "A New Book About Plant Intelligence Highlights the Messiness of Scientific Change",
             "excerpt": "In “The Light Eaters,” by Zoë Schlanger, the field of botany itself functions as a character—one in the process of undergoing a potentially radical transformation.",
@@ -497,6 +538,7 @@
         {
           "id": "2ada37c2-03d9-4905-adda-01809f1f4b5e",
           "corpusItem": {
+            "id": "c14ee3ae-1d59-4db1-b195-54d68af3b8e6",
             "url": "https://www.esquire.com/style/big-black-book-summer-2024/a60872988/summer-shoes-from-around-the-world/",
             "title": "7 Summer Shoes From Around the World to Add to Your Rotation",
             "excerpt": "Tired of the same old sandals and slip-ons? Try one of these picks from a few of the balmiest—and most stylish—spots on Earth.",
@@ -509,6 +551,7 @@
         {
           "id": "8fc9e19e-3095-4d68-b31d-d8316cd02668",
           "corpusItem": {
+            "id": "7c9f1ebc-0b35-4f1a-9bae-6f8467b9db6e",
             "url": "https://www.theatlantic.com/international/archive/2024/06/thitu-island-south-china-sea-tension/678692/",
             "title": "Between a Rock and a Hard Place in the South China Sea",
             "excerpt": "A remote outpost of the Philippines in the South China Sea is on the front line of potential geopolitical conflict.",
@@ -521,6 +564,7 @@
         {
           "id": "e7cb5af5-432f-49f1-86d1-5c09b8bb1c4c",
           "corpusItem": {
+            "id": "4f770944-c703-4fc7-a9f2-3ec09c0be333",
             "url": "https://www.theatlantic.com/newsletters/archive/2024/06/an-all-american-hot-dog-controversy/678705/",
             "title": "An All-American Hot-Dog Controversy",
             "excerpt": "What happens when you combine franks, the Fourth of July, a sponsorship dispute, and a Netflix special?",
@@ -533,6 +577,7 @@
         {
           "id": "5e0c3a40-d633-4a5b-8e5c-ef3af36731ce",
           "corpusItem": {
+            "id": "e4d5aad6-8ccd-4fd1-abcb-242449abf58e",
             "url": "https://www.elle.com/culture/movies-tv/a61061462/olivia-cooke-house-of-the-dragon-season-2-interview/",
             "title": "Olivia Cooke Can Do It All",
             "excerpt": "Olivia Cooke talks to ELLE.com about Alicent’s journey in “House of the Dragon” season 2, Rhaenicent, and going viral.",
@@ -545,6 +590,7 @@
         {
           "id": "c3c7dbab-65e7-4cc2-a927-79b657fe6ac5",
           "corpusItem": {
+            "id": "63a11716-233a-402d-8534-63571134f2b7",
             "url": "https://aeon.co/essays/why-intelligence-exists-only-in-the-eye-of-the-beholder",
             "title": "What Is Intelligent Life?",
             "excerpt": "Our human minds hold us back from truly understanding the many brilliant ways that other creatures solve their problems",
@@ -557,6 +603,7 @@
         {
           "id": "36a340f7-fde8-4b88-9a6f-65849969b934",
           "corpusItem": {
+            "id": "7faf6577-cbee-4d23-b60d-aa88303f3dd7",
             "url": "https://www.theguardian.com/lifeandstyle/article/2024/jun/14/its-feeding-time-why-plants-need-more-than-sunlight-and-water-to-thrive",
             "title": "It’s Feeding Time: Why Plants Need More Than Sunlight and Water to Thrive",
             "excerpt": "With warmer weather comes an explosion of growth – so make sure your plants get the ingredients they need to sustain it",
@@ -569,6 +616,7 @@
         {
           "id": "67615b99-1b3e-47ff-a533-56b4ad2320d4",
           "corpusItem": {
+            "id": "ff25a8f5-52cf-4c89-88dc-dbf399a13327",
             "url": "https://psyche.co/ideas/grief-is-not-a-process-with-five-stages-it-is-shattered-glass",
             "title": "Grief Is Not a Process With Five Stages. It Is Shattered Glass",
             "excerpt": "The five stages describe a grief that’s knowable and controlled. An accident in my kitchen helped me find a truer metaphor",
@@ -581,6 +629,7 @@
         {
           "id": "d80675e6-85ac-4fa2-956a-d6e38cfb2d6f",
           "corpusItem": {
+            "id": "696f9ffd-c41f-4cfd-9cb8-a5818f3db705",
             "url": "https://knowablemagazine.org/content/article/food-environment/2024/the-scientific-mission-to-save-the-sharks",
             "title": "A Scientific Mission to Save the Sharks",
             "excerpt": "Despite increasing protection measures, these fish are among the world’s most endangered animals. New tests to detect species being traded, as well as population studies, aim to help save them.",
@@ -593,6 +642,7 @@
         {
           "id": "8d94e4fa-2893-4404-8e38-a057ee303d61",
           "corpusItem": {
+            "id": "1cea67f2-523a-401f-81ac-759aaa88ccd5",
             "url": "https://19thnews.org/2024/06/this-cartoonist-wants-to-tell-the-complicated-history-of-womens-voting-rights/",
             "title": "This Cartoonist Wants to Tell the Complicated History of Women’s Voting Rights",
             "excerpt": "In her new nonfiction graphic book, Caitlin Cass unpacks the active role that some White women played in suppressing voting rights for all — and the lessons today in the ongoing fight for universal ballot access.",
@@ -605,6 +655,7 @@
         {
           "id": "03662fe5-54a1-4fe7-95a5-e4a33a47ecc3",
           "corpusItem": {
+            "id": "85e8ac21-70ed-407e-9077-8cac4e81689e",
             "url": "https://www.technologyreview.com/2024/06/13/1093375/gamification-behaviorism-npcs-video-games/",
             "title": "How Gamification Took Over the World",
             "excerpt": "Gamification was always just behaviorism dressed up in pixels and point systems. Why did we fall for it?",
@@ -617,6 +668,7 @@
         {
           "id": "2a463366-608e-4a7d-ae00-35c25daf491b",
           "corpusItem": {
+            "id": "224f54c1-28fd-44d6-a847-44c2f8d681c6",
             "url": "https://www.wired.com/story/film-photography-beginners-guide/",
             "title": "Analog Photography: the Beginner’s Guide to Film Cameras",
             "excerpt": "Which film camera should you get? Which films are the best? We demystify the world of analog photography to help you get started.",
@@ -629,6 +681,7 @@
         {
           "id": "5576778c-1074-40d3-a109-f4a60cd46e8c",
           "corpusItem": {
+            "id": "02bf4c47-13fe-488a-a404-6e00f744d529",
             "url": "https://www.npr.org/2024/06/14/g-s1-4570/a-major-disinformation-research-teams-future-is-uncertain-after-political-attacks",
             "title": "A Major Disinformation Research Team’s Future Is Uncertain After Political Attacks",
             "excerpt": "The Stanford Internet Observatory studied how social media platforms are abused. Now, its top leaders are out and future funding is uncertain amid attacks on its work by conservatives.",
@@ -641,6 +694,7 @@
         {
           "id": "711852d1-329b-47e4-b693-3c037bba73e0",
           "corpusItem": {
+            "id": "e30a9487-cbdc-4750-b834-eb9fe50ec81d",
             "url": "https://www.thetakeout.com/1581701/fridge-russia-milk-fresh-frogs/",
             "title": "Before Fridges, Russians Used to Keep Their Milk Fresh With Frogs",
             "excerpt": "Letting an amphibian take up residence in your dairy products may not seem like a good idea, but believe it or not ... it works! Here’s why.",
@@ -653,6 +707,7 @@
         {
           "id": "47de1668-16ab-4fea-8792-3bd3624c091f",
           "corpusItem": {
+            "id": "e2cd0fbf-781e-4faa-a246-49cc45892e37",
             "url": "https://www.theatlantic.com/magazine/archive/2024/07/anthony-fauci-covid-trump-white-house-response/678491/",
             "title": "The First Three Months",
             "excerpt": "What I saw inside the government’s response to COVID-19",
@@ -665,6 +720,7 @@
         {
           "id": "371f2878-5cfb-42c6-8043-0697c57110d6",
           "corpusItem": {
+            "id": "f6f51ccb-c27d-4a9c-a73c-89c715ec9bf4",
             "url": "https://lithub.com/how-colorism-impacts-black-womens-physical-and-mental-health/",
             "title": "How Colorism Impacts Black Women’s Physical and Mental Health",
             "excerpt": "Layal Liverpool on racist beauty standards and the hidden harms of hair relaxers.",
@@ -677,6 +733,7 @@
         {
           "id": "92a93eca-9038-4364-88d3-a8c1bf8574bf",
           "corpusItem": {
+            "id": "4b0a318f-3715-4590-a878-9dde0d27b1c6",
             "url": "https://aeon.co/essays/in-memory-of-all-that-i-lost-when-tinnitus-took-away-my-silence",
             "title": "Eulogy for Silence",
             "excerpt": "Tinnitus is like a constant scream inside my head, depriving me of what I formerly treasured: the moments of serene quiet.",
@@ -689,6 +746,7 @@
         {
           "id": "0ef6c793-02fc-4f78-90c8-cdf6070c7699",
           "corpusItem": {
+            "id": "c4495c88-8d8f-4190-b3f6-92d295976a27",
             "url": "https://gizmodo.com/americas-notorious-cancer-alley-is-even-more-toxic-than-1851532462",
             "title": "America’s Notorious ‘Cancer Alley’ Is Even More Toxic Than We Thought",
             "excerpt": "A new study finds levels of the carcinogen ethylene oxide that are nine times higher than those estimated by the EPA’s models.",
@@ -701,6 +759,7 @@
         {
           "id": "479e4681-c203-4e70-8219-3d3ed3704f88",
           "corpusItem": {
+            "id": "1472e108-034f-4adf-921c-1ffb001429df",
             "url": "https://www.vox.com/future-perfect/355108/alzheimers-disease-drug-approval-research-retraction",
             "title": "Do We Have Alzheimer’s Disease All Wrong?",
             "excerpt": "Retracted studies and new treatments reveal the confusing state of Alzheimer’s research.",
@@ -713,6 +772,7 @@
         {
           "id": "20f42c85-6a4f-4b94-bf8f-76e72300a183",
           "corpusItem": {
+            "id": "580c1f91-c95c-4e59-beb9-5b61236bcf4e",
             "url": "https://www.wired.com/story/banks-are-finally-realizing-what-climate-change-will-do-to-housing/",
             "title": "Banks Are Finally Realizing What Climate Change Will Do to Housing",
             "excerpt": "Extreme weather threatens the investment value of many properties, but financing for climate mitigation efforts are only just getting going.",
@@ -725,6 +785,7 @@
         {
           "id": "85b3052b-6d92-4d89-9212-f6d874b9c377",
           "corpusItem": {
+            "id": "824d4167-81aa-47ab-88ba-b625b70420d6",
             "url": "https://www.nature.com/articles/d41586-024-02038-9",
             "title": "My Pivot From Grain Scientist to Slave-Trade Historian",
             "excerpt": "Geoff Palmer, Scotland’s first Black professor, now applies scientific rigour to researching slavery.",
@@ -737,6 +798,7 @@
         {
           "id": "873e2cd3-6b4b-4bf0-ac2c-3bd09b5e98ed",
           "corpusItem": {
+            "id": "407f2295-dbec-42d7-b426-b7a9dcc9b668",
             "url": "https://www.bbc.com/news/articles/ceqqex325vgo",
             "title": "‘I Feel Broken’: Inside the Mind of the Woman Who Ran 1,000km in 12 Days",
             "excerpt": "At the end of her challenge, the 52-year-old says ultra-running is a good way to “get uncomfortable”.",
@@ -749,6 +811,7 @@
         {
           "id": "0cbb007c-b917-4c2a-9cb8-7932922b28e1",
           "corpusItem": {
+            "id": "491e002b-d1e0-44b5-8cd8-b4b3fdf6f9b6",
             "url": "https://thewalrus.ca/the-scourge-of-self-checkout/",
             "title": "The Scourge of Self-Checkout",
             "excerpt": "The technology promised to make shopping easier. It has done the opposite",
@@ -761,6 +824,7 @@
         {
           "id": "80a3cee8-bc24-41d8-8afc-be4d38de5645",
           "corpusItem": {
+            "id": "dd4ac2e7-c1cd-44a4-b88e-afb6570844e4",
             "url": "https://www.nature.com/articles/d41586-024-02029-w",
             "title": "Push and Pull: How to Measure the Forces That Sculpt Embryos",
             "excerpt": "A steadily growing toolbox is giving researchers the ability to monitor and measure the physical forces that shape embryonic development.",
@@ -773,6 +837,7 @@
         {
           "id": "772f2429-d40a-4cc9-ad36-80b6c46b1c07",
           "corpusItem": {
+            "id": "acfde80d-4426-44d5-8e12-64ef7326e23b",
             "url": "https://www.bbc.com/future/article/20240614-how-neurosurgery-in-the-womb-is-saving-babies-lives",
             "title": "Neurological Conditions Claim the Lives of Thousands of Children Every Year. New Treatments in the Womb May Save Them",
             "excerpt": "Cutting-edge therapies delivering treatment to foetuses diagnosed with neurological defects have the potential to change natal care as we know it.",
@@ -785,6 +850,7 @@
         {
           "id": "b9badf0e-e559-4ec7-952f-03f116ae3b85",
           "corpusItem": {
+            "id": "3bd1d62f-b64c-486f-a3a1-66f3522bc307",
             "url": "https://www.inverse.com/science/problem-humans-colonize-the-moon-geopolitical-commercial-gain",
             "title": "An Astrophysicist Reveals a Major Problem We’ll Encounter If Humans Colonize the Moon",
             "excerpt": "Astronomers have started thinking about the potential conflicts between expanding knowledge of the universe and commercial gain.",
@@ -797,6 +863,7 @@
         {
           "id": "a277532b-2cb9-40da-977e-6de0450324d8",
           "corpusItem": {
+            "id": "17c4a252-d6cb-4519-884d-b73b06eb60eb",
             "url": "https://www.vox.com/policy/355088/rent-tenants-cash-vouchers-housing",
             "title": "The Federal Government’s New Plan to (Maybe) Give Renters Straight Cash",
             "excerpt": "A bold experiment to help tenants is advancing.",
@@ -809,6 +876,7 @@
         {
           "id": "1a97f882-9e02-4a91-8bc7-2e7860a89e0c",
           "corpusItem": {
+            "id": "8d6709fb-bc2a-4d7e-8f00-dc73af6acb07",
             "url": "https://www.polygon.com/24177873/sports-video-games-fanfiction-challengers-topspin",
             "title": "Sports Video Games Made Me Understand Fanfiction",
             "excerpt": "Challengers’ Tashi Duncan... I can save her",
@@ -821,6 +889,7 @@
         {
           "id": "29376209-6736-4775-a36b-ace56e72b94f",
           "corpusItem": {
+            "id": "42050045-dac2-4f28-9eda-d0367b35d7fe",
             "url": "https://www.themarginalian.org/2024/06/13/rose-macaulay-personal-pleasures/",
             "title": "The Pleasure of Being Left Alone",
             "excerpt": "There is a form of being together that feels as easy and spacious as being alone, when your experience is not crowded out or eclipsed by the presence of the other but deepened and magnified. Such companionship is extremely rare and extremely precious.",
@@ -833,6 +902,7 @@
         {
           "id": "796032b5-6a55-47f4-a211-e2e60d56dbda",
           "corpusItem": {
+            "id": "5ce3560f-c805-49a5-af5d-1707f906c17c",
             "url": "http://businessinsider.com/most-beautiful-places-to-visit-from-expert-2024-6",
             "title": "6 of the Most Beautiful Places in the World, According to Someone Who’s Been to 107 Countries",
             "excerpt": "I’ve visited 107 countries, and these six places, from Iceland to Slovenia, are the most beautiful places I’ve seen. \n    ",
@@ -845,6 +915,7 @@
         {
           "id": "f9f1e9b7-ba96-44d9-bfbe-6c901b619bbf",
           "corpusItem": {
+            "id": "c7347e3c-1b2e-4cc1-9f17-974fb1cb7705",
             "url": "https://www.zocalopublicsquare.org/2024/06/17/how-does-a-therapist-stay-neutral/ideas/essay/",
             "title": "How Does a Therapist Stay Neutral?",
             "excerpt": "Counseling couples or families is about empathy, not objectivity.",
@@ -857,6 +928,7 @@
         {
           "id": "1d133673-2911-4d91-b433-cc0d96540831",
           "corpusItem": {
+            "id": "6eff9d07-eda9-4a73-8a3f-3d24697a6169",
             "url": "https://www.afar.com/magazine/the-best-things-to-see-and-do-in-a-long-weekend-in-tokyo",
             "title": "How to Make the Most of 4 Days in Tokyo",
             "excerpt": "Fuel up on coffee at artist Takashi Murakami’s retro cafe, immerse yourself in a new digital art museum, and take a meditative walk in the heart of a forest.",
@@ -869,6 +941,7 @@
         {
           "id": "1fad0944-1e9b-4842-a195-97ea94cb08b1",
           "corpusItem": {
+            "id": "b6c66b4a-7fdf-45fa-b1bf-dafd9eea5b7a",
             "url": "https://undark.org/2024/06/17/tracking-illegal-cheetah-trade/",
             "title": "On the Hunt: The Effort to Track the Illegal Cheetah Trade",
             "excerpt": "Scientists are testing new tools to spot the origin of cheetahs poached from the wild and smuggled for the pet trade.",
@@ -881,6 +954,7 @@
         {
           "id": "b02e194b-fed5-447b-9ff3-5964fc75e6cb",
           "corpusItem": {
+            "id": "cf229fba-a662-4c99-b6e3-aa395da78a19",
             "url": "https://www.thecut.com/article/shopping-ban-for-years.html",
             "title": "What It’s Like to Not Buy New Clothes for 7 Years",
             "excerpt": "Three women who have done long-term shopping bans share their advice.",
@@ -893,6 +967,7 @@
         {
           "id": "b01e5e6c-a0c6-4a02-a3ea-77bceeb2939a",
           "corpusItem": {
+            "id": "006f9f6b-e96b-4cd2-be7f-4e550dcc3dcf",
             "url": "https://getpocket.com/explore/item/10-gardening-mistakes-to-avoid-at-all-costs",
             "title": "10 Gardening Mistakes to Avoid at All Costs",
             "excerpt": "Practice grows progress.",
@@ -905,6 +980,7 @@
         {
           "id": "4b2ab72e-1d3c-43c3-83d8-1e7489a5a759",
           "corpusItem": {
+            "id": "a7ec746b-0b83-4c7b-aaf5-45b92b11f1d6",
             "url": "https://www.collectorsweekly.com/articles/the-curious-melodic-case-of-the-regina-music-box/",
             "title": "The Curious Melodic Case of The Regina Music Box ",
             "excerpt": "The tale of the Regina Music Box Company is one composed of innovation, initial success, perseverance, and the struggle to remain relevant in the capricious home music landscape of the US at the turn of the century.",
@@ -917,6 +993,7 @@
         {
           "id": "7bdff6ea-4300-4604-8f59-19f15ebeaab5",
           "corpusItem": {
+            "id": "116fb147-2466-4399-8e2d-2a576388b9a4",
             "url": "https://www.okayplayer.com/black-country-music",
             "title": "Black Music Month: Country Music’s Black Past and Present",
             "excerpt": "​Cowboy Carter wasn’t Black music’s first foray into the country genre.",
@@ -929,6 +1006,7 @@
         {
           "id": "2f50cc70-cba3-454f-8192-76000f7190ad",
           "corpusItem": {
+            "id": "b9ef9621-b0bb-466d-8cd2-79e80dae6744",
             "url": "https://lifehacker.com/home/improve-your-homes-lighting",
             "title": "Six Ways to Improve Your Home’s Lighting",
             "excerpt": "Better lighting can increase your home’s safety—adding visibility will reduce trip hazards in dark hallways or stairwells, for example—and improve energy efficiency to save you money on your electricity bill. Upgraded lighting may also add value to your h",
@@ -941,6 +1019,7 @@
         {
           "id": "add20454-4ef4-4d7e-b0a1-29b6e2044cef",
           "corpusItem": {
+            "id": "60e50f2b-e5a9-4bbd-9edb-353b0e133d8e",
             "url": "https://nymag.com/intelligencer/article/conservatives-republican-party-women-rebecca-traister.html",
             "title": "How Did Republican Women End Up Like This?",
             "excerpt": "The baffling, contradictory demands of being female in the party of Donald Trump.",
@@ -953,6 +1032,7 @@
         {
           "id": "4096468c-dcf2-4f00-9501-df7eb630b6a4",
           "corpusItem": {
+            "id": "f7d9145f-bab5-4283-bb78-4b0227393bf7",
             "url": "https://getpocket.com/collections/no-heat-pump-no-problem-ways-to-cool-down-when-a-heatwave-strikes",
             "title": "No Heat Pump, No Problem: 5 Ways to Cool Down When a Heatwave Strikes",
             "excerpt": "How to cook without cooking, find the sweet spot for your fan, and get to sleep when the temperatures just won’t drop.",

--- a/tests/data/scheduled_surface_short.json
+++ b/tests/data/scheduled_surface_short.json
@@ -5,6 +5,7 @@
         {
           "id": "de614b6b-6df6-470a-97f2-30344c56c1b3",
           "corpusItem": {
+            "id": "edc41c85-1613-4be6-a4a1-fd495f07b875",
             "url": "https://getpocket.com/explore/item/milk-powder-is-the-key-to-better-cookies-brownies-and-cakes",
             "title": "Milk Powder Is the Key to Better Cookies, Brownies, and Cakes",
             "excerpt": "Consider this pantry staple your secret ingredient for making more flavorful desserts.",
@@ -17,6 +18,7 @@
         {
           "id": "886ce027-4e50-4b29-ba13-ad799e77e382",
           "corpusItem": {
+            "id": "22222222-1613-4be6-a4a1-fd495f07b875",
             "url": "https://getpocket.com/explore/item/a-hot-drink-on-a-hot-day-can-cool-you-down",
             "title": "A Hot Drink on a Hot Day Can Cool You Down",
             "excerpt": "A rigorous experiment revealed that on a hot, dry day, drinking a hot beverage can help your body stay cool.",
@@ -29,6 +31,7 @@
         {
           "id": "50f86ebe-3f25-41d8-bd84-53ead7bdc76e",
           "corpusItem": {
+            "id": "33333333-1613-4be6-a4a1-fd495f07b875",
             "url": "https://www.themarginalian.org/2024/05/28/passenger-pigeon/",
             "title": "Thunder, Bells, and Silence: the Eclipse That Went Extinct",
             "excerpt": "Juneteenth isn’t the “other” Independence Day, it is THE Independence Day.",
@@ -41,6 +44,7 @@
         {
           "id": "1452b7ea-7ba9-4da9-ba39-ab44e8147d5e",
           "corpusItem": {
+            "id": "44444444-1613-4be6-a4a1-fd495f07b875",
             "url": "https://getpocket.com/explore/item/other-countries-have-social-safety-nets-the-u-s-has-women?utm_source=old_source",
             "title": "Other Countries Have Social Safety Nets. The U.S. Has Women.",
             "excerpt": "Anne Helen Petersen and Jessica Calarco discuss how mothers are experiencing and responding to pandemic-related disruptions in their normal routines.",
@@ -53,6 +57,7 @@
         {
           "id": "1134669c-3ab8-4f68-8514-4e2ec9c0b5b1",
           "corpusItem": {
+            "id": "55555555-1613-4be6-a4a1-fd495f07b875",
             "url": "https://getpocket.com/explore/item/worried-about-sending-your-baby-to-daycare-our-research-shows-they-like-being-in-groups",
             "title": "Worried About Sending Your Baby to Daycare? Research Shows They Like Being in Groups",
             "excerpt": "Babies as young as six months respond to and enjoy being in groups with other babies.",

--- a/tests/integration/api/v1/curated_recommendations/corpus_backends/test_corpus_api_backend.py
+++ b/tests/integration/api/v1/curated_recommendations/corpus_backends/test_corpus_api_backend.py
@@ -41,6 +41,7 @@ async def test_fetch(corpus_backend: CorpusApiBackend, fixture_response_data):
             "40e30ce2-a298-4b34-ab58-8f0f3910ee39.jpeg"
         ),
         scheduledCorpusItemId="de614b6b-6df6-470a-97f2-30344c56c1b3",
+        corpusItemId="4095b364-02ff-402c-b58a-792a067fccf2",
     )
 
 
@@ -82,6 +83,7 @@ async def test_fetch_days_since_today(
                             {
                                 "id": "de614b6b-6df6-470a-97f2-30344c56c1b3",
                                 "corpusItem": {
+                                    "id": "f00ba411-6df6-470a-97f2-30344c56c1b3",
                                     "url": "https://example.com",
                                     "title": f"Scheduled items from day {days_ago}",
                                     "excerpt": "",

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -184,6 +184,7 @@ async def test_curated_recommendations(repeat):
         # expected recommendation with topic = None
         expected_recommendation = CuratedRecommendation(
             scheduledCorpusItemId="de614b6b-6df6-470a-97f2-30344c56c1b3",
+            corpusItemId="4095b364-02ff-402c-b58a-792a067fccf2",
             url=HttpUrl(
                 "https://getpocket.com/explore/item/milk-powder-is-the-key-to-better-cookies-brownies-and-cakes?utm_source=firefox-newtab-en-us"
             ),

--- a/tests/unit/curated_recommendations/test_provider.py
+++ b/tests/unit/curated_recommendations/test_provider.py
@@ -206,6 +206,7 @@ class TestCuratedRecommendationTileId:
 
     # Common parameters for initializing CuratedRecommendation
     common_params = {
+        "corpusItemId": "00000000-0000-0000-0000-000000000000",
         "url": HttpUrl("https://example.com"),
         "title": "Example Title",
         "excerpt": "Example Excerpt",
@@ -283,6 +284,7 @@ class TestCuratedRecommendationsProviderRankNeedToKnowRecommendations:
 
         for i in range(length):
             rec = CuratedRecommendation(
+                corpusItemId=str(uuid.uuid4()),
                 tileId=MIN_TILE_ID + random.randint(0, 101),
                 receivedRank=i,
                 scheduledCorpusItemId=str(uuid.uuid4()),

--- a/tests/unit/curated_recommendations/test_rankers.py
+++ b/tests/unit/curated_recommendations/test_rankers.py
@@ -1,5 +1,7 @@
 """Unit test for ranker algorithms used to rank curated recommendations."""
 
+import uuid
+
 import pytest
 import random
 
@@ -18,6 +20,7 @@ class TestCuratedRecommendationsProviderSpreadPublishers:
         recs = []
         for item_id in item_ids:
             rec = CuratedRecommendation(
+                corpusItemId=str(uuid.uuid4()),
                 tileId=MIN_TILE_ID + random.randint(0, 101),
                 receivedRank=random.randint(0, 101),
                 scheduledCorpusItemId=item_id,
@@ -178,6 +181,7 @@ class TestCuratedRecommendationsProviderBoostPreferredTopic:
         i = 1
         for topic in topics:
             rec = CuratedRecommendation(
+                corpusItemId=str(uuid.uuid4()),
                 tileId=MIN_TILE_ID + random.randint(0, 101),
                 receivedRank=i,
                 scheduledCorpusItemId=str(i),


### PR DESCRIPTION
## References

JIRA: [HNT-273](https://mozilla-hub.atlassian.net/browse/HNT-273)

## Description
The curated-recommendations endpoint responds with the `corpusItemId`, such that Firefox New Tab can emit this identifier with engagement telemetry.

I have left making `scheduledCorpusItemId` nullable out-of-scope for this PR, because it's a breaking change that all clients should sign-off on, even though they're not directly impacted by the experiment.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[HNT-273]: https://mozilla-hub.atlassian.net/browse/HNT-273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ