### PR TITLE
[DISCO-3088] weather: add more rules to country,city,region pathfinder

### DIFF
--- a/merino/providers/weather/backends/accuweather/backend.py
+++ b/merino/providers/weather/backends/accuweather/backend.py
@@ -666,7 +666,9 @@ class AccuweatherBackend:
 
             if location is None:
                 if not skip_log:
-                    logger.warning(f"Unable to find location for {country}/{city}")
+                    logger.warning(
+                        f"Unable to find location for {country}/{city}/{geolocation.regions}"
+                    )
                 return None
 
         try:

--- a/merino/providers/weather/backends/accuweather/backend.py
+++ b/merino/providers/weather/backends/accuweather/backend.py
@@ -667,7 +667,7 @@ class AccuweatherBackend:
             if location is None:
                 if not skip_log:
                     logger.warning(
-                        f"Unable to find location for {country}/{city}/{geolocation.regions}"
+                        f"Unable to find location for {country}/{city}, regions: {geolocation.regions}"
                     )
                 return None
 

--- a/tests/unit/providers/weather/test_provider.py
+++ b/tests/unit/providers/weather/test_provider.py
@@ -18,7 +18,10 @@ from merino.config import settings
 from merino.middleware.geolocation import Location
 from merino.providers.base import BaseSuggestion, SuggestionRequest
 from merino.providers.custom_details import CustomDetails, WeatherDetails
-from merino.providers.weather.backends.accuweather.pathfinder import set_region_mapping
+from merino.providers.weather.backends.accuweather.pathfinder import (
+    set_region_mapping,
+    clear_region_mapping,
+)
 from merino.providers.weather.backends.protocol import (
     CurrentConditions,
     Forecast,
@@ -182,7 +185,9 @@ async def test_fetch_mapping(
 
     assert len(statsd_mock.gauge.call_args_list) == 0
 
-    set_region_mapping("Canada", "Vancouver", "BC")
+    clear_region_mapping()
+    set_region_mapping("NL", "Andel", "NB")
+
     await provider._report_mapping()
 
     assert len(statsd_mock.gauge.call_args_list) == 1
@@ -192,6 +197,4 @@ async def test_fetch_mapping(
 
     records = filter_caplog(caplog.records, "merino.providers.weather.provider")
     assert len(records) == 1
-    assert (
-        records[0].message == "Weather Successful Mapping Values: {('Canada', 'Vancouver'): 'BC'}"
-    )
+    assert records[0].message == "Weather Successful Mapping Values: {('NL', 'Andel'): 'NB'}"


### PR DESCRIPTION
## References

JIRA: [DISCO-3088](https://mozilla-hub.atlassian.net/browse/DISCO-3088)

## Description
I pulled the logs after #718 was merged. Added some more countries to our pathfinder. 
This isn't reflective of all the countries/cities found in the logs, but I think it's a start. As a result with this though, if there is a city within those countries that don't follow the same region convention (like London). It'll fail and appear in the logs...
11 countries.... out of 195? 😅 Alternatively we could have another "wonder" file with the mapping, but I think that's too much.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3088]: https://mozilla-hub.atlassian.net/browse/DISCO-3088?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ