### PR TITLE
[DISCO-2808] delete partial wiki upload on stream failure

### DIFF
--- a/merino/jobs/wikipedia_indexer/filemanager.py
+++ b/merino/jobs/wikipedia_indexer/filemanager.py
@@ -143,8 +143,6 @@ class FileManager:
                     logger.error(f"Failed to delete partial upload: {delete_error}")
             raise WikipediaFilemanagerError("Failed to stream dump to GCS") from e
 
-
-
     def stream_from_gcs(self, blob: Blob) -> Generator:
         """Streaming reader from GCS"""
         reader: BlobReader

--- a/merino/jobs/wikipedia_indexer/filemanager.py
+++ b/merino/jobs/wikipedia_indexer/filemanager.py
@@ -135,9 +135,9 @@ class FileManager:
 
             if blob.exists():
                 try:
-                    logger.warning(f"Deleting partial upload: gs://{self.gcs_bucket}/{blob.name}")
+                    logger.info(f"Deleting partial upload: gs://{self.gcs_bucket}/{blob.name}")
                     blob.delete()
-                    logger.warning(f"Deleted partial upload: gs://{self.gcs_bucket}/{blob.name}")
+                    logger.info(f"Deleted partial upload: gs://{self.gcs_bucket}/{blob.name}")
 
                 except GoogleAPIError as delete_error:
                     logger.error(f"Failed to delete partial upload: {delete_error}")


### PR DESCRIPTION
## References

JIRA: [DISCO-2808](https://mozilla-hub.atlassian.net/browse/DISCO-2808)

## Description
The wikipedia airflow job sometimes fails in the process of streaming the dump to GCS. This leaves behind an incomplete file which has to be manually removed by SRE before re-run. This PR adds a fix by deleting the partial upload file on failure.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2808]: https://mozilla-hub.atlassian.net/browse/DISCO-2808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ