### PR TITLE
[DISCO-3210] [load test: abort] Use async gcs client for manifest

### DIFF
--- a/merino/providers/manifest/backends/filemanager.py
+++ b/merino/providers/manifest/backends/filemanager.py
@@ -13,7 +13,18 @@ from merino.utils.metrics import get_metrics_client
 
 logger = logging.getLogger(__name__)
 
-
+## TODO use this probably for blob generation logic
+""" async def download(
+    self, bucket: str, object_name: str, *,
+    headers: Optional[Dict[str, Any]] = None,
+    timeout: int = DEFAULT_TIMEOUT,
+    session: Optional[Session] = None,
+) -> bytes:
+    return await self._download(
+        bucket, object_name, headers=headers,
+        timeout=timeout, params={'alt': 'media'},
+        session=session,
+    )"""
 class ManifestRemoteFilemanager:
     """Filemanager for fetching manifest data from GCS and storing only in memory."""
 

--- a/merino/providers/manifest/backends/filemanager.py
+++ b/merino/providers/manifest/backends/filemanager.py
@@ -1,6 +1,6 @@
 """A Filemanager to retrieve data for the Manifest Provider (Remote-Only)."""
 
-import json
+import orjson
 import logging
 
 from json import JSONDecodeError
@@ -8,7 +8,7 @@ from json import JSONDecodeError
 from pydantic import ValidationError
 
 from merino.providers.manifest.backends.protocol import ManifestData, GetManifestResultCode
-from merino.utils.gcs.gcs_uploader import GcsUploader
+from gcloud.aio.storage import Blob, Bucket, Storage
 from merino.utils.metrics import get_metrics_client
 
 logger = logging.getLogger(__name__)
@@ -17,53 +17,45 @@ logger = logging.getLogger(__name__)
 class ManifestRemoteFilemanager:
     """Filemanager for fetching manifest data from GCS and storing only in memory."""
 
-    gcs_client: GcsUploader
+    gcs_client: Storage
     blob_name: str
     blob_generation: int
 
-    def __init__(self, gcs_project_path: str, gcs_bucket_path: str, blob_name: str) -> None:
-        """:param gcs_project_path: Google Cloud project.
-        :param gcs_bucket_path: GCS bucket name to fetch from.
+    def __init__(self, gcs_bucket_path: str, blob_name: str) -> None:
+        """:param gcs_bucket_path: GCS bucket name to fetch from.
         :param blob_name: Name of the blob in the GCS bucket.
         """
-        self.gcs_client = GcsUploader(gcs_project_path, gcs_bucket_path, "")
+        self.gcs_client = Storage()
         self.blob_name = blob_name
+        self.bucket = Bucket(storage=self.gcs_client, name=gcs_bucket_path)
+
+        # TODO figure out this
         self.blob_generation = 0
 
-    def get_file(self) -> tuple[GetManifestResultCode, ManifestData | None]:
+    async def get_file(self) -> tuple[GetManifestResultCode, ManifestData | None]:
         """Fetch the remote manifest file from GCS"""
         metrics_client = get_metrics_client()
 
         try:
-            blob = self.gcs_client.get_file_by_name(self.blob_name, self.blob_generation)
+            # TODO
+            # blob.reload()
+            blob: Blob = await self.bucket.get_blob(self.blob_name)
+            blob_data = await blob.download()
 
-            if blob is not None:
-                blob.reload()
-                metrics_client.gauge("manifest.size", value=blob.size)
+            metrics_client.gauge("manifest.size", value=blob.size)
 
-                blob_data = blob.download_as_text()
+            manifest_content = ManifestData.model_validate(orjson.loads(blob_data))
+            metrics_client.gauge("manifest.domains.count", value=len(manifest_content.domains))
 
-                try:
-                    manifest_content = ManifestData.model_validate(json.loads(blob_data))
-                    metrics_client.gauge(
-                        "manifest.domains.count", value=len(manifest_content.domains)
-                    )
-                except JSONDecodeError as json_error:
-                    logger.error("Failed to decode manifest JSON: %s", json_error)
-                    return GetManifestResultCode.FAIL, None
-                except ValidationError as val_err:
-                    logger.error(f"Invalid manifest content: {val_err}")
-                    return GetManifestResultCode.FAIL, None
+            logger.info("Successfully loaded remote manifest file: %s", self.blob_name)
+            return GetManifestResultCode.SUCCESS, manifest_content
 
-                logger.info("Successfully loaded remote manifest file: %s", self.blob_name)
-                return GetManifestResultCode.SUCCESS, manifest_content
-
-            # If `get_file_by_name` returned None, that usually means no new generation (SKIP).
-            logger.info(
-                f"No new GCS generation for {self.blob_name}; returning SKIP or blob doesn't exist.",
-            )
-            return GetManifestResultCode.SKIP, None
-
+        except JSONDecodeError as json_error:
+            logger.error("Failed to decode manifest JSON: %s", json_error)
+            return GetManifestResultCode.FAIL, None
+        except ValidationError as val_err:
+            logger.error(f"Invalid manifest content: {val_err}")
+            return GetManifestResultCode.FAIL, None
         except Exception as e:
             logger.error(f"Error fetching remote manifest file {self.blob_name}: {e}")
             return GetManifestResultCode.FAIL, None

--- a/merino/providers/manifest/backends/manifest.py
+++ b/merino/providers/manifest/backends/manifest.py
@@ -1,6 +1,5 @@
 """A backend wrapper for the Manifest Provider I/O Interactions (Remote-Only)."""
 
-import asyncio
 import logging
 
 from merino.configs import settings
@@ -30,27 +29,22 @@ class ManifestBackend:
             (SKIP, None): If there's no new generation (blob unchanged).
             (FAIL, None): If there's an error with fetching or parsing.
         """
-        return await asyncio.to_thread(self.fetch_manifest_data)
+        return await self.fetch_manifest_data()
 
-    def fetch_manifest_data(self) -> tuple[GetManifestResultCode, ManifestData | None]:
+    async def fetch_manifest_data(self) -> tuple[GetManifestResultCode, ManifestData | None]:
         """Fetch manifest data from GCS through the remote filemanager."""
         remote_filemanager = ManifestRemoteFilemanager(
-            gcs_project_path=settings.image_manifest.gcs_project,
             gcs_bucket_path=settings.image_manifest.gcs_bucket,
             blob_name=GCS_BLOB_NAME,
         )
 
-        result_code, manifest_data = remote_filemanager.get_file()
+        result_code, manifest_data = await remote_filemanager.get_file()
 
         match GetManifestResultCode(result_code):
             case GetManifestResultCode.SUCCESS:
                 logger.info("Manifest data loaded remotely from GCS.")
-                return result_code, manifest_data
-
-            case GetManifestResultCode.SKIP:
-                logger.info("Manifest data was not updated (SKIP).")
-                return result_code, None
+                return (result_code, manifest_data)
 
             case GetManifestResultCode.FAIL:
                 logger.error("Failed to fetch manifest from GCS (FAIL).")
-                return result_code, None
+                return (result_code, None)

--- a/merino/providers/manifest/backends/protocol.py
+++ b/merino/providers/manifest/backends/protocol.py
@@ -18,7 +18,6 @@ class GetManifestResultCode(Enum):
 
     SUCCESS = 0
     FAIL = 1
-    SKIP = 2
 
 
 class Domain(BaseModel):

--- a/merino/providers/manifest/provider.py
+++ b/merino/providers/manifest/provider.py
@@ -75,12 +75,9 @@ class Provider:
                     }
                     self.last_fetch_at = time.time()
 
-                case GetManifestResultCode.SKIP:
-                    return None
-
                 case GetManifestResultCode.FAIL:
                     logger.error("Failed to fetch data from Manifest backend.")
-                    return None
+
         except ManifestBackendError as err:
             logger.error("Failed to fetch data from Manifest backend: %s", err)
 

--- a/tests/integration/api/v1/manifest/test_manifest.py
+++ b/tests/integration/api/v1/manifest/test_manifest.py
@@ -27,7 +27,6 @@ def cleanup_tasks_fixture():
     return cleanup_tasks
 
 
-# TODO fix BUCKET URL IS EMPTY
 @pytest.mark.asyncio
 async def test_get_manifest_success(client, gcp_uploader, mock_manifest, cleanup):
     """Uploads a manifest to the gcs bucket and verifies that the endpoint returns the uploaded file."""
@@ -39,9 +38,6 @@ async def test_get_manifest_success(client, gcp_uploader, mock_manifest, cleanup
 
     # upload a manifest file to GCS test container
     gcp_uploader.upload_content(orjson.dumps(mock_manifest), "top_picks_latest.json")
-    # http://localhost:4443/storage/v1/b//o/top_picks_latest.json
-    # test_gcp_uploader_bucket
-    print(f"@@@@@@@@@@@ gcp_uploader_bucket: {gcp_uploader.bucket_name}")
 
     provider = get_provider()
     await provider.data_fetched_event.wait()

--- a/tests/integration/api/v1/manifest/test_manifest.py
+++ b/tests/integration/api/v1/manifest/test_manifest.py
@@ -27,6 +27,7 @@ def cleanup_tasks_fixture():
     return cleanup_tasks
 
 
+# TODO fix BUCKET URL IS EMPTY
 @pytest.mark.asyncio
 async def test_get_manifest_success(client, gcp_uploader, mock_manifest, cleanup):
     """Uploads a manifest to the gcs bucket and verifies that the endpoint returns the uploaded file."""
@@ -38,6 +39,9 @@ async def test_get_manifest_success(client, gcp_uploader, mock_manifest, cleanup
 
     # upload a manifest file to GCS test container
     gcp_uploader.upload_content(orjson.dumps(mock_manifest), "top_picks_latest.json")
+    # http://localhost:4443/storage/v1/b//o/top_picks_latest.json
+    # test_gcp_uploader_bucket
+    print(f"@@@@@@@@@@@ gcp_uploader_bucket: {gcp_uploader.bucket_name}")
 
     provider = get_provider()
     await provider.data_fetched_event.wait()

--- a/tests/unit/providers/manifest/backends/test_filemanager.py
+++ b/tests/unit/providers/manifest/backends/test_filemanager.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock
 from merino.providers.manifest.backends.filemanager import ManifestRemoteFilemanager
 from merino.providers.manifest.backends.protocol import GetManifestResultCode, ManifestData
 
+
 # TODO ADD the new fixture here
 @pytest.mark.asyncio
 async def test_get_file_async(fixture_filemanager):

--- a/tests/unit/providers/manifest/backends/test_filemanager.py
+++ b/tests/unit/providers/manifest/backends/test_filemanager.py
@@ -6,35 +6,15 @@
 
 import orjson
 import pytest
-from unittest.mock import patch, MagicMock, AsyncMock
-from pydantic import ValidationError
+from unittest.mock import AsyncMock
 from merino.providers.manifest.backends.filemanager import ManifestRemoteFilemanager
 from merino.providers.manifest.backends.protocol import GetManifestResultCode, ManifestData
 
-
+# TODO ADD the new fixture here
 @pytest.mark.asyncio
-async def test_get_file_async(blob_json):
+async def test_get_file_async(fixture_filemanager):
     """Test that the async get_file method returns manifest data."""
-    # Mocking blob response
-    mock_blob = AsyncMock()
-    mock_blob.download.return_value = blob_json
-    mock_blob.size = 1234
-
-    # Mocking bucket
-    mock_bucket = AsyncMock()
-    mock_bucket.get_blob.return_value = mock_blob
-
-    # Mocking storage client
-    mock_storage = AsyncMock()
-    mock_storage.bucket.return_value = mock_bucket
-
-    # Instantiating the filemanager with mocks
-    filemanager = ManifestRemoteFilemanager("test-bucket", "test-blob")
-    filemanager.gcs_client = mock_storage
-    filemanager.bucket = mock_bucket
-
-    # Run test
-    get_file_result_code, result = await filemanager.get_file()
+    get_file_result_code, result = await fixture_filemanager.get_file()
 
     # Assertions
     assert get_file_result_code is GetManifestResultCode.SUCCESS
@@ -42,6 +22,7 @@ async def test_get_file_async(blob_json):
     assert result.domains
     assert len(result.domains) == 3
     assert result.domains[0].domain == "google"
+
 
 @pytest.mark.asyncio
 async def test_get_file_json_decode_error():
@@ -64,6 +45,7 @@ async def test_get_file_json_decode_error():
     assert get_file_result_code is GetManifestResultCode.FAIL
     assert result is None
 
+
 @pytest.mark.asyncio
 async def test_get_file_validation_error():
     """Test that the async get_file method handles validation errors."""
@@ -84,6 +66,7 @@ async def test_get_file_validation_error():
 
     assert get_file_result_code is GetManifestResultCode.FAIL
     assert result is None
+
 
 @pytest.mark.asyncio
 async def test_get_file_exception():

--- a/tests/unit/providers/manifest/backends/test_manifest.py
+++ b/tests/unit/providers/manifest/backends/test_manifest.py
@@ -29,10 +29,11 @@ async def test_fetch_manifest_data(backend: ManifestBackend, fixture_filemanager
         assert result.domains[1].domain == "microsoft"
 
 
+# TODO re-evaluate after blob generation logic figured out
 @pytest.mark.asyncio
 async def test_fetch_manifest_data_skip(backend: ManifestBackend, fixture_filemanager) -> None:
     # TODO fix comment
-    """Verify that the fetch_manifest_data method returns SKIP code for no new blob generation"""
+    """Verify that the fetch_manifest_data method returns FAIL code for no new blob generation"""
     fixture_filemanager.bucket.get_blob.return_value = None
     with patch(
         "merino.providers.manifest.backends.manifest.ManifestRemoteFilemanager",
@@ -44,21 +45,25 @@ async def test_fetch_manifest_data_skip(backend: ManifestBackend, fixture_filema
         assert result is None
 
 
-# TODO
-# @pytest.mark.asyncio
-# async def test_fetch_manifest_data_fail(backend: ManifestBackend, fixture_filemanager) -> None:
-#     """Verify that the fetch_manifest_data method returns FAIL code when an error occurs"""
-#     with patch.object(
-#         fixture_filemanager,
-#         "get_file",
-#         return_value=(GetManifestResultCode.FAIL, None),
-#     ) as mock_get_file:
-#         get_file_result_code, result = await backend.fetch_manifest_data()
+# TODO do we need this?
+@pytest.mark.asyncio
+async def test_fetch_manifest_data_fail(backend: ManifestBackend, fixture_filemanager) -> None:
+    """Verify that the fetch_manifest_data method returns FAIL code when an error occurs"""
+    with patch(
+        "merino.providers.manifest.backends.manifest.ManifestRemoteFilemanager",
+        return_value=fixture_filemanager,
+    ):
+        with patch.object(
+            fixture_filemanager,
+            "get_file",
+            return_value=(GetManifestResultCode.FAIL, None),
+        ) as mock_get_file:
+            get_file_result_code, result = await backend.fetch_manifest_data()
 
-#         assert get_file_result_code is GetManifestResultCode.FAIL
-#         assert result is None
+            assert get_file_result_code is GetManifestResultCode.FAIL
+            assert result is None
 
-#         mock_get_file.assert_called_once()
+            mock_get_file.assert_called_once()
 
 
 # TODO duplicate test except last assert

--- a/tests/unit/providers/manifest/backends/test_manifest.py
+++ b/tests/unit/providers/manifest/backends/test_manifest.py
@@ -43,6 +43,7 @@ async def test_fetch_manifest_data_skip(backend: ManifestBackend, fixture_filema
         assert get_file_result_code is GetManifestResultCode.FAIL
         assert result is None
 
+
 # TODO
 # @pytest.mark.asyncio
 # async def test_fetch_manifest_data_fail(backend: ManifestBackend, fixture_filemanager) -> None:

--- a/tests/unit/providers/manifest/backends/test_manifest.py
+++ b/tests/unit/providers/manifest/backends/test_manifest.py
@@ -4,27 +4,23 @@
 
 """Unit tests for the Manifest backend module."""
 
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 import pytest
-from merino.providers.manifest.backends.filemanager import ManifestRemoteFilemanager
 from merino.providers.manifest.backends.protocol import GetManifestResultCode
 from merino.providers.manifest.backends.manifest import ManifestBackend
 
 
-def test_fetch_manifest_data(
-    manifest_remote_filemanager: ManifestRemoteFilemanager,
-    backend: ManifestBackend,
-    gcs_blob_mock,
-) -> None:
+@pytest.mark.asyncio
+async def test_fetch_manifest_data(backend: ManifestBackend, fixture_filemanager) -> None:
     """Verify that the fetch_manifest_data method returns manifest data on success"""
-    manifest_remote_filemanager.gcs_client = MagicMock()
-    manifest_remote_filemanager.gcs_client.get_file_by_name.return_value = gcs_blob_mock
-
+    # Since we only initialize ManifestRemoteFilemanager inside the fetch_manifest_data function,
+    # we will have to patch the actual path for ManifestRemoteFilemanager class with our fixture.
     with patch(
         "merino.providers.manifest.backends.manifest.ManifestRemoteFilemanager",
-        return_value=manifest_remote_filemanager,
+        return_value=fixture_filemanager,
     ):
-        get_file_result_code, result = backend.fetch_manifest_data()
+        # call our backend function
+        get_file_result_code, result = await backend.fetch_manifest_data()
 
         assert get_file_result_code is GetManifestResultCode.SUCCESS
         assert result is not None
@@ -33,62 +29,48 @@ def test_fetch_manifest_data(
         assert result.domains[1].domain == "microsoft"
 
 
-def test_fetch_manifest_data_skip(
-    manifest_remote_filemanager: ManifestRemoteFilemanager,
-    backend: ManifestBackend,
-) -> None:
+@pytest.mark.asyncio
+async def test_fetch_manifest_data_skip(backend: ManifestBackend, fixture_filemanager) -> None:
+    # TODO fix comment
     """Verify that the fetch_manifest_data method returns SKIP code for no new blob generation"""
-    manifest_remote_filemanager.gcs_client = MagicMock()
-    manifest_remote_filemanager.gcs_client.get_file_by_name.return_value = None
-
+    fixture_filemanager.bucket.get_blob.return_value = None
     with patch(
         "merino.providers.manifest.backends.manifest.ManifestRemoteFilemanager",
-        return_value=manifest_remote_filemanager,
+        return_value=fixture_filemanager,
     ):
-        get_file_result_code, result = backend.fetch_manifest_data()
+        get_file_result_code, result = await backend.fetch_manifest_data()
 
-        assert get_file_result_code is GetManifestResultCode.SKIP
+        assert get_file_result_code is GetManifestResultCode.FAIL
         assert result is None
 
+# TODO
+# @pytest.mark.asyncio
+# async def test_fetch_manifest_data_fail(backend: ManifestBackend, fixture_filemanager) -> None:
+#     """Verify that the fetch_manifest_data method returns FAIL code when an error occurs"""
+#     with patch.object(
+#         fixture_filemanager,
+#         "get_file",
+#         return_value=(GetManifestResultCode.FAIL, None),
+#     ) as mock_get_file:
+#         get_file_result_code, result = await backend.fetch_manifest_data()
 
-def test_fetch_manifest_data_fail(
-    manifest_remote_filemanager: ManifestRemoteFilemanager,
-    backend: ManifestBackend,
-) -> None:
-    """Verify that the fetch_manifest_data method returns FAIL code when an error occurs"""
-    manifest_remote_filemanager.gcs_client = MagicMock()
-    manifest_remote_filemanager.gcs_client.get_file_by_name.return_value = None
+#         assert get_file_result_code is GetManifestResultCode.FAIL
+#         assert result is None
 
-    with patch(
-        "merino.providers.manifest.backends.manifest.ManifestRemoteFilemanager",
-        return_value=manifest_remote_filemanager,
-    ):
-        with patch.object(
-            manifest_remote_filemanager,
-            "get_file",
-            return_value=(GetManifestResultCode.FAIL, None),
-        ) as mock_get_file:
-            get_file_result_code, result = backend.fetch_manifest_data()
-
-            assert get_file_result_code is GetManifestResultCode.FAIL
-            assert result is None
-
-            mock_get_file.assert_called_once()
+#         mock_get_file.assert_called_once()
 
 
+# TODO duplicate test except last assert
 @pytest.mark.asyncio
 async def test_fetch(
-    manifest_remote_filemanager: ManifestRemoteFilemanager,
     backend: ManifestBackend,
+    fixture_filemanager,
     gcs_blob_mock,
 ) -> None:
     """Verify that the fetch method returns manifest data"""
-    manifest_remote_filemanager.gcs_client = MagicMock()
-    manifest_remote_filemanager.gcs_client.get_file_by_name.return_value = gcs_blob_mock
-
     with patch(
         "merino.providers.manifest.backends.manifest.ManifestRemoteFilemanager",
-        return_value=manifest_remote_filemanager,
+        return_value=fixture_filemanager,
     ):
         get_file_result_code, result = await backend.fetch()
 

--- a/tests/unit/providers/manifest/conftest.py
+++ b/tests/unit/providers/manifest/conftest.py
@@ -40,7 +40,6 @@ def cleanup_tasks_fixture():
 def fixture_manifest_remote_filemanager_parameters() -> dict[str, Any]:
     """Define ManifestRemoteFilemanager parameters for test."""
     return {
-        "gcs_project_path": "test_gcp_uploader_project",
         "gcs_bucket_path": "test_gcp_uploader_bucket",
         "blob_name": "test_blob_name",
     }

--- a/tests/unit/providers/manifest/conftest.py
+++ b/tests/unit/providers/manifest/conftest.py
@@ -44,7 +44,7 @@ def fixture_manifest_remote_filemanager_parameters() -> dict[str, Any]:
         "blob_name": "test_blob_name",
     }
 
-
+# TODO REFACTOR THIS
 @pytest.fixture(name="manifest_remote_filemanager")
 def fixture_manifest_remote_filemanager(
     manifest_remote_filemanager_parameters: dict[str, Any], gcs_client_mock

--- a/tests/unit/providers/manifest/test_provider.py
+++ b/tests/unit/providers/manifest/test_provider.py
@@ -34,7 +34,7 @@ async def test_initialize(
         assert manifest_provider.manifest_data == manifest_data
         assert manifest_provider.last_fetch_at > 0
 
-
+# TODO REFACTOR THIS
 @pytest.mark.asyncio
 async def test_get_manifest_data(
     manifest_provider: Provider, manifest_data: ManifestData, cleanup
@@ -53,20 +53,20 @@ async def test_get_manifest_data(
         assert manifest_provider.manifest_data == manifest_data
 
 
-@pytest.mark.asyncio
-async def test_get_manifest_data_empty_data(manifest_provider: Provider, cleanup) -> None:
-    """Test get_manifest_data method returns empty manifest data object if backend returns SKIP"""
-    with patch(
-        "merino.providers.manifest.backends.manifest.ManifestBackend.fetch",
-        return_value=(GetManifestResultCode.SKIP, None),
-    ):
-        await manifest_provider.initialize()
-        await cleanup(manifest_provider)
+# @pytest.mark.asyncio
+# async def test_get_manifest_data_empty_data(manifest_provider: Provider, cleanup) -> None:
+#     """Test get_manifest_data method returns empty manifest data object if backend returns SKIP"""
+#     with patch(
+#         "merino.providers.manifest.backends.manifest.ManifestBackend.fetch",
+#         return_value=(GetManifestResultCode.SKIP, None),
+#     ):
+#         await manifest_provider.initialize()
+#         await cleanup(manifest_provider)
 
-        manifest_data = manifest_provider.get_manifest_data()
+#         manifest_data = manifest_provider.get_manifest_data()
 
-        assert manifest_data is not None
-        assert manifest_data.domains == []
+#         assert manifest_data is not None
+#         assert manifest_data.domains == []
 
 
 @pytest.mark.asyncio
@@ -129,21 +129,21 @@ async def test_fetch_data_success(
         assert manifest_provider.manifest_data == manifest_data
 
 
-@pytest.mark.asyncio
-async def test_fetch_data_skip(manifest_provider: Provider, cleanup) -> None:
-    """Test fetch_data method does not set manifest data on SKIP"""
-    with patch(
-        "merino.providers.manifest.backends.manifest.ManifestBackend.fetch",
-        return_value=(GetManifestResultCode.SKIP, None),
-    ):
-        await manifest_provider.initialize()
-        await cleanup(manifest_provider)
+# @pytest.mark.asyncio
+# async def test_fetch_data_skip(manifest_provider: Provider, cleanup) -> None:
+#     """Test fetch_data method does not set manifest data on SKIP"""
+#     with patch(
+#         "merino.providers.manifest.backends.manifest.ManifestBackend.fetch",
+#         return_value=(GetManifestResultCode.SKIP, None),
+#     ):
+#         await manifest_provider.initialize()
+#         await cleanup(manifest_provider)
 
-        await manifest_provider._fetch_data()
+#         await manifest_provider._fetch_data()
 
-        # manifest data remains empty ManifestData instance after initialization
-        assert manifest_provider.manifest_data is not None
-        assert manifest_provider.manifest_data.domains == []
+#         # manifest data remains empty ManifestData instance after initialization
+#         assert manifest_provider.manifest_data is not None
+#         assert manifest_provider.manifest_data.domains == []
 
 
 @pytest.mark.asyncio

--- a/tests/unit/providers/manifest/test_provider.py
+++ b/tests/unit/providers/manifest/test_provider.py
@@ -34,6 +34,7 @@ async def test_initialize(
         assert manifest_provider.manifest_data == manifest_data
         assert manifest_provider.last_fetch_at > 0
 
+
 # TODO REFACTOR THIS
 @pytest.mark.asyncio
 async def test_get_manifest_data(

--- a/tests/unit/providers/manifest/test_provider.py
+++ b/tests/unit/providers/manifest/test_provider.py
@@ -54,6 +54,7 @@ async def test_get_manifest_data(
         assert manifest_provider.manifest_data == manifest_data
 
 
+# TODO do we need this?
 # @pytest.mark.asyncio
 # async def test_get_manifest_data_empty_data(manifest_provider: Provider, cleanup) -> None:
 #     """Test get_manifest_data method returns empty manifest data object if backend returns SKIP"""
@@ -130,6 +131,7 @@ async def test_fetch_data_success(
         assert manifest_provider.manifest_data == manifest_data
 
 
+# TODO do we need this?
 # @pytest.mark.asyncio
 # async def test_fetch_data_skip(manifest_provider: Provider, cleanup) -> None:
 #     """Test fetch_data method does not set manifest data on SKIP"""


### PR DESCRIPTION
## References

JIRA: [DISCO-3210](https://mozilla-hub.atlassian.net/browse/DISCO-3210)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3210]: https://mozilla-hub.atlassian.net/browse/DISCO-3210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ