### PR TITLE
[DISCO-3207] [load test: skip] Remove mermaid architeture diagram config values

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -62,12 +62,6 @@ Merino wool (from Merino sheep) produces exceptionally smooth felt.
 ## Architecture
 
 ```mermaid
----
-config:
-  look: neo
-  layout: elk
-  theme: default
----
 flowchart TD
 subgraph Firefox["fa:fa-firefox-browser Firefox"]
         NewTab


### PR DESCRIPTION
## References

JIRA: [DISCO-3207](https://mozilla-hub.atlassian.net/browse/DISCO-3207)

## Description
Architecture diagram on Github Pages is broken possibly due to the addition of config values. Removing those for it to render correctly.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3207]: https://mozilla-hub.atlassian.net/browse/DISCO-3207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ