### PR TITLE
[DISCO-3189] update max age cache control for manifest endpoint

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -42,6 +42,15 @@ disabled_providers = ["amo"]
 # MERINO_RUNTIME__DEFAULT_SUGGESTIONS_RESPONSE_TTL_SEC
 default_suggestions_response_ttl_sec = 300 # 5 mins
 
+
+# MERINO_RUNTIME__DEFAULT_MANIFEST_RESPONSE_TTL_SEC
+# 8 hours ensures that clients reuse cached data
+# for up to 8 hours before making a new request.
+# Since the manifest file updates once per day via a cron job, this
+# provides a balance between reducing unnecessary API requests and
+# ensuring reasonably fresh data.
+default_manifest_response_ttl_sec = 28800 # 8 hours
+
 [default.logging]
 # MERINO_LOGGING__LEVEL
 # Minimum level of logs that should be reported.

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -349,7 +349,7 @@ async def get_manifest(
                 content=jsonable_encoder(manifest_data),
                 headers={
                     "Cache-Control": (
-                        f"private, max-age={settings.runtime.default_suggestions_response_ttl_sec}"
+                        f"private, max-age={settings.runtime.default_manifest_response_ttl_sec}"
                     )
                 },
             )


### PR DESCRIPTION
## References

JIRA: [DISCO-3189](https://mozilla-hub.atlassian.net/browse/DISCO-3189)

## Description
A slight performance improvement - since we only fetch new data every 24 hours, we can afford to serve cached data for longer. This PR increases the max age in the Cache Control header from 5 mins to 8 hours. 



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
