### PR TITLE
[HNT-306] Topic sections tweaks and rank fixes

### DIFF
--- a/merino/curated_recommendations/layouts.py
+++ b/merino/curated_recommendations/layouts.py
@@ -16,9 +16,9 @@ layout_4_medium = Layout(
             columnCount=4,
             tiles=[
                 Tile(size=TileSize.MEDIUM, position=0, hasAd=False, hasExcerpt=True),
-                Tile(size=TileSize.MEDIUM, position=1, hasAd=True, hasExcerpt=True),
+                Tile(size=TileSize.MEDIUM, position=1, hasAd=False, hasExcerpt=True),
                 Tile(size=TileSize.MEDIUM, position=2, hasAd=False, hasExcerpt=True),
-                Tile(size=TileSize.MEDIUM, position=3, hasAd=False, hasExcerpt=True),
+                Tile(size=TileSize.MEDIUM, position=3, hasAd=True, hasExcerpt=True),
             ],
         ),
         ResponsiveLayout(

--- a/merino/curated_recommendations/localization.py
+++ b/merino/curated_recommendations/localization.py
@@ -29,7 +29,6 @@ LOCALIZED_SECTION_TITLES: LocalizedTopicSectionTitles = {
         "travel": "Travel",
         "home": "Home & Garden",
         "top-stories": "Popular Today",
-        "news-section": "In the News",
     },
     # reference: https://github.com/mozilla-l10n/firefox-l10n/blob/main/de/browser/browser/newtab/newtab.ftl#L407
     ScheduledSurfaceId.NEW_TAB_DE_DE: {
@@ -50,7 +49,6 @@ LOCALIZED_SECTION_TITLES: LocalizedTopicSectionTitles = {
         "travel": "Reisen",
         "home": "Haus und Garten",
         "top-stories": "Meistgelesen",
-        "news-section": "In den News",
     },
 }
 

--- a/merino/curated_recommendations/protocol.py
+++ b/merino/curated_recommendations/protocol.py
@@ -238,7 +238,6 @@ class CuratedRecommendationsFeed(BaseModel):
     # Renaming an alias of a section is a breaking change. New Tab stores section names when users
     # follow or block sections, and references 'top_stories_section' to show topic labels.
     top_stories_section: Section | None = None
-    news_section: Section | None = None
     # Topic sections are named according to the lowercase Topic enum name, and aliased to the topic
     # id. The alias determines the section name in the JSON response.
     business: Section | None = Field(None, alias="business")

--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -3,7 +3,6 @@
 import logging
 import time
 import re
-from datetime import datetime
 from typing import cast
 
 from merino.curated_recommendations import ExtendedExpirationCorpusBackend

--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -345,18 +345,11 @@ class CuratedRecommendationsProvider:
 
         # Create "Today's top stories" section with the first 6 recommendations
         feeds = CuratedRecommendationsFeed(
-            news_section=Section(
-                receivedFeedRank=0,
-                recommendations=news_recs,
-                title=get_translation(surface_id, "news-section", "In the News"),
-                subtitle=datetime.now().strftime("%B %d, %Y"),  # e.g., "October 24, 2024"
-                layout=layout_4_large,
-            ),
             top_stories_section=Section(
-                receivedFeedRank=1,
+                receivedFeedRank=0,
                 recommendations=top_stories,
                 title=get_translation(surface_id, "top-stories", "Popular Today"),
-                layout=layout_4_medium,
+                layout=layout_4_large,
             ),
         )
 

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -1299,7 +1299,6 @@ class TestSections:
         replacement_section_titles = {topic.name.lower(): topic.value for topic in Topic}
         # top-stories is not in the Topic enum, do separately
         replacement_section_titles["top_stories_section"] = "top-stories"
-        replacement_section_titles["news_section"] = "news-section"
 
         # Get all Section titles in CuratedRecommendationsFeed
         # Replace strings using the Topic enum-derived map
@@ -1356,12 +1355,6 @@ class TestSections:
             # Ensure all topics are present and are named according to the Topic Enum value.
             assert all(topic.value in feeds for topic in Topic)
 
-            # Assert that news_section only has time sensitive items, and other sections do not.
-            for section_name, section in sections.items():
-                is_expected_time_sensitive = section_name == "news_section"
-                for recommendation in section["recommendations"]:
-                    assert recommendation["isTimeSensitive"] == is_expected_time_sensitive
-
     @pytest.mark.asyncio
     async def test_curated_recommendations_with_sections_feed_boost_followed_sections(
         self, caplog
@@ -1414,7 +1407,6 @@ class TestSections:
                 "en-US",
                 {
                     "top_stories_section": "Popular Today",
-                    "news_section": "In the News",
                     "arts": "Entertainment",
                     "education": "Education",
                     "sports": "Sports",
@@ -1424,7 +1416,6 @@ class TestSections:
                 "de-DE",
                 {
                     "top_stories_section": "Meistgelesen",
-                    "news_section": "In den News",
                     "arts": "Unterhaltung",
                     "education": "Bildung",
                     "sports": "Sport",
@@ -1453,11 +1444,6 @@ class TestSections:
             top_stories_section = data["feeds"].get("top_stories_section")
             assert top_stories_section is not None
             assert top_stories_section["subtitle"] is None
-
-            # Ensure "Today's top stories" is present with a valid date subtitle
-            news_section = data["feeds"].get("news_section")
-            assert news_section is not None
-            assert news_section["subtitle"] is not None
 
 
 class TestExtendedExpiration:

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -1352,6 +1352,13 @@ class TestSections:
             # All sections have a layout
             assert all(Layout(**section["layout"]) for section in sections.values())
 
+            # Section receivedFeedRank should be numbered 0, 1, 2, ..., len(sections) - 1.
+            assert {s["receivedFeedRank"] for s in sections.values()} == set(range(len(sections)))
+            # Recommendation receivedRank should be numbered 0, 1, 2, ..., len(recommendations) - 1.
+            for section in sections.values():
+                recs = section["recommendations"]
+                assert {rec["receivedRank"] for rec in recs} == set(range(len(recs)))
+
             # Ensure all topics are present and are named according to the Topic Enum value.
             assert all(topic.value in feeds for topic in Topic)
 


### PR DESCRIPTION
## References

JIRA: [HNT-306](https://mozilla-hub.atlassian.net/browse/HNT-306)

## Description
Tweaks and fixes for the topic section experiment.

Fixes:
- Section `receivedFeedRank` is numbered correctly in case sections are removed because we don't have enough recommendations.
- Recommendation `receivedRank` is numbered correctly for `top_stories_section`.

Changed product requirements:
- For 4 medium card layout, move the Ad to the last slot, as long as this doesn’t break the layout when we shrink the viewport
- Remove In the News
- Update Popular Today layout (which will now now be at the top) to Large, 2 small, medium (i.e. what we’re using for In the News now)

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[HNT-306]: https://mozilla-hub.atlassian.net/browse/HNT-306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ