### PR TITLE
[DISCO-3173] Add metric to count number of weather report queries

### DIFF
--- a/docs/data.md
+++ b/docs/data.md
@@ -156,6 +156,7 @@ The weather provider records additional metrics.
   cache store returned an error when fetching or storing a weather report. This should be 0 in
   normal operation. In case of an error, the logs will include a `WARNING` with the full error
   message.
+- `merino.providers.accuweather.query.weather_report` - A counter to measure the number of queries that are for weather
 - `merino.providers.accuweather.skip_cities_mapping.total.size` - A counter to measure the total number of occurrences cities were skipped due to no location
 - `merino.providers.accuweather.skip_cities_mapping.unique.size` - A counter to measure the number of unique cities that are skipped due to no location
 

--- a/merino/providers/suggest/weather/provider.py
+++ b/merino/providers/suggest/weather/provider.py
@@ -136,7 +136,7 @@ class Provider(BaseProvider):
                     )
                 else:
                     weather_context.geolocation.key = srequest.query
-                    self.metrics_client.increment(f"providers.{self.name}.weather_report.request")
+                    self.metrics_client.increment(f"providers.{self.name}.query.weather_report")
                     weather_report = await self.backend.get_weather_report(weather_context)
 
         except BackendError as backend_error:

--- a/merino/providers/suggest/weather/provider.py
+++ b/merino/providers/suggest/weather/provider.py
@@ -136,6 +136,7 @@ class Provider(BaseProvider):
                     )
                 else:
                     weather_context.geolocation.key = srequest.query
+                    self.metrics_client.increment(f"providers.{self.name}.weather_report.request")
                     weather_report = await self.backend.get_weather_report(weather_context)
 
         except BackendError as backend_error:

--- a/tests/unit/providers/suggest/weather/test_provider.py
+++ b/tests/unit/providers/suggest/weather/test_provider.py
@@ -144,9 +144,7 @@ async def test_query_weather_report_returned(
     assert suggestions == expected_suggestions
 
     assert len(statsd_mock.increment.call_args_list) == 1
-    assert statsd_mock.increment.call_args_list == [
-        call("providers.weather.weather_report.request")
-    ]
+    assert statsd_mock.increment.call_args_list == [call("providers.weather.query.weather_report")]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/providers/suggest/weather/test_provider.py
+++ b/tests/unit/providers/suggest/weather/test_provider.py
@@ -108,6 +108,7 @@ def test_not_hidden_by_default(provider: Provider) -> None:
 
 @pytest.mark.asyncio
 async def test_query_weather_report_returned(
+    statsd_mock: Any,
     backend_mock: Any,
     provider: Provider,
     geolocation: Location,
@@ -141,6 +142,11 @@ async def test_query_weather_report_returned(
     )
 
     assert suggestions == expected_suggestions
+
+    assert len(statsd_mock.increment.call_args_list) == 1
+    assert statsd_mock.increment.call_args_list == [
+        call("providers.weather.weather_report.request")
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## References

JIRA: [DISCO-3173](https://mozilla-hub.atlassian.net/browse/DISCO-3173)

## Description
As we expand weather globally, it will be good to know the number of weather queries we have, in contrast with the number of skips, processing errors etc.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3173]: https://mozilla-hub.atlassian.net/browse/DISCO-3173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ