### PR TITLE
DISCO-3180 Use GcsUploader for top_picks provider

### DIFF
--- a/merino/providers/suggest/top_picks/backends/top_picks.py
+++ b/merino/providers/suggest/top_picks/backends/top_picks.py
@@ -167,8 +167,8 @@ class TopPicksBackend:
                     gcs_project_path=settings.image_manifest.gcs_project,
                     gcs_bucket_path=settings.image_manifest.gcs_bucket,
                 )
-                client = remote_filemanager.create_gcs_client()
-                get_file_result_code, remote_domains = remote_filemanager.get_file(client)
+
+                get_file_result_code, remote_domains = remote_filemanager.get_file()
 
                 match GetFileResultCode(get_file_result_code):
                     case GetFileResultCode.SUCCESS:

--- a/tests/unit/providers/manifest/backends/test_filemanager.py
+++ b/tests/unit/providers/manifest/backends/test_filemanager.py
@@ -21,6 +21,7 @@ def test_get_file(
     """Test that the get_file method returns manifest data."""
     manifest_remote_filemanager.gcs_client = MagicMock()
     manifest_remote_filemanager.gcs_client.get_file_by_name.return_value = gcs_blob_mock
+    gcs_blob_mock.download_as_text.return_value = blob_json
 
     get_file_result_code, result = manifest_remote_filemanager.get_file()
 


### PR DESCRIPTION
## References

JIRA: [DISCO-3180](https://mozilla-hub.atlassian.net/browse/DISCO-3180)

## Description
Instead of using `google.cloud.storage.Client` directly, we use our own `GcsUploader` module. This PR switches the `top_picks` provider over to `GcsUploader` as well.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3180]: https://mozilla-hub.atlassian.net/browse/DISCO-3180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ