### PR TITLE
fix: Fix all the warnings in tests

### DIFF
--- a/merino/curated_recommendations/rankers.py
+++ b/merino/curated_recommendations/rankers.py
@@ -10,7 +10,6 @@ from merino.curated_recommendations.protocol import (
     CuratedRecommendation,
     CuratedRecommendationsFeed,
     SectionConfiguration,
-    Section,
 )
 from scipy.stats import beta
 
@@ -184,25 +183,23 @@ def boost_followed_sections(
     # 3. Update isBlocked based on blocked_section_ids
     # For now, we will only update isBlocked value on a Section
     # The client-side will handle the actual blocking action
-    for section_id in dir(feeds):
-        section = getattr(feeds, section_id, None)
-        if isinstance(section, Section):
-            section.isBlocked = section_id in blocked_section_ids
+    for section_id in feeds.model_fields_set:
+        section = getattr(feeds, section_id)
+        section.isBlocked = section_id in blocked_section_ids
 
     # 4. Update isFollowed based on followed_section_ids
     # Extract followed sections & unfollowed sections
     if followed_section_ids:
-        for section_id in dir(feeds):
-            section = getattr(feeds, section_id, None)
-            if isinstance(section, Section):
-                section.isFollowed = section_id in followed_section_ids
-                if section_id == "top_stories_section":
-                    # top_stories_section is always on the top
-                    section.receivedFeedRank = 0
-                elif section.isFollowed:
-                    followed_sections.append(section)
-                else:
-                    unfollowed_sections.append(section)
+        for section_id in feeds.model_fields_set:
+            section = getattr(feeds, section_id)
+            section.isFollowed = section_id in followed_section_ids
+            if section_id == "top_stories_section":
+                # top_stories_section is always on the top
+                section.receivedFeedRank = 0
+            elif section.isFollowed:
+                followed_sections.append(section)
+            else:
+                unfollowed_sections.append(section)
 
         # 5. Sort followed & unfollowed sections by their rank (ascending)
         # This is to ensure relative order is kept

--- a/tests/unit/providers/suggest/weather/backends/test_accuweather.py
+++ b/tests/unit/providers/suggest/weather/backends/test_accuweather.py
@@ -1703,7 +1703,7 @@ async def test_get_location_no_location_returned(
     "weather_context",
     [
         WeatherContext(Location(country="US", city=None), languages=[]),
-        WeatherContext(Location(country="None", city="N/A"), languages=[]),
+        WeatherContext(Location(country=None, city="N/A"), languages=[]),
     ],
     ids=["no-city", "no-country"],
 )


### PR DESCRIPTION
## References

JIRA: [DISCO-3130](https://mozilla-hub.atlassian.net/browse/DISCO-3130)

## Description
Most of the warnings in this patch are either using deprecated code or code errors by us.

@Trinaa I am more leaning towards treating test warnings as errors now :)



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3130]: https://mozilla-hub.atlassian.net/browse/DISCO-3130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ