### PR TITLE
[DISCO-3134] Fix Test Artifacts Upload to GCS on Failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,11 +62,6 @@ workflows:
           requires:
             - unit-tests
             - integration-tests
-      - upload-test-artifacts:
-          <<: *main-filters
-          requires:
-            - unit-tests
-            - integration-tests
       - docker-image-build:
           <<: *main-filters
       - docker-image-build-locust:
@@ -101,6 +96,7 @@ jobs:
     executor: python-executor
     steps:
       - checkout
+      - gcp-cli/setup
       - run:
           name: Create Workspace
           command: mkdir -p workspace
@@ -118,6 +114,14 @@ jobs:
           root: workspace
           paths:
             - test-results
+      - upload_to_gcs:
+          source: workspace/test-results
+          destination: gs://ecosystem-test-eng-metrics/merino-py/junit
+          extension: xml
+      - upload_to_gcs:
+          source: workspace/test-results
+          destination: gs://ecosystem-test-eng-metrics/merino-py/coverage
+          extension: json
   integration-tests:
     executor: ubuntu-executor
     steps:
@@ -125,6 +129,7 @@ jobs:
       - run:
           name: Create Workspace
           command: mkdir -p workspace
+      - gcp-cli/setup
       - setup-python-on-machine
       - run:
           name: Integration tests
@@ -140,6 +145,14 @@ jobs:
           root: workspace
           paths:
             - test-results
+      - upload_to_gcs:
+          source: workspace/test-results
+          destination: gs://ecosystem-test-eng-metrics/merino-py/junit
+          extension: xml
+      - upload_to_gcs:
+          source: workspace/test-results
+          destination: gs://ecosystem-test-eng-metrics/merino-py/coverage
+          extension: json
   test-coverage-check:
     executor: python-executor
     steps:
@@ -151,21 +164,6 @@ jobs:
           command: make test-coverage-check
           environment:
             TEST_RESULTS_DIR: workspace/test-results
-  upload-test-artifacts:
-    executor: gcp-cli/default
-    steps:
-      - attach_workspace:
-          at: workspace
-      - gcp-cli/setup:
-          version: 404.0.0
-      - upload_to_gcs:
-          source: workspace/test-results
-          destination: gs://ecosystem-test-eng-metrics/merino-py/junit
-          extension: xml
-      - upload_to_gcs:
-          source: workspace/test-results
-          destination: gs://ecosystem-test-eng-metrics/merino-py/coverage
-          extension: json
   docker-image-build:
     executor: image-build-executor
     steps:
@@ -369,13 +367,18 @@ commands:
     steps:
       - run:
           name: Upload << parameters.source >> << parameters.extension >> Files to GCS
+          when: always  # Ensure the step runs even if previous steps, like test runs, fail
           command: |
-            FILES=$(find << parameters.source >> -maxdepth 1 -type f -name "*.<< parameters.extension >>")
-            if [ -z "$FILES" ]; then
-              echo "No << parameters.extension >> files found in << parameters.source >>/"
-              exit 1
+            if [ "$CIRCLE_BRANCH" = "main" ]; then
+              FILES=$(ls -1 << parameters.source>>/*.<< parameters.extension>> )
+              if [ -z "$FILES" ]; then
+                echo "No << parameters.extension >> files found in << parameters.source >>/"
+                exit 1
+              fi
+              gsutil cp $FILES << parameters.destination >>
+            else
+              echo "Skipping artifact upload, not on 'main' branch."
             fi
-            gsutil cp $FILES << parameters.destination >>
 
   write-version:
     steps:

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ POETRY := $(shell command -v poetry 2> /dev/null)
 # In order to be consumed by the ETE Test Metric Pipeline, files need to follow a strict naming
 # convention: {job_number}__{utc_epoch_datetime}__{workflow}__{test_suite}__results{-index}.xml
 WORKFLOW := main-workflow
-EPOCH_TIME := $(shell date +%s)
+EPOCH_TIME := $(shell date +"%s")
 TEST_FILE_PREFIX := $(if $(CIRCLECI),$(CIRCLE_BUILD_NUM)__$(EPOCH_TIME)__$(CIRCLE_PROJECT_REPONAME)__$(WORKFLOW)__)
 UNIT_JUNIT_XML := $(TEST_RESULTS_DIR)/$(TEST_FILE_PREFIX)unit__results.xml
 UNIT_COVERAGE_JSON := $(TEST_RESULTS_DIR)/$(TEST_FILE_PREFIX)unit__coverage.json


### PR DESCRIPTION
## References

JIRA: [DISCO-3134](https://mozilla-hub.atlassian.net/browse/DISCO-3134)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->

Uploading test artifacts using the 'upload-test-artifacts' job will not work should one of its dependent test jobs fail. This fix uses a step with the directive to run 'when: always' to assure artifact upload.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3134]: https://mozilla-hub.atlassian.net/browse/DISCO-3134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ