### PR TITLE
DISCO-3109 - Adding metrics to manifest endpoint

### DIFF
--- a/docs/data.md
+++ b/docs/data.md
@@ -169,9 +169,9 @@ The following additional metrics are recorded when curated recommendations are r
  A timer to measure the duration (in ms) of updating the engagement data from GCS.
 - `recommendation.engagement.size` - A gauge to track the size of the engagement blob on GCS.
 - `recommendation.engagement.count` - A gauge to measure the total number of engagement records.
-- `recommendation.engagement.{country}.count` - A gauge to measure the number of scheduled corpus 
+- `recommendation.engagement.{country}.count` - A gauge to measure the number of scheduled corpus
  items with engagement data per country.
-- `recommendation.engagement.{country}.clicks` - A gauge to measure the number of clicks per country 
+- `recommendation.engagement.{country}.clicks` - A gauge to measure the number of clicks per country
  in our GCS engagement blob.
 - `recommendation.engagement.{country}.impressions` - A gauge to measure the number of impressions
  per country in our GCS engagement blob.
@@ -184,3 +184,13 @@ The following additional metrics are recorded when curated recommendations are r
 - `recommendation.prior.last_updated` -
  A gauge for the staleness (in seconds) of the prior data, measured between when the data was
  updated in GCS and the current time.
+
+### Manifest
+
+When requesting a manifest file, we record the following metrics.
+
+- `manifest.request.get` - A counter for how many requests against the `/manifest` endpoint where made.
+- `manifest.request.timing` - A timer for how long it took the endpoint to fulfill the request.
+- `manifest.gcs.fetch_time` - A timer for how long it took to download the latest manifest file from the Google Cloud bucket.
+- `manifest.request.no_manifest` - A counter to measure how many times we didn't find the latest manifest file.
+- `manifest.request.error` - A counter to measure how many times we could not provide a valid JSON manifest file.

--- a/tests/integration/api/v1/test_manifest.py
+++ b/tests/integration/api/v1/test_manifest.py
@@ -1,35 +1,66 @@
-"""Tests for the manifest endpoint."""
+"""Integration tests for the /manifest endpoint, including metrics injection."""
 
 import json
-import pytest
 import logging
-from fastapi import FastAPI
 from unittest.mock import Mock
+
+import pytest
+from typing import Generator
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from google.cloud.storage import Blob
+
+from aiodogstatsd import Client
+from merino.middleware import ScopeKey
 from merino.utils.gcs.gcp_uploader import GcsUploader, get_gcs_uploader_for_manifest
 from merino.web.api_v1 import router
 from merino.web.models_v1 import Manifest
 
-# Set up logging
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 test_app = FastAPI()
 test_app.include_router(router, prefix="/api/v1")
 
-test_client = TestClient(test_app)
+
+class NoOpMetricsClient(Client):
+    """Create a no-op metrics client for test usage.
+
+    This class inherits from `aiodogstatsd.Client`, but overrides `increment` and
+    `timeit` so they do nothing. This prevents KeyErrors or real metric calls in tests.
+    """
+
+    def increment(self, *args, **kwargs):
+        """Do nothing instead of sending a metric increment."""
+        pass
+
+    def timeit(self, *args, **kwargs):
+        """Return a no-op context manager instead of timing anything."""
+        from contextlib import nullcontext
+
+        return nullcontext()
 
 
 @pytest.fixture
-def mock_uploader():
-    """Create a mock GCS uploader."""
-    uploader = Mock(spec=GcsUploader)
-    return uploader
+def client_with_metrics() -> Generator[TestClient, None, None]:
+    """Wrap `test_app` in an ASGI function that inserts a
+    NoOpMetricsClient into the request scope, so that any endpoint referencing
+    `request.scope[ScopeKey.METRICS_CLIENT]` won't crash.
+    """
+
+    async def asgi_wrapper(scope, receive, send):
+        """Insert NoOpMetricsClient into the scope, then call the real app."""
+        scope[ScopeKey.METRICS_CLIENT] = NoOpMetricsClient()
+        await test_app(scope, receive, send)
+
+    with TestClient(asgi_wrapper) as client:
+        yield client
 
 
-def test_get_manifest_success():
-    """Test that the endpoint returns a valid Manifest."""
+def test_get_manifest_success(client_with_metrics):
+    """Test that the /manifest endpoint returns a valid Manifest, while
+    also ensuring the request scope has a NoOpMetricsClient so it doesn't fail.
+    """
     mock_manifest = {
         "domains": [
             {
@@ -44,34 +75,24 @@ def test_get_manifest_success():
         ]
     }
 
-    # Create a mock uploader
     mock_uploader = Mock(spec=GcsUploader)
 
-    # Create a mock blob
     mock_blob = Mock(spec=Blob)
     mock_blob.name = "20240110_top_picks.json"
     mock_blob.download_as_text.return_value = json.dumps(mock_manifest)
-
-    # Set up get_most_recent_file to return our mock blob
     mock_uploader.get_most_recent_file.return_value = mock_blob
 
-    # Override the dependency
     test_app.dependency_overrides[get_gcs_uploader_for_manifest] = lambda: mock_uploader
 
     try:
-        response = test_client.get("/api/v1/manifest")
+        response = client_with_metrics.get("/api/v1/manifest")
         assert response.status_code == 200
 
-        # Validate the shape with the typed Pydantic model
-        manifest = Manifest(**response.json())  # raises ValidationError if mismatch
-
-        # Optionally, check fields
+        manifest = Manifest(**response.json())
         assert len(manifest.domains) == 1
         assert manifest.domains[0].domain == "google"
 
-        # Check headers
         assert "Cache-Control" in response.headers
 
     finally:
-        # Clean up
         test_app.dependency_overrides.clear()


### PR DESCRIPTION
## References

JIRA: [DISCO-3109](https://mozilla-hub.atlassian.net/browse/DISCO-3109)

## Description
Adding the following metrics to the `/manifest` endpoint:

```
- `manifest.request.get` - A counter for how many requests against the `/manifest` endpoint where made.
- `manifest.request.timing` - A timer how long it took the endpoint to fulfill the request.
- `manifest.gcs.fetch_time` - A timer for how long it took to download the latest manifest file from the Google Cloud bucket.
- `manifest.request.no_manifest` - A counter to measure how many times we didn't find the latest manifest file.
- `manifest.request.error` - A counter to measure how many times we could not provide a valid JSON manifest file.
```

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3109]: https://mozilla-hub.atlassian.net/browse/DISCO-3109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ