### PR TITLE
[HNT-281] Topic section ids match the topic id

### DIFF
--- a/merino/curated_recommendations/corpus_backends/protocol.py
+++ b/merino/curated_recommendations/corpus_backends/protocol.py
@@ -8,7 +8,13 @@ from pydantic import BaseModel, HttpUrl
 
 @unique
 class Topic(str, Enum):
-    """Topics supported for curated recommendations."""
+    """Topics supported for curated recommendations.
+
+    The section names must match the corresponding topic names in lowercase. Please update
+    merino/curated_recommendations/protocol.py if the enum names (e.g. BUSINESS) are changed.
+
+    The enum values correspond to the topic identifiers. Changing them would be a breaking change.
+    """
 
     BUSINESS = "business"
     CAREER = "career"

--- a/merino/curated_recommendations/layouts.py
+++ b/merino/curated_recommendations/layouts.py
@@ -8,9 +8,6 @@ TODO: HNT-252 will document the QA process for layout changes. PR review suffice
 
 from merino.curated_recommendations.protocol import Layout, ResponsiveLayout, Tile, TileSize
 
-# The following layouts are based on work-in-progress designs. The goal is to get some mock data to
-# FE developers. Names and layouts will likely be changed.
-
 # Layout 1: 4 medium tiles on 4 columns. Small tiles are used on fewer columns to display all items.
 layout_4_medium = Layout(
     name="4-medium-small-1-ad",

--- a/merino/curated_recommendations/protocol.py
+++ b/merino/curated_recommendations/protocol.py
@@ -233,22 +233,22 @@ class CuratedRecommendationsFeed(BaseModel):
     top_stories_section: Section | None = None
     # Topic sections are named according to the lowercase Topic enum name, and aliased to the topic
     # id, suffixed with '-section'. The alias determines the section name in the JSON response.
-    business: Section | None = Field(None, alias="business-section")
-    career: Section | None = Field(None, alias="career-section")
-    arts: Section | None = Field(None, alias="arts-section")
-    food: Section | None = Field(None, alias="food-section")
-    health_fitness: Section | None = Field(None, alias="health-section")
-    home: Section | None = Field(None, alias="home-section")
-    personal_finance: Section | None = Field(None, alias="finance-section")
-    politics: Section | None = Field(None, alias="government-section")
-    sports: Section | None = Field(None, alias="sports-section")
-    technology: Section | None = Field(None, alias="tech-section")
-    travel: Section | None = Field(None, alias="travel-section")
-    education: Section | None = Field(None, alias="education-section")
-    gaming: Section | None = Field(None, alias="hobbies-section")
-    parenting: Section | None = Field(None, alias="society-parenting-section")
-    science: Section | None = Field(None, alias="education-science-section")
-    self_improvement: Section | None = Field(None, alias="society-section")
+    business: Section | None = Field(None, alias="business")
+    career: Section | None = Field(None, alias="career")
+    arts: Section | None = Field(None, alias="arts")
+    food: Section | None = Field(None, alias="food")
+    health_fitness: Section | None = Field(None, alias="health")
+    home: Section | None = Field(None, alias="home")
+    personal_finance: Section | None = Field(None, alias="finance")
+    politics: Section | None = Field(None, alias="government")
+    sports: Section | None = Field(None, alias="sports")
+    technology: Section | None = Field(None, alias="tech")
+    travel: Section | None = Field(None, alias="travel")
+    education: Section | None = Field(None, alias="education")
+    gaming: Section | None = Field(None, alias="hobbies")
+    parenting: Section | None = Field(None, alias="society-parenting")
+    science: Section | None = Field(None, alias="education-science")
+    self_improvement: Section | None = Field(None, alias="society")
 
     def has_topic_section(self, topic: Topic) -> bool:
         """Check if a section for the given topic exists as an attribute."""

--- a/merino/curated_recommendations/protocol.py
+++ b/merino/curated_recommendations/protocol.py
@@ -232,7 +232,7 @@ class CuratedRecommendationsFeed(BaseModel):
     # follow or block sections, and references 'top_stories_section' to show topic labels.
     top_stories_section: Section | None = None
     # Topic sections are named according to the lowercase Topic enum name, and aliased to the topic
-    # id, suffixed with '-section'. The alias determines the section name in the JSON response.
+    # id. The alias determines the section name in the JSON response.
     business: Section | None = Field(None, alias="business")
     career: Section | None = Field(None, alias="career")
     arts: Section | None = Field(None, alias="arts")

--- a/merino/curated_recommendations/protocol.py
+++ b/merino/curated_recommendations/protocol.py
@@ -227,25 +227,39 @@ class CuratedRecommendationsFeed(BaseModel):
     need_to_know: CuratedRecommendationsBucket | None = None
     fakespot: FakespotFeed | None = None
 
-    # The following feeds are used as mock data for the 'sections' experiment.
-    # They should be removed when the sections are implemented that we'll actually launch with.
-    business: Section | None = None
-    career: Section | None = None
-    arts: Section | None = None
-    food: Section | None = None
-    health_fitness: Section | None = None
-    home: Section | None = None
-    personal_finance: Section | None = None
-    politics: Section | None = None
-    sports: Section | None = None
-    technology: Section | None = None
-    travel: Section | None = None
-    education: Section | None = None
-    gaming: Section | None = None
-    parenting: Section | None = None
-    science: Section | None = None
-    self_improvement: Section | None = None
-    top_stories_section: Section | None = None
+    # Topic sections are named according to the lowercase Topic enum name, and aliased to its value.
+    # The alias determines what's being returned in the JSON response.
+    business: Section | None = Field(None, alias="business")
+    career: Section | None = Field(None, alias="career")
+    arts: Section | None = Field(None, alias="arts")
+    food: Section | None = Field(None, alias="food")
+    health_fitness: Section | None = Field(None, alias="health")
+    home: Section | None = Field(None, alias="home")
+    personal_finance: Section | None = Field(None, alias="finance")
+    politics: Section | None = Field(None, alias="government")
+    sports: Section | None = Field(None, alias="sports")
+    technology: Section | None = Field(None, alias="tech")
+    travel: Section | None = Field(None, alias="travel")
+    education: Section | None = Field(None, alias="education")
+    gaming: Section | None = Field(None, alias="hobbies")
+    parenting: Section | None = Field(None, alias="society-parenting")
+    science: Section | None = Field(None, alias="education-science")
+    self_improvement: Section | None = Field(None, alias="society")
+    # Other sections
+    top_stories_section: Section | None = None  # Fx134+ shows topic labels for top_stories_section
+
+    class Config:
+        """Pydantic configs, as documented in https://docs.pydantic.dev/latest/api/config"""
+
+        populate_by_name = True  # Feeds are named according to their alias in the JSON response.
+
+    def has_topic_section(self, topic: Topic) -> bool:
+        """Check if a section for the given topic exists as an attribute."""
+        return hasattr(self, topic.name.lower())
+
+    def set_topic_section(self, topic: Topic, section: Section):
+        """Set a section for the given topic."""
+        setattr(self, topic.name.lower(), section)
 
 
 class CuratedRecommendationsResponse(BaseModel):

--- a/merino/curated_recommendations/protocol.py
+++ b/merino/curated_recommendations/protocol.py
@@ -2,7 +2,7 @@
 
 import hashlib
 from enum import unique, Enum
-from typing import Annotated
+from typing import Annotated, Optional, Union
 import logging
 
 from pydantic import (
@@ -237,11 +237,15 @@ CuratedRecommendationsFeed = create_model(
     "CuratedRecommendationsFeed",
     **(
         {
-            "need_to_know": (CuratedRecommendationsBucket | None, None),
-            "fakespot": (FakespotFeed | None, None),
-            "top_stories_section": (Section | None, None)
+            "need_to_know": (Union[CuratedRecommendationsBucket, None], None),  # 'big rectangle' news
+            "fakespot": (Union[FakespotFeed, None], None),  # fakespot products in the 'big rectangle'
+            "top_stories_section": (Union[Section, None], None),  # 'Popular Today' section
         }
-        | {topic.name.lower(): (Section | None, Field(None, alias=topic.value)) for topic in Topic}
+        # topic sections
+        | {
+            topic.name.lower(): (Union[Section, None], Field(None, alias=topic.value))
+            for topic in Topic
+        }
     ),
 )
 

--- a/merino/curated_recommendations/protocol.py
+++ b/merino/curated_recommendations/protocol.py
@@ -228,25 +228,27 @@ class CuratedRecommendationsFeed(BaseModel):
     fakespot: FakespotFeed | None = None
 
     # Sections
-    top_stories_section: Section | None = None  # Fx134+ shows topic labels for top_stories_section
-    # Topic sections are named according to the lowercase Topic enum name, and aliased to its value.
-    # The alias determines what's being returned in the JSON response.
-    business: Section | None = Field(None, alias="business")
-    career: Section | None = Field(None, alias="career")
-    arts: Section | None = Field(None, alias="arts")
-    food: Section | None = Field(None, alias="food")
-    health_fitness: Section | None = Field(None, alias="health")
-    home: Section | None = Field(None, alias="home")
-    personal_finance: Section | None = Field(None, alias="finance")
-    politics: Section | None = Field(None, alias="government")
-    sports: Section | None = Field(None, alias="sports")
-    technology: Section | None = Field(None, alias="tech")
-    travel: Section | None = Field(None, alias="travel")
-    education: Section | None = Field(None, alias="education")
-    gaming: Section | None = Field(None, alias="hobbies")
-    parenting: Section | None = Field(None, alias="society-parenting")
-    science: Section | None = Field(None, alias="education-science")
-    self_improvement: Section | None = Field(None, alias="society")
+    # Renaming an alias of a section is a breaking change. New Tab stores section names when users
+    # follow or block sections, and references 'top_stories_section' to show topic labels.
+    top_stories_section: Section | None = None
+    # Topic sections are named according to the lowercase Topic enum name, and aliased to the topic
+    # id, suffixed with '-section'. The alias determines the section name in the JSON response.
+    business: Section | None = Field(None, alias="business-section")
+    career: Section | None = Field(None, alias="career-section")
+    arts: Section | None = Field(None, alias="arts-section")
+    food: Section | None = Field(None, alias="food-section")
+    health_fitness: Section | None = Field(None, alias="health-section")
+    home: Section | None = Field(None, alias="home-section")
+    personal_finance: Section | None = Field(None, alias="finance-section")
+    politics: Section | None = Field(None, alias="government-section")
+    sports: Section | None = Field(None, alias="sports-section")
+    technology: Section | None = Field(None, alias="tech-section")
+    travel: Section | None = Field(None, alias="travel-section")
+    education: Section | None = Field(None, alias="education-section")
+    gaming: Section | None = Field(None, alias="hobbies-section")
+    parenting: Section | None = Field(None, alias="society-parenting-section")
+    science: Section | None = Field(None, alias="education-science-section")
+    self_improvement: Section | None = Field(None, alias="society-section")
 
     def has_topic_section(self, topic: Topic) -> bool:
         """Check if a section for the given topic exists as an attribute."""

--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -20,7 +20,7 @@ from merino.curated_recommendations.layouts import (
     layout_4_large,
     layout_6_tiles,
 )
-from merino.curated_recommendations.localization import get_translation
+from merino.curated_recommendations.localization import get_translation, LOCALIZED_SECTION_TITLES
 from merino.curated_recommendations.prior_backends.protocol import PriorBackend
 from merino.curated_recommendations.protocol import (
     Locale,
@@ -184,9 +184,16 @@ class CuratedRecommendationsProvider:
         )
 
     @staticmethod
-    def is_sections_experiment(request) -> bool:
+    def is_sections_experiment(
+        request: CuratedRecommendationsRequest,
+        surface_id: ScheduledSurfaceId,
+    ) -> bool:
         """Check if the 'sections' experiment is enabled."""
-        return request.feeds and "sections" in request.feeds
+        return (
+            request.feeds is not None
+            and "sections" in request.feeds  # Clients must request "feeds": ["sections"]
+            and surface_id in LOCALIZED_SECTION_TITLES  # The locale must be supported
+        )
 
     @staticmethod
     def is_fakespot_experiment(request, surface_id) -> bool:
@@ -409,7 +416,7 @@ class CuratedRecommendationsProvider:
             need_to_know_feed = CuratedRecommendationsBucket(
                 recommendations=need_to_know_recs, title=title
             )
-        elif self.is_sections_experiment(curated_recommendations_request):
+        elif self.is_sections_experiment(curated_recommendations_request, surface_id):
             sections_feeds = self.get_sections(
                 recommendations, curated_recommendations_request, surface_id
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ exclude_dirs = [
 
 [tool.mypy]
 python_version = "3.12"
+plugins = ['pydantic.mypy']
 disallow_untyped_calls = true
 follow_imports = "normal"
 ignore_missing_imports = true

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -1342,7 +1342,7 @@ class TestSections:
         assert top_stories_section["subtitle"] is not None
 
         # Verify that every section in the response data has a valid name
-        section_identifiers = {f"{topic.value}-section" for topic in Topic}
+        section_identifiers = {f"{topic.value}" for topic in Topic}
         section_identifiers.add("top_stories_section")
 
         for section_name, section in feeds.items():
@@ -1424,12 +1424,12 @@ class TestSections:
             self.assert_section_feed_helper(data, self.de_section_title_top_stories)
 
             # Ensure that topic section titles are in German, check at least one topic translation
-            if data["feeds"]["arts-section"] is not None:
-                assert data["feeds"]["arts-section"]["title"] == "Unterhaltung"
-            if data["feeds"]["education-section"] is not None:
-                assert data["feeds"]["education-section"]["title"] == "Bildung"
-            if data["feeds"]["sports-section"] is not None:
-                assert data["feeds"]["sports-section"]["title"] == "Sport"
+            if data["feeds"]["arts"] is not None:
+                assert data["feeds"]["arts"]["title"] == "Unterhaltung"
+            if data["feeds"]["education"] is not None:
+                assert data["feeds"]["education"]["title"] == "Bildung"
+            if data["feeds"]["sports"] is not None:
+                assert data["feeds"]["sports"]["title"] == "Sport"
 
             # Assert no errors were logged
             errors = [r for r in caplog.records if r.levelname == "ERROR"]
@@ -1455,12 +1455,12 @@ class TestSections:
             self.assert_section_feed_helper(data, self.en_us_section_title_top_stories)
 
             # Ensure that topic section titles fallback to English
-            if data["feeds"]["arts-section"] is not None:
-                assert data["feeds"]["arts-section"]["title"] == "Arts"
-            if data["feeds"]["education-section"] is not None:
-                assert data["feeds"]["education-section"]["title"] == "Education"
-            if data["feeds"]["sports-section"] is not None:
-                assert data["feeds"]["sports-section"]["title"] == "Sports"
+            if data["feeds"]["arts"] is not None:
+                assert data["feeds"]["arts"]["title"] == "Arts"
+            if data["feeds"]["education"] is not None:
+                assert data["feeds"]["education"]["title"] == "Education"
+            if data["feeds"]["sports"] is not None:
+                assert data["feeds"]["sports"]["title"] == "Sports"
 
             # Assert that errors were logged with a descriptive message when missing translation
             expected_error = "No translations found for surface 'ScheduledSurfaceId.NEW_TAB_IT_IT'"

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -1341,6 +1341,14 @@ class TestSections:
         assert top_stories_section["title"] == top_stories_title
         assert top_stories_section["subtitle"] is not None
 
+        # Verify that every section in the response data has a valid name
+        section_identifiers = {topic.value for topic in Topic}
+        section_identifiers.add("top_stories_section")
+
+        for section_name, section in feeds.items():
+            if section is not None:
+                assert section_name in section_identifiers, f"Invalid section name: {section_name}"
+
     @pytest.mark.parametrize(
         "surface_id",
         [
@@ -1457,7 +1465,7 @@ class TestSections:
             # Assert that errors were logged with a descriptive message when missing translation
             expected_error = "No translations found for surface 'ScheduledSurfaceId.NEW_TAB_IT_IT'"
             errors = [r for r in caplog.records if r.levelname == "ERROR"]
-            assert len(errors) == 9
+            assert len(errors) >= 9
             assert all(expected_error in error.message for error in errors)
 
 

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -1342,7 +1342,7 @@ class TestSections:
         assert top_stories_section["subtitle"] is not None
 
         # Verify that every section in the response data has a valid name
-        section_identifiers = {topic.value for topic in Topic}
+        section_identifiers = {f"{topic.value}-section" for topic in Topic}
         section_identifiers.add("top_stories_section")
 
         for section_name, section in feeds.items():
@@ -1424,12 +1424,12 @@ class TestSections:
             self.assert_section_feed_helper(data, self.de_section_title_top_stories)
 
             # Ensure that topic section titles are in German, check at least one topic translation
-            if data["feeds"]["arts"] is not None:
-                assert data["feeds"]["arts"]["title"] == "Unterhaltung"
-            if data["feeds"]["education"] is not None:
-                assert data["feeds"]["education"]["title"] == "Bildung"
-            if data["feeds"]["sports"] is not None:
-                assert data["feeds"]["sports"]["title"] == "Sport"
+            if data["feeds"]["arts-section"] is not None:
+                assert data["feeds"]["arts-section"]["title"] == "Unterhaltung"
+            if data["feeds"]["education-section"] is not None:
+                assert data["feeds"]["education-section"]["title"] == "Bildung"
+            if data["feeds"]["sports-section"] is not None:
+                assert data["feeds"]["sports-section"]["title"] == "Sport"
 
             # Assert no errors were logged
             errors = [r for r in caplog.records if r.levelname == "ERROR"]
@@ -1455,12 +1455,12 @@ class TestSections:
             self.assert_section_feed_helper(data, self.en_us_section_title_top_stories)
 
             # Ensure that topic section titles fallback to English
-            if data["feeds"]["arts"] is not None:
-                assert data["feeds"]["arts"]["title"] == "Arts"
-            if data["feeds"]["education"] is not None:
-                assert data["feeds"]["education"]["title"] == "Education"
-            if data["feeds"]["sports"] is not None:
-                assert data["feeds"]["sports"]["title"] == "Sports"
+            if data["feeds"]["arts-section"] is not None:
+                assert data["feeds"]["arts-section"]["title"] == "Arts"
+            if data["feeds"]["education-section"] is not None:
+                assert data["feeds"]["education-section"]["title"] == "Education"
+            if data["feeds"]["sports-section"] is not None:
+                assert data["feeds"]["sports-section"]["title"] == "Sports"
 
             # Assert that errors were logged with a descriptive message when missing translation
             expected_error = "No translations found for surface 'ScheduledSurfaceId.NEW_TAB_IT_IT'"

--- a/tests/unit/curated_recommendations/test_localization.py
+++ b/tests/unit/curated_recommendations/test_localization.py
@@ -1,0 +1,30 @@
+"""Tests covering merino/curated_recommendations/localization.py"""
+
+from merino.curated_recommendations.localization import get_translation
+from merino.curated_recommendations.corpus_backends.protocol import ScheduledSurfaceId
+
+
+def test_get_translation_existing_translation():
+    """Test that get_translation returns existing translations."""
+    result = get_translation(ScheduledSurfaceId.NEW_TAB_EN_US, "business", "Default")
+    assert result == "Business"
+
+
+def test_get_translation_non_existing_locale(caplog):
+    """Test logs error and falls back to default when locale translations do not exist."""
+    result = get_translation(ScheduledSurfaceId.NEW_TAB_IT_IT, "business", "Default")
+    assert result == "Default"
+
+    errors = [r for r in caplog.records if r.levelname == "ERROR"]
+    assert len(errors) == 1
+    assert "No translations found for surface" in errors[0].message
+
+
+def test_get_translation_non_existing_slug(caplog):
+    """Test logs error and falls back to default when the topic slug does not exist."""
+    result = get_translation(ScheduledSurfaceId.NEW_TAB_EN_US, "non_existing_slug", "Default")
+    assert result == "Default"
+
+    errors = [r for r in caplog.records if r.levelname == "ERROR"]
+    assert len(errors) == 1
+    assert "Missing or empty translation for topic" in errors[0].message


### PR DESCRIPTION
## References

JIRA: [HNT-281](https://mozilla-hub.atlassian.net/browse/HNT-281)

## Description
Change topic section identifiers to match their corresponding topic identifier.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[HNT-281]: https://mozilla-hub.atlassian.net/browse/HNT-281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ