### PR TITLE
[HNT-402] updating item identifier in engagement backend

### DIFF
--- a/merino/curated_recommendations/engagement_backends/protocol.py
+++ b/merino/curated_recommendations/engagement_backends/protocol.py
@@ -30,7 +30,7 @@ class Engagement(BaseModel):
 class EngagementBackend(Protocol):
     """Protocol for Engagement backend that the provider depends on."""
 
-    def get(self, scheduled_corpus_item_id: str, region: str | None = None) -> Engagement | None:
+    def get(self, corpus_item_id: str, region: str | None = None) -> Engagement | None:
         """Fetch engagement data for the given scheduled corpus item id and optionally region"""
         ...
 

--- a/merino/curated_recommendations/rankers.py
+++ b/merino/curated_recommendations/rankers.py
@@ -38,7 +38,7 @@ def thompson_sampling(
     CTR with exploration of new items using a prior.
 
     :param recs: A list of recommendations in the desired order (pre-publisher spread).
-    :param engagement_backend: Provides aggregate click and impression engagement by scheduledCorpusItemId.
+    :param engagement_backend: Provides aggregate click and impression engagement by corpusItemId.
     :param prior_backend: Provides prior alpha and beta values for Thompson sampling.
     :param enable_region_engagement: If True, regional engagement weighs higher. False by default.
     :param region: Optionally, the client's region, e.g. 'US'.
@@ -54,7 +54,7 @@ def thompson_sampling(
         rec: CuratedRecommendation, region_query: str | None = None
     ) -> tuple[float, float]:
         """Get opens and no-opens counts for a recommendation, optionally in a region."""
-        engagement = engagement_backend.get(rec.scheduledCorpusItemId, region_query)
+        engagement = engagement_backend.get(rec.corpusItemId, region_query)
         if engagement:
             return engagement.click_count, engagement.impression_count - engagement.click_count
         else:

--- a/tests/integration/api/v1/curated_recommendations/engagement_backends/test_gcs_engagement.py
+++ b/tests/integration/api/v1/curated_recommendations/engagement_backends/test_gcs_engagement.py
@@ -76,24 +76,24 @@ def blob(gcs_bucket):
     return create_blob(
         gcs_bucket,
         [
-            {"scheduled_corpus_item_id": "1A", "click_count": 30, "impression_count": 300},
-            {"scheduled_corpus_item_id": "6A", "click_count": 40, "impression_count": 400},
+            {"corpus_item_id": "1A", "click_count": 30, "impression_count": 300},
+            {"corpus_item_id": "6A", "click_count": 40, "impression_count": 400},
             # Some records have a region
             {
-                "scheduled_corpus_item_id": "1A",
+                "corpus_item_id": "1A",
                 "region": "US",
                 "click_count": 3,
                 "impression_count": 9,
             },
             {
-                "scheduled_corpus_item_id": "6A",
+                "corpus_item_id": "6A",
                 "region": "US",
                 "click_count": 4,
                 "impression_count": 9,
             },
-            # Some records have a corpus_item_id
+            # Some records have a scheduled_corpus_item_id
             {
-                "corpus_item_id": "C1",
+                "scheduled_corpus_item_id": "C1",
                 "click_count": 50,
                 "impression_count": 100,
             },
@@ -146,10 +146,10 @@ async def test_gcs_engagement_fetches_data(gcs_storage_client, gcs_bucket, metri
     await wait_until_engagement_is_updated(gcs_engagement)
 
     assert gcs_engagement.get("1A") == Engagement(
-        scheduled_corpus_item_id="1A", click_count=30, impression_count=300
+        corpus_item_id="1A", click_count=30, impression_count=300
     )
     assert gcs_engagement.get("6A") == Engagement(
-        scheduled_corpus_item_id="6A", click_count=40, impression_count=400
+        corpus_item_id="6A", click_count=40, impression_count=400
     )
 
 
@@ -162,10 +162,10 @@ async def test_gcs_engagement_fetches_region_data(
     await wait_until_engagement_is_updated(gcs_engagement)
 
     assert gcs_engagement.get("6A") == Engagement(
-        scheduled_corpus_item_id="6A", click_count=40, impression_count=400
+        corpus_item_id="6A", click_count=40, impression_count=400
     )
     assert gcs_engagement.get("6A", "US") == Engagement(
-        scheduled_corpus_item_id="6A", region="US", click_count=4, impression_count=9
+        corpus_item_id="6A", region="US", click_count=4, impression_count=9
     )
 
     # Fixture does not contain data for AU, so None should be returned.

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -55,15 +55,15 @@ from tests.integration.api.conftest import fakespot_feed
 class MockEngagementBackend(EngagementBackend):
     """Mock class implementing the protocol for EngagementBackend."""
 
-    def get(self, scheduled_corpus_item_id: str, region: str | None = None) -> Engagement | None:
+    def get(self, corpus_item_id: str, region: str | None = None) -> Engagement | None:
         """Return random click and impression counts based on the scheduled corpus id and region."""
-        seed_input = "_".join(filter(None, [scheduled_corpus_item_id, region]))
+        seed_input = "_".join(filter(None, [corpus_item_id, region]))
         rng = np.random.default_rng(seed=int.from_bytes(seed_input.encode()))
 
-        if scheduled_corpus_item_id == "50f86ebe-3f25-41d8-bd84-53ead7bdc76e":
+        if corpus_item_id == "0d186d8b-9b81-4447-926c-0dcecbd6e95f":
             # Give the first item 100% click-through rate to put it on top with high certainty.
             return Engagement(
-                scheduled_corpus_item_id=scheduled_corpus_item_id,
+                corpus_item_id=corpus_item_id,
                 click_count=1000000,
                 impression_count=1000000,
             )
@@ -73,7 +73,7 @@ class MockEngagementBackend(EngagementBackend):
         else:
             # Uniformly random clicks (10k-50k) and impressions (1M-5M)
             return Engagement(
-                scheduled_corpus_item_id=scheduled_corpus_item_id,
+                corpus_item_id=corpus_item_id,
                 click_count=rng.integers(10_000, 50_000),
                 impression_count=rng.integers(1_000_000, 5_000_000),
             )
@@ -1216,13 +1216,13 @@ class TestCorpusApiRanking:
                 corpus_items = data["data"]
 
                 # Assert that no response was ranked in the same way before.
-                id_order = [item["scheduledCorpusItemId"] for item in corpus_items]
+                id_order = [item["corpusItemId"] for item in corpus_items]
                 assert id_order not in past_id_orders, f"Duplicate order at iteration {i}."
                 past_id_orders.append(id_order)  # a list of lists with all orders
 
                 engagement_region = derived_region if regional_ranking_is_expected else None
                 engagements = [
-                    engagement_backend.get(item["scheduledCorpusItemId"], region=engagement_region)
+                    engagement_backend.get(item["corpusItemId"], region=engagement_region)
                     for item in corpus_items
                 ]
                 ctr_by_rank = [


### PR DESCRIPTION
## References

JIRA: [HNT-402](https://mozilla-hub.atlassian.net/browse/HNT-402)

## Description

We updated Thompson sampling to rank on the `corpus_item_id` in anticipation of the section-based layout for new tab using `corpus_item_id` as the item identifier.  Engagement data will have both `corpus_item_id` and `scheduled_item_id` for now but ranking will be based on the `corpus_item_id` for Thompson sampling within individual sections.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[HNT-402]: https://mozilla-hub.atlassian.net/browse/HNT-402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ