### PR TITLE
[DISCO-3129] Fakespot category field

### DIFF
--- a/merino/jobs/csv_rs_uploader/fakespot.py
+++ b/merino/jobs/csv_rs_uploader/fakespot.py
@@ -20,6 +20,7 @@ class Suggestion(RowMajorBaseSuggestion):
     product_id: str
     rating: float
     title: str
+    category: str
     product_type: str
     keywords: str
     total_reviews: int
@@ -57,6 +58,7 @@ class Suggestion(RowMajorBaseSuggestion):
             "product_id": "product_id",
             "rating": "rating",
             "title": "title",
+            "category": "category",
             "product_type": "product_type",
             "keywords": "keywords",
             "total_reviews": "total_reviews",
@@ -81,3 +83,9 @@ class Suggestion(RowMajorBaseSuggestion):
     def validate_title(cls, value):
         """Validate title"""
         return cls._validate_str(value, "title")
+
+    @field_validator("category", mode="before")
+    @classmethod
+    def validate_category(cls, value):
+        """Validate category"""
+        return cls._validate_str(value, "category")

--- a/tests/unit/jobs/csv_rs_uploader/test_fakespot.py
+++ b/tests/unit/jobs/csv_rs_uploader/test_fakespot.py
@@ -18,6 +18,7 @@ TEST_CSV_ROW = {
     "product_id": "test-ABCDEF",
     "rating": "3.6",
     "title": "Brand new widget",
+    "category": "doodads",
     "product_type": "widget",
     "keywords": "widget",
     "total_reviews": "10",
@@ -37,6 +38,7 @@ def test_upload(mocker):
                 "product_id": "test-ABCDEF",
                 "rating": "3.6",
                 "title": "Brand new widget",
+                "category": "doodads",
                 "product_type": "widget",
                 "keywords": "widget",
                 "total_reviews": "10",
@@ -48,6 +50,7 @@ def test_upload(mocker):
                 "product_id": "  test-XYZ  ",
                 "rating": "3.0",
                 "title": "  Refurbished widget  \n  ",
+                "category": "doodads",
                 "product_type": "widget",
                 "keywords": "",
                 "total_reviews": "15",
@@ -61,6 +64,7 @@ def test_upload(mocker):
                 "product_id": "test-ABCDEF",
                 "rating": 3.6,
                 "title": "Brand new widget",
+                "category": "doodads",
                 "product_type": "widget",
                 "keywords": "widget",
                 "total_reviews": 10,
@@ -72,6 +76,7 @@ def test_upload(mocker):
                 "product_id": "test-XYZ",
                 "rating": 3.0,
                 "title": "Refurbished widget",
+                "category": "doodads",
                 "product_type": "widget",
                 "keywords": "",
                 "total_reviews": 15,
@@ -95,6 +100,7 @@ def test_blocklist(mocker, monkeypatch):
                 "rating": "3.6",
                 "title": "Brand new widget",
                 "product_type": "widget",
+                "category": "doodads",
                 "keywords": "widget",
                 "total_reviews": "10",
                 "url": "https://example.com/new-widget",
@@ -106,6 +112,7 @@ def test_blocklist(mocker, monkeypatch):
                 "rating": "3.0",
                 "title": "  Refurbished widget  \n  ",
                 "product_type": "widget",
+                "category": "doodads",
                 "keywords": "",
                 "total_reviews": "15",
                 "url": "https://example.com/old-widget",
@@ -120,6 +127,7 @@ def test_blocklist(mocker, monkeypatch):
                 "rating": 3.0,
                 "title": "Refurbished widget",
                 "product_type": "widget",
+                "category": "doodads",
                 "keywords": "",
                 "total_reviews": 15,
                 "url": "https://example.com/old-widget",
@@ -206,3 +214,9 @@ def test_score(verify_field_validation_error, verify_field_required):
     verify_field_required("score")
     verify_field_validation_error("score", "")
     verify_field_validation_error("score", "five and a third")
+
+
+def test_category(verify_field_validation_error, verify_field_required):
+    """Test validation for the category field"""
+    verify_field_required("category")
+    verify_field_validation_error("category", "")


### PR DESCRIPTION
Fakespot will be adding a category field to their CSV uploads, this commit makes us ready to start using it when they do. In the meantime, devs won't be able to use the script with the current Fakespot CSV format.  I checked in with them and this is okay.

## References

JIRA: [DISCO-TODO](https://mozilla-hub.atlassian.net/browse/DISCO-TODO)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
