### PR TITLE
[DISCO-3125] Remove city name normalization

### DIFF
--- a/merino/middleware/geolocation.py
+++ b/merino/middleware/geolocation.py
@@ -87,7 +87,7 @@ class GeolocationMiddleware:
                 country_name=record.country.names.get("en"),
                 regions=get_regions(record.subdivisions),
                 region_names=get_region_names(record.subdivisions),
-                city=city if (city := record.city.names.get("en")) else None,
+                city=record.city.names.get("en"),
                 dma=record.location.metro_code,
                 postal_code=record.postal.code if record.postal else None,
                 coordinates=Coordinates(

--- a/merino/middleware/geolocation.py
+++ b/merino/middleware/geolocation.py
@@ -1,7 +1,6 @@
 """The middleware that parses geolocation from the client IP address."""
 
 import logging
-import unicodedata
 from typing import Optional
 
 import geoip2.database
@@ -40,11 +39,6 @@ class Location(BaseModel):
     postal_code: Optional[str] = None
     key: Optional[str] = None
     coordinates: Optional[Coordinates] = None
-
-
-def normalize_string(input_str) -> str:
-    """Normalize string with special characters."""
-    return unicodedata.normalize("NFKD", input_str).encode("ascii", "ignore").decode("ascii")
 
 
 def get_regions(subdivisions) -> Optional[list[str]]:
@@ -93,7 +87,7 @@ class GeolocationMiddleware:
                 country_name=record.country.names.get("en"),
                 regions=get_regions(record.subdivisions),
                 region_names=get_region_names(record.subdivisions),
-                city=normalize_string(city) if (city := record.city.names.get("en")) else None,
+                city=city if (city := record.city.names.get("en")) else None,
                 dma=record.location.metro_code,
                 postal_code=record.postal.code if record.postal else None,
                 coordinates=Coordinates(

--- a/merino/providers/weather/backends/accuweather/pathfinder.py
+++ b/merino/providers/weather/backends/accuweather/pathfinder.py
@@ -9,16 +9,24 @@ MaybeStr = Optional[str]
 Pair = tuple[MaybeStr, MaybeStr]
 
 SUCCESSFUL_REGIONS_MAPPING: dict[tuple[str, str], str | None] = {("GB", "London"): "LND"}
-REGION_MAPPING_EXCLUSIONS: frozenset = frozenset(["CA", "ES", "GR", "IT", "US"])
+REGION_MAPPING_EXCLUSIONS: frozenset = frozenset(
+    ["AU", "CA", "CN", "DE", "ES", "FR", "GB", "GR", "IT", "PL", "PT", "RU", "US"]
+)
 CITY_NAME_CORRECTION_MAPPING: dict[str, str] = {
+    "‘Aiea": "Aiea",
+    "Kīhei": "Kihei",
     "La'ie": "Laie",
+    "Kleinburg Station": "Kleinburg",
     "Mitchell/Ontario": "Mitchell",
     "Montreal East": "Montreal",
     "Montreal West": "Montreal",
-    "Kleinburg Station": "Kleinburg",
     "Middlebury (village)": "Middlebury",
-    "TracadieSheila": "Tracadie Sheila",
+    "Orléans": "Orleans",
+    "Pohénégamook": "Pohenegamook",
+    "Sainte-Clotilde-de-Châteauguay": "Sainte-Clotilde-de-Chateauguay",
+    "Sainte-Geneviève": "Sainte-Genevieve",
     "Queretaro City": "Querétaro",
+    "TracadieSheila": "Tracadie Sheila",
 }
 SKIP_CITIES_LIST: frozenset = frozenset(
     [

--- a/merino/providers/weather/backends/accuweather/pathfinder.py
+++ b/merino/providers/weather/backends/accuweather/pathfinder.py
@@ -22,10 +22,10 @@ CITY_NAME_CORRECTION_MAPPING: dict[str, str] = {
     "Montreal West": "Montreal",
     "Middlebury (village)": "Middlebury",
     "Orléans": "Orleans",
+    "Queretaro City": "Querétaro",
     "Pohénégamook": "Pohenegamook",
     "Sainte-Clotilde-de-Châteauguay": "Sainte-Clotilde-de-Chateauguay",
     "Sainte-Geneviève": "Sainte-Genevieve",
-    "Queretaro City": "Querétaro",
     "TracadieSheila": "Tracadie Sheila",
 }
 SKIP_CITIES_LIST: frozenset = frozenset(

--- a/tests/unit/middleware/test_geolocation.py
+++ b/tests/unit/middleware/test_geolocation.py
@@ -13,7 +13,6 @@ from merino.middleware import ScopeKey
 from merino.middleware.geolocation import (
     GeolocationMiddleware,
     Location,
-    normalize_string,
     Coordinates,
 )
 
@@ -171,16 +170,3 @@ async def test_geolocation_invalid_scope_type(
 
     assert ScopeKey.GEOLOCATION not in scope
     assert len(caplog.messages) == 0
-
-
-@pytest.mark.parametrize(
-    "input_string, expected_output",
-    [
-        ("Kīhei", "Kihei"),
-        ("‘Aiea", "Aiea"),
-        ("Querétaro", "Queretaro"),
-    ],
-)
-def test_normalize_string(input_string, expected_output) -> None:
-    """Test the normalization of strings with special characters"""
-    assert normalize_string(input_string) == expected_output

--- a/tests/unit/providers/weather/backends/test_pathfinder.py
+++ b/tests/unit/providers/weather/backends/test_pathfinder.py
@@ -28,8 +28,8 @@ from merino.providers.weather.backends.accuweather.pathfinder import (
             ("77", "Matera"),
         ),
         (
-            Location(country="GB", regions=["ENG", "HWT"], city="London"),
-            ("LND", "London"),
+            Location(country="AR", regions=["B", "5"], city="La Plata"),
+            ("STE", "La Plata"),
         ),
         (
             Location(country="BR", regions=["DF"], city="Brasilia"),
@@ -55,7 +55,7 @@ from merino.providers.weather.backends.accuweather.pathfinder import (
 )
 def test_compass(location: Location, expected_region_and_city: Tuple) -> None:
     """Test country that returns the most specific region."""
-    set_region_mapping("GB", "London", "LND")
+    set_region_mapping("AR", "La Plata", "STE")
     assert next(compass(location)) == expected_region_and_city
 
     clear_region_mapping()


### PR DESCRIPTION
## References

JIRA: [DISCO-3125](https://mozilla-hub.atlassian.net/browse/DISCO-3125)

## Description
Normalization city names seems to cause more harm than good from a global perspective.
Removing it and adding the CA and US cities that need normalization to the mapping list



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3125]: https://mozilla-hub.atlassian.net/browse/DISCO-3125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ