### PR TITLE
fix: Fix the log leakages in integration tests

### DIFF
--- a/tests/integration/api/conftest.py
+++ b/tests/integration/api/conftest.py
@@ -5,7 +5,7 @@
 """Module for test configurations for the integration test directory."""
 
 from logging import LogRecord
-from typing import Iterator, Generator
+from typing import Iterator
 from unittest.mock import AsyncMock
 
 import pytest
@@ -30,7 +30,6 @@ from merino.curated_recommendations.fakespot_backend.protocol import (
 )
 from merino.main import app
 from merino.utils.log_data_creators import RequestSummaryLogDataModel
-from merino.middleware import ScopeKey
 from tests.integration.api.types import RequestSummaryLogDataFixture
 
 
@@ -68,18 +67,6 @@ def fixture_test_client() -> TestClient:
     the app, see: https://fastapi.tiangolo.com/advanced/testing-events/
     """
     return TestClient(app)
-
-
-@pytest.fixture(name="client_with_metrics")
-def fixture_client_with_metrics() -> Generator[TestClient, None, None]:
-    """Create test client with NoOpMetricsClient in request scope."""
-
-    async def asgi_wrapper(scope, receive, send):
-        scope[ScopeKey.METRICS_CLIENT] = NoOpMetricsClient()
-        await app(scope, receive, send)
-
-    with TestClient(asgi_wrapper) as client:
-        yield client
 
 
 @pytest.fixture(name="client_with_events")

--- a/tests/integration/api/v1/manifest/test_manifest.py
+++ b/tests/integration/api/v1/manifest/test_manifest.py
@@ -28,7 +28,7 @@ def cleanup_tasks_fixture():
 
 
 @pytest.mark.asyncio
-async def test_get_manifest_success(client_with_metrics, gcp_uploader, mock_manifest, cleanup):
+async def test_get_manifest_success(client, gcp_uploader, mock_manifest, cleanup):
     """Uploads a manifest to the gcs bucket and verifies that the endpoint returns the uploaded file."""
     # initialize provider on startup
     await init_provider()
@@ -44,7 +44,7 @@ async def test_get_manifest_success(client_with_metrics, gcp_uploader, mock_mani
 
     cleanup(provider)
 
-    response = client_with_metrics.get("/api/v1/manifest")
+    response = client.get("/api/v1/manifest")
     assert response.status_code == 200
 
     manifest = ManifestData(**response.json())
@@ -55,9 +55,7 @@ async def test_get_manifest_success(client_with_metrics, gcp_uploader, mock_mani
 
 
 @pytest.mark.asyncio
-async def test_get_manifest_from_gcs_bucket_should_return_empty_manifest_file(
-    client_with_metrics, cleanup
-):
+async def test_get_manifest_from_gcs_bucket_should_return_empty_manifest_file(client, cleanup):
     """Does not upload any manifests to the gcs bucket. Should return none and a 404."""
     await init_provider()
 
@@ -69,7 +67,7 @@ async def test_get_manifest_from_gcs_bucket_should_return_empty_manifest_file(
 
     cleanup(provider)
 
-    response = client_with_metrics.get("/api/v1/manifest")
+    response = client.get("/api/v1/manifest")
     assert response.status_code == 404
 
     assert response.json()["domains"] == []


### PR DESCRIPTION
## References

JIRA: [DISCO-3226](https://mozilla-hub.atlassian.net/browse/DISCO-3226)

## Description
Leaking unexpected logs could cause flaky tests in Merino.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3226]: https://mozilla-hub.atlassian.net/browse/DISCO-3226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ