### PR TITLE
DISCO-3185 Add metrics for manifest

### DIFF
--- a/merino/providers/manifest/backends/filemanager.py
+++ b/merino/providers/manifest/backends/filemanager.py
@@ -9,6 +9,7 @@ from pydantic import ValidationError
 
 from merino.providers.manifest.backends.protocol import ManifestData, GetManifestResultCode
 from merino.utils.gcs.gcp_uploader import GcsUploader
+from merino.utils.metrics import get_metrics_client
 
 logger = logging.getLogger(__name__)
 
@@ -31,30 +32,38 @@ class ManifestRemoteFilemanager:
 
     def get_file(self) -> tuple[GetManifestResultCode, ManifestData | None]:
         """Fetch the remote manifest file from GCS"""
+        metrics_client = get_metrics_client()
+
         try:
             blob = self.gcs_client.get_file_by_name(self.blob_name, self.blob_generation)
 
             if blob is not None:
+                blob.reload()
+                metrics_client.gauge("manifest.size", value=blob.size)
+
                 blob_data = blob.download_as_text()
 
                 try:
                     manifest_content = ManifestData.model_validate(json.loads(blob_data))
+                    metrics_client.gauge(
+                        "manifest.domains.count", value=len(manifest_content.domains)
+                    )
                 except JSONDecodeError as json_error:
                     logger.error("Failed to decode manifest JSON: %s", json_error)
-                    return (GetManifestResultCode.FAIL, None)
+                    return GetManifestResultCode.FAIL, None
                 except ValidationError as val_err:
                     logger.error(f"Invalid manifest content: {val_err}")
-                    return (GetManifestResultCode.FAIL, None)
+                    return GetManifestResultCode.FAIL, None
 
                 logger.info("Successfully loaded remote manifest file: %s", self.blob_name)
-                return (GetManifestResultCode.SUCCESS, manifest_content)
+                return GetManifestResultCode.SUCCESS, manifest_content
 
             # If `get_file_by_name` returned None, that usually means no new generation (SKIP).
             logger.info(
                 f"No new GCS generation for {self.blob_name}; returning SKIP or blob doesn't exist.",
             )
-            return (GetManifestResultCode.SKIP, None)
+            return GetManifestResultCode.SKIP, None
 
         except Exception as e:
             logger.error(f"Error fetching remote manifest file {self.blob_name}: {e}")
-            return (GetManifestResultCode.FAIL, None)
+            return GetManifestResultCode.FAIL, None

--- a/merino/providers/manifest/backends/manifest.py
+++ b/merino/providers/manifest/backends/manifest.py
@@ -45,12 +45,12 @@ class ManifestBackend:
         match GetManifestResultCode(result_code):
             case GetManifestResultCode.SUCCESS:
                 logger.info("Manifest data loaded remotely from GCS.")
-                return (result_code, manifest_data)
+                return result_code, manifest_data
 
             case GetManifestResultCode.SKIP:
                 logger.info("Manifest data was not updated (SKIP).")
-                return (result_code, None)
+                return result_code, None
 
             case GetManifestResultCode.FAIL:
                 logger.error("Failed to fetch manifest from GCS (FAIL).")
-                return (result_code, None)
+                return result_code, None


### PR DESCRIPTION
## References

JIRA: [DISCO-3185](https://mozilla-hub.atlassian.net/browse/DISCO-3185)

## Description
Adding two metrics for the `manifest` provider:
- `manifest.domains.count`
- `manifest.size`


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3185]: https://mozilla-hub.atlassian.net/browse/DISCO-3185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ