### PR TITLE
[DISCO-3148] add GH Action workflows for docs build & publish pages jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,9 +14,6 @@ executors:
   image-build-executor:
     docker:
       - image: cimg/base:2025.02
-  node-executor:
-    docker:
-      - image: cimg/node:16.18.1
   python-executor:
     docker:
       - image: cimg/python:3.12
@@ -44,8 +41,6 @@ workflows:
           <<: *pr-filters
       - docker-image-build-locust:
           <<: *pr-filters
-      - docs-build:
-          <<: *pr-filters
 
   main-workflow:
     jobs:
@@ -66,12 +61,6 @@ workflows:
           <<: *main-filters
       - docker-image-build-locust:
           <<: *main-filters
-      - docs-build:
-          <<: *main-filters
-      - docs-publish-github-pages:
-          <<: *main-filters
-          requires:
-            - docs-build
       - docker-image-publish-locust:
           <<: *main-filters
           requires:
@@ -272,57 +261,6 @@ jobs:
             docker images
             docker push "${DOCKERHUB_MERINO_LOCUST_REPO}:${DOCKER_TAG}"
             docker push "${DOCKERHUB_MERINO_LOCUST_REPO}:latest"
-  docs-build:
-    executor: image-build-executor
-    steps:
-      - checkout
-      - run:
-          name: Setup Build docs
-          command: |
-            mkdir bin
-            echo 'export PATH=$(pwd)/bin:"$PATH"' >> "$BASH_ENV"
-            source "$BASH_ENV"
-            curl -sSL \
-              https://github.com/rust-lang/mdBook/releases/download/v0.4.24/mdbook-v0.4.24-x86_64-unknown-linux-gnu.tar.gz \
-              | tar -xz --directory=bin
-            curl -sSL \
-              https://github.com/badboy/mdbook-mermaid/releases/download/v0.12.6/mdbook-mermaid-v0.12.6-x86_64-unknown-linux-gnu.tar.gz \
-              | tar -xz --directory=bin
-      - run:
-          name: Build docs
-          command: |
-            mdbook-mermaid install ./
-            ./dev/make-all-docs.sh
-            mkdir workspace
-            cp -r ./book workspace/doc
-      - persist_to_workspace:
-          root: workspace
-          paths:
-            - doc
-  docs-publish-github-pages:
-    executor: node-executor
-    steps:
-      - checkout
-      - attach_workspace:
-          at: workspace
-      - run:
-          name: Disable jekyll builds
-          command: touch workspace/doc/.nojekyll
-      - add_ssh_keys:
-          fingerprints:
-            - "af:ac:a0:85:b4:a1:af:4d:e1:08:42:b5:16:e3:67:2d"
-      - run:
-          name: Set remote origin if needed
-          command: |
-            git remote add origin git@github.com:mozilla-services/merino-py.git || true
-      - run:
-          name: Deploy docs to gh-pages
-          command: |
-            npx --yes gh-pages@3.0.0 \
-              --user "ci-build <ci-build@merino.mozilla.org>" \
-              --message "[skip ci] Docs updates" \
-              --repo "git@github.com:mozilla-services/merino-py.git" \
-              --dist workspace/doc
 
 commands:
   dockerhub-login:
@@ -367,7 +305,7 @@ commands:
     steps:
       - run:
           name: Upload << parameters.source >> << parameters.extension >> Files to GCS
-          when: always  # Ensure the step runs even if previous steps, like test runs, fail
+          when: always # Ensure the step runs even if previous steps, like test runs, fail
           command: |
             if [ "$CIRCLE_BRANCH" = "main" ]; then
               FILES=$(ls -1 << parameters.source>>/*.<< parameters.extension>> )

--- a/.github/workflows/main-workflow.yaml
+++ b/.github/workflows/main-workflow.yaml
@@ -1,0 +1,111 @@
+name: Production Deployment
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up to run
+        uses: ./.github/actions/weave
+      - name: Run Code Linting
+        run: make -k lint
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up to run
+        uses: ./.github/actions/weave
+      - name: Run unit tests
+        run: make unit-tests
+        env:
+          TEST_RESULTS_DIR: workspace/test-results
+      - name: Generate Test Coverage
+        run: make coverage-unit
+      - uses: actions/upload-artifact@v4
+        with:
+          name: unit-test-results
+          include-hidden-files: true
+          path: |
+            workspace/test-results
+  integration-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up to run
+        uses: ./.github/actions/weave
+      - name: Run Integration Tests
+        run: make integration-tests
+        env:
+          TEST_RESULTS_DIR: workspace/test-results
+      - name: Generate Test Coverage
+        run: make coverage-integration
+      - uses: actions/upload-artifact@v4
+        with:
+          name: integration-test-results
+          include-hidden-files: true
+          path: |
+            workspace/test-results
+  test-coverage-checks:
+    needs: [unit-tests, integration-tests]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up to run
+        uses: ./.github/actions/weave
+      - name: Download All Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: workspace/test-results/
+          merge-multiple: true
+      - name: Evaluate Minimum Test Coverage
+        run: make test-coverage-check
+        env:
+          TEST_RESULTS_DIR: workspace/test-results
+  docs-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Build docs
+        run: |
+          mkdir -p bin
+          echo "PATH=$(pwd)/bin:$PATH" >> $GITHUB_ENV
+          curl -sSL \
+            https://github.com/rust-lang/mdBook/releases/download/v0.4.24/mdbook-v0.4.24-x86_64-unknown-linux-gnu.tar.gz \
+            | tar -xz --directory=bin
+          curl -sSL \
+            https://github.com/badboy/mdbook-mermaid/releases/download/v0.12.6/mdbook-mermaid-v0.12.6-x86_64-unknown-linux-gnu.tar.gz \
+            | tar -xz --directory=bin
+      - name: Build docs
+        run: |
+          mdbook-mermaid install ./
+          ./dev/make-all-docs.sh
+          mkdir workspace
+          cp -r ./book workspace/doc
+      - name: Upload documentation as an artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs
+          path: workspace/doc
+  docs-publish-github-pages:
+    needs: docs-build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download built docs
+        uses: actions/download-artifact@v4
+        with:
+          name: docs
+          path: workspace/doc
+      - name: Disable Jekyll builds
+        run: touch workspace/doc/.nojekyll
+      - name: Deploy docs to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: workspace/doc
+          commit_message: "[skip ci] Update documentation"

--- a/.github/workflows/pr-workflow.yaml
+++ b/.github/workflows/pr-workflow.yaml
@@ -1,6 +1,13 @@
-name: CI Workflow
+name: PR Checks Workflow
 
-on: pull_request
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+    branches-ignore:
+      - main
 
 jobs:
   checks:
@@ -63,3 +70,28 @@ jobs:
         run: make test-coverage-check
         env:
           TEST_RESULTS_DIR: workspace/test-results
+  docs-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Build docs
+        run: |
+          mkdir -p bin
+          echo "PATH=$(pwd)/bin:$PATH" >> $GITHUB_ENV
+          curl -sSL \
+            https://github.com/rust-lang/mdBook/releases/download/v0.4.24/mdbook-v0.4.24-x86_64-unknown-linux-gnu.tar.gz \
+            | tar -xz --directory=bin
+          curl -sSL \
+            https://github.com/badboy/mdbook-mermaid/releases/download/v0.12.6/mdbook-mermaid-v0.12.6-x86_64-unknown-linux-gnu.tar.gz \
+            | tar -xz --directory=bin
+      - name: Build docs
+        run: |
+          mdbook-mermaid install ./
+          ./dev/make-all-docs.sh
+          mkdir workspace
+          cp -r ./book workspace/doc
+      - name: Upload documentation as an artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs
+          path: workspace/doc


### PR DESCRIPTION
## References

JIRA: [DISCO-3148](https://mozilla-hub.atlassian.net/browse/DISCO-3148)

## Description
- Added two workflow files. One that runs on every PR, and one that runs when we push to main. the main workflow does the additional job of publishing the docs. This follows the current setup in circleci



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3148]: https://mozilla-hub.atlassian.net/browse/DISCO-3148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ