### PR TITLE
HNT-278: Boost followed sections

### DIFF
--- a/merino/curated_recommendations/protocol.py
+++ b/merino/curated_recommendations/protocol.py
@@ -73,6 +73,14 @@ MAX_TILE_ID = (1 << 53) - 1
 MIN_TILE_ID = 10000000
 
 
+class SectionConfiguration(BaseModel):
+    """Configuration settings for a Section"""
+
+    sectionId: str
+    isFollowed: bool
+    isBlocked: bool
+
+
 class CuratedRecommendation(CorpusItem):
     """Extends CorpusItem with additional fields for a curated recommendation"""
 
@@ -110,6 +118,7 @@ class CuratedRecommendationsRequest(BaseModel):
     count: int = 100
     topics: list[Topic | str] | None = None
     feeds: list[str] | None = None
+    sections: list[SectionConfiguration] | None = None
     # Firefox sends the name and branch for Nimbus experiments on the "pocketNewtab" feature:
     # https://searchfox.org/mozilla-central/source/browser/components/newtab/lib/DiscoveryStreamFeed.sys.mjs
     # Allow any string value or null, because ExperimentName is not meant to be an exhaustive list.
@@ -217,6 +226,8 @@ class Section(BaseModel):
     title: str
     subtitle: str | None = None
     layout: Layout
+    isFollowed: bool = False
+    isBlocked: bool = False
 
 
 class CuratedRecommendationsFeed(BaseModel):

--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -199,16 +199,6 @@ class CuratedRecommendationsProvider:
         )
 
     @staticmethod
-    def is_follow_unfollow_block_section_experiment(request, surface_id) -> bool:
-        """Check if the Follow/Unfollow & Block Sections experiment is enabled."""
-        return (
-            request.feeds
-            and "sections" in request.feeds
-            and request.sections
-            and surface_id == ScheduledSurfaceId.NEW_TAB_EN_US
-        )
-
-    @staticmethod
     def get_fakespot_feed(
         fakespot_backend: FakespotBackend, surface_id: ScheduledSurfaceId
     ) -> FakespotFeed | None:
@@ -449,11 +439,10 @@ class CuratedRecommendationsProvider:
             response.feeds = sections_feeds
 
         if (
-            curated_recommendations_request.sections
+            sections_feeds
+            and curated_recommendations_request.sections
             and response.feeds
-            and self.is_follow_unfollow_block_section_experiment(
-                curated_recommendations_request, surface_id
-            )
+            and surface_id == ScheduledSurfaceId.NEW_TAB_EN_US
         ):
             response.feeds = boost_followed_sections(
                 curated_recommendations_request.sections, response.feeds

--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -438,12 +438,7 @@ class CuratedRecommendationsProvider:
         elif sections_feeds:
             response.feeds = sections_feeds
 
-        if (
-            sections_feeds
-            and curated_recommendations_request.sections
-            and response.feeds
-            and surface_id == ScheduledSurfaceId.NEW_TAB_EN_US
-        ):
+        if sections_feeds and curated_recommendations_request.sections and response.feeds:
             response.feeds = boost_followed_sections(
                 curated_recommendations_request.sections, response.feeds
             )

--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -37,6 +37,7 @@ from merino.curated_recommendations.rankers import (
     boost_preferred_topic,
     spread_publishers,
     thompson_sampling,
+    boost_followed_sections,
 )
 
 
@@ -187,6 +188,16 @@ class CuratedRecommendationsProvider:
         return (
             request.feeds
             and "fakespot" in request.feeds
+            and surface_id == ScheduledSurfaceId.NEW_TAB_EN_US
+        )
+
+    @staticmethod
+    def is_follow_unfollow_block_section_experiment(request, surface_id) -> bool:
+        """Check if the Follow/Unfollow & Block Sections experiment is enabled."""
+        return (
+            request.feeds
+            and "sections" in request.feeds
+            and request.sections
             and surface_id == ScheduledSurfaceId.NEW_TAB_EN_US
         )
 
@@ -428,6 +439,17 @@ class CuratedRecommendationsProvider:
             )
         elif sections_feeds:
             response.feeds = sections_feeds
+
+        if (
+            curated_recommendations_request.sections
+            and response.feeds
+            and self.is_follow_unfollow_block_section_experiment(
+                curated_recommendations_request, surface_id
+            )
+        ):
+            response.feeds = boost_followed_sections(
+                curated_recommendations_request.sections, response.feeds
+            )
 
         return response
 

--- a/merino/curated_recommendations/rankers.py
+++ b/merino/curated_recommendations/rankers.py
@@ -6,7 +6,12 @@ from merino.curated_recommendations import ConstantPrior
 from merino.curated_recommendations.corpus_backends.protocol import Topic
 from merino.curated_recommendations.engagement_backends.protocol import EngagementBackend
 from merino.curated_recommendations.prior_backends.protocol import PriorBackend, Prior
-from merino.curated_recommendations.protocol import CuratedRecommendation
+from merino.curated_recommendations.protocol import (
+    CuratedRecommendation,
+    CuratedRecommendationsFeed,
+    SectionConfiguration,
+    Section,
+)
 from scipy.stats import beta
 
 # In a weighted average, how much to weigh the metrics from the requested region. 0.95 was chosen
@@ -146,3 +151,67 @@ def boost_preferred_topic(
             remaining_recs.append(rec)
 
     return boosted_recs + remaining_recs
+
+
+def boost_followed_sections(
+    req_sections: list[SectionConfiguration], feeds: CuratedRecommendationsFeed
+) -> CuratedRecommendationsFeed:
+    """Boost followed sections to the very top, right after top_stories_section.
+    Received feed rank for top_stories_section should always stay 0.
+    Received feed rank for followed_sections should follow top_stories_section.
+    Unfollowed sections should be ranked after followed_sections, and relative order should be preserved.
+
+    :param req_sections: List of Section configurations
+    :param feeds: CuratedRecommendationsFeed object
+    :return: updated CuratedRecommendationsFeed with boosted followed sections (if found)
+    """
+    followed_sections = []
+    unfollowed_sections = []
+
+    # 1. Extract followed section ids from req_sections param
+    followed_section_ids = [section.sectionId for section in req_sections if section.isFollowed]
+
+    # 2. Extract blocked section ids from req_sections param
+    blocked_section_ids = [section.sectionId for section in req_sections if section.isBlocked]
+
+    # 3. Update isBlocked based on blocked_section_ids
+    # For now, we will only update isBlocked value on a Section
+    # The client-side will handle the actual blocking action
+    for section_id in dir(feeds):
+        section = getattr(feeds, section_id, None)
+        if isinstance(section, Section):
+            section.isBlocked = section_id in blocked_section_ids
+
+    # 4. Update isFollowed based on followed_section_ids
+    # Extract followed sections & unfollowed sections
+    if followed_section_ids:
+        for section_id in dir(feeds):
+            section = getattr(feeds, section_id, None)
+            if isinstance(section, Section):
+                section.isFollowed = section_id in followed_section_ids
+                if section_id == "top_stories_section":
+                    # top_stories_section is always on the top
+                    section.receivedFeedRank = 0
+                elif section.isFollowed:
+                    followed_sections.append(section)
+                else:
+                    unfollowed_sections.append(section)
+
+        # 5. Sort followed & unfollowed sections by their rank (ascending)
+        # This is to ensure relative order is kept
+        followed_sections.sort(key=lambda section: section.receivedFeedRank)
+        unfollowed_sections.sort(key=lambda section: section.receivedFeedRank)
+
+        # 6. Assign new rank starting from 1 for followed sections.
+        current_received_feed_rank = 1
+        for section in followed_sections:
+            section.receivedFeedRank = current_received_feed_rank
+            current_received_feed_rank += 1
+
+        # 7. Assign new rank (starting from last rank value assigned to a followed section)
+        # to unfollowed sections. Keep relative order.
+        for section in unfollowed_sections:
+            section.receivedFeedRank = current_received_feed_rank
+            current_received_feed_rank += 1
+
+    return feeds

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -1424,16 +1424,20 @@ class TestSections:
             # Check if the response is valid
             assert response.status_code == 200
 
-            self.assert_section_feed_helper(data, self.en_us_section_title_top_stories)
-
             # assert isFollowed & isBlocked have been correctly set
             if data["feeds"]["arts"] is not None:
                 assert data["feeds"]["arts"]["isFollowed"]
+                # assert followed section ARTS has a lower receivedFeedRank than unfollowed section EDUCATION
+                if data["feeds"]["education"] is not None:
+                    assert data["feeds"]["arts"]["receivedFeedRank"] < data["feeds"]["education"]["receivedFeedRank"]
             if data["feeds"]["education"] is not None:
                 assert not data["feeds"]["education"]["isFollowed"]
                 assert data["feeds"]["education"]["isBlocked"]
             if data["feeds"]["sports"] is not None:
                 assert data["feeds"]["sports"]["isFollowed"]
+                # assert followed section SPORTS has a lower receivedFeedRank than unfollowed section EDUCATION
+                if data["feeds"]["education"] is not None:
+                    assert data["feeds"]["sports"]["receivedFeedRank"] < data["feeds"]["education"]["receivedFeedRank"]
 
             # Assert no errors were logged
             errors = [r for r in caplog.records if r.levelname == "ERROR"]

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -1454,11 +1454,6 @@ class TestSections:
                 json={
                     "locale": "de-DE",
                     "feeds": ["sections"],
-                    "sections": [
-                        {"sectionId": "sports", "isFollowed": True, "isBlocked": False},
-                        {"sectionId": "arts", "isFollowed": True, "isBlocked": False},
-                        {"sectionId": "education", "isFollowed": False, "isBlocked": True},
-                    ],
                 },
             )
             data = response.json()
@@ -1471,16 +1466,10 @@ class TestSections:
             # Ensure that topic section titles are in German, check at least one topic translation
             if data["feeds"]["arts"] is not None:
                 assert data["feeds"]["arts"]["title"] == "Unterhaltung"
-                assert not data["feeds"]["arts"]["isFollowed"]
-                assert not data["feeds"]["arts"]["isBlocked"]
             if data["feeds"]["education"] is not None:
                 assert data["feeds"]["education"]["title"] == "Bildung"
-                assert not data["feeds"]["education"]["isFollowed"]
-                assert not data["feeds"]["education"]["isBlocked"]
             if data["feeds"]["sports"] is not None:
                 assert data["feeds"]["sports"]["title"] == "Sport"
-                assert not data["feeds"]["sports"]["isFollowed"]
-                assert not data["feeds"]["sports"]["isBlocked"]
 
             # Assert no errors were logged
             errors = [r for r in caplog.records if r.levelname == "ERROR"]

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -1427,17 +1427,15 @@ class TestSections:
             # assert isFollowed & isBlocked have been correctly set
             if data["feeds"]["arts"] is not None:
                 assert data["feeds"]["arts"]["isFollowed"]
-                # assert followed section ARTS has a lower receivedFeedRank than unfollowed section EDUCATION
-                if data["feeds"]["education"] is not None:
-                    assert data["feeds"]["arts"]["receivedFeedRank"] < data["feeds"]["education"]["receivedFeedRank"]
+                # assert followed section ARTS comes after top-stories and before unfollowed sections (education).
+                assert data["feeds"]["arts"]["receivedFeedRank"] in [1, 2]
             if data["feeds"]["education"] is not None:
                 assert not data["feeds"]["education"]["isFollowed"]
                 assert data["feeds"]["education"]["isBlocked"]
             if data["feeds"]["sports"] is not None:
                 assert data["feeds"]["sports"]["isFollowed"]
-                # assert followed section SPORTS has a lower receivedFeedRank than unfollowed section EDUCATION
-                if data["feeds"]["education"] is not None:
-                    assert data["feeds"]["sports"]["receivedFeedRank"] < data["feeds"]["education"]["receivedFeedRank"]
+                # assert followed section SPORTS comes after top-stories and before unfollowed sections (education).
+                assert data["feeds"]["sports"]["receivedFeedRank"] in [1, 2]
 
             # Assert no errors were logged
             errors = [r for r in caplog.records if r.levelname == "ERROR"]

--- a/tests/unit/curated_recommendations/test_rankers.py
+++ b/tests/unit/curated_recommendations/test_rankers.py
@@ -397,26 +397,28 @@ class TestCuratedRecommendationsProviderBoostFollowedSections:
         )
         # Let's first assert original feed received ranks
         assert feed.top_stories_section.receivedFeedRank == 0
-        assert feed.arts.receivedFeedRank == 5
-        assert feed.food.receivedFeedRank == 3
         assert feed.business.receivedFeedRank == 2
+        assert feed.food.receivedFeedRank == 3
+        assert feed.arts.receivedFeedRank == 5
         assert feed.travel.receivedFeedRank == 6
 
         # Get the updated feed with boosted followed sections
         new_feed = boost_followed_sections(req_sections, feed)
 
         # Now let's assert the updated feed and check that followed sections were boosted
+
+        # Assertions for receivedFeedRank
         assert new_feed.top_stories_section.receivedFeedRank == 0  # should always remain 0
-        assert feed.arts.receivedFeedRank == 2
-        assert feed.arts.isFollowed
-        assert feed.food.receivedFeedRank == 3
-        assert not feed.food.isFollowed
-        assert feed.business.receivedFeedRank == 1  # had a rank==2, should now be 1
-        assert feed.business.isFollowed
-        assert (
-            feed.travel.receivedFeedRank == 4
-        )  # was originally ranked after Food, should still be ranked after
-        assert not feed.travel.isFollowed
+        assert new_feed.business.receivedFeedRank == 1  # had a rank==2, should now be 1
+        assert new_feed.arts.receivedFeedRank == 2
+        assert new_feed.food.receivedFeedRank == 3
+        assert new_feed.travel.receivedFeedRank == 4  # originally ranked after Food, should still be after
+
+        # Assertions for isFollowed
+        assert new_feed.arts.isFollowed
+        assert new_feed.business.isFollowed
+        assert not new_feed.food.isFollowed
+        assert not new_feed.travel.isFollowed
 
     def test_boost_followed_sections_no_followed_sections_found_block_section(self):
         """Test boosting sections only boosts followed sections. If no followed sections found in request,
@@ -432,9 +434,9 @@ class TestCuratedRecommendationsProviderBoostFollowedSections:
         )
         # Let's first assert original feed received ranks
         assert feed.top_stories_section.receivedFeedRank == 0
-        assert feed.arts.receivedFeedRank == 5
-        assert feed.food.receivedFeedRank == 3
         assert feed.business.receivedFeedRank == 2
+        assert feed.food.receivedFeedRank == 3
+        assert feed.arts.receivedFeedRank == 5
         assert not feed.business.isBlocked  # isBlocked should be false by default
         assert feed.travel.receivedFeedRank == 6
         assert not feed.travel.isBlocked  # isBlocked should be false by default
@@ -443,14 +445,18 @@ class TestCuratedRecommendationsProviderBoostFollowedSections:
         new_feed = boost_followed_sections(req_sections, feed)
 
         # Now let's assert the updated feed and check that receivedFeedRank has not changed for sections
+
+        # Assertions for receivedFeedRank
         assert new_feed.top_stories_section.receivedFeedRank == 0
-        assert new_feed.arts.receivedFeedRank == 5
-        assert not new_feed.arts.isFollowed
-        assert new_feed.food.receivedFeedRank == 3
-        assert not new_feed.food.isFollowed
         assert new_feed.business.receivedFeedRank == 2
+        assert new_feed.food.receivedFeedRank == 3
+        assert new_feed.arts.receivedFeedRank == 5
+        assert new_feed.travel.receivedFeedRank == 6
+
+        # Assertions for isFollowed & isBlocked
+        assert not new_feed.arts.isFollowed
+        assert not new_feed.food.isFollowed
         assert not new_feed.business.isFollowed
         assert new_feed.business.isBlocked  # isBlocked should be now true
-        assert new_feed.travel.receivedFeedRank == 6
         assert not new_feed.travel.isFollowed
         assert new_feed.travel.isBlocked  # isBlocked should be now true

--- a/tests/unit/curated_recommendations/test_rankers.py
+++ b/tests/unit/curated_recommendations/test_rankers.py
@@ -412,7 +412,9 @@ class TestCuratedRecommendationsProviderBoostFollowedSections:
         assert new_feed.business.receivedFeedRank == 1  # had a rank==2, should now be 1
         assert new_feed.arts.receivedFeedRank == 2
         assert new_feed.food.receivedFeedRank == 3
-        assert new_feed.travel.receivedFeedRank == 4  # originally ranked after Food, should still be after
+        assert (
+            new_feed.travel.receivedFeedRank == 4
+        )  # originally ranked after Food, should still be after
 
         # Assertions for isFollowed
         assert new_feed.arts.isFollowed


### PR DESCRIPTION
## References

JIRA: https://mozilla-hub.atlassian.net/browse/HNT-278

## Description
Boost followed sections to the very top. `top_stories_section` should always be at the very top (`receivedFeedRank==0`), followed by followed sections + unfollowed sections.

Client can send a new request param `sections`:
```
"sections": [
    {
      "sectionId": "food",
      "isFollowed": true,
      "isBlocked": false
    },
    {
      "sectionId": "arts",
      "isFollowed": false,
      "isBlocked": true
    },
    {
      "sectionId": "education",
      "isFollowed": true,
      "isBlocked": false
    }
  ]
```

`isFollowed` & `isBlocked` is set to `False` by default, unless specified by the client. For now, `isBlocked` is ignored on the server, blocking action is handled on the client-side. 

`boost_followed_sections` in `rankers.py`:
* updates `isBlocked` on a section, does nothing with this.
* updates `isFollowed` on a section & updates `receivedFeedRank` based on `isFollowed` param. Relative order of sections is preserved.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
