### PR TITLE
DISCO-3202 - Enrich the curated-recommendations endpoint with icon-urls

### DIFF
--- a/merino/curated_recommendations/__init__.py
+++ b/merino/curated_recommendations/__init__.py
@@ -31,6 +31,8 @@ from merino.utils.metrics import get_metrics_client
 from merino.utils.http_client import create_http_client
 from merino.utils.synced_gcs_blob import SyncedGcsBlob
 
+from merino.providers.manifest import get_provider as get_manifest_provider
+
 logger = logging.getLogger(__name__)
 
 _provider: CuratedRecommendationsProvider
@@ -121,6 +123,7 @@ def init_provider() -> None:
         http_client=create_http_client(base_url=""),
         graph_config=CorpusApiGraphConfig(),
         metrics_client=get_metrics_client(),
+        manifest_provider=get_manifest_provider(),
     )
 
     extended_expiration_corpus_backend = ExtendedExpirationCorpusBackend(

--- a/merino/curated_recommendations/corpus_backends/protocol.py
+++ b/merino/curated_recommendations/corpus_backends/protocol.py
@@ -61,6 +61,7 @@ class CorpusItem(BaseModel):
     publisher: str
     isTimeSensitive: bool
     imageUrl: HttpUrl
+    iconUrl: HttpUrl | None = None
 
 
 class CorpusBackend(Protocol):

--- a/tests/integration/api/v1/curated_recommendations/corpus_backends/fixtures.py
+++ b/tests/integration/api/v1/curated_recommendations/corpus_backends/fixtures.py
@@ -65,11 +65,12 @@ def corpus_http_client(fixture_response_data, fixture_request_data) -> AsyncMock
 
 
 @pytest.fixture()
-def corpus_backend(corpus_http_client: AsyncMock) -> CorpusApiBackend:
+def corpus_backend(corpus_http_client: AsyncMock, manifest_provider) -> CorpusApiBackend:
     """Mock corpus api backend."""
     # Initialize the backend with the mock HTTP client
     return CorpusApiBackend(
         http_client=corpus_http_client,
         graph_config=CorpusApiGraphConfig(),
         metrics_client=get_metrics_client(),
+        manifest_provider=manifest_provider,
     )

--- a/tests/integration/api/v1/curated_recommendations/corpus_backends/test_corpus_api_backend.py
+++ b/tests/integration/api/v1/curated_recommendations/corpus_backends/test_corpus_api_backend.py
@@ -42,6 +42,7 @@ async def test_fetch(corpus_backend: CorpusApiBackend, fixture_response_data):
         ),
         scheduledCorpusItemId="de614b6b-6df6-470a-97f2-30344c56c1b3",
         corpusItemId="4095b364-02ff-402c-b58a-792a067fccf2",
+        iconUrl=None,
     )
 
 

--- a/tests/integration/api/v1/manifest/test_manifest.py
+++ b/tests/integration/api/v1/manifest/test_manifest.py
@@ -11,24 +11,6 @@ from merino.providers.manifest import get_provider, init_provider
 from merino.web.api_v1 import router
 
 
-@pytest.fixture(scope="module")
-def mock_manifest_2025() -> dict:
-    """Mock manifest json for the year 2025"""
-    return {
-        "domains": [
-            {
-                "rank": 1,
-                "domain": "spotify",
-                "categories": ["Entertainment"],
-                "serp_categories": [0],
-                "url": "https://www.spotify.com",
-                "title": "Spotify",
-                "icon": "",
-            }
-        ]
-    }
-
-
 @pytest.fixture(autouse=True, name="cleanup")
 def cleanup_tasks_fixture():
     """Return a method that cleans up existing cron tasks after initialization"""
@@ -46,9 +28,7 @@ def cleanup_tasks_fixture():
 
 
 @pytest.mark.asyncio
-async def test_get_manifest_success(
-    client_with_metrics, gcp_uploader, mock_manifest_2025, cleanup
-):
+async def test_get_manifest_success(client_with_metrics, gcp_uploader, mock_manifest, cleanup):
     """Uploads a manifest to the gcs bucket and verifies that the endpoint returns the uploaded file."""
     # initialize provider on startup
     await init_provider()
@@ -57,7 +37,7 @@ async def test_get_manifest_success(
     app.include_router(router, prefix="/api/v1")
 
     # upload a manifest file to GCS test container
-    gcp_uploader.upload_content(orjson.dumps(mock_manifest_2025), "top_picks_latest.json")
+    gcp_uploader.upload_content(orjson.dumps(mock_manifest), "top_picks_latest.json")
 
     provider = get_provider()
     await provider.data_fetched_event.wait()

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -13,6 +13,7 @@ from google.auth.credentials import AnonymousCredentials
 from pytest_mock import MockerFixture
 
 from merino.middleware.geolocation import Location
+from merino.providers.manifest.backends.protocol import ManifestData
 from merino.providers.suggest.base import SuggestionRequest
 from tests.unit.types import SuggestionRequestFixture
 from google.cloud.storage import Blob, Bucket, Client
@@ -88,7 +89,8 @@ def fixture_blob_json() -> str:
                     "serp_categories": [0],
                     "url": "https://www.microsoft.com/",
                     "title": "Microsoft – AI, Cloud, Productivity, Computing, Gaming & Apps",
-                    "icon": "https://merino-images.services.mozilla.com/favicons/90cdaf487716184e4034000935c605d1633926d348116d198f355a98b8c6cd21_17174.oct",
+                    "icon": "https://merino-images.services.mozilla.com/favicons"
+                    "/90cdaf487716184e4034000935c605d1633926d348116d198f355a98b8c6cd21_17174.oct",
                 },
                 {
                     "rank": 3,
@@ -97,8 +99,15 @@ def fixture_blob_json() -> str:
                     "serp_categories": [0],
                     "url": "https://www.facebook.com/",
                     "title": "Log in to Facebook",
-                    "icon": "https://merino-images.services.mozilla.com/favicons/e673f8818103a583c9a98ee38aa7892d58969ec2a8387deaa46ef6d94e8a3796_4535.png",
+                    "icon": "https://merino-images.services.mozilla.com/favicons"
+                    "/e673f8818103a583c9a98ee38aa7892d58969ec2a8387deaa46ef6d94e8a3796_4535.png",
                 },
             ]
         }
     )
+
+
+@pytest.fixture(name="manifest_data")
+def fixture_manifest_data(blob_json: str) -> ManifestData:
+    """Return parsed ManifestData object for testing."""
+    return ManifestData.model_validate_json(blob_json)

--- a/tests/unit/curated_recommendations/test_provider.py
+++ b/tests/unit/curated_recommendations/test_provider.py
@@ -295,6 +295,7 @@ class TestCuratedRecommendationsProviderRankNeedToKnowRecommendations:
                 publisher="cohens",
                 isTimeSensitive=i in time_sensitive_indices,
                 imageUrl=HttpUrl("https://placehold.co/600x400/"),
+                iconUrl=None,
             )
 
             recs.append(rec)

--- a/tests/unit/curated_recommendations/test_rankers.py
+++ b/tests/unit/curated_recommendations/test_rankers.py
@@ -42,6 +42,7 @@ class TestCuratedRecommendationsProviderSpreadPublishers:
                 publisher="cohens",
                 isTimeSensitive=False,
                 imageUrl=HttpUrl("https://placehold.co/600x400/"),
+                iconUrl=None,
             )
 
             recs.append(rec)
@@ -203,6 +204,7 @@ class TestCuratedRecommendationsProviderBoostPreferredTopic:
                 publisher="cohens",
                 isTimeSensitive=False,
                 imageUrl=HttpUrl("https://placehold.co/600x400/"),
+                iconUrl=None,
             )
             recs.append(rec)
             i += 1

--- a/tests/unit/providers/manifest/test_get_url.py
+++ b/tests/unit/providers/manifest/test_get_url.py
@@ -1,0 +1,134 @@
+"""Unit tests for the get_icon_url method of the manifest provider."""
+
+import pytest
+from pydantic import HttpUrl
+
+from merino.providers.manifest.backends.protocol import GetManifestResultCode, ManifestData
+from merino.providers.manifest.provider import Provider
+from unittest.mock import patch
+
+
+@pytest.mark.asyncio
+async def test_domain_lookup_table_initialization(
+    manifest_provider: Provider, manifest_data: ManifestData, cleanup
+):
+    """Test that domain_lookup_table is correctly initialized during provider setup."""
+    with patch(
+        "merino.providers.manifest.backends.manifest.ManifestBackend.fetch",
+        return_value=(GetManifestResultCode.SUCCESS, manifest_data),
+    ):
+        await manifest_provider.initialize()
+        await cleanup(manifest_provider)
+
+        assert len(manifest_provider.domain_lookup_table) == len(manifest_data.domains)
+        for domain in manifest_data.domains:
+            assert domain.domain in manifest_provider.domain_lookup_table
+
+
+@pytest.mark.asyncio
+async def test_get_icon_url_success(
+    manifest_provider: Provider, manifest_data: ManifestData, cleanup
+):
+    """Test successful icon URL retrieval for known domains."""
+    with patch(
+        "merino.providers.manifest.backends.manifest.ManifestBackend.fetch",
+        return_value=(GetManifestResultCode.SUCCESS, manifest_data),
+    ):
+        await manifest_provider.initialize()
+        await cleanup(manifest_provider)
+
+        # Test with Google domain which exists in fixture
+        google_icon = manifest_provider.get_icon_url("https://www.google.com/search")
+        assert google_icon == ""  # Google has empty icon in fixture
+
+
+@pytest.mark.asyncio
+async def test_get_icon_url_domain_variants(
+    manifest_provider: Provider, manifest_data: ManifestData, cleanup
+):
+    """Test icon URL retrieval with different domain format variants."""
+    with patch(
+        "merino.providers.manifest.backends.manifest.ManifestBackend.fetch",
+        return_value=(GetManifestResultCode.SUCCESS, manifest_data),
+    ):
+        await manifest_provider.initialize()
+        await cleanup(manifest_provider)
+
+        test_cases = [
+            "https://google.com/search",
+            "http://www.google.com",
+            "https://google.com",
+            "http://google.com/maps",
+        ]
+
+        for url in test_cases:
+            result = manifest_provider.get_icon_url(url)
+            assert result == ""  # Google has empty icon in fixture
+
+
+@pytest.mark.asyncio
+async def test_get_icon_url_not_found(
+    manifest_provider: Provider, manifest_data: ManifestData, cleanup
+):
+    """Test icon URL retrieval for non-existent domain."""
+    with patch(
+        "merino.providers.manifest.backends.manifest.ManifestBackend.fetch",
+        return_value=(GetManifestResultCode.SUCCESS, manifest_data),
+    ):
+        await manifest_provider.initialize()
+        await cleanup(manifest_provider)
+
+        assert manifest_provider.get_icon_url("https://nonexistent.com") is None
+
+
+@pytest.mark.asyncio
+async def test_get_icon_url_invalid_url(
+    manifest_provider: Provider, manifest_data: ManifestData, cleanup
+):
+    """Test icon URL retrieval with invalid URLs."""
+    with patch(
+        "merino.providers.manifest.backends.manifest.ManifestBackend.fetch",
+        return_value=(GetManifestResultCode.SUCCESS, manifest_data),
+    ):
+        await manifest_provider.initialize()
+        await cleanup(manifest_provider)
+
+        invalid_urls = [
+            "not-a-url",
+            "http://",
+            "",
+            "google",  # Just a domain name without protocol
+        ]
+
+        for invalid_url in invalid_urls:
+            assert manifest_provider.get_icon_url(invalid_url) is None
+
+
+@pytest.mark.asyncio
+async def test_get_icon_url_with_pydantic_url(
+    manifest_provider: Provider, manifest_data: ManifestData, cleanup
+):
+    """Test icon URL retrieval with Pydantic HttpUrl type."""
+    with patch(
+        "merino.providers.manifest.backends.manifest.ManifestBackend.fetch",
+        return_value=(GetManifestResultCode.SUCCESS, manifest_data),
+    ):
+        await manifest_provider.initialize()
+        await cleanup(manifest_provider)
+
+        url = HttpUrl("https://google.com/search")
+        assert manifest_provider.get_icon_url(url) == ""  # Google has empty icon
+
+
+@pytest.mark.asyncio
+async def test_get_icon_url_empty_manifest(manifest_provider: Provider, cleanup):
+    """Test icon URL retrieval with empty manifest data."""
+    empty_manifest = ManifestData(domains=[])
+    with patch(
+        "merino.providers.manifest.backends.manifest.ManifestBackend.fetch",
+        return_value=(GetManifestResultCode.SUCCESS, empty_manifest),
+    ):
+        await manifest_provider.initialize()
+        await cleanup(manifest_provider)
+
+        assert manifest_provider.get_icon_url("https://google.com") is None

--- a/tests/unit/providers/manifest/test_init_provider.py
+++ b/tests/unit/providers/manifest/test_init_provider.py
@@ -7,8 +7,7 @@
 from unittest.mock import patch
 import pytest
 
-from merino.providers.manifest import get_provider, init_provider
-from merino.providers.manifest.provider import Provider as ManifestProvider
+from merino.providers.manifest import get_provider, init_provider, Provider as ManifestProvider
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## References

JIRA: 
- [DISCO-3204](https://mozilla-hub.atlassian.net/browse/DISCO-3204)
- [DISCO-3204](https://mozilla-hub.atlassian.net/browse/DISCO-3203)
- [DISCO-3204](https://mozilla-hub.atlassian.net/browse/DISCO-3205)

## Description
Enriching the `/curated-recommendations` endpoint with a `iconUrl` field for each article recommendation. The `iconUrl` is a `HttpUrl`, taken from the `Manifest` provider, and if the favicon for the domain is available, we attach it to a recommendation. Otherwise, we return an empty string. 

In the background, the `Manifest` is updated once a week, and therefore the icons will be updated in this interval. Which means newly added domains to the `Manifest` will be available to this endpoint at that time.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3204]: https://mozilla-hub.atlassian.net/browse/DISCO-3204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DISCO-3204]: https://mozilla-hub.atlassian.net/browse/DISCO-3204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DISCO-3204]: https://mozilla-hub.atlassian.net/browse/DISCO-3204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ