### PR TITLE
chore: correct city mapping addition for Querétaro

### DIFF
--- a/merino/providers/weather/backends/accuweather/pathfinder.py
+++ b/merino/providers/weather/backends/accuweather/pathfinder.py
@@ -18,6 +18,7 @@ CITY_NAME_CORRECTION_MAPPING: dict[str, str] = {
     "Kleinburg Station": "Kleinburg",
     "Middlebury (village)": "Middlebury",
     "TracadieSheila": "Tracadie Sheila",
+    "Queretaro City": "Querétaro",
 }
 SKIP_CITIES_LIST: frozenset = frozenset(
     [


### PR DESCRIPTION
## References


## Description
 We originally normalized strings due to some cities in hawaii where accuweather expected the normalized string name. I think it's time to figure out whether normalizing strings is more beneficial or detrimental. 



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
