### PR TITLE
[DISCO-3091] weather: Add lat/long distance logic

### DIFF
--- a/merino/providers/weather/backends/accuweather/utils.py
+++ b/merino/providers/weather/backends/accuweather/utils.py
@@ -1,15 +1,17 @@
 """Utilities for the AccuWeather backend."""
 
+import math
 from enum import StrEnum
-from typing import Any
+from typing import Any, TypedDict
 
 from httpx import URL, InvalidURL
 from merino.config import settings
-
+from merino.middleware.geolocation import Coordinates
 
 PARTNER_PARAM_ID: str | None = settings.accuweather.get("url_param_partner_code")
 PARTNER_CODE: str | None = settings.accuweather.get("partner_code")
 VALID_LANGUAGES: frozenset = frozenset(settings.accuweather.default_languages)
+DISTANCE_THRESHOLD = 50  # 50 km
 
 
 class RequestType(StrEnum):
@@ -22,6 +24,14 @@ class RequestType(StrEnum):
     CURRENT_CONDITIONS = "currentconditions"
     FORECASTS = "forecasts"
     AUTOCOMPLETE = "autocomplete"
+
+
+class ProcessedLocationResponse(TypedDict):
+    """Class for response keys and values processed from Accuweather location requests."""
+
+    key: str
+    localized_name: str
+    administrative_area_id: str
 
 
 def add_partner_code(
@@ -65,7 +75,9 @@ def process_location_completion_response(response: Any) -> list[dict[str, Any]] 
     ]
 
 
-def process_location_response_with_country_and_region(response: Any) -> dict[str, Any] | None:
+def process_location_response_with_country_and_region(
+    response: Any,
+) -> ProcessedLocationResponse | None:
     """Process the API response for location keys.
 
     Note that if you change the return format, ensure you update `LUA_SCRIPT_CACHE_BULK_FETCH`
@@ -93,7 +105,9 @@ def process_location_response_with_country_and_region(response: Any) -> dict[str
             return None
 
 
-def process_location_response_with_country(response: Any) -> dict[str, Any] | None:
+def process_location_response_with_country(
+    coordinates: Coordinates | None, response: Any
+) -> ProcessedLocationResponse | None:
     """Process the API response for a single location key from country code endpoint.
 
     Note that if you change the return format, ensure you update `LUA_SCRIPT_CACHE_BULK_FETCH`
@@ -117,7 +131,7 @@ def process_location_response_with_country(response: Any) -> dict[str, Any] | No
                 "administrative_area_id": administrative_area_id,
             }
         case _:
-            return None
+            return get_closest_location_by_distance(response, coordinates)  # type: ignore
 
 
 def process_current_condition_response(response: Any) -> dict[str, Any] | None:
@@ -197,3 +211,59 @@ def get_language(requested_languages: list[str]) -> str:
     return next(
         (language for language in requested_languages if language in VALID_LANGUAGES), "en-US"
     )
+
+
+def get_closest_location_by_distance(
+    locations: list[dict[str, Any]], coordinates: Coordinates
+) -> ProcessedLocationResponse | None:
+    """Get the closest location by distance within the DISTANCE THRESHOLD."""
+    closest_location = None
+    min_distance = math.inf
+    if coordinates:
+        lat1 = coordinates.latitude
+        long1 = coordinates.longitude
+
+        if not lat1 or not long1:
+            return None
+
+        for location in locations:
+            try:
+                lat2 = location["GeoPosition"]["Latitude"]
+                long2 = location["GeoPosition"]["Longitude"]
+
+                d = get_lat_long_distance(lat1, long1, lat2, long2)
+                if d < min_distance and d <= DISTANCE_THRESHOLD:
+                    closest_location = location
+                    min_distance = d
+            except KeyError:
+                continue
+
+    if closest_location:
+        try:
+            return {
+                "key": closest_location["Key"],
+                "localized_name": closest_location["LocalizedName"],
+                "administrative_area_id": closest_location["AdministrativeArea"]["ID"],
+            }
+        except KeyError:
+            return None
+    return None
+
+
+def get_lat_long_distance(lat1: float, long1: float, lat2: float, long2: float) -> float:
+    """Calculate distance between two coordinates via the Haversine formula."""
+    lat1 = math.radians(lat1)
+    long1 = math.radians(long1)
+
+    lat2 = math.radians(lat2)
+    long2 = math.radians(long2)
+
+    d_lat = lat2 - lat1
+    d_long = long2 - long1
+
+    radicand = 1 - math.cos(d_lat) + (math.cos(lat1) * math.cos(lat2) * (1 - math.cos(d_long)))
+    s9rt = math.sqrt(radicand / 2)
+    # radius of the earth
+    r = 6371
+
+    return 2 * r * math.asin(s9rt)

--- a/merino/providers/weather/backends/protocol.py
+++ b/merino/providers/weather/backends/protocol.py
@@ -1,6 +1,6 @@
 """Protocol for weather provider backends."""
 
-from typing import Protocol
+from typing import Protocol, Optional
 
 from pydantic import BaseModel, HttpUrl
 
@@ -81,6 +81,7 @@ class WeatherContext:
 
     geolocation: Location
     languages: list[str]
+    selected_region: Optional[str] = None
 
 
 class WeatherBackend(Protocol):

--- a/tests/unit/providers/weather/backends/test_pathfinder.py
+++ b/tests/unit/providers/weather/backends/test_pathfinder.py
@@ -21,21 +21,27 @@ from merino.providers.weather.backends.accuweather.pathfinder import (
     [
         (
             Location(country="CA", regions=["BC"], city="Vancouver"),
-            ("CA", "BC", "Vancouver"),
+            "BC",
         ),
         (
             Location(country="IT", regions=["MT", "77"], city="Matera"),
-            ("IT", "77", "Matera"),
+            "77",
         ),
         (
             Location(country="GB", regions=["ENG", "HWT"], city="London"),
-            ("GB", "LND", "London"),
+            "LND",
         ),
-        (Location(country="BR", regions=["DF"], city="Brasilia"), ("BR", "DF", "Brasilia")),
-        (Location(country="IE", regions=None, city="Dublin"), ("IE", None, "Dublin")),
+        (
+            Location(country="BR", regions=["DF"], city="Brasilia"),
+            "DF",
+        ),
+        (
+            Location(country="IE", regions=None, city="Dublin"),
+            None,
+        ),
         (
             Location(country="CA", regions=["ON"], city="Mitchell/Ontario"),
-            ("CA", "ON", "Mitchell"),
+            "ON",
         ),
     ],
     ids=[

--- a/tests/unit/providers/weather/backends/test_utils.py
+++ b/tests/unit/providers/weather/backends/test_utils.py
@@ -1,0 +1,179 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Unit tests for the weather backend utils."""
+
+from typing import Any
+
+import pytest
+
+from merino.middleware.geolocation import Coordinates
+from merino.providers.weather.backends.accuweather.utils import (
+    get_lat_long_distance,
+    get_closest_location_by_distance,
+    process_location_response_with_country,
+)
+
+
+@pytest.fixture(name="location_response")
+def fixture_location_response():
+    """Location Response to Testing."""
+    return [
+        {
+            "Version": 1,
+            "Key": "282828",
+            "Type": "City",
+            "Rank": 85,
+            "LocalizedName": "North Park",
+            "EnglishName": "North Park",
+            "PrimaryPostalCode": "V8T",
+            "Region": {
+                "ID": "NAM",
+                "LocalizedName": "North America",
+                "EnglishName": "North America",
+            },
+            "Country": {"ID": "CA", "LocalizedName": "Canada", "EnglishName": "Canada"},
+            "AdministrativeArea": {
+                "ID": "BC",
+                "LocalizedName": "British Columbia",
+                "EnglishName": "British Columbia",
+                "Level": 1,
+                "LocalizedType": "Province",
+                "EnglishType": "Province",
+                "CountryID": "CA",
+            },
+            "TimeZone": {
+                "Code": "PST",
+                "Name": "America/Vancouver",
+                "GmtOffset": -8.0,
+                "IsDaylightSaving": False,
+                "NextOffsetChange": "2025-03-09T10:00:00Z",
+            },
+            "GeoPosition": {
+                "Latitude": 48.431,
+                "Longitude": -123.361,
+                "Elevation": {
+                    "Metric": {"Value": 11.0, "Unit": "m", "UnitType": 5},
+                    "Imperial": {"Value": 36.0, "Unit": "ft", "UnitType": 0},
+                },
+            },
+            "IsAlias": False,
+            "ParentCity": {"Key": "47163", "LocalizedName": "Victoria", "EnglishName": "Victoria"},
+            "SupplementalAdminAreas": [
+                {"Level": 2, "LocalizedName": "Capital", "EnglishName": "Capital"}
+            ],
+            "DataSets": [
+                "AirQualityCurrentConditions",
+                "AirQualityForecasts",
+                "Alerts",
+                "ForecastConfidence",
+                "FutureRadar",
+                "MinuteCast",
+                "Radar",
+                "TidalForecast",
+            ],
+        },
+        {
+            "Version": 1,
+            "Key": "888888",
+            "Type": "City",
+            "Rank": 85,
+            "LocalizedName": "North Park",
+            "EnglishName": "North Park",
+            "PrimaryPostalCode": "S7K",
+            "Region": {
+                "ID": "NAM",
+                "LocalizedName": "North America",
+                "EnglishName": "North America",
+            },
+            "Country": {"ID": "CA", "LocalizedName": "Canada", "EnglishName": "Canada"},
+            "AdministrativeArea": {
+                "ID": "SK",
+                "LocalizedName": "Saskatchewan",
+                "EnglishName": "Saskatchewan",
+                "Level": 1,
+                "LocalizedType": "Province",
+                "EnglishType": "Province",
+                "CountryID": "CA",
+            },
+            "TimeZone": {
+                "Code": "CST",
+                "Name": "America/Regina",
+                "GmtOffset": -6.0,
+                "IsDaylightSaving": False,
+                "NextOffsetChange": None,
+            },
+            "GeoPosition": {
+                "Latitude": 52.145,
+                "Longitude": -106.652,
+                "Elevation": {
+                    "Metric": {"Value": 454.0, "Unit": "m", "UnitType": 5},
+                    "Imperial": {"Value": 1489.0, "Unit": "ft", "UnitType": 0},
+                },
+            },
+            "IsAlias": False,
+            "ParentCity": {
+                "Key": "50338",
+                "LocalizedName": "Saskatoon",
+                "EnglishName": "Saskatoon",
+            },
+            "SupplementalAdminAreas": [],
+            "DataSets": [
+                "AirQualityCurrentConditions",
+                "AirQualityForecasts",
+                "Alerts",
+                "ForecastConfidence",
+                "FutureRadar",
+                "MinuteCast",
+                "Radar",
+            ],
+        },
+    ]
+
+
+@pytest.fixture(name="coordinates")
+def fixture_coordinates():
+    """Coordinate object for testing."""
+    return Coordinates(latitude=48.4308, longitude=-123.3586)
+
+
+@pytest.fixture(name="expected_location_results")
+def fixture_expected_location_results():
+    """Location Results for testing."""
+    return {
+        "administrative_area_id": "BC",
+        "key": "282828",
+        "localized_name": "North Park",
+    }
+
+
+def test_get_lat_long_distance():
+    """Test distance calculate between two coordinates."""
+    lat1 = 49.2827
+    long1 = -123.120
+    lat2 = 43.6532
+    long2 = -79.3832
+    assert 3358 == int(get_lat_long_distance(lat1, long1, lat2, long2))
+
+
+def test_get_closest_location_by_distance(
+    coordinates: Coordinates,
+    location_response: list[dict[str, Any]],
+    expected_location_results: dict[str, Any],
+):
+    """Test retrieval of the closest location for a given Coordinate."""
+    assert expected_location_results == get_closest_location_by_distance(
+        location_response, coordinates
+    )
+
+
+def test_process_location_response_with_country(
+    coordinates: Coordinates,
+    location_response: dict[str, Any],
+    expected_location_results: dict[str, Any],
+):
+    """Test location response with multiple locations are handled correctly."""
+    assert expected_location_results == process_location_response_with_country(
+        coordinates, location_response
+    )


### PR DESCRIPTION
## References

JIRA: [DISCO-3091](https://mozilla-hub.atlassian.net/browse/DISCO-3091)

## Description
For cases where we request location keys with just country and city and the response returns more than one location, we can use lat long to calculate the closer one. 

In the event of cases like North Park, ON and accuweather only returns North Park, SK and North Park, BC, I decided to have a distance threshold so that we don't accidentally pick the wrong location



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3091]: https://mozilla-hub.atlassian.net/browse/DISCO-3091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ