### PR TITLE
DISCO-3175 - script for running domain_metadata_extractor separately

### DIFF
--- a/docs/operations/jobs/navigational_suggestions.md
+++ b/docs/operations/jobs/navigational_suggestions.md
@@ -48,3 +48,33 @@ To see the navigational suggestions code that is run when the job is invoked, vi
 [merino_jobs_code]: https://workflow.telemetry.mozilla.org/dags/merino_jobs/code?root=
 [merino_jobs-grid]: https://workflow.telemetry.mozilla.org/dags/merino_jobs/grid
 [merino_jobs-graph]: https://workflow.telemetry.mozilla.org/dags/merino_jobs/graph?root=
+
+## Running the favicon extractor locally
+
+```bash
+$ poetry run probe-images mozilla.org wikipedia.org
+```
+
+There is a Python script (`domain_tester.py`) which imports the `DomainMetadataExtractor`,  `Scraper` and `FaviconDownloader` and runs them locally, without saving the results to the cloud.
+
+This is meant to troubleshoot domains locally and iterate over the functionality in a contained environment.
+
+Example output:
+```bash
+$ poetry run probe-images mozilla.org
+
+Testing domain: mozilla.org
+✅ Success!
+ Title           Mozilla - Internet for people, not profit (UK)
+ Best Icon       https://www.mozilla.org/media/img/favicons/mozilla/m24/favicon-196x196.e143075360ea.png
+ Total Favicons  3
+
+All favicons found:
+- https://www.mozilla.org/media/img/favicons/mozilla/m24/apple-touch-icon.05aa000f6748.png (rel=apple-touch-icon
+size=180x180 type=image/png)
+- https://www.mozilla.org/media/img/favicons/mozilla/m24/favicon-196x196.e143075360ea.png (rel=icon size=196x196
+type=image/png)
+- https://www.mozilla.org/media/img/favicons/mozilla/m24/favicon.d0be64e474b1.ico (rel=shortcut,icon)
+
+Summary: 1/1 domains processed successfully
+```

--- a/merino/jobs/utils/__init__.py
+++ b/merino/jobs/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Util scripts for merino jobs."""

--- a/merino/jobs/utils/domain_tester.py
+++ b/merino/jobs/utils/domain_tester.py
@@ -1,0 +1,150 @@
+"""Domain metadata extraction testing tool."""
+
+from datetime import datetime
+from typing import Any, Optional
+import typer
+from rich.console import Console
+from rich.table import Table
+from pydantic import BaseModel
+
+from merino.jobs.navigational_suggestions.domain_metadata_extractor import (
+    DomainMetadataExtractor,
+    Scraper,
+    FaviconDownloader,
+)
+
+cli = typer.Typer(no_args_is_help=True)
+console = Console()
+
+
+class DomainTestResult(BaseModel):
+    """Results from testing domain metadata extraction"""
+
+    domain: str
+    timestamp: str
+    success: bool
+    metadata: dict[str, Any]
+    details: dict[str, Any]
+    favicon_data: Optional[dict[str, list[dict[str, Any]]]]
+    error: Optional[str] = None
+
+
+def test_domain(domain: str, min_width: int) -> DomainTestResult:
+    """Test metadata extraction for a single domain"""
+    timestamp = datetime.now().isoformat()
+
+    try:
+        domain_data = {
+            "rank": 1,
+            "domain": domain,
+            "host": f"www.{domain}" if not domain.startswith("www.") else domain,
+            "origin": f"https://{domain}",
+            "suffix": domain.split(".")[-1],
+            "categories": ["Unknown"],
+        }
+
+        scraper = Scraper()
+        favicon_downloader = FaviconDownloader()
+        extractor = DomainMetadataExtractor(
+            blocked_domains=set(), scraper=scraper, favicon_downloader=favicon_downloader
+        )
+
+        metadata = extractor.get_domain_metadata([domain_data], min_width)[0]
+
+        favicon_data = None
+        total_favicons = 0
+        if metadata["url"]:
+            raw_favicon_data = scraper.scrape_favicon_data(metadata["url"])
+            favicon_data = raw_favicon_data.model_dump()
+            favicon_urls = set()
+
+            for link in raw_favicon_data.links:
+                if "href" in link:
+                    favicon_urls.add(link["href"])
+
+            for meta in raw_favicon_data.metas:
+                if "content" in meta:
+                    favicon_urls.add(meta["content"])
+
+            if metadata["icon"]:
+                favicon_urls.add(metadata["icon"])
+
+            total_favicons = len(favicon_urls)
+
+        details = {
+            "base_url_tried": f"https://{domain}",
+            "www_url_tried": f"https://www.{domain}",
+            "final_url": metadata["url"],
+            "favicons_found": total_favicons,
+            "manifest_found": bool(favicon_data and favicon_data["manifests"]),
+        }
+
+        return DomainTestResult(
+            domain=domain,
+            timestamp=timestamp,
+            success=bool(metadata["url"] and metadata["icon"]),
+            metadata=metadata,
+            details=details,
+            favicon_data=favicon_data,
+        )
+
+    except Exception as e:
+        return DomainTestResult(
+            domain=domain,
+            timestamp=timestamp,
+            success=False,
+            metadata={},
+            details={},
+            favicon_data=None,
+            error=str(e),
+        )
+
+
+@cli.command()
+def test_domains(
+    domains: list[str] = typer.Argument(..., help="List of domains to test"),
+    min_width: int = typer.Option(32, help="Minimum favicon width", show_default=True),
+):
+    """Test domain metadata extraction for multiple domains"""
+    results = []
+
+    for domain in domains:
+        with console.status(f"Testing {domain}..."):
+            result = test_domain(domain, min_width)
+            results.append(result)
+
+        if result.success:
+            console.print(f"\nTesting domain: {domain}")
+
+            table = Table(show_header=False, box=None)
+            table.add_row("Title", result.metadata.get("title", "N/A"))
+            table.add_row("Best Icon", result.metadata.get("icon", "N/A"))
+            table.add_row("Total Favicons", str(result.details["favicons_found"]))
+
+            console.print("✅ Success!")
+            console.print(table)
+
+            if result.favicon_data:
+                console.print("\nAll favicons found:")
+                for link in result.favicon_data["links"]:
+                    if "href" in link:
+                        desc = []
+                        if "rel" in link:
+                            desc.append(f"rel={','.join(link['rel'])}")
+                        if "sizes" in link:
+                            desc.append(f"size={link['sizes']}")
+                        if "type" in link:
+                            desc.append(f"type={link['type']}")
+                        console.print(f"- {link['href']} ({' '.join(desc)})")
+        else:
+            console.print("❌ Failed!")
+            if result.error:
+                console.print(f"Error: {result.error}")
+
+    successful = len([r for r in results if r.success])
+    console.print(f"\nSummary: {successful}/{len(results)} domains processed successfully")
+
+
+def main():
+    """Entry point for CLI"""
+    cli()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,8 @@ branch = true
 relative_files = true
 omit = [
   # Data file only
-  "merino/jobs/utils/domain_category_mapping.py"
+  "merino/jobs/utils/domain_category_mapping.py",
+  "merino/jobs/utils/domain_tester.py"
 ]
 
 [tool.coverage.report]
@@ -75,6 +76,7 @@ packages = [
 
 [tool.poetry.scripts]
 merino-jobs = "merino.jobs.cli:cli"
+probe-images = "merino.jobs.utils.domain_tester:main"
 
 [tool.poetry.dependencies]
 python = "^3.12"


### PR DESCRIPTION
## References

JIRA: [DISCO-3175](https://mozilla-hub.atlassian.net/browse/DISCO-3175)

## Description
We may want to iterate over the functionality of fetching favicons from websites locally. I added a script to run the extractor:

```bash
$ poetry run probe-images mozilla.org wikipedia.org
```


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3175]: https://mozilla-hub.atlassian.net/browse/DISCO-3175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ