### PR TITLE
[DISCO-3126] chore: poetry update removes 'export', need to add plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM python:${PYTHON_VERSION}-slim AS build
 WORKDIR /tmp
 
 # Pin Poetry to reduce image size
-RUN pip install --no-cache-dir --quiet poetry
+RUN pip install --no-cache-dir --quiet poetry-plugin-export
 
 COPY ./pyproject.toml ./poetry.lock /tmp/
 


### PR DESCRIPTION
## References

JIRA: [DISCO-3126](https://mozilla-hub.atlassian.net/browse/DISCO-3126)

## Description
With the release of [Poetry 2.0.0](https://github.com/python-poetry/poetry/releases/tag/2.0.0), the command [export](https://github.com/python-poetry/poetry/pull/5980) is no longer included by default, we'll need to add the plugin.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3126]: https://mozilla-hub.atlassian.net/browse/DISCO-3126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ