### PR TITLE
fix: Use the remote icon for dynamic wikipedia

### DIFF
--- a/merino/providers/suggest/wikipedia/provider.py
+++ b/merino/providers/suggest/wikipedia/provider.py
@@ -10,9 +10,11 @@ from merino.exceptions import BackendError
 from merino.providers.suggest.base import BaseProvider, BaseSuggestion, SuggestionRequest, Category
 from merino.providers.suggest.wikipedia.backends.protocol import WikipediaBackend
 
-# The packaged Wikipedia icon
+# The Wikipedia icon backed by Merino's image CDN.
+# TODO: Use a better way to fetch this icon URL instead of hardcoding it here.
 ICON: Final[str] = (
-    "chrome://activity-stream/content/data/content/tippytop/favicons/wikipedia-org.ico"
+    "https://merino-images.services.mozilla.com/favicons/"
+    "4c8bf96d667fa2e9f072bdd8e9f25c8ba6ba2ad55df1af7d9ea0dd575c12abee_1313.png"
 )
 ADVERTISER: Final[str] = "dynamic-wikipedia"
 BLOCK_ID: Final[int] = 0


### PR DESCRIPTION
## References

JIRA: [DISCO-3196](https://mozilla-hub.atlassian.net/browse/DISCO-3196)

## Description
Now that there is Merino hosted Wikipedia icon, let's use that to replace the hardcoded one.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3196]: https://mozilla-hub.atlassian.net/browse/DISCO-3196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ