### PR TITLE
DISCO 3314: only process in-use images for AMP

### DIFF
--- a/merino/providers/suggest/adm/backends/remotesettings.py
+++ b/merino/providers/suggest/adm/backends/remotesettings.py
@@ -87,6 +87,7 @@ class RemoteSettingsBackend:
         full_keywords: list[str] = []
         results: list[dict[str, Any]] = []
         icons: dict[str, str] = {}
+        icons_in_use: set[str] = set()
 
         records: list[dict[str, Any]] = await self.get_records()
         attachment_host: str = await self.get_attachment_host()
@@ -99,6 +100,7 @@ class RemoteSettingsBackend:
         for suggestion in rs_suggestions:
             result_id = len(results)
             keywords = suggestion.keywords
+            icons_in_use.add(suggestion.icon)
             full_keywords_tuples = suggestion.full_keywords
             begin = 0
             for full_keyword, n in full_keywords_tuples:
@@ -118,6 +120,8 @@ class RemoteSettingsBackend:
 
         for icon in icon_record:
             id = icon["id"].replace("icon-", "")
+            if id not in icons_in_use:
+                continue
             original_icon_url = urljoin(base=attachment_host, url=icon["attachment"]["location"])
             icon_data.append((id, original_icon_url))
 

--- a/tests/integration/providers/suggest/adm/backends/test_remotesettings_icon.py
+++ b/tests/integration/providers/suggest/adm/backends/test_remotesettings_icon.py
@@ -46,6 +46,7 @@ def fixture_rs_records() -> list[dict]:
             "id": "data-01",
             "last_modified": 123,
         },
+        # This icon is in use.
         {
             "type": "icon",
             "schema": 456,
@@ -60,6 +61,7 @@ def fixture_rs_records() -> list[dict]:
             "id": "icon-01",
             "last_modified": 123,
         },
+        # This icon is not in use.
         {
             "type": "icon",
             "schema": 789,
@@ -196,8 +198,8 @@ async def test_remotesettings_with_icon_processor(
     # Fetch the suggestions
     suggestion_content: SuggestionContent = await rs_backend.fetch()
 
-    # Verify that the icon URLs were processed
-    assert len(suggestion_content.icons) == 2  # Should have 2 icons from rs_records
+    # Verify that the in-use icon URLs were processed, the not-in-use one shouldn't be processed.
+    assert len(suggestion_content.icons) == 1
 
     # Check that each icon URL was processed
     for icon_id, icon_url in suggestion_content.icons.items():
@@ -246,7 +248,7 @@ async def test_remotesettings_icon_processor_error_handling(
     suggestion_content: SuggestionContent = await rs_backend.fetch()
 
     # Verify that the icon URLs defaulted to original URLs due to error
-    assert len(suggestion_content.icons) == 2  # Should have 2 icons from rs_records
+    assert len(suggestion_content.icons) == 1
 
     # Check that each icon URL is the original attachment URL
     for icon_id, icon_url in suggestion_content.icons.items():
@@ -310,8 +312,8 @@ async def test_remotesettings_with_gcs_integration(
         # Fetch the suggestions
         suggestion_content: SuggestionContent = await rs_backend.fetch()
 
-        # Verify that the icon URLs were processed
-        assert len(suggestion_content.icons) == 2  # Should have 2 icons from rs_records
+        # Verify that the in-use icon URLs were processed, the not-in-use one shouldn't be processed.
+        assert len(suggestion_content.icons) == 1
 
         # Check that each icon URL points to expected location
         for icon_url in suggestion_content.icons.values():

--- a/tests/unit/utils/test_icon_processor.py
+++ b/tests/unit/utils/test_icon_processor.py
@@ -8,7 +8,10 @@ import pytest
 from pytest_mock import MockerFixture
 
 from merino.configs import settings
-from merino.providers.suggest.adm.backends.remotesettings import RemoteSettingsBackend
+from merino.providers.suggest.adm.backends.remotesettings import (
+    RemoteSettingsBackend,
+    KintoSuggestion,
+)
 from merino.utils.gcs.models import Image
 from merino.utils.icon_processor import IconProcessor
 
@@ -418,7 +421,17 @@ async def test_fetch_with_icon_processing_errors():
         {"id": "icon-456", "attachment": {"location": "/path/to/icon2.png"}},
         {"id": "icon-789", "attachment": {"location": "/path/to/icon3.png"}},
     ]
-
+    mock_suggestions = [
+        KintoSuggestion(
+            id=id,
+            advertiser="Example.org",
+            iab_category="5 - Education",
+            icon=icon_id,
+            title="Test Suggestion",
+            url="https://example.org/test",
+        )
+        for id, icon_id in enumerate(["123", "456", "789"])
+    ]
     attachment_host = "https://example.com"
 
     # Create instance with mock icon processor
@@ -428,7 +441,7 @@ async def test_fetch_with_icon_processing_errors():
     # Mock the methods directly on the instance
     backend.get_records = AsyncMock(return_value=[])
     backend.get_attachment_host = AsyncMock(return_value=attachment_host)
-    backend.get_suggestions = AsyncMock(return_value=[])
+    backend.get_suggestions = AsyncMock(return_value=mock_suggestions)
     backend.filter_records = MagicMock(return_value=mock_records)
 
     # Mock icon processor's process_icon_url method with different behaviors


### PR DESCRIPTION
## References

JIRA: [DISCO-3314](https://mozilla-hub.atlassian.net/browse/DISCO-3314)

## Description
This saves about 1/3 of image processing workload for AMP.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
