### PR TITLE
[DISCO-3168] Don't record dist calc metric when no locations

### DIFF
--- a/merino/providers/suggest/weather/backends/accuweather/utils.py
+++ b/merino/providers/suggest/weather/backends/accuweather/utils.py
@@ -262,7 +262,7 @@ def get_closest_location_by_distance(
             weather_context.distance_calculation = False
             return None
     # temp for debugging
-    if temp_min_distance < math.inf:
+    if not math.isinf(temp_min_distance):
         logger.warning(
             f"Unable to calculate closest city: {weather_context.geolocation.country}, {weather_context.geolocation.city}, dist: {int(temp_min_distance)}"
         )

--- a/merino/providers/suggest/weather/backends/accuweather/utils.py
+++ b/merino/providers/suggest/weather/backends/accuweather/utils.py
@@ -264,7 +264,7 @@ def get_closest_location_by_distance(
     # temp for debugging
     if temp_min_distance < math.inf:
         logger.warning(
-            f"Unable to calculate closest city: {weather_context.geolocation.country}, {weather_context.geolocation.city}, dist:{temp_min_distance} "
+            f"Unable to calculate closest city: {weather_context.geolocation.country}, {weather_context.geolocation.city}, dist: {int(temp_min_distance)}"
         )
     return None
 

--- a/merino/providers/suggest/weather/backends/accuweather/utils.py
+++ b/merino/providers/suggest/weather/backends/accuweather/utils.py
@@ -220,7 +220,7 @@ def get_closest_location_by_distance(
     locations: list[dict[str, Any]], weather_context: WeatherContext
 ) -> ProcessedLocationResponse | None:
     """Get the closest location by distance within the DISTANCE THRESHOLD."""
-    weather_context.distance_calculation = False
+    weather_context.distance_calculation = False if locations else None
     coordinates = weather_context.geolocation.coordinates
     closest_location = None
     min_distance = math.inf
@@ -261,9 +261,11 @@ def get_closest_location_by_distance(
         except KeyError:
             weather_context.distance_calculation = False
             return None
-    logger.warning(
-        f"Unable to calculate closest city: {weather_context.geolocation.country}, {weather_context.geolocation.city}, dist:{temp_min_distance} "
-    )
+    # temp for debugging
+    if temp_min_distance < math.inf:
+        logger.warning(
+            f"Unable to calculate closest city: {weather_context.geolocation.country}, {weather_context.geolocation.city}, dist:{temp_min_distance} "
+        )
     return None
 
 

--- a/tests/unit/providers/suggest/weather/backends/test_utils.py
+++ b/tests/unit/providers/suggest/weather/backends/test_utils.py
@@ -173,6 +173,15 @@ def test_get_closest_location_by_distance(
     assert weather_context.distance_calculation is True
 
 
+def test_get_closest_location_by_distance_does_not_update_distance_calc_when_no_location(
+    weather_context: WeatherContext,
+    expected_location_results: dict[str, Any],
+):
+    """When no locations are provided, distance_calculation should stay Nqone."""
+    get_closest_location_by_distance([], weather_context)
+    assert weather_context.distance_calculation is None
+
+
 def test_process_location_response_with_country(
     weather_context: WeatherContext,
     location_response: dict[str, Any],


### PR DESCRIPTION
## References

JIRA: [DISCO-3168](https://mozilla-hub.atlassian.net/browse/DISCO-3168)

## Description
Metrics were inaccurate as we were including cases where accuweather did not provide locations and we considered that as a distance calculation fail.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3168]: https://mozilla-hub.atlassian.net/browse/DISCO-3168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ