### PR TITLE
DISCO-3109 - fix some metrics

### DIFF
--- a/tests/integration/api/v1/test_manifest.py
+++ b/tests/integration/api/v1/test_manifest.py
@@ -34,6 +34,10 @@ class NoOpMetricsClient(Client):
         """Do nothing instead of sending a metric increment."""
         pass
 
+    def gauge(self, *args, **kwargs):
+        """Do nothing instead of sending a metric gauge."""
+        pass
+
     def timeit(self, *args, **kwargs):
         """Return a no-op context manager instead of timing anything."""
         from contextlib import nullcontext


### PR DESCRIPTION
## References

JIRA: [DISCO-3109](https://mozilla-hub.atlassian.net/browse/DISCO-3109)

## Description
Some minor adjustments, adding metric for size of the manifest file.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3109]: https://mozilla-hub.atlassian.net/browse/DISCO-3109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ