### PR TITLE
[DISCO-3226] Fix flaky amo backend unit test

### DIFF
--- a/tests/unit/providers/suggest/amo/backends/test_dynamic.py
+++ b/tests/unit/providers/suggest/amo/backends/test_dynamic.py
@@ -58,7 +58,10 @@ async def test_fetch_addons_succeed(mocker: MockerFixture, dynamic_backend: Dyna
 
 @pytest.mark.asyncio
 async def test_fetch_addons_skipped_api_failure(
-    mocker: MockerFixture, caplog: LogCaptureFixture, dynamic_backend: DynamicAmoBackend, filter_caplog: FilterCaplogFixture
+    mocker: MockerFixture,
+    caplog: LogCaptureFixture,
+    dynamic_backend: DynamicAmoBackend,
+    filter_caplog: FilterCaplogFixture,
 ):
     """Test that fetch fails raises error when Addon requests fails before it
     returns a response.
@@ -68,14 +71,19 @@ async def test_fetch_addons_skipped_api_failure(
 
     # Ensure that all the messages are errors due to the timeout.
     with caplog.at_level(logging.ERROR):
-        records: list[LogRecord] = filter_caplog(caplog.records, "merino.providers.suggest.amo.backends.dynamic")
+        records: list[LogRecord] = filter_caplog(
+            caplog.records, "merino.providers.suggest.amo.backends.dynamic"
+        )
         for record in records:
             assert record.message.startswith("Addons API failed request to fetch addon")
 
 
 @pytest.mark.asyncio
 async def test_fetch_addons_skipped_api_request_failure(
-    mocker: MockerFixture, caplog: LogCaptureFixture, dynamic_backend: DynamicAmoBackend, filter_caplog: FilterCaplogFixture
+    mocker: MockerFixture,
+    caplog: LogCaptureFixture,
+    dynamic_backend: DynamicAmoBackend,
+    filter_caplog: FilterCaplogFixture,
 ):
     """Test that fetch fails raises error when Addon request fails."""
     sample_addon_resp = json.dumps(
@@ -110,7 +118,9 @@ async def test_fetch_addons_skipped_api_request_failure(
     await dynamic_backend.fetch_and_cache_addons_info()
 
     with caplog.at_level(logging.ERROR):
-        records: list[LogRecord] = filter_caplog(caplog.records, "merino.providers.suggest.amo.backends.dynamic")
+        records: list[LogRecord] = filter_caplog(
+            caplog.records, "merino.providers.suggest.amo.backends.dynamic"
+        )
 
         assert len(dynamic_backend.dynamic_data) == len(SupportedAddon) - 1
         assert len(records) == 1


### PR DESCRIPTION
## References

JIRA: [DISCO-3226](https://mozilla-hub.atlassian.net/browse/DISCO-3226)

## Description
Found another flaky unit test that was failing on captured log output assertions. [This test](https://app.circleci.com/pipelines/github/mozilla-services/merino-py/4174/workflows/fc69668d-769a-448a-a545-e8283229f176/jobs/29034) was failing because it was encountering an extra / leaked log output (WARN level) from other place. 

I couldn't trace that extra leaky log output but I was able to set the level of logs we want to capture for this set.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3226]: https://mozilla-hub.atlassian.net/browse/DISCO-3226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ