### PR TITLE
feat: geonames uploader - include names with punctuation stripped - Bug 1934766

### DIFF
--- a/merino/jobs/geonames_uploader/downloader.py
+++ b/merino/jobs/geonames_uploader/downloader.py
@@ -8,6 +8,7 @@ regions, and countries [1]. See technical documentation at [2].
 """
 
 import logging
+import re
 from typing import Any, Callable
 import unicodedata
 
@@ -425,8 +426,9 @@ def _remove_diacritics(value: str) -> str:
 def _normalize_name(name: str) -> set[str]:
     normalized = set()
     casefolded = name.casefold()
-    normalized.add(casefolded)
     without_diacritics = _remove_diacritics(casefolded)
-    if casefolded != without_diacritics:
-        normalized.add(without_diacritics)
+    normalized.add(casefolded)
+    normalized.add(without_diacritics)
+    normalized.add(re.sub(r"\W+", " ", casefolded))
+    normalized.add(re.sub(r"\W+", " ", without_diacritics))
     return normalized

--- a/tests/unit/jobs/geonames_uploader/test_downloader.py
+++ b/tests/unit/jobs/geonames_uploader/test_downloader.py
@@ -132,6 +132,42 @@ GEONAMES = [
         admin1_code="10",
         population=1,
     ),
+    # A made-up city with punctuation in its name
+    Geoname(
+        id=9,
+        name="St. Punctuation-on-the-Marsh",
+        latitude="45.50884",
+        longitude="-73.58781",
+        feature_class="P",
+        feature_code="PPLA2",
+        country_code="US",
+        admin1_code="NY",
+        population=1,
+    ),
+    # A made-up city with diacritics and punctuation in its name
+    Geoname(
+        id=10,
+        name="Öĩ-Guvnör-One",
+        latitude="45.50884",
+        longitude="-73.58781",
+        feature_class="P",
+        feature_code="PPLA2",
+        country_code="US",
+        admin1_code="NY",
+        population=1,
+    ),
+    # Another made-up city with diacritics and punctuation in its name
+    Geoname(
+        id=11,
+        name="Öĩ-Guvnör-Two",
+        latitude="45.50884",
+        longitude="-73.58781",
+        feature_class="P",
+        feature_code="PPLA2",
+        country_code="US",
+        admin1_code="NY",
+        population=1,
+    ),
 ]
 
 # Alternates that will populate the mock GeoNames files
@@ -233,6 +269,33 @@ ALTERNATES = [
     GeonameAlternate(
         geoname_id=8,
         name="Öũ",
+        iso_language="en",
+    ),
+    # Another made-up city with diacritics and punctuation in its name -- Add
+    # every normalized name as an explicit alternate to make sure they're not
+    # duplicated in the output.
+    GeonameAlternate(
+        geoname_id=11,
+        # casefolded
+        name="öĩ-guvnör-two",
+        iso_language="en",
+    ),
+    GeonameAlternate(
+        geoname_id=11,
+        # diacritics removed
+        name="oi-guvnor-two",
+        iso_language="en",
+    ),
+    GeonameAlternate(
+        geoname_id=11,
+        # punctuation removed
+        name="öĩ guvnör two",
+        iso_language="en",
+    ),
+    GeonameAlternate(
+        geoname_id=11,
+        # diacritics and punctuation removed
+        name="oi guvnor two",
         iso_language="en",
     ),
 ]
@@ -478,11 +541,60 @@ def test_all_populations_and_iso_languages(
                     GeonameAlternate(8, "öũ", "en"),
                 ],
             ),
+            Geoname(
+                id=9,
+                name="St. Punctuation-on-the-Marsh",
+                latitude="45.50884",
+                longitude="-73.58781",
+                feature_class="P",
+                feature_code="PPLA2",
+                country_code="US",
+                admin1_code="NY",
+                population=1,
+                alternates=[
+                    GeonameAlternate(9, "st. punctuation-on-the-marsh"),
+                    GeonameAlternate(9, "st punctuation on the marsh"),
+                ],
+            ),
+            Geoname(
+                id=10,
+                name="Öĩ-Guvnör-One",
+                latitude="45.50884",
+                longitude="-73.58781",
+                feature_class="P",
+                feature_code="PPLA2",
+                country_code="US",
+                admin1_code="NY",
+                population=1,
+                alternates=[
+                    GeonameAlternate(10, "öĩ-guvnör-one"),
+                    GeonameAlternate(10, "oi-guvnor-one"),
+                    GeonameAlternate(10, "oi guvnor one"),
+                    GeonameAlternate(10, "öĩ guvnör one"),
+                ],
+            ),
+            Geoname(
+                id=11,
+                name="Öĩ-Guvnör-Two",
+                latitude="45.50884",
+                longitude="-73.58781",
+                feature_class="P",
+                feature_code="PPLA2",
+                country_code="US",
+                admin1_code="NY",
+                population=1,
+                alternates=[
+                    GeonameAlternate(11, "öĩ-guvnör-two"),
+                    GeonameAlternate(11, "oi-guvnor-two"),
+                    GeonameAlternate(11, "oi guvnor two"),
+                    GeonameAlternate(11, "öĩ guvnör two"),
+                ],
+            ),
         ],
         expected_metrics=DownloadMetrics(
             # No excluded cities or regions
             excluded_geonames_count=0,
-            included_alternates_count=16,
+            included_alternates_count=20,
         ),
     )
 
@@ -572,7 +684,7 @@ def test_one_million_population_and_all_iso_languages(
         ],
         expected_metrics=DownloadMetrics(
             # No Waterloo AL, Waterloo IA, or city with diacritics
-            excluded_geonames_count=3,
+            excluded_geonames_count=6,
             included_alternates_count=12,
         ),
     )
@@ -643,7 +755,7 @@ def test_one_million_population_and_en_only(
         ],
         expected_metrics=DownloadMetrics(
             # No Waterloo AL, Waterloo IA, or city with diacritics
-            excluded_geonames_count=3,
+            excluded_geonames_count=6,
             # Only "al", "ia", "new york" (city), and "ny" (state). Other
             # values in `altername_names` are lowercased versions of `name`.
             included_alternates_count=4,


### PR DESCRIPTION
## References

[Bug 1934766 - In the geonames uploader, include names with punctuation removed](https://bugzilla.mozilla.org/show_bug.cgi?id=1934766)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
