### PR TITLE
[HNT-374] Add interest picker

### DIFF
--- a/merino/curated_recommendations/interest_picker.py
+++ b/merino/curated_recommendations/interest_picker.py
@@ -1,0 +1,86 @@
+"""Module for the New Tab 'interest picker' component that allows users to follow sections."""
+
+import random
+
+from merino.curated_recommendations.protocol import (
+    CuratedRecommendationsResponse,
+    InterestPickerSection,
+    InterestPicker,
+)
+
+
+MIN_INITIALLY_VISIBLE_SECTION_COUNT = 3  # Minimum number of sections that are shown by default.
+MIN_INTEREST_PICKER_COUNT = 8  # Minimum number of items in the interest picker.
+
+
+def apply_interest_picker(response: CuratedRecommendationsResponse) -> None:
+    """Set the interest picker on the given response.
+
+    This method processes the sections in the response's feeds to determine which sections
+    should be initially visible and which should be hidden. It sets `isInitiallyVisible` to True
+    for the first `MIN_INITIALLY_VISIBLE_SECTION_COUNT` sections and for follows sections.
+    It then checks if there are at least MIN_INTEREST_PICKER_COUNT hidden sections available.
+    If there are not enough hidden sections, all sections are made visible and no interest
+    picker is created. Otherwise, the hidden sections are added to the interestPicker.sections.
+
+    Args:
+        response (CuratedRecommendationsResponse): The API response containing sections.
+    """
+    # If there are no feeds in the response, nothing to do.
+    if not response.feeds:
+        return
+
+    # Get all available sections sorted by the order in which they should be shown.
+    sections = sorted(response.feeds.get_sections(), key=lambda tup: tup[0].receivedFeedRank)
+
+    # The first MIN_INITIALLY_VISIBLE_SECTION_COUNT and followed sections must be visible.
+    visible_count = 0
+    for section, _ in sections:
+        if section.isFollowed or visible_count < MIN_INITIALLY_VISIBLE_SECTION_COUNT:
+            section.isInitiallyVisible = True
+            visible_count += 1
+        else:
+            section.isInitiallyVisible = False
+
+    # The interest pick may only have sections that are not visible by default.
+    picker_sections = [
+        (section, section_id)
+        for (section, section_id) in sections
+        if not section.isInitiallyVisible
+    ]
+
+    # If there are not enough hidden sections, then show all sections without an interest picker.
+    if len(picker_sections) < MIN_INTEREST_PICKER_COUNT:
+        for section, _ in sections:
+            section.isInitiallyVisible = True
+        return
+
+    # Randomize the positioning of the interest picker within a range. If any section is followed,
+    # then this range shifts down by 1. Note that the rank is 0-indexed, so rank 1 is the 2nd row.
+    if any(section.isFollowed for section, _ in sections):
+        interest_picker_rank = random.randint(2, 4)
+    else:
+        interest_picker_rank = random.randint(1, 3)
+
+    # Renumber the receivedFeedRank of all sections such that they increment by 1,
+    # and that the section following the picker has a rank equal to interest_picker_rank + 1.
+    new_rank = 0
+    for section, section_id in sections:
+        if new_rank == interest_picker_rank:
+            # Skip the rank for the interest picker.
+            new_rank += 1
+        section.receivedFeedRank = new_rank
+        new_rank += 1
+
+    # Create and attach the interestPicker to the response.
+    response.interestPicker = InterestPicker(
+        receivedFeedRank=interest_picker_rank,
+        title="Follow topics to personalize your feed",
+        subtitle=(
+            "We will bring you personalized content, all while respecting your privacy. "
+            "You'll have powerful control over what content you see and what you don't."
+        ),
+        sections=[
+            InterestPickerSection(sectionId=section_id) for _, section_id in picker_sections
+        ],
+    )

--- a/merino/curated_recommendations/interest_picker.py
+++ b/merino/curated_recommendations/interest_picker.py
@@ -1,6 +1,4 @@
-"""Module for the New Tab 'interest picker' component that allows users to follow
-sections.
-"""
+"""Module for the New Tab 'interest picker' component that allows users to follow sections."""
 
 import random
 from merino.curated_recommendations.protocol import (

--- a/merino/curated_recommendations/interest_picker.py
+++ b/merino/curated_recommendations/interest_picker.py
@@ -1,107 +1,90 @@
-"""Module for the New Tab 'interest picker' component that allows users to follow sections."""
+"""Module for the New Tab 'interest picker' component that allows users to follow
+sections.
+"""
 
 import random
-
 from merino.curated_recommendations.protocol import (
-    CuratedRecommendationsFeed,
     InterestPickerSection,
     InterestPicker,
+    SectionWithID,
 )
 
-
-MIN_INITIALLY_VISIBLE_SECTION_COUNT = 3  # Minimum number of sections that are shown by default.
+MIN_INITIALLY_VISIBLE_SECTION_COUNT = 3  # Minimum number of sections shown by default.
 MIN_INTEREST_PICKER_COUNT = 8  # Minimum number of items in the interest picker.
 
 
-def create_interest_picker(
-    feed: CuratedRecommendationsFeed,
-) -> tuple[CuratedRecommendationsFeed, InterestPicker | None]:
-    """Set the interest picker on the given feed.
+def create_interest_picker(sections: list[SectionWithID]) -> InterestPicker | None:
+    """Process feed sections and set the interest picker.
 
-    This method processes the sections in the feed to determine which sections
-    should be initially visible and which should be hidden. It sets `isInitiallyVisible` to True
-    for the first `MIN_INITIALLY_VISIBLE_SECTION_COUNT` sections and for followed sections.
-    It then checks if there are at least MIN_INTEREST_PICKER_COUNT hidden sections available.
-    If there are not enough hidden sections, all sections are made visible and no interest
-    picker is created. Otherwise, the hidden sections are added to the interestPicker.sections.
-
-    Args:
-        feed (CuratedRecommendationsFeed): The feed containing sections.
-
-    Returns:
-        tuple[CuratedRecommendationsFeed, InterestPicker | None]:
-            A tuple where the first element is the updated feed and the second element is the
-            constructed InterestPicker. If there are not enough hidden sections, the InterestPicker
-            is not created and None is returned as the second element.
+    Returns a tuple of the updated feed and the constructed InterestPicker, or None.
     """
-    # Get all available sections sorted by the order in which they should be shown.
-    sections = sorted(feed.get_sections(), key=lambda tup: tup[0].receivedFeedRank)
+    sections = sorted(sections, key=lambda s: s.section.receivedFeedRank)
+    _set_section_initial_visibility(
+        sections, MIN_INITIALLY_VISIBLE_SECTION_COUNT, MIN_INTEREST_PICKER_COUNT
+    )
+    picker = _build_picker(sections, MIN_INTEREST_PICKER_COUNT)
+    if picker is not None:
+        _renumber_sections(sections, picker.receivedFeedRank)
+    return picker
 
-    _set_is_initially_visible(sections)
 
-    picker_sections = [
-        (section, section_id)
-        for (section, section_id) in sections
-        if not section.isInitiallyVisible
-    ]
+def _set_section_initial_visibility(
+    sections: list[SectionWithID],
+    min_visible: int,
+    min_picker: int,
+) -> None:
+    """Mark first min_visible and followed sections as visible; else hide."""
+    visible_count = 0
+    for s in sections:
+        if s.section.isFollowed or visible_count < min_visible:
+            s.section.isInitiallyVisible = True
+            visible_count += 1
+        else:
+            s.section.isInitiallyVisible = False
+    invisible = sum(1 for s in sections if not s.section.isInitiallyVisible)
+    if invisible < min_picker:
+        for s in sections:
+            s.section.isInitiallyVisible = True
 
-    # If there are not enough hidden sections, then show all sections without an interest picker.
-    if len(picker_sections) < MIN_INTEREST_PICKER_COUNT:
-        for section, _ in sections:
-            section.isInitiallyVisible = True
-        return feed, None
 
-    interest_picker_rank = _get_interest_picker_rank(sections)
-    _renumber_sections(sections, interest_picker_rank)
+def _get_interest_picker_rank(
+    sections: list[SectionWithID],
+) -> int:
+    """Return a random rank for the interest picker."""
+    if any(s.section.isFollowed for s in sections):
+        return random.randint(2, 4)
+    return random.randint(1, 3)
 
-    interest_picker = InterestPicker(
-        receivedFeedRank=interest_picker_rank,
+
+def _renumber_sections(
+    sections: list[SectionWithID],
+    picker_rank: int,
+) -> None:
+    """Renumber section ranks, leaving a gap for the interest picker."""
+    new_rank = 0
+    for s in sections:
+        if new_rank == picker_rank:
+            # Skip the rank for the interest picker.
+            new_rank += 1
+        s.section.receivedFeedRank = new_rank
+        new_rank += 1
+
+
+def _build_picker(
+    sections: list[SectionWithID],
+    min_picker_sections: int,
+) -> InterestPicker | None:
+    """Create an InterestPicker if enough sections are eligible, by not being visible initially."""
+    picker_sections = [s for s in sections if not s.section.isInitiallyVisible]
+    if len(picker_sections) < min_picker_sections:
+        return None
+    picker_rank = _get_interest_picker_rank(sections)
+    return InterestPicker(
+        receivedFeedRank=picker_rank,
         title="Follow topics to personalize your feed",
         subtitle=(
             "We will bring you personalized content, all while respecting your privacy. "
             "You'll have powerful control over what content you see and what you don't."
         ),
-        sections=[
-            InterestPickerSection(sectionId=section_id) for _, section_id in picker_sections
-        ],
+        sections=[InterestPickerSection(sectionId=s.ID) for s in picker_sections],
     )
-    return feed, interest_picker
-
-
-def _set_is_initially_visible(sections: list[tuple]) -> None:
-    """Set initial visibility for sections.
-
-    Marks the first MIN_INITIALLY_VISIBLE_SECTION_COUNT and followed sections as visible;
-    others are hidden.
-    """
-    visible_count = 0
-    for section, _ in sections:
-        if section.isFollowed or visible_count < MIN_INITIALLY_VISIBLE_SECTION_COUNT:
-            section.isInitiallyVisible = True
-            visible_count += 1
-        else:
-            section.isInitiallyVisible = False
-
-
-def _get_interest_picker_rank(sections: list[tuple]) -> int:
-    """Return a randomized rank for the interest picker.
-
-    If any section is followed, choose a random int in [2, 4]; otherwise, in [1, 3].
-    """
-    if any(section.isFollowed for section, _ in sections):
-        return random.randint(2, 4)
-    return random.randint(1, 3)
-
-
-def _renumber_sections(sections: list[tuple], picker_rank: int) -> None:
-    """Renumber section ranks, leaving a gap for the interest picker.
-
-    Increments ranks by 1 so that the section after the picker has rank picker_rank+1.
-    """
-    new_rank = 0
-    for section, _ in sections:
-        if new_rank == picker_rank:
-            # Skip the rank for the interest picker.
-            new_rank += 1
-        section.receivedFeedRank = new_rank
-        new_rank += 1

--- a/merino/curated_recommendations/interest_picker.py
+++ b/merino/curated_recommendations/interest_picker.py
@@ -12,8 +12,9 @@ from merino.curated_recommendations.protocol import (
 MIN_INITIALLY_VISIBLE_SECTION_COUNT = 3  # Minimum number of sections that are shown by default.
 MIN_INTEREST_PICKER_COUNT = 8  # Minimum number of items in the interest picker.
 
+
 def create_interest_picker(
-        feed: CuratedRecommendationsFeed
+    feed: CuratedRecommendationsFeed,
 ) -> tuple[CuratedRecommendationsFeed, InterestPicker | None]:
     """Set the interest picker on the given feed.
 

--- a/merino/curated_recommendations/interest_picker.py
+++ b/merino/curated_recommendations/interest_picker.py
@@ -18,7 +18,6 @@ def create_interest_picker(sections: list[SectionWithID]) -> InterestPicker | No
 
     Returns a tuple of the updated feed and the constructed InterestPicker, or None.
     """
-    sections = sorted(sections, key=lambda s: s.section.receivedFeedRank)
     _set_section_initial_visibility(
         sections, MIN_INITIALLY_VISIBLE_SECTION_COUNT, MIN_INTEREST_PICKER_COUNT
     )
@@ -33,7 +32,9 @@ def _set_section_initial_visibility(
     min_visible: int,
     min_picker: int,
 ) -> None:
-    """Mark first min_visible and followed sections as visible; else hide."""
+    """Make the first min_visible and followed sections by receivedFeedRank visible; else hide."""
+    sections = sorted(sections, key=lambda s: s.section.receivedFeedRank)
+
     visible_count = 0
     for s in sections:
         if s.section.isFollowed or visible_count < min_visible:

--- a/merino/curated_recommendations/protocol.py
+++ b/merino/curated_recommendations/protocol.py
@@ -1,6 +1,7 @@
 """Curated Recommendations provider top-level request and response models"""
 
 import hashlib
+from collections import namedtuple
 from enum import unique, Enum
 from typing import Annotated, cast
 import logging
@@ -230,6 +231,9 @@ class Section(BaseModel):
     isInitiallyVisible: bool = True
 
 
+SectionWithID = namedtuple("SectionWithID", ["section", "ID"])
+
+
 class CuratedRecommendationsFeed(BaseModel):
     """Multiple lists of curated recommendations, that are currently in an experimental phase."""
 
@@ -270,10 +274,10 @@ class CuratedRecommendationsFeed(BaseModel):
                 return cast(Section, getattr(self, field_name, None))
         return None
 
-    def get_sections(self) -> list[tuple[Section, str]]:
+    def get_sections(self) -> list[SectionWithID]:
         """Get a list of all sections as tuples, where each tuple is a Section and its ID."""
         return [
-            (feed, str(model_field.alias))  # alias defines the section id
+            SectionWithID(feed, str(model_field.alias))  # alias defines the section id
             for field_name, model_field in self.model_fields.items()
             if (feed := getattr(self, field_name)) is not None and type(feed) is Section
         ]

--- a/merino/curated_recommendations/protocol.py
+++ b/merino/curated_recommendations/protocol.py
@@ -273,7 +273,7 @@ class CuratedRecommendationsFeed(BaseModel):
     def get_sections(self) -> list[tuple[Section, str]]:
         """Get a list of all sections as tuples, where each tuple is a Section and its ID."""
         return [
-            (feed, model_field.alias)  # alias defines the section id
+            (feed, str(model_field.alias))  # alias defines the section id
             for field_name, model_field in self.model_fields.items()
             if (feed := getattr(self, field_name)) is not None and type(feed) is Section
         ]

--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -469,10 +469,10 @@ class CuratedRecommendationsProvider:
                 curated_recommendations_request.sections, response.feeds
             )
 
-        if curated_recommendations_request.enableInterestPicker:
+        if curated_recommendations_request.enableInterestPicker and response.feeds:
             feeds, interest_picker = create_interest_picker(response.feeds)
             response.feeds = feeds
-            response.interest_picker = interest_picker
+            response.interestPicker = interest_picker
 
         return response
 

--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -470,8 +470,7 @@ class CuratedRecommendationsProvider:
             )
 
         if curated_recommendations_request.enableInterestPicker and response.feeds:
-            feeds, interest_picker = create_interest_picker(response.feeds)
-            response.feeds = feeds
+            interest_picker = create_interest_picker(response.feeds.get_sections())
             response.interestPicker = interest_picker
 
         return response

--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -15,6 +15,7 @@ from merino.curated_recommendations.engagement_backends.protocol import Engageme
 from merino.curated_recommendations.fakespot_backend.protocol import (
     FakespotBackend,
 )
+from merino.curated_recommendations.interest_picker import apply_interest_picker
 from merino.curated_recommendations.layouts import (
     layout_4_medium,
     layout_4_large,
@@ -467,6 +468,9 @@ class CuratedRecommendationsProvider:
             response.feeds = boost_followed_sections(
                 curated_recommendations_request.sections, response.feeds
             )
+
+        if curated_recommendations_request.enableInterestPicker:
+            apply_interest_picker(response)
 
         return response
 

--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -15,7 +15,7 @@ from merino.curated_recommendations.engagement_backends.protocol import Engageme
 from merino.curated_recommendations.fakespot_backend.protocol import (
     FakespotBackend,
 )
-from merino.curated_recommendations.interest_picker import apply_interest_picker
+from merino.curated_recommendations.interest_picker import create_interest_picker
 from merino.curated_recommendations.layouts import (
     layout_4_medium,
     layout_4_large,
@@ -470,7 +470,9 @@ class CuratedRecommendationsProvider:
             )
 
         if curated_recommendations_request.enableInterestPicker:
-            apply_interest_picker(response)
+            feeds, interest_picker = create_interest_picker(response.feeds)
+            response.feeds = feeds
+            response.interest_picker = interest_picker
 
         return response
 

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -1466,7 +1466,7 @@ class TestSections:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("enable_interest_picker", [True, False, None])
-    async def test_sections_interest_picker(self, enable_interest_picker, monkeypatch, repeat):
+    async def test_sections_interest_picker(self, enable_interest_picker, monkeypatch):
         """Test the curated recommendations endpoint returns an interest picker when enabled"""
         # The fixture data doesn't have enough sections for the interest picker to show up, so lower
         # the minimum number of sections that it needs to have to 1.

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -1465,7 +1465,7 @@ class TestSections:
             assert top_stories_section["subtitle"] is None
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("enable_interest_picker", [True, False, None])
+    @pytest.mark.parametrize("enable_interest_picker", [True, False])
     async def test_sections_interest_picker(self, enable_interest_picker, monkeypatch):
         """Test the curated recommendations endpoint returns an interest picker when enabled"""
         # The fixture data doesn't have enough sections for the interest picker to show up, so lower
@@ -1483,10 +1483,11 @@ class TestSections:
             )
             data = response.json()
 
+            interest_picker_response = data["interestPicker"]
             if enable_interest_picker:
-                assert data["interestPicker"] is not None
+                assert interest_picker_response is not None
             else:
-                assert data.get("interestPicker") is None
+                assert interest_picker_response is None
 
 
 class TestExtendedExpiration:

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -1465,7 +1465,6 @@ class TestSections:
             assert top_stories_section["subtitle"] is None
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("repeat", list(range(1000)))
     @pytest.mark.parametrize("enable_interest_picker", [True, False, None])
     async def test_sections_interest_picker(self, enable_interest_picker, monkeypatch, repeat):
         """Test the curated recommendations endpoint returns an interest picker when enabled"""

--- a/tests/unit/curated_recommendations/test_interest_picker.py
+++ b/tests/unit/curated_recommendations/test_interest_picker.py
@@ -4,20 +4,16 @@ import pytest
 
 from merino.curated_recommendations.corpus_backends.protocol import Topic
 from merino.curated_recommendations.interest_picker import (
-    apply_interest_picker,
+    create_interest_picker,
     MIN_INITIALLY_VISIBLE_SECTION_COUNT,
     MIN_INTEREST_PICKER_COUNT,
 )
 from merino.curated_recommendations.layouts import layout_4_medium
-from merino.curated_recommendations.protocol import (
-    CuratedRecommendationsResponse,
-    Section,
-    CuratedRecommendationsFeed,
-)
-
+from merino.curated_recommendations.protocol import Section, CuratedRecommendationsFeed
 
 def generate_feed(section_count: int, followed_count: int = 0) -> CuratedRecommendationsFeed:
     """Create a CuratedRecommendationsFeed populated with sections.
+
     Args:
         section_count (int): Number of sections to create.
         followed_count (int, optional): Number of sections to follow. Defaults to 0.
@@ -49,53 +45,41 @@ def generate_feed(section_count: int, followed_count: int = 0) -> CuratedRecomme
 
     return feed
 
+def test_no_sections():
+    """Test that if the feed has no sections, no interest picker is created."""
+    feed, interest_picker = create_interest_picker(CuratedRecommendationsFeed())
+    assert interest_picker is None
 
-@pytest.fixture
-def response():
-    """Fixture for CuratedRecommendationsResponse"""
-    return CuratedRecommendationsResponse(
-        recommendedAt=0, data=[], feeds=None, interestPicker=None
-    )
-
-
-def test_no_feeds(response):
-    """Test that if the response has no feeds, the function does nothing."""
-    apply_interest_picker(response)
-    assert response.interestPicker is None
-
-
-def test_not_enough_sections(response):
+def test_not_enough_sections():
     """Test that the interest picker is not shown if insufficient sections are available."""
-    # Create 10 sections. With MIN_INITIALLY_VISIBLE_SECTION_COUNT = 3, there will be 7 sections
+    # Create 10 sections. With MIN_INITIALLY_VISIBLE_SECTION_COUNT = 3, there will be 10 - 3 = 7 sections
     # eligible for the interest picker, which is less than the min of 8.
     section_count = MIN_INTEREST_PICKER_COUNT + MIN_INITIALLY_VISIBLE_SECTION_COUNT - 1
-    response.feeds = generate_feed(section_count)
-    apply_interest_picker(response)
+    feed, interest_picker = create_interest_picker(generate_feed(section_count))
 
     # Interest picker should not be created.
-    assert response.interestPicker is None
+    assert interest_picker is None
 
     # All sections must be visible.
-    for section, _ in response.feeds.get_sections():
-        assert section.isInitiallyVisible
-
+    for section, _ in feed.get_sections():
+        assert section.isInitiallyVisible is True
 
 @pytest.mark.parametrize("followed_count", list(range(7)))
-def test_interest_picker_is_created(response, followed_count: int):
+def test_interest_picker_is_created(followed_count: int):
     """Test that the interest picker is created as expected, if enough sections are available."""
     section_count = 15
-    response.feeds = generate_feed(section_count, followed_count=followed_count)
-    apply_interest_picker(response)
+    feed = generate_feed(section_count, followed_count=followed_count)
+    feed, interest_picker = create_interest_picker(feed)
 
-    assert response.interestPicker is not None
+    assert interest_picker is not None
 
     # The picker is ranked randomly, with different ranges depending on if any sections are followed
     min_picker_rank = 1 if followed_count == 0 else 2
     max_picker_rank = min_picker_rank + 2
-    assert min_picker_rank <= response.interestPicker.receivedFeedRank <= max_picker_rank
+    assert min_picker_rank <= interest_picker.receivedFeedRank <= max_picker_rank
 
     # Verify that the first MIN_INITIALLY_VISIBLE_SECTION_COUNT sections are visible.
-    sections = response.feeds.get_sections()
+    sections = feed.get_sections()
     visible_sections = [section for section, _ in sections if section.isInitiallyVisible]
     assert len(visible_sections) == max(MIN_INITIALLY_VISIBLE_SECTION_COUNT, 1 + followed_count)
 
@@ -106,12 +90,10 @@ def test_interest_picker_is_created(response, followed_count: int):
 
     # Verify that receivedFeedRank (including on interestPicker) is numbered 0, 1, 2, etc.
     ranks = [section.receivedFeedRank for section, _ in sections]
-    assert sorted(ranks) == [
-        i for i in range(section_count + 1) if i != response.interestPicker.receivedFeedRank
-    ]
+    expected_ranks = [i for i in range(section_count + 1) if i != interest_picker.receivedFeedRank]
+    assert sorted(ranks) == expected_ranks
 
     # Verify that the interest picker's sections include all sections not visible by default.
-    hidden_section_ids = [
-        section_id for section, section_id in sections if not section.isInitiallyVisible
-    ]
-    assert set([s.sectionId for s in response.interestPicker.sections]) == set(hidden_section_ids)
+    hidden_section_ids: list[str | None] = [section_id for section, section_id in sections if not section.isInitiallyVisible]
+    picker_ids = [s.sectionId for s in interest_picker.sections]
+    assert set(picker_ids) == set(hidden_section_ids)

--- a/tests/unit/curated_recommendations/test_interest_picker.py
+++ b/tests/unit/curated_recommendations/test_interest_picker.py
@@ -1,0 +1,128 @@
+"""Tests covering merino/curated_recommendations/interest_picker.py"""
+
+import pytest
+
+from merino.curated_recommendations.corpus_backends.protocol import Topic
+from merino.curated_recommendations.interest_picker import (
+    apply_interest_picker,
+    MIN_INITIALLY_VISIBLE_SECTION_COUNT,
+    MIN_INTEREST_PICKER_COUNT,
+)
+from merino.curated_recommendations.layouts import layout_4_medium
+from merino.curated_recommendations.protocol import (
+    CuratedRecommendationsResponse,
+    Section,
+    CuratedRecommendationsFeed,
+)
+
+
+def generate_feed(section_count: int, followed_count: int = 0) -> CuratedRecommendationsFeed:
+    """Create a CuratedRecommendationsFeed populated with sections.
+    Args:
+        section_count (int): Number of sections to create.
+        followed_count (int, optional): Number of sections to follow. Defaults to 0.
+
+    Returns:
+        CuratedRecommendationsFeed: A feed instance containing the generated sections.
+    """
+    feed = CuratedRecommendationsFeed()
+    if section_count == 0:
+        return feed
+
+    # Set top_stories_section first.
+    feed.top_stories_section = Section(
+        receivedFeedRank=0,
+        recommendations=[],  # No recommendations are added for dummy purposes.
+        title="Top Stories",
+        layout=layout_4_medium,
+    )
+
+    # Iterate over the Topic enum and add topic sections.
+    topics = list(Topic)[: section_count - 1]
+    for i, topic in enumerate(topics):
+        section = Section(
+            receivedFeedRank=i + 1,  # Ranks start after top_stories_section.
+            recommendations=[],
+            title=f"{topic.value.title()} Section",
+            layout=layout_4_medium,
+            isFollowed=i < followed_count,
+        )
+        feed.set_topic_section(topic, section)
+
+    return feed
+
+
+# --- Pytest Fixture --- #
+
+
+@pytest.fixture
+def response():
+    """Fixture for CuratedRecommendationsResponse"""
+    return CuratedRecommendationsResponse(
+        recommendedAt=0, data=[], feeds=None, interestPicker=None
+    )
+
+
+def test_no_feeds(response):
+    """Test that if the response has no feeds, the function does nothing."""
+    apply_interest_picker(response)
+    assert response.interestPicker is None
+
+
+def test_not_enough_hidden_sections(response):
+    """Test that when there are fewer than MIN_INTEREST_PICKER_COUNT hidden sections,
+    the function sets all sections to be visible and does not attach an interest picker.
+    """
+    # Create 10 sections. With MIN_INITIALLY_VISIBLE_SECTION_COUNT = 3, there will be 7 sections
+    # eligible for the interest picker, which is less than the min of 8.
+    section_count = MIN_INTEREST_PICKER_COUNT + MIN_INITIALLY_VISIBLE_SECTION_COUNT - 1
+    response.feeds = generate_feed(section_count)
+    apply_interest_picker(response)
+
+    # Interest picker should not be created.
+    assert response.interestPicker is None
+
+    # All sections must be visible.
+    for section, _ in response.feeds.get_sections():
+        assert section.isInitiallyVisible
+
+
+@pytest.mark.parametrize("followed_count", list(range(7)))
+def test_enough_hidden_sections_no_followed(response, followed_count: int):
+    """Test that when there are enough hidden sections (>= MIN_INTEREST_PICKER_COUNT) the interest
+    picker is created as expected, and sections are ranked incrementally.
+    """
+    section_count = 15
+    response.feeds = generate_feed(section_count, followed_count=followed_count)
+    apply_interest_picker(response)
+
+    assert response.interestPicker is not None
+
+    # The picker is ranked randomly, with different ranges depending on if any sections are followed
+    min_picker_rank = 1 if followed_count == 0 else 2
+    max_picker_rank = min_picker_rank + 2
+    assert min_picker_rank <= response.interestPicker.receivedFeedRank <= max_picker_rank
+
+    # Verify that the first MIN_INITIALLY_VISIBLE_SECTION_COUNT sections are visible.
+    sections = response.feeds.get_sections()
+    visible_sections = [section for section, _ in sections if section.isInitiallyVisible]
+    assert len(visible_sections) == max(MIN_INITIALLY_VISIBLE_SECTION_COUNT, 1 + followed_count)
+
+    # Verify that all followed sections are visible.
+    for section, _ in sections:
+        if section.isFollowed:
+            assert section.isInitiallyVisible is True
+
+    # Verify renumbering: there should be no section with rank equal to the interest picker rank (2),
+    # and the smallest rank greater than 2 should be 3.
+    ranks = [section.receivedFeedRank for section, _ in sections]
+    assert sorted(ranks) == [
+        i for i in range(section_count + 1) if i != response.interestPicker.receivedFeedRank
+    ]
+
+    # Verify that the interest picker's sections include all hidden sections.
+    hidden_section_ids = [
+        section_id for section, section_id in sections if not section.isInitiallyVisible
+    ]
+    picker_ids = [s.sectionId for s in response.interestPicker.sections]
+    assert set(picker_ids) == set(hidden_section_ids)

--- a/tests/unit/curated_recommendations/test_interest_picker.py
+++ b/tests/unit/curated_recommendations/test_interest_picker.py
@@ -5,11 +5,18 @@ import pytest
 from merino.curated_recommendations.corpus_backends.protocol import Topic
 from merino.curated_recommendations.interest_picker import (
     create_interest_picker,
+    _set_section_initial_visibility,
+    _get_interest_picker_rank,
+    _renumber_sections,
     MIN_INITIALLY_VISIBLE_SECTION_COUNT,
     MIN_INTEREST_PICKER_COUNT,
 )
 from merino.curated_recommendations.layouts import layout_4_medium
-from merino.curated_recommendations.protocol import Section, CuratedRecommendationsFeed
+from merino.curated_recommendations.protocol import (
+    Section,
+    CuratedRecommendationsFeed,
+    SectionWithID,
+)
 
 
 def generate_feed(section_count: int, followed_count: int = 0) -> CuratedRecommendationsFeed:
@@ -20,19 +27,19 @@ def generate_feed(section_count: int, followed_count: int = 0) -> CuratedRecomme
         followed_count (int, optional): Number of sections to follow. Defaults to 0.
 
     Returns:
-        CuratedRecommendationsFeed: A feed instance containing the generated sections.
+        CuratedRecommendationsFeed: A feed with generated sections.
     """
     feed = CuratedRecommendationsFeed()
 
     # Set top_stories_section first.
     feed.top_stories_section = Section(
         receivedFeedRank=0,
-        recommendations=[],  # No recommendations are added for dummy purposes.
+        recommendations=[],  # Dummy recommendations.
         title="Top Stories",
         layout=layout_4_medium,
     )
 
-    # Iterate over the Topic enum and add topic sections.
+    # Use topics to generate remaining sections.
     topics = list(Topic)[: section_count - 1]
     for i, topic in enumerate(topics):
         section = Section(
@@ -40,7 +47,7 @@ def generate_feed(section_count: int, followed_count: int = 0) -> CuratedRecomme
             recommendations=[],
             title=f"{topic.value.title()} Section",
             layout=layout_4_medium,
-            isFollowed=i < followed_count,
+            isFollowed=(i < followed_count),
         )
         feed.set_topic_section(topic, section)
 
@@ -49,57 +56,135 @@ def generate_feed(section_count: int, followed_count: int = 0) -> CuratedRecomme
 
 def test_no_sections():
     """Test that if the feed has no sections, no interest picker is created."""
-    feed, interest_picker = create_interest_picker(CuratedRecommendationsFeed())
-    assert interest_picker is None
+    feed = CuratedRecommendationsFeed()
+    sections: list[SectionWithID] = feed.get_sections()  # Expected to be empty.
+    picker = create_interest_picker(sections)
+    assert picker is None
 
 
 def test_not_enough_sections():
-    """Test that the interest picker is not shown if insufficient sections are available."""
-    # Create 10 sections. With MIN_INITIALLY_VISIBLE_SECTION_COUNT = 3, there will be 10 - 3 = 7 sections
-    # eligible for the interest picker, which is less than the min of 8.
-    section_count = MIN_INTEREST_PICKER_COUNT + MIN_INITIALLY_VISIBLE_SECTION_COUNT - 1
-    feed, interest_picker = create_interest_picker(generate_feed(section_count))
-
-    # Interest picker should not be created.
-    assert interest_picker is None
-
+    """Test that no interest picker is created if insufficient sections are eligible."""
+    # Create feed such that hidden sections = total - MIN_INITIALLY_VISIBLE_SECTION_COUNT
+    total = MIN_INTEREST_PICKER_COUNT + MIN_INITIALLY_VISIBLE_SECTION_COUNT - 1
+    feed = generate_feed(total)
+    sections = feed.get_sections()
+    picker = create_interest_picker(sections)
+    # Not enough hidden sections -> no picker.
+    assert picker is None
     # All sections must be visible.
-    for section, _ in feed.get_sections():
-        assert section.isInitiallyVisible is True
+    for s in sections:
+        assert s.section.isInitiallyVisible is True
 
 
 @pytest.mark.parametrize("followed_count", list(range(7)))
 def test_interest_picker_is_created(followed_count: int):
-    """Test that the interest picker is created as expected, if enough sections are available."""
-    section_count = 15
-    feed = generate_feed(section_count, followed_count=followed_count)
-    feed, interest_picker = create_interest_picker(feed)
-
-    assert interest_picker is not None
-
-    # The picker is ranked randomly, with different ranges depending on if any sections are followed
+    """Test that an interest picker is created when enough sections are available."""
+    total = 15
+    feed = generate_feed(total, followed_count=followed_count)
+    sections = feed.get_sections()
+    picker = create_interest_picker(sections)
+    assert picker is not None
+    # Picker rank range depends on followed sections.
     min_picker_rank = 1 if followed_count == 0 else 2
     max_picker_rank = min_picker_rank + 2
-    assert min_picker_rank <= interest_picker.receivedFeedRank <= max_picker_rank
+    assert min_picker_rank <= picker.receivedFeedRank <= max_picker_rank
+    # Check that first MIN_INITIALLY_VISIBLE_SECTION_COUNT sections are visible.
+    visible = [s for s in sections if s.section.isInitiallyVisible]
+    expected_vis = max(MIN_INITIALLY_VISIBLE_SECTION_COUNT, 1 + followed_count)
+    assert len(visible) == expected_vis
+    # All followed sections must be visible.
+    for s in sections:
+        if s.section.isFollowed:
+            assert s.section.isInitiallyVisible is True
+    # Check renumbering: ranks should be sequential and skip the picker rank.
+    ranks = [s.section.receivedFeedRank for s in sections]
+    expected = [i for i in range(total + 1) if i != picker.receivedFeedRank]
+    assert sorted(ranks) == expected
+    # Check picker sections: they must include all sections not initially visible.
+    hidden_ids = {s.ID for s in sections if not s.section.isInitiallyVisible}
+    picker_ids = {ps.sectionId for ps in picker.sections}
+    assert picker_ids == hidden_ids
 
-    # Verify that the first MIN_INITIALLY_VISIBLE_SECTION_COUNT sections are visible.
-    sections = feed.get_sections()
-    visible_sections = [section for section, _ in sections if section.isInitiallyVisible]
-    assert len(visible_sections) == max(MIN_INITIALLY_VISIBLE_SECTION_COUNT, 1 + followed_count)
 
-    # Verify that all followed sections are visible.
-    for section, _ in sections:
-        if section.isFollowed:
-            assert section.isInitiallyVisible is True
+def test_renumber_sections_preserves_order():
+    """Test that _renumber_sections assigns sequential ranks skipping the picker rank."""
+    # Create a simple list of SectionWithID with preset ranks.
+    sections = []
+    for i in range(5):
+        sec = Section(
+            receivedFeedRank=i, recommendations=[], title=f"S{i}", layout=layout_4_medium
+        )
+        # Dummy ID is "id{i}"
+        sections.append(SectionWithID(section=sec, ID=f"id{i}"))
+    # Suppose picker rank is 2.
+    _renumber_sections(sections, 2)
+    new_ranks = [s.section.receivedFeedRank for s in sections]
+    # Expected ranks: 0,1,3,4,5 (2 is skipped).
+    assert new_ranks == [0, 1, 3, 4, 5]
 
-    # Verify that receivedFeedRank (including on interestPicker) is numbered 0, 1, 2, etc.
-    ranks = [section.receivedFeedRank for section, _ in sections]
-    expected_ranks = [i for i in range(section_count + 1) if i != interest_picker.receivedFeedRank]
-    assert sorted(ranks) == expected_ranks
 
-    # Verify that the interest picker's sections include all sections not visible by default.
-    hidden_section_ids: list[str | None] = [
-        section_id for section, section_id in sections if not section.isInitiallyVisible
-    ]
-    picker_ids = [s.sectionId for s in interest_picker.sections]
-    assert set(picker_ids) == set(hidden_section_ids)
+def test_get_interest_picker_rank_no_followed():
+    """Test _get_interest_picker_rank returns values in [1, 3] when no section is followed."""
+    sections = []
+    for i in range(10):
+        sec = Section(
+            receivedFeedRank=i, recommendations=[], title=f"S{i}", layout=layout_4_medium
+        )
+        sec.isFollowed = False
+        sections.append(SectionWithID(section=sec, ID=f"id{i}"))
+    results = {_get_interest_picker_rank(sections) for _ in range(100)}
+    # All values must be in the range [1,3]
+    for r in results:
+        assert 1 <= r <= 3
+
+
+def test_get_interest_picker_rank_with_followed():
+    """Test _get_interest_picker_rank returns values in [2, 4] when at least one section is followed."""
+    sections = []
+    for i in range(10):
+        sec = Section(
+            receivedFeedRank=i, recommendations=[], title=f"S{i}", layout=layout_4_medium
+        )
+        sec.isFollowed = i == 5
+        sections.append(SectionWithID(section=sec, ID=f"id{i}"))
+    results = {_get_interest_picker_rank(sections) for _ in range(100)}
+    for r in results:
+        assert 2 <= r <= 4
+
+
+def test_set_section_initial_visibility_without_enough_sections():
+    """Test _set_section_initial_visibility makes all sections visible exceeding min_picker."""
+    # Create 10 sections; mark none as followed initially.
+    sections = []
+    for i in range(10):
+        sec = Section(
+            receivedFeedRank=i, recommendations=[], title=f"S{i}", layout=layout_4_medium
+        )
+        sec.isFollowed = False
+        # Initially, set all to False.
+        sec.isInitiallyVisible = False
+        sections.append(SectionWithID(section=sec, ID=f"id{i}"))
+    # Call function with min_visible=3, min_picker=8.
+    _set_section_initial_visibility(sections, 3, 8)
+    # Since there are 10 sections, invisible count would be 10-3=7 < 8, so all become visible.
+    assert all(s.section.isInitiallyVisible for s in sections if s.section.isInitiallyVisible)
+
+
+def test_set_section_initial_visibility_with_followed():
+    """Test that followed sections are always visible and minimum count is met."""
+    sections = []
+    for i in range(15):
+        sec = Section(
+            receivedFeedRank=i, recommendations=[], title=f"S{i}", layout=layout_4_medium
+        )
+        # Mark sections 2 and 7 as followed.
+        sec.isFollowed = i in [2, 7]
+        sec.isInitiallyVisible = False
+        sections.append(SectionWithID(section=sec, ID=f"id{i}"))
+    _set_section_initial_visibility(sections, 3, 8)
+    visible = [s for s in sections if s.section.isInitiallyVisible]
+    # At least sections 2 and 7 must be visible, and the top 3 overall.
+    assert [s.ID for s in visible] == ["id0", "id1", "id2", "id7"]
+    for s in sections:
+        if s.section.isFollowed:
+            assert s.section.isInitiallyVisible is True

--- a/tests/unit/curated_recommendations/test_interest_picker.py
+++ b/tests/unit/curated_recommendations/test_interest_picker.py
@@ -11,6 +11,7 @@ from merino.curated_recommendations.interest_picker import (
 from merino.curated_recommendations.layouts import layout_4_medium
 from merino.curated_recommendations.protocol import Section, CuratedRecommendationsFeed
 
+
 def generate_feed(section_count: int, followed_count: int = 0) -> CuratedRecommendationsFeed:
     """Create a CuratedRecommendationsFeed populated with sections.
 
@@ -45,10 +46,12 @@ def generate_feed(section_count: int, followed_count: int = 0) -> CuratedRecomme
 
     return feed
 
+
 def test_no_sections():
     """Test that if the feed has no sections, no interest picker is created."""
     feed, interest_picker = create_interest_picker(CuratedRecommendationsFeed())
     assert interest_picker is None
+
 
 def test_not_enough_sections():
     """Test that the interest picker is not shown if insufficient sections are available."""
@@ -63,6 +66,7 @@ def test_not_enough_sections():
     # All sections must be visible.
     for section, _ in feed.get_sections():
         assert section.isInitiallyVisible is True
+
 
 @pytest.mark.parametrize("followed_count", list(range(7)))
 def test_interest_picker_is_created(followed_count: int):
@@ -94,6 +98,8 @@ def test_interest_picker_is_created(followed_count: int):
     assert sorted(ranks) == expected_ranks
 
     # Verify that the interest picker's sections include all sections not visible by default.
-    hidden_section_ids: list[str | None] = [section_id for section, section_id in sections if not section.isInitiallyVisible]
+    hidden_section_ids: list[str | None] = [
+        section_id for section, section_id in sections if not section.isInitiallyVisible
+    ]
     picker_ids = [s.sectionId for s in interest_picker.sections]
     assert set(picker_ids) == set(hidden_section_ids)

--- a/tests/unit/curated_recommendations/test_interest_picker.py
+++ b/tests/unit/curated_recommendations/test_interest_picker.py
@@ -191,7 +191,7 @@ def test_set_section_initial_visibility_with_followed():
     visible = [s for s in sections if s.section.isInitiallyVisible]
 
     # At least sections 2 and 7 must be visible, and the top 3 overall.
-    assert [s.ID for s in visible] == ["id0", "id1", "id2", "id7"]
+    assert {s.ID for s in visible} == {"id0", "id1", "id2", "id7"}
     for s in sections:
         if s.section.isFollowed:
             assert s.section.isInitiallyVisible is True


### PR DESCRIPTION
## References

- JIRA: [HNT-374](https://mozilla-hub.atlassian.net/browse/HNT-374)
- [Interest picker API spec](https://mozilla-hub.atlassian.net/wiki/spaces/FPS/pages/1287553025/Inline+Interest+Picker+-+API+Specification)
- [Product plan](https://docs.google.com/document/d/1dTHDMNhxRre0ubsjBDWQJ7Z_X-J9EBiP9noRyLla7EI/edit?tab=t.0)

## Description
Return an 'Interest Picker' from the curated recommendation endpoint, to allow clients to follow sections.

![image](https://github.com/user-attachments/assets/d73df7b6-1873-4605-9016-236c78f416cd)


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[HNT-374]: https://mozilla-hub.atlassian.net/browse/HNT-374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ