### PR TITLE
DISCO-3183 Consolidate manifest configs

### DIFF
--- a/merino/configs/__init__.py
+++ b/merino/configs/__init__.py
@@ -15,6 +15,8 @@ _validators = [
     Validator("metrics.dev_logger", is_type_of=bool),
     Validator("metrics.host", is_type_of=str),
     Validator("metrics.port", gte=0, is_type_of=int),
+    Validator("image_manifest.gcs_project", is_type_of=str),
+    Validator("image_manifest.gcs_bucket", is_type_of=str),
     Validator("accuweather.url_location_key_placeholder", is_type_of=str, must_exist=True),
     Validator(
         "accuweather.url_param_partner_code",
@@ -98,8 +100,6 @@ _validators = [
     ),
     Validator("providers.top_picks.resync_interval_sec", gt=0),
     Validator("providers.top_picks.cron_interval_sec", gt=0),
-    Validator("providers.top_picks.gcs_project", is_type_of=str),
-    Validator("providers.top_picks.gcs_bucket", is_type_of=str),
     Validator(
         "providers.top_picks.domain_data_source",
         is_type_of=str,
@@ -143,8 +143,6 @@ _validators = [
     Validator("sentry.traces_sample_rate", gte=0, lte=1),
     Validator("manifest.resync_interval_sec", gt=0),
     Validator("manifest.cron_interval_sec", gt=0),
-    Validator("manifest.gcs_project", is_type_of=str),
-    Validator("manifest.gcs_bucket", is_type_of=str),
 ]
 
 # `root_path` = The root path for Dynaconf, DO NOT CHANGE.

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -185,6 +185,14 @@ env = "dev"
 # If set to `debug`, the DSN will be set to a testing value recommended by Sentry,
 # and extra output will be included in the logs.
 
+[default.image_manifest]
+# MERINO_IMAGE_MANIFEST__GCS_PROJECT
+# GCS project name that contains domain data
+gcs_project = ""
+
+# MERINO_IMAGE_MANIFEST__GCS_BUCKET
+# GCS bucket that contains domain data files
+gcs_bucket = ""
 
 [default.providers.accuweather]
 # MERINO_PROVIDERS__ACCUWEATHER__TYPE
@@ -248,14 +256,6 @@ cron_interval_sec = 60
 # MERINO_PROVIDERS__MANIFEST__RESYNC_INTERVAL_SEC
 # Time between re-syncs of the manifest file, in seconds. Defaults to 24 hours.
 resync_interval_sec = 86400
-
-# MERINO_PROVIDERS__MANIFEST__GCS_PROJECT
-# GCS project name that contains domain data
-gcs_project = ""
-
-# MERINO_PROVIDERS__MANIFEST__GCS_BUCKET
-# GCS bucket that contains domain data files
-gcs_bucket = ""
 
 [default.accuweather]
 # MERINO_ACCUWEATHER__API_KEY
@@ -457,14 +457,6 @@ resync_interval_sec = 43200
 # Enum of either `remote` or `local` that defines whether domain data
 # is remotely or locally acquired.
 domain_data_source = "local"
-
-# MERINO_PROVIDERS__TOP_PICKS__GCS_PROJECT
-# GCS project name that contains domain data
-gcs_project = ""
-
-# MERINO_PROVIDERS__TOP_PICKS__GCS_BUCKET
-# GCS bucket that contains domain data files
-gcs_bucket = ""
 
 [default.providers.wikipedia]
 # MERINO_PROVIDERS__WIKIPEDIA__TYPE

--- a/merino/configs/production.toml
+++ b/merino/configs/production.toml
@@ -13,7 +13,7 @@ dynaconf_merge = true
 [production.accuweather]
 url_base = "https://api.accuweather.com"
 
-[production.providers.top_picks]
+[production.image_manifest]
 # MERINO_PROVIDERS__TOP_PICKS__GCS_PROJECT
 # GCS project name that contains domain data
 gcs_project = "moz-fx-merino-prod-1c2f"
@@ -22,19 +22,11 @@ gcs_project = "moz-fx-merino-prod-1c2f"
 # GCS bucket that contains domain data files
 gcs_bucket = "merino-images-prodpy"
 
+[production.providers.top_picks]
 # MERINO_PROVIDERS__TOP_PICKS__DOMAIN_DATA_SOURCE
 # Enum of either `remote` or `local` that defines whether domain data
 # is remotely or locally acquired.
 domain_data_source = "remote"
-
-[production.manifest]
-# MERINO_PROVIDERS__MANIFEST__GCS_PROJECT
-# GCS project name that contains domain data
-gcs_project = "moz-fx-merino-prod-1c2f"
-
-# MERINO_PROVIDERS__MANIFEST__GCS_BUCKET
-# GCS bucket that contains domain data files
-gcs_bucket = "merino-images-prodpy"
 
 [production.curated_recommendations.gcs]
 # MERINO__CURATED_RECOMMENDATIONS__GCS__BUCKET_NAME

--- a/merino/configs/stage.toml
+++ b/merino/configs/stage.toml
@@ -13,22 +13,17 @@ dynaconf_merge = true
 [stage.accuweather]
 url_base = "https://api.accuweather.com"
 
-[stage.providers.top_picks]
+[stage.image_manifest]
 # MERINO_PROVIDERS__TOP_PICKS__GCS_PROJECT
 gcs_project = "moz-fx-merino-nonprod-ee93"
 
 # MERINO_PROVIDERS__TOP_PICKS__GCS_BUCKET
 gcs_bucket = "merino-images-stagepy"
 
+
+[stage.providers.top_picks]
 # MERINO_PROVIDERS__TOP_PICKS__DOMAIN_DATA_SOURCE
 domain_data_source = "remote"
-
-[stage.manifest]
-# MERINO_PROVIDERS__MANIFEST__GCS_PROJECT
-gcs_project = "moz-fx-merino-nonprod-ee93"
-
-# MERINO_PROVIDERS__MANIFEST__GCS_BUCKET
-gcs_bucket = "merino-images-stagepy"
 
 [stage.curated_recommendations.gcs]
 # MERINO__CURATED_RECOMMENDATIONS__GCS__BUCKET_NAME

--- a/merino/configs/testing.toml
+++ b/merino/configs/testing.toml
@@ -64,7 +64,7 @@ domain_data_source = "local"
 # The backend of the provider. Either "elasticsearch" or "test".
 backend = "test"
 
-[testing.manifest]
+[testing.image_manifest]
 gcs_project = "test_gcp_uploader_project"
 gcs_bucket = "test_gcp_uploader_bucket"
 

--- a/merino/providers/manifest/backends/manifest.py
+++ b/merino/providers/manifest/backends/manifest.py
@@ -35,8 +35,8 @@ class ManifestBackend:
     def fetch_manifest_data(self) -> tuple[GetManifestResultCode, ManifestData | None]:
         """Fetch manifest data from GCS through the remote filemanager."""
         remote_filemanager = ManifestRemoteFilemanager(
-            gcs_project_path=settings.manifest.gcs_project,
-            gcs_bucket_path=settings.manifest.gcs_bucket,
+            gcs_project_path=settings.image_manifest.gcs_project,
+            gcs_bucket_path=settings.image_manifest.gcs_bucket,
             blob_name=GCS_BLOB_NAME,
         )
 

--- a/merino/providers/suggest/top_picks/backends/top_picks.py
+++ b/merino/providers/suggest/top_picks/backends/top_picks.py
@@ -164,8 +164,8 @@ class TopPicksBackend:
         match DomainDataSource(domain_data_source):
             case DomainDataSource.REMOTE:
                 remote_filemanager = TopPicksRemoteFilemanager(
-                    gcs_project_path=settings.providers.top_picks.gcs_project,
-                    gcs_bucket_path=settings.providers.top_picks.gcs_bucket,
+                    gcs_project_path=settings.image_manifest.gcs_project,
+                    gcs_bucket_path=settings.image_manifest.gcs_bucket,
                 )
                 client = remote_filemanager.create_gcs_client()
                 get_file_result_code, remote_domains = remote_filemanager.get_file(client)

--- a/tests/unit/providers/suggest/top_picks/backends/test_filemanager.py
+++ b/tests/unit/providers/suggest/top_picks/backends/test_filemanager.py
@@ -46,8 +46,8 @@ def fixture_top_picks_remote_filemanager_parameters() -> dict[str, Any]:
     """Define TopPicksRemoteFilemanager parameters for test."""
     # These settings read from testing.toml, not default.toml.
     return {
-        "gcs_project_path": settings.providers.top_picks.gcs_project,
-        "gcs_bucket_path": settings.providers.top_picks.gcs_bucket,
+        "gcs_project_path": settings.image_manifest.gcs_project,
+        "gcs_bucket_path": settings.image_manifest.gcs_bucket,
     }
 
 


### PR DESCRIPTION
## References

JIRA: [DISCO-3183](https://mozilla-hub.atlassian.net/browse/DISCO-3183)

## Description
TopPicks and Manifest are using the same bucket and the same file.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3183]: https://mozilla-hub.atlassian.net/browse/DISCO-3183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ