### PR TITLE
[GENAI-467] support for reduced exploration prior experiment

### DIFF
--- a/merino/curated_recommendations/protocol.py
+++ b/merino/curated_recommendations/protocol.py
@@ -61,6 +61,8 @@ class ExperimentName(str, Enum):
     REGION_SPECIFIC_CONTENT_EXPANSION_SMALL = "new-tab-region-specific-content-expansion-small"
     # Experiment where high-engaging items scheduled for past dates are included.
     EXTENDED_EXPIRATION_EXPERIMENT = "new-tab-extend-content-duration"
+    # Experiment where we apply a modified prior to reduce exploration
+    MODIFIED_PRIOR_EXPERIMENT = "new-tab-feed-reduce-exploration"
 
 
 # Maximum tileId that Firefox can support. Firefox uses Javascript to store this value. The max

--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -163,6 +163,13 @@ class CuratedRecommendationsProvider:
         )
 
     @staticmethod
+    def is_enrolled_in_prior_experiment(request: CuratedRecommendationsRequest) -> bool:
+        """Return True if Thompson sampling should use modified prior with reduced beta (treatment)."""
+        return (CuratedRecommendationsProvider.is_enrolled_in_experiment(
+            request, ExperimentName.MODIFIED_PRIOR_EXPERIMENT.value, "treatment"
+        ))
+
+    @staticmethod
     def is_need_to_know_experiment(request, surface_id) -> bool:
         """Check if the 'need_to_know' experiment is enabled."""
         return (
@@ -220,6 +227,7 @@ class CuratedRecommendationsProvider:
             prior_backend=self.prior_backend,
             region=self.derive_region(request.locale, request.region),
             enable_region_engagement=self.is_enrolled_in_regional_engagement(request),
+            enable_prior_experiment=self.is_enrolled_in_prior_experiment(request),
         )
 
         # 2. Perform publisher spread on the recommendation set

--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -165,9 +165,9 @@ class CuratedRecommendationsProvider:
     @staticmethod
     def is_enrolled_in_prior_experiment(request: CuratedRecommendationsRequest) -> bool:
         """Return True if Thompson sampling should use modified prior with reduced beta (treatment)."""
-        return (CuratedRecommendationsProvider.is_enrolled_in_experiment(
+        return CuratedRecommendationsProvider.is_enrolled_in_experiment(
             request, ExperimentName.MODIFIED_PRIOR_EXPERIMENT.value, "treatment"
-        ))
+        )
 
     @staticmethod
     def is_need_to_know_experiment(request, surface_id) -> bool:

--- a/merino/curated_recommendations/rankers.py
+++ b/merino/curated_recommendations/rankers.py
@@ -26,6 +26,7 @@ def thompson_sampling(
     engagement_backend: EngagementBackend,
     prior_backend: PriorBackend,
     enable_region_engagement: bool = False,
+    enable_prior_experiment: bool = False,
     region: str | None = None,
     region_weight: float = REGION_ENGAGEMENT_WEIGHT,
 ) -> list[CuratedRecommendation]:
@@ -71,6 +72,13 @@ def thompson_sampling(
                 no_opens = (region_weight * region_no_opens) + ((1 - region_weight) * no_opens)
                 a_prior = (region_weight * region_prior.alpha) + ((1 - region_weight) * a_prior)
                 b_prior = (region_weight * region_prior.beta) + ((1 - region_weight) * b_prior)
+
+        # the experiment scales the parameters describing the prior distribution for item CTR by 0.5
+        # this reduces the approximate number of impressions over which the prior CTR will influence
+        # the final CTR estimate used for ranking.  this in turn reduces the expected exploration period
+        if enable_prior_experiment and not enable_region_engagement:
+            a_prior *= 0.5
+            b_prior *= 0.5
 
         # Add priors and ensure opens and no_opens are > 0, which is required by beta.rvs.
         opens += max(a_prior, 1e-18)

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -1197,6 +1197,8 @@ class TestCorpusApiRanking:
             (f"optin-{ExperimentName.REGION_SPECIFIC_CONTENT_EXPANSION.value}", "treatment", True),
             (ExperimentName.REGION_SPECIFIC_CONTENT_EXPANSION_SMALL.value, "control", False),
             (ExperimentName.REGION_SPECIFIC_CONTENT_EXPANSION_SMALL.value, "treatment", True),
+            (ExperimentName.MODIFIED_PRIOR_EXPERIMENT.value, "control", False),
+            (ExperimentName.MODIFIED_PRIOR_EXPERIMENT.value, "treatment", False),
             (
                 f"optin-{ExperimentName.REGION_SPECIFIC_CONTENT_EXPANSION_SMALL.value}",
                 "treatment",


### PR DESCRIPTION
## References

[Experiment brief](https://docs.google.com/document/d/1u1_wwi2Da44yKW7JRp0oW4EwC9Hkc0E5CgKYWXJWGRE/edit?usp=sharing)

[JIRA](https://mozilla-hub.atlassian.net/browse/GENAI-467)

## Description

In the above experiment, we intend to reduce the exploration period for items in the new tab content feed.  This is accomplished by scaling the $\alpha$ and $\beta$ parameters that determine the CTR prior for Thompson sampling.

We decided to keep this experiment separate from the region-based ranking experiment which has region-specific priors.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
