### PR TITLE
[HNT-405] Remove blocked topics from sections

### DIFF
--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -312,7 +312,9 @@ class CuratedRecommendationsProvider:
         return general_feed, need_to_know_feed
 
     @staticmethod
-    def exclude_recommendations_from_blocked_sections(recommendations, requested_sections):
+    def exclude_recommendations_from_blocked_sections(
+        recommendations, requested_sections
+    ) -> list[CuratedRecommendation]:
         """Return recommendations which topic doesn't match any blocked section"""
         blocked_section_ids = {rs.sectionId for rs in requested_sections if rs.isBlocked}
         return [

--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -323,6 +323,13 @@ class CuratedRecommendationsProvider:
         min_fallback_recs_per_section = 1
         top_stories_count = 6
 
+        # Recommendations whose topic matches a blocked section should not be shown.
+        if request.sections:
+            blocked_section_ids = {rs.sectionId for rs in request.sections if rs.isBlocked}
+            recommendations = [
+                r for r in recommendations if r.topic and r.topic.value not in blocked_section_ids
+            ]
+
         # Apply Thompson sampling to rank all recommendations by engagement
         recommendations = thompson_sampling(
             recommendations,

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -1418,6 +1418,34 @@ class TestSections:
             assert len(errors) == 0
 
     @pytest.mark.asyncio
+    async def test_curated_recommendations_with_sections_feed_removes_blocked_topics(self, caplog):
+        """Test that when topic sections are blocked, those recommendations don't show up, not even
+        in other sections like Popular Today.
+        """
+        blocked_topics = [Topic.CAREER.value, Topic.SCIENCE.value, Topic.HEALTH_FITNESS.value]
+
+        async with AsyncClient(app=app, base_url="http://test") as ac:
+            # Mock the endpoint to request the sections feed
+            response = await ac.post(
+                "/api/v1/curated-recommendations",
+                json={
+                    "locale": "en-US",
+                    "feeds": ["sections"],
+                    "sections": [
+                        {"sectionId": topic_id, "isFollowed": False, "isBlocked": True}
+                        for topic_id in blocked_topics
+                    ],
+                },
+            )
+            data = response.json()
+
+            # assert that none of the recommendations has a blocked topic.
+            for _, feed in data["feeds"].items():
+                if feed:
+                    for recommendation in feed["recommendations"]:
+                        assert recommendation["topic"] not in blocked_topics
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "locale, expected_titles",
         [


### PR DESCRIPTION
## References

JIRA: [HNT-405](https://mozilla-hub.atlassian.net/browse/HNT-405)

## Description
If a user blocks a section using the Follow/Block feature (e.g. Food, Politics), we remove recommendations with those topics from sections, including 'Popular Today'.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[HNT-405]: https://mozilla-hub.atlassian.net/browse/HNT-405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ