### PR TITLE
HNT-260: Hardcode localized topic section titles for US & Germany

### DIFF
--- a/merino/curated_recommendations/corpus_backends/protocol.py
+++ b/merino/curated_recommendations/corpus_backends/protocol.py
@@ -41,6 +41,51 @@ class ScheduledSurfaceId(str, Enum):
     NEW_TAB_IT_IT = "NEW_TAB_IT_IT"
 
 
+# Hardcoded localized topic section titles (for now) for en-US & de-DE
+LocalizedTopicSectionTitles = dict[ScheduledSurfaceId, dict[str, str]]
+
+LOCALIZED_TOPIC_SECTION_TITLES: LocalizedTopicSectionTitles = {
+    # reference: https://searchfox.org/mozilla-central/source/browser/locales/en-US/browser/newtab/newtab.ftl#392
+    ScheduledSurfaceId.NEW_TAB_EN_US: {
+        "business": "Business",
+        "career": "Career",
+        "education": "Education",
+        "arts": "Entertainment",
+        "food": "Food",
+        "health": "Health",
+        "hobbies": "Gaming",
+        "finance": "Money",
+        "society-parenting": "Parenting",
+        "government": "Politics",
+        "education-science": "Science",
+        "society": "Life Hacks",
+        "sports": "Sports",
+        "tech": "Tech",
+        "travel": "Travel",
+        "home": "Home & Garden",
+    },
+    # reference: https://github.com/mozilla-l10n/firefox-l10n/blob/main/de/browser/browser/newtab/newtab.ftl#L407
+    ScheduledSurfaceId.NEW_TAB_DE_DE: {
+        "business": "Geschäftliches",
+        "career": "Karriere",
+        "education": "Bildung",
+        "arts": "Unterhaltung",
+        "food": "Essen",
+        "health": "Gesundheit",
+        "hobbies": "Gaming",
+        "finance": "Finanzen",
+        "society-parenting": "Erziehung",
+        "government": "Politik",
+        "education-science": "Wissenschaft",
+        "society": "Life-Hacks",
+        "sports": "Sport",
+        "tech": "Technik",
+        "travel": "Reisen",
+        "home": "Haus und Garten",
+    },
+}
+
+
 class CorpusItem(BaseModel):
     """Represents a scheduled item from our 'corpus'.
     The corpus is the set of all curated items deemed recommendable.

--- a/merino/curated_recommendations/corpus_backends/protocol.py
+++ b/merino/curated_recommendations/corpus_backends/protocol.py
@@ -41,51 +41,6 @@ class ScheduledSurfaceId(str, Enum):
     NEW_TAB_IT_IT = "NEW_TAB_IT_IT"
 
 
-# Hardcoded localized topic section titles (for now) for en-US & de-DE
-LocalizedTopicSectionTitles = dict[ScheduledSurfaceId, dict[str, str]]
-
-LOCALIZED_TOPIC_SECTION_TITLES: LocalizedTopicSectionTitles = {
-    # reference: https://searchfox.org/mozilla-central/source/browser/locales/en-US/browser/newtab/newtab.ftl#392
-    ScheduledSurfaceId.NEW_TAB_EN_US: {
-        "business": "Business",
-        "career": "Career",
-        "education": "Education",
-        "arts": "Entertainment",
-        "food": "Food",
-        "health": "Health",
-        "hobbies": "Gaming",
-        "finance": "Money",
-        "society-parenting": "Parenting",
-        "government": "Politics",
-        "education-science": "Science",
-        "society": "Life Hacks",
-        "sports": "Sports",
-        "tech": "Tech",
-        "travel": "Travel",
-        "home": "Home & Garden",
-    },
-    # reference: https://github.com/mozilla-l10n/firefox-l10n/blob/main/de/browser/browser/newtab/newtab.ftl#L407
-    ScheduledSurfaceId.NEW_TAB_DE_DE: {
-        "business": "Geschäftliches",
-        "career": "Karriere",
-        "education": "Bildung",
-        "arts": "Unterhaltung",
-        "food": "Essen",
-        "health": "Gesundheit",
-        "hobbies": "Gaming",
-        "finance": "Finanzen",
-        "society-parenting": "Erziehung",
-        "government": "Politik",
-        "education-science": "Wissenschaft",
-        "society": "Life-Hacks",
-        "sports": "Sport",
-        "tech": "Technik",
-        "travel": "Reisen",
-        "home": "Haus und Garten",
-    },
-}
-
-
 class CorpusItem(BaseModel):
     """Represents a scheduled item from our 'corpus'.
     The corpus is the set of all curated items deemed recommendable.

--- a/merino/curated_recommendations/localization.py
+++ b/merino/curated_recommendations/localization.py
@@ -44,6 +44,6 @@ LOCALIZED_TOPIC_SECTION_TITLES: LocalizedTopicSectionTitles = {
         "tech": "Technik",
         "travel": "Reisen",
         "home": "Haus und Garten",
-        "top-stories": "Popular Today",
+        "top-stories": "Heute Beliebt",
     },
 }

--- a/merino/curated_recommendations/localization.py
+++ b/merino/curated_recommendations/localization.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 LocalizedTopicSectionTitles = dict[ScheduledSurfaceId, dict[str, str]]
 
 # Hardcoded localized topic section titles (for now) for en-US & de-DE
-LOCALIZED_TOPIC_SECTION_TITLES: LocalizedTopicSectionTitles = {
+LOCALIZED_SECTION_TITLES: LocalizedTopicSectionTitles = {
     # reference: https://searchfox.org/mozilla-central/source/browser/locales/en-US/browser/newtab/newtab.ftl#392
     ScheduledSurfaceId.NEW_TAB_EN_US: {
         "business": "Business",
@@ -48,20 +48,20 @@ LOCALIZED_TOPIC_SECTION_TITLES: LocalizedTopicSectionTitles = {
         "tech": "Technik",
         "travel": "Reisen",
         "home": "Haus und Garten",
-        "top-stories": "Heute Beliebt",
+        "top-stories": "Meistgelesen",
     },
 }
 
 
 def get_translation(surface_id: ScheduledSurfaceId, topic: str, default_topic: str) -> str:
     """Retrieve a translation and log an error if a translation doesn't exist."""
-    if surface_id not in LOCALIZED_TOPIC_SECTION_TITLES:
+    if surface_id not in LOCALIZED_SECTION_TITLES:
         logger.error(
             f"No translations found for surface '{surface_id}'. Defaulting to topic: '{default_topic}'"
         )
         return default_topic
 
-    translations = LOCALIZED_TOPIC_SECTION_TITLES.get(surface_id, {})
+    translations = LOCALIZED_SECTION_TITLES.get(surface_id, {})
     if topic not in translations or not translations[topic]:
         logger.error(
             f"Missing or empty translation for topic '{topic}' for surface '{surface_id}'. "

--- a/merino/curated_recommendations/localization.py
+++ b/merino/curated_recommendations/localization.py
@@ -1,0 +1,49 @@
+"""Hardcoded localized strings."""
+
+# Hardcoded localized topic section titles (for now) for en-US & de-DE
+from merino.curated_recommendations.corpus_backends.protocol import ScheduledSurfaceId
+
+LocalizedTopicSectionTitles = dict[ScheduledSurfaceId, dict[str, str]]
+
+LOCALIZED_TOPIC_SECTION_TITLES: LocalizedTopicSectionTitles = {
+    # reference: https://searchfox.org/mozilla-central/source/browser/locales/en-US/browser/newtab/newtab.ftl#392
+    ScheduledSurfaceId.NEW_TAB_EN_US: {
+        "business": "Business",
+        "career": "Career",
+        "education": "Education",
+        "arts": "Entertainment",
+        "food": "Food",
+        "health": "Health",
+        "hobbies": "Gaming",
+        "finance": "Money",
+        "society-parenting": "Parenting",
+        "government": "Politics",
+        "education-science": "Science",
+        "society": "Life Hacks",
+        "sports": "Sports",
+        "tech": "Tech",
+        "travel": "Travel",
+        "home": "Home & Garden",
+        "top-stories": "Popular Today",
+    },
+    # reference: https://github.com/mozilla-l10n/firefox-l10n/blob/main/de/browser/browser/newtab/newtab.ftl#L407
+    ScheduledSurfaceId.NEW_TAB_DE_DE: {
+        "business": "Geschäftliches",
+        "career": "Karriere",
+        "education": "Bildung",
+        "arts": "Unterhaltung",
+        "food": "Essen",
+        "health": "Gesundheit",
+        "hobbies": "Gaming",
+        "finance": "Finanzen",
+        "society-parenting": "Erziehung",
+        "government": "Politik",
+        "education-science": "Wissenschaft",
+        "society": "Life-Hacks",
+        "sports": "Sport",
+        "tech": "Technik",
+        "travel": "Reisen",
+        "home": "Haus und Garten",
+        "top-stories": "Popular Today",
+    },
+}

--- a/merino/curated_recommendations/localization.py
+++ b/merino/curated_recommendations/localization.py
@@ -1,10 +1,14 @@
 """Hardcoded localized strings."""
 
-# Hardcoded localized topic section titles (for now) for en-US & de-DE
 from merino.curated_recommendations.corpus_backends.protocol import ScheduledSurfaceId
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 LocalizedTopicSectionTitles = dict[ScheduledSurfaceId, dict[str, str]]
 
+# Hardcoded localized topic section titles (for now) for en-US & de-DE
 LOCALIZED_TOPIC_SECTION_TITLES: LocalizedTopicSectionTitles = {
     # reference: https://searchfox.org/mozilla-central/source/browser/locales/en-US/browser/newtab/newtab.ftl#392
     ScheduledSurfaceId.NEW_TAB_EN_US: {
@@ -47,3 +51,22 @@ LOCALIZED_TOPIC_SECTION_TITLES: LocalizedTopicSectionTitles = {
         "top-stories": "Heute Beliebt",
     },
 }
+
+
+def get_translation(surface_id: ScheduledSurfaceId, topic: str, default_topic: str) -> str:
+    """Retrieve a translation and log an error if a translation doesn't exist."""
+    if surface_id not in LOCALIZED_TOPIC_SECTION_TITLES:
+        logger.error(
+            f"No translations found for surface '{surface_id}'. Defaulting to topic: '{default_topic}'"
+        )
+        return default_topic
+
+    translations = LOCALIZED_TOPIC_SECTION_TITLES.get(surface_id, {})
+    if topic not in translations or not translations[topic]:
+        logger.error(
+            f"Missing or empty translation for topic '{topic}' for surface '{surface_id}'. "
+            f"Defaulting to topic: '{default_topic}'"
+        )
+        return default_topic
+
+    return translations[topic]

--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -323,7 +323,9 @@ class CuratedRecommendationsProvider:
             top_stories_section=Section(
                 receivedFeedRank=0,
                 recommendations=top_stories,
-                title="Today's top stories",
+                title=LOCALIZED_TOPIC_SECTION_TITLES.get(surface_id, {}).get(
+                    "top-stories", "Popular Today"
+                ),
                 subtitle=datetime.now().strftime("%B %d, %Y"),  # e.g., "October 24, 2024"
                 layout=layout_order[0],
             )

--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -324,9 +324,6 @@ class CuratedRecommendationsProvider:
                 receivedFeedRank=0,
                 recommendations=top_stories,
                 title=get_translation(surface_id, "top-stories", "Popular Today"),
-                # title=LOCALIZED_TOPIC_SECTION_TITLES.get(surface_id, {}).get(
-                #     "top-stories", "Popular Today"
-                # ),
                 subtitle=datetime.now().strftime("%B %d, %Y"),  # e.g., "October 24, 2024"
                 layout=layout_order[0],
             )
@@ -349,9 +346,6 @@ class CuratedRecommendationsProvider:
                         # return the hardcoded localized topic section title
                         # fallback on en-US topic title
                         title=get_translation(surface_id, rec.topic, formatted_topic_en_us),
-                        # title=LOCALIZED_TOPIC_SECTION_TITLES.get(surface_id, {}).get(
-                        #     rec.topic, formatted_topic_en_us
-                        # ),
                         layout=layout_order[len(sections_by_topic) % len(layout_order)],
                     )
 

--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -10,7 +10,6 @@ from merino.curated_recommendations.corpus_backends.protocol import (
     CorpusBackend,
     ScheduledSurfaceId,
     Topic,
-    LOCALIZED_TOPIC_SECTION_TITLES,
 )
 from merino.curated_recommendations.engagement_backends.protocol import EngagementBackend
 from merino.curated_recommendations.fakespot_backend.protocol import (
@@ -21,6 +20,7 @@ from merino.curated_recommendations.layouts import (
     layout_4_large,
     layout_6_tiles,
 )
+from merino.curated_recommendations.localization import LOCALIZED_TOPIC_SECTION_TITLES
 from merino.curated_recommendations.prior_backends.protocol import PriorBackend
 from merino.curated_recommendations.protocol import (
     Locale,
@@ -338,7 +338,7 @@ class CuratedRecommendationsProvider:
                 if topic in sections_by_topic:
                     section = sections_by_topic[topic]
                 else:
-                    formatted_topic = rec.topic.replace("_", " ")
+                    formatted_topic_en_us = rec.topic.replace("_", " ")
                     section = sections_by_topic[topic] = Section(
                         receivedFeedRank=len(sections_by_topic)
                         + 1,  # add 1 for top_stories_section
@@ -346,7 +346,7 @@ class CuratedRecommendationsProvider:
                         # return the hardcoded localized topic section title
                         # fallback on en-US topic title
                         title=LOCALIZED_TOPIC_SECTION_TITLES.get(surface_id, {}).get(
-                            formatted_topic, formatted_topic.capitalize()
+                            rec.topic, formatted_topic_en_us.capitalize()
                         ),
                         layout=layout_order[len(sections_by_topic) % len(layout_order)],
                     )

--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -20,7 +20,7 @@ from merino.curated_recommendations.layouts import (
     layout_4_large,
     layout_6_tiles,
 )
-from merino.curated_recommendations.localization import LOCALIZED_TOPIC_SECTION_TITLES
+from merino.curated_recommendations.localization import get_translation
 from merino.curated_recommendations.prior_backends.protocol import PriorBackend
 from merino.curated_recommendations.protocol import (
     Locale,
@@ -323,9 +323,10 @@ class CuratedRecommendationsProvider:
             top_stories_section=Section(
                 receivedFeedRank=0,
                 recommendations=top_stories,
-                title=LOCALIZED_TOPIC_SECTION_TITLES.get(surface_id, {}).get(
-                    "top-stories", "Popular Today"
-                ),
+                title=get_translation(surface_id, "top-stories", "Popular Today"),
+                # title=LOCALIZED_TOPIC_SECTION_TITLES.get(surface_id, {}).get(
+                #     "top-stories", "Popular Today"
+                # ),
                 subtitle=datetime.now().strftime("%B %d, %Y"),  # e.g., "October 24, 2024"
                 layout=layout_order[0],
             )
@@ -340,16 +341,17 @@ class CuratedRecommendationsProvider:
                 if topic in sections_by_topic:
                     section = sections_by_topic[topic]
                 else:
-                    formatted_topic_en_us = rec.topic.replace("_", " ")
+                    formatted_topic_en_us = rec.topic.replace("_", " ").capitalize()
                     section = sections_by_topic[topic] = Section(
                         receivedFeedRank=len(sections_by_topic)
                         + 1,  # add 1 for top_stories_section
                         recommendations=[],
                         # return the hardcoded localized topic section title
                         # fallback on en-US topic title
-                        title=LOCALIZED_TOPIC_SECTION_TITLES.get(surface_id, {}).get(
-                            rec.topic, formatted_topic_en_us.capitalize()
-                        ),
+                        title=get_translation(surface_id, rec.topic, formatted_topic_en_us),
+                        # title=LOCALIZED_TOPIC_SECTION_TITLES.get(surface_id, {}).get(
+                        #     rec.topic, formatted_topic_en_us
+                        # ),
                         layout=layout_order[len(sections_by_topic) % len(layout_order)],
                     )
 

--- a/tests/integration/api/v1/curated_recommendations/corpus_backends/test_corpus_api_backend.py
+++ b/tests/integration/api/v1/curated_recommendations/corpus_backends/test_corpus_api_backend.py
@@ -58,8 +58,6 @@ async def test_fetch(corpus_backend: CorpusApiBackend, fixture_response_data):
 )
 async def test_fetch_days_since_today(
     corpus_backend: CorpusApiBackend,
-    fixture_response_data,
-    fixture_response_data_short,
     fixture_request_data,
     corpus_http_client,
     test_input,

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -36,7 +36,7 @@ from merino.curated_recommendations.fakespot_backend.protocol import (
     FakespotBackend,
     FakespotFeed,
 )
-from merino.curated_recommendations.localization import LOCALIZED_TOPIC_SECTION_TITLES
+from merino.curated_recommendations.localization import LOCALIZED_SECTION_TITLES
 from merino.curated_recommendations.prior_backends.protocol import PriorBackend
 from merino.curated_recommendations.protocol import (
     ExperimentName,
@@ -1318,7 +1318,7 @@ class TestSections:
     """Test the behavior of the sections feeds"""
 
     en_us_section_title_top_stories = "Popular Today"
-    de_section_title_top_stories = "Heute Beliebt"
+    de_section_title_top_stories = "Meistgelesen"
 
     @staticmethod
     def assert_section_feed_helper(data, top_stories_title):
@@ -1365,7 +1365,7 @@ class TestSections:
         ]
 
         # Get the localized titles for the current surface_id
-        localized_titles = LOCALIZED_TOPIC_SECTION_TITLES[surface_id]
+        localized_titles = LOCALIZED_SECTION_TITLES[surface_id]
 
         # Assert that each section title has a translation
         for title in section_titles:

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -1317,8 +1317,11 @@ class TestNeedToKnow:
 class TestSections:
     """Test the behavior of the sections feeds"""
 
+    en_us_section_title_top_stories = "Popular Today"
+    de_section_title_top_stories = "Heute Beliebt"
+
     @staticmethod
-    def assert_section_feed_helper(data):
+    def assert_section_feed_helper(data, top_stories_title):
         """Help assert the section feed for correctness."""
         # Assert that an empty data array is returned. All recommendations are under "feeds".
         assert len(data["data"]) == 0
@@ -1333,7 +1336,7 @@ class TestSections:
         # Ensure "Today's top stories" is present with a valid date subtitle
         top_stories_section = data["feeds"].get("top_stories_section")
         assert top_stories_section is not None
-        assert top_stories_section["title"] == "Today's top stories"
+        assert top_stories_section["title"] == top_stories_title
         assert top_stories_section["subtitle"] is not None
 
     @pytest.mark.parametrize(
@@ -1386,7 +1389,7 @@ class TestSections:
             # Check if the response is valid
             assert response.status_code == 200
 
-            self.assert_section_feed_helper(data)
+            self.assert_section_feed_helper(data, self.en_us_section_title_top_stories)
 
     @pytest.mark.asyncio
     async def test_curated_recommendations_with_sections_feed_de(self):
@@ -1404,7 +1407,7 @@ class TestSections:
             # Check if the response is valid
             assert response.status_code == 200
 
-            self.assert_section_feed_helper(data)
+            self.assert_section_feed_helper(data, self.de_section_title_top_stories)
 
             # Ensure that topic section titles are in German, check at least one topic translation
             if data["feeds"]["arts"] is not None:
@@ -1430,7 +1433,7 @@ class TestSections:
             # Check if the response is valid
             assert response.status_code == 200
 
-            self.assert_section_feed_helper(data)
+            self.assert_section_feed_helper(data, self.en_us_section_title_top_stories)
 
             # Ensure that topic section titles fallback to English
             if data["feeds"]["arts"] is not None:


### PR DESCRIPTION
## References

JIRA: https://mozilla-hub.atlassian.net/browse/HNT-260

## Description

Created a `LOCALIZED_TOPIC_SECTION_TITLES` dictionary in `corpus_backends/protocol` to hold the localized topic section titles for `new_tab_en_us` & `new_tab_de_de`.

EN-US strings: https://searchfox.org/mozilla-central/source/browser/locales/en-US/browser/newtab/newtab.ftl#392
DE-DE strings: https://github.com/mozilla-l10n/firefox-l10n/blob/main/de/browser/browser/newtab/newtab.ftl#L407



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
