### PR TITLE
[DISCO-3247] fix: weather pathfinder to use region when None

### DIFF
--- a/merino/providers/suggest/weather/backends/accuweather/backend.py
+++ b/merino/providers/suggest/weather/backends/accuweather/backend.py
@@ -729,7 +729,7 @@ class AccuweatherBackend:
         """
         geolocation = weather_context.geolocation
         country = geolocation.country
-        city = geolocation.city
+        city = weather_context.selected_city
         region = weather_context.selected_region
 
         if country is None or city is None:

--- a/merino/providers/suggest/weather/backends/accuweather/pathfinder.py
+++ b/merino/providers/suggest/weather/backends/accuweather/pathfinder.py
@@ -155,21 +155,19 @@ async def explore(
     for city in cities:
         if city in explored_cities:
             continue
-        else:
-            explored_cities.append(city)
-            for region in compass(weather_context.geolocation):
-                if country and city and (country, region, city) in SKIP_CITIES_MAPPING:
-                    # increment since we tried to look up this combo again.
-                    increment_skip_cities_mapping(country, region, city)
+        explored_cities.append(city)
+        for region in compass(weather_context.geolocation):
+            if country and city and (country, region, city) in SKIP_CITIES_MAPPING:
+                # increment since we tried to look up this combo again.
+                increment_skip_cities_mapping(country, region, city)
+                return None, True
 
-                    return None, True
+            weather_context.selected_region = region
+            weather_context.selected_city = city
+            res = await probe(weather_context)
 
-                weather_context.selected_region = region
-                weather_context.selected_city = city
-                res = await probe(weather_context)
-
-                if res is not None:
-                    return res, is_skipped
+            if res is not None:
+                return res, is_skipped
 
     return None, is_skipped
 

--- a/merino/providers/suggest/weather/backends/accuweather/pathfinder.py
+++ b/merino/providers/suggest/weather/backends/accuweather/pathfinder.py
@@ -150,26 +150,26 @@ async def explore(
     city = CITY_NAME_CORRECTION_MAPPING.get(geolocation.city, geolocation.city)
     # map is lazy, so items of `cities` would only be evaluated one by one if needed
     cities = map(lambda fn: fn(city), CITY_NAME_NORMALIZERS)
-    for region in compass(weather_context.geolocation):
-        # store the explored cities to avoid duplicates
-        explored_cities: list[str] = []
-        for city in cities:
-            if city in explored_cities:
-                continue
-            else:
-                explored_cities.append(city)
-            if country and city and (country, region, city) in SKIP_CITIES_MAPPING:
-                # increment since we tried to look up this combo again.
-                increment_skip_cities_mapping(country, region, city)
+    # store the explored cities to avoid duplicates
+    explored_cities: list[str] = []
+    for city in cities:
+        if city in explored_cities:
+            continue
+        else:
+            explored_cities.append(city)
+            for region in compass(weather_context.geolocation):
+                if country and city and (country, region, city) in SKIP_CITIES_MAPPING:
+                    # increment since we tried to look up this combo again.
+                    increment_skip_cities_mapping(country, region, city)
 
-                return None, True
+                    return None, True
 
-            weather_context.selected_region = region
-            weather_context.selected_city = city
-            res = await probe(weather_context)
+                weather_context.selected_region = region
+                weather_context.selected_city = city
+                res = await probe(weather_context)
 
-            if res is not None:
-                return res, is_skipped
+                if res is not None:
+                    return res, is_skipped
 
     return None, is_skipped
 

--- a/tests/unit/providers/suggest/weather/backends/test_accuweather.py
+++ b/tests/unit/providers/suggest/weather/backends/test_accuweather.py
@@ -1647,6 +1647,7 @@ async def test_get_location_by_geolocation(
         key="39376", localized_name="San Francisco", administrative_area_id="CA"
     )
     weather_context_without_location_key.selected_region = "CA"
+    weather_context_without_location_key.selected_city = "San Francisco"
     client_mock: AsyncMock = cast(AsyncMock, accuweather.http_client)
     client_mock.get.return_value = Response(
         status_code=200,
@@ -1728,6 +1729,7 @@ async def test_get_location_by_geolocation_error(
     """
     expected_error_value: str = "Unexpected location response from: /locations/v1/cities/US/CA/search.json, city: San Francisco"
     weather_context_without_location_key.selected_region = "CA"
+    weather_context_without_location_key.selected_city = "San Francisco"
     client_mock: AsyncMock = cast(AsyncMock, accuweather.http_client)
     client_mock.get.return_value = Response(
         status_code=403,
@@ -1764,6 +1766,7 @@ async def test_get_location_by_geolocation_raises_accuweather_error_on_generic_e
     client_mock: AsyncMock = cast(AsyncMock, accuweather.http_client)
     client_mock.get.side_effect = ValueError
     weather_context_without_location_key.selected_region = "CA"
+    weather_context_without_location_key.selected_city = "San Francisco"
 
     with pytest.raises(AccuweatherError) as accuweather_error:
         await accuweather.get_location_by_geolocation(weather_context_without_location_key)

--- a/tests/unit/providers/suggest/weather/backends/test_pathfinder.py
+++ b/tests/unit/providers/suggest/weather/backends/test_pathfinder.py
@@ -4,7 +4,7 @@
 
 """Unit tests for the Accuweather pathfinder module."""
 
-from unittest.mock import AsyncMock, _Call, call
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -66,109 +66,31 @@ def test_compass(location: Location, expected_region_and_city: str) -> None:
 
 
 @pytest.mark.parametrize(
-    ("weather_context", "expected_calls"),
+    ("weather_context", "expected_calls_count"),
     [
         (
             WeatherContext(
-                Location(country="CA", regions=["BC"], city="Accènted City"), languages=["en-US"]
+                Location(country="AA", regions=["BC"], city="Accènted City"), languages=["en-US"]
             ),
-            [
-                call(
-                    WeatherContext(
-                        geolocation=Location(
-                            country="CA",
-                            country_name=None,
-                            regions=["BC"],
-                            region_names=None,
-                            city="Accènted City",
-                            dma=None,
-                            postal_code=None,
-                            key=None,
-                            coordinates=None,
-                        ),
-                        languages=["en-US"],
-                        selected_region="BC",
-                        selected_city="Accented",
-                        distance_calculation=None,
-                    )
-                ),
-                call(
-                    WeatherContext(
-                        geolocation=Location(
-                            country="CA",
-                            country_name=None,
-                            regions=["BC"],
-                            region_names=None,
-                            city="Accènted City",
-                            dma=None,
-                            postal_code=None,
-                            key=None,
-                            coordinates=None,
-                        ),
-                        languages=["en-US"],
-                        selected_region="BC",
-                        selected_city="Accented",
-                        distance_calculation=None,
-                    )
-                ),
-                call(
-                    WeatherContext(
-                        geolocation=Location(
-                            country="CA",
-                            country_name=None,
-                            regions=["BC"],
-                            region_names=None,
-                            city="Accènted City",
-                            dma=None,
-                            postal_code=None,
-                            key=None,
-                            coordinates=None,
-                        ),
-                        languages=["en-US"],
-                        selected_region="BC",
-                        selected_city="Accented",
-                        distance_calculation=None,
-                    )
-                ),
-            ],
+            6,
         ),
         (
             WeatherContext(
                 Location(country="CA", regions=["BC"], city="Plain"), languages=["en-US"]
             ),
-            [
-                call(
-                    WeatherContext(
-                        geolocation=Location(
-                            country="CA",
-                            country_name=None,
-                            regions=["BC"],
-                            region_names=None,
-                            city="Plain",
-                            dma=None,
-                            postal_code=None,
-                            key=None,
-                            coordinates=None,
-                        ),
-                        languages=["en-US"],
-                        selected_region="BC",
-                        selected_city="Plain",
-                        distance_calculation=None,
-                    )
-                ),
-            ],
+            1,
         ),
     ],
 )
 @pytest.mark.asyncio
 async def test_explore_uses_all_the_right_city_combos(
-    weather_context: WeatherContext, expected_calls: list[_Call]
+    weather_context: WeatherContext, expected_calls_count: int
 ) -> None:
     """Test we try the number of right cities."""
     mock_probe = AsyncMock(return_value=None)
 
     _ = await explore(weather_context, mock_probe)
-    assert mock_probe.mock_calls == expected_calls
+    assert len(mock_probe.call_args_list) == expected_calls_count
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## References

JIRA: [DISCO-3247](https://mozilla-hub.atlassian.net/browse/DISCO-3247)

## Description
We tried to be fancy and it sort of bit us. We can't iterate over a map twice, so I swapped the two for loops. so we can keep map. In theory there's only a small number of edge cases where the first iteration is not successful and we would have more iterations then if the for loop order was swapped



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3247]: https://mozilla-hub.atlassian.net/browse/DISCO-3247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ