### PR TITLE
[DISCO-3251] fix flaky amo test

### DIFF
--- a/tests/unit/providers/suggest/amo/backends/test_dynamic.py
+++ b/tests/unit/providers/suggest/amo/backends/test_dynamic.py
@@ -132,6 +132,7 @@ async def test_fetch_addons_skipped_bad_response(
     mocker: MockerFixture, caplog: LogCaptureFixture, dynamic_backend: DynamicAmoBackend
 ):
     """Test that fetch fails raises error when Addon request fails."""
+    caplog.set_level(logging.ERROR, logger="merino.providers.suggest.amo.backends.dynamic")
     sample_addon_resp = json.dumps(
         {
             "icon_url": "https://this.is.image",


### PR DESCRIPTION
## References

JIRA: [DISCO-3251](https://mozilla-hub.atlassian.net/browse/DISCO-3251)

## Description
Follow up to this PR https://github.com/mozilla-services/merino-py/pull/789, adding filtering to a flaky test. this is a temporary fix till we can figure out why the tests are flaky.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3251]: https://mozilla-hub.atlassian.net/browse/DISCO-3251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ