### PR TITLE
[DISCO-3098] fix: set corrected city name into WeatherContext

### DIFF
--- a/merino/providers/weather/backends/accuweather/pathfinder.py
+++ b/merino/providers/weather/backends/accuweather/pathfinder.py
@@ -47,8 +47,9 @@ def compass(location: Location) -> Generator[str | None, None, None]:
     city = location.city
 
     if regions and country and city:
-        city = CITY_NAME_CORRECTION_MAPPING.get(city, city)
-        match (country, city):
+        corrected_city = CITY_NAME_CORRECTION_MAPPING.get(city, city)
+        location.city = corrected_city
+        match (country, corrected_city):
             case (country, city) if (
                 country,
                 city,

--- a/tests/unit/providers/weather/backends/test_pathfinder.py
+++ b/tests/unit/providers/weather/backends/test_pathfinder.py
@@ -56,7 +56,6 @@ from merino.providers.weather.backends.accuweather.pathfinder import (
 def test_compass(location: Location, expected_region_and_city: Tuple) -> None:
     """Test country that returns the most specific region."""
     set_region_mapping("GB", "London", "LND")
-    region = next(compass(location))
-    assert (region, location.city) == expected_region_and_city
+    assert next(compass(location)) == expected_region_and_city
 
     clear_region_mapping()

--- a/tests/unit/providers/weather/backends/test_pathfinder.py
+++ b/tests/unit/providers/weather/backends/test_pathfinder.py
@@ -17,31 +17,31 @@ from merino.providers.weather.backends.accuweather.pathfinder import (
 
 
 @pytest.mark.parametrize(
-    ("location", "expected_tuple"),
+    ("location", "expected_region_and_city"),
     [
         (
             Location(country="CA", regions=["BC"], city="Vancouver"),
-            "BC",
+            ("BC", "Vancouver"),
         ),
         (
             Location(country="IT", regions=["MT", "77"], city="Matera"),
-            "77",
+            ("77", "Matera"),
         ),
         (
             Location(country="GB", regions=["ENG", "HWT"], city="London"),
-            "LND",
+            ("LND", "London"),
         ),
         (
             Location(country="BR", regions=["DF"], city="Brasilia"),
-            "DF",
+            ("DF", "Brasilia"),
         ),
         (
             Location(country="IE", regions=None, city="Dublin"),
-            None,
+            (None, "Dublin"),
         ),
         (
             Location(country="CA", regions=["ON"], city="Mitchell/Ontario"),
-            "ON",
+            ("ON", "Mitchell"),
         ),
     ],
     ids=[
@@ -53,10 +53,10 @@ from merino.providers.weather.backends.accuweather.pathfinder import (
         "Corrected City Name",
     ],
 )
-def test_compass(location: Location, expected_tuple: Tuple) -> None:
+def test_compass(location: Location, expected_region_and_city: Tuple) -> None:
     """Test country that returns the most specific region."""
     set_region_mapping("GB", "London", "LND")
-
-    assert next(compass(location)) == expected_tuple
+    region = next(compass(location))
+    assert (region, location.city) == expected_region_and_city
 
     clear_region_mapping()


### PR DESCRIPTION
## References

JIRA: [DISCO-3098](https://mozilla-hub.atlassian.net/browse/DISCO-3098)

## Description
Since we're using WeatherContext to get city downstream, we need to set it to the corrected string, which was missed when I did #722 



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3098]: https://mozilla-hub.atlassian.net/browse/DISCO-3098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ