### PR TITLE
fix: Remove hardcoded chrome image URIs from top picks

### DIFF
--- a/dev/top_picks.json
+++ b/dev/top_picks.json
@@ -8,7 +8,7 @@
       ],
       "url": "https://www.google.com",
       "title": "Google",
-      "icon": "chrome://activity-stream/content/data/content/tippytop/images/google-com@2x.png",
+      "icon": "",
       "serp_categories": [
         18
       ]
@@ -62,7 +62,7 @@
       ],
       "url": "https://www.youtube.com",
       "title": "YouTube",
-      "icon": "chrome://activity-stream/content/data/content/tippytop/images/youtube-com@2x.png",
+      "icon": "",
       "serp_categories": [
         0
       ]
@@ -75,7 +75,7 @@
       ],
       "url": "https://twitter.com",
       "title": "Twitter",
-      "icon": "chrome://activity-stream/content/data/content/tippytop/images/twitter-com@2x.png",
+      "icon": "",
       "serp_categories": [
         16
       ]
@@ -182,7 +182,7 @@
       ],
       "url": "https://www.bing.com",
       "title": "Bing",
-      "icon": "chrome://activity-stream/content/data/content/tippytop/images/bing-com@2x.svg",
+      "icon": "",
       "serp_categories": [
         18
       ]

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -24,7 +24,7 @@ The `/manifest` endpoint returns a curated list of websites with associated meta
       ],
       "url": "https://www.google.com/",
       "title": "Google",
-      "icon": "chrome://activity-stream/content/data/content/tippytop/images/google-com@2x.png"
+      "icon": ""
     },
     {
       "rank": 2,

--- a/merino/jobs/navigational_suggestions/__init__.py
+++ b/merino/jobs/navigational_suggestions/__init__.py
@@ -22,9 +22,6 @@ from merino.jobs.navigational_suggestions.domain_metadata_extractor import (
 from merino.jobs.navigational_suggestions.domain_metadata_uploader import (
     DomainMetadataUploader,
 )
-from merino.jobs.navigational_suggestions.utils import (
-    update_top_picks_with_firefox_favicons,
-)
 from merino.providers.suggest.base import Category
 from merino.utils.blocklists import TOP_PICKS_BLOCKLIST
 
@@ -158,9 +155,8 @@ def prepare_domain_metadata(
     uploaded_favicons = domain_metadata_uploader.upload_favicons(favicons)
     logger.info("domain favicons uploaded to GCS")
 
-    # construct top pick contents, update them with firefox packaged favicons and upload to gcs
+    # construct top pick contents
     top_picks = _construct_top_picks(domain_data, uploaded_favicons, domain_metadata)
-    update_top_picks_with_firefox_favicons(top_picks)
 
     # Create diff class for comparison of Top Picks Files
     old_top_picks: dict[str, list[dict[str, str]]] | None = (

--- a/merino/jobs/navigational_suggestions/utils.py
+++ b/merino/jobs/navigational_suggestions/utils.py
@@ -23,14 +23,6 @@ REQUEST_HEADERS: dict[str, str] = {
 
 TIMEOUT: int = 10
 
-# Some high resolution domain favicons that are internally packaged in Firefox
-FIREFOX_PACKAGED_FAVICONS: dict[str, str] = {
-    "google": "chrome://activity-stream/content/data/content/tippytop/images/google-com@2x.png",
-    "bing": "chrome://activity-stream/content/data/content/tippytop/images/bing-com@2x.svg",
-    "youtube": "chrome://activity-stream/content/data/content/tippytop/images/youtube-com@2x.png",
-    "twitter": "chrome://activity-stream/content/data/content/tippytop/images/twitter-com@2x.png",
-}
-
 logger = logging.getLogger(__name__)
 
 
@@ -74,17 +66,3 @@ def requests_get(url: str) -> requests.Response | None:
         timeout=TIMEOUT,
     )
     return response if response.status_code == 200 else None
-
-
-def update_top_picks_with_firefox_favicons(
-    top_picks: dict[str, list[dict[str, str]]],
-) -> None:
-    """Update top picks with high resolution favicons that are internally packaged in firefox
-    for some of the selected domains for which favicon scraping didn't return anything
-    """
-    domains_metadata: list[dict[str, str]] = top_picks["domains"]
-    for domain_metadata in domains_metadata:
-        domain = domain_metadata["domain"]
-        firefox_favicon: str | None = FIREFOX_PACKAGED_FAVICONS.get(domain)
-        if firefox_favicon:
-            domain_metadata["icon"] = firefox_favicon

--- a/tests/integration/api/v1/manifest/test_manifest.py
+++ b/tests/integration/api/v1/manifest/test_manifest.py
@@ -23,7 +23,7 @@ def mock_manifest_2025() -> dict:
                 "serp_categories": [0],
                 "url": "https://www.spotify.com",
                 "title": "Spotify",
-                "icon": "chrome://activity-stream/content/data/content/tippytop/images/google-com@2x.png",
+                "icon": "",
             }
         ]
     }

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -79,7 +79,7 @@ def fixture_blob_json() -> str:
                     "serp_categories": [0],
                     "url": "https://www.google.com/",
                     "title": "Google",
-                    "icon": "chrome://activity-stream/content/data/content/tippytop/images/google-com@2x.png",
+                    "icon": "",
                 },
                 {
                     "rank": 2,

--- a/tests/unit/jobs/navigational_suggestions/test_navigational_suggestions_utils.py
+++ b/tests/unit/jobs/navigational_suggestions/test_navigational_suggestions_utils.py
@@ -12,77 +12,7 @@ from pytest_mock import MockerFixture
 from merino.jobs.navigational_suggestions.utils import (
     REQUEST_HEADERS,
     FaviconDownloader,
-    update_top_picks_with_firefox_favicons,
 )
-
-
-def test_update_top_picks_with_firefox_favicons_favicon_added_for_special_domains():
-    """Test that top picks is updated with firefox favicon for special domains
-    when scraped available to top picks
-    """
-    input_top_picks = {
-        "domains": [
-            {
-                "rank": 1,
-                "domain": "google",
-                "categories": ["Search Engines"],
-                "url": "https://www.google.com",
-                "title": "Google",
-                "icon": "",
-            },
-        ]
-    }
-
-    updated_top_picks = {
-        "domains": [
-            {
-                "rank": 1,
-                "domain": "google",
-                "categories": ["Search Engines"],
-                "url": "https://www.google.com",
-                "title": "Google",
-                "icon": (
-                    "chrome://activity-stream/content/data/content/tippytop/"
-                    "images/google-com@2x.png"
-                ),
-            },
-        ]
-    }
-
-    update_top_picks_with_firefox_favicons(input_top_picks)
-    assert input_top_picks == updated_top_picks
-
-
-def test_update_top_picks_with_firefox_favicons_favicon_not_added_for_non_special_domains():
-    """Test that top picks is not updated with firefox favicon for non special domains"""
-    input_top_picks = {
-        "domains": [
-            {
-                "rank": 2,
-                "domain": "facebook",
-                "categories": ["Social Networks"],
-                "url": "https://www.facebook.com",
-                "title": "Facebook \u2013 log in or sign up",
-                "icon": "",
-            },
-        ]
-    }
-
-    updated_top_picks = {
-        "domains": [
-            {
-                "rank": 2,
-                "domain": "facebook",
-                "categories": ["Social Networks"],
-                "url": "https://www.facebook.com",
-                "title": "Facebook \u2013 log in or sign up",
-                "icon": "",
-            },
-        ]
-    }
-
-    update_top_picks_with_firefox_favicons(input_top_picks)
-    assert input_top_picks == updated_top_picks
 
 
 def test_favicon_downloader(requests_mock):


### PR DESCRIPTION
## References

JIRA: [DISCO-3197](https://mozilla-hub.atlassian.net/browse/DISCO-3197)

## Description
Drop those hardcoded TippyTop image URIs from Top Picks, those domains will fall back to the generic globe icon until better image replacements are provisioned in the future.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3197]: https://mozilla-hub.atlassian.net/browse/DISCO-3197?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ