### PR TITLE
[DISCO-3209] metrics to include user agent tags

### DIFF
--- a/merino/middleware/metrics.py
+++ b/merino/middleware/metrics.py
@@ -39,6 +39,7 @@ class MetricsMiddleware:
         loop = get_event_loop()
         request = Request(scope=scope)
         started_at = loop.time()
+        user_agent = scope[ScopeKey.USER_AGENT]
 
         async def send_wrapper(message: Message) -> None:
             if message["type"] == "http.response.start":
@@ -54,11 +55,13 @@ class MetricsMiddleware:
                         value=duration,
                     )
                     metrics_client.increment(
-                        f"{metric_name}.status_codes.{status_code}",
+                        f"{metric_name}.status_codes.{status_code}", tags=user_agent.model_dump()
                     )
 
                 # track all status codes here.
-                metrics_client.increment(f"response.status_codes.{status_code}")
+                metrics_client.increment(
+                    f"response.status_codes.{status_code}", tags=user_agent.model_dump()
+                )
 
             await send(message)
 
@@ -68,9 +71,15 @@ class MetricsMiddleware:
             status_code = HTTPStatus.INTERNAL_SERVER_ERROR.value
             duration = (loop.time() - started_at) * 1000
             metric_name = self._build_metric_name(request.method, request.url.path)
-            metrics_client.timing(f"{metric_name}.timing", value=duration)
-            metrics_client.increment(f"{metric_name}.status_codes.{status_code}")
-            metrics_client.increment(f"response.status_codes.{status_code}")
+            metrics_client.timing(
+                f"{metric_name}.timing", value=duration, tags=user_agent.model_dump()
+            )
+            metrics_client.increment(
+                f"{metric_name}.status_codes.{status_code}", tags=user_agent.model_dump()
+            )
+            metrics_client.increment(
+                f"response.status_codes.{status_code}", tags=user_agent.model_dump()
+            )
             raise
 
     @cache

--- a/tests/integration/api/v1/suggest/test_suggest.py
+++ b/tests/integration/api/v1/suggest/test_suggest.py
@@ -341,22 +341,34 @@ def test_suggest_with_invalid_geolocation_ip(
         (
             "/api/v1/suggest?q=none",
             [
-                "providers.sponsored.query",
-                "providers.non-sponsored.query",
-                "suggestions-per.request",
-                "suggestions-per.provider.sponsored",
-                "suggestions-per.provider.non-sponsored",
-                "get.api.v1.suggest.timing",
-                "get.api.v1.suggest.status_codes.200",
-                "response.status_codes.200",
+                ("providers.sponsored.query", None),
+                ("providers.non-sponsored.query", None),
+                ("suggestions-per.request", None),
+                ("suggestions-per.provider.sponsored", None),
+                ("suggestions-per.provider.non-sponsored", None),
+                ("get.api.v1.suggest.timing", None),
+                (
+                    "get.api.v1.suggest.status_codes.200",
+                    {"browser": "Firefox(103.0)", "form_factor": "desktop", "os_family": "macos"},
+                ),
+                (
+                    "response.status_codes.200",
+                    {"browser": "Firefox(103.0)", "form_factor": "desktop", "os_family": "macos"},
+                ),
             ],
         ),
         (
             "/api/v1/suggest",
             [
-                "get.api.v1.suggest.timing",
-                "get.api.v1.suggest.status_codes.400",
-                "response.status_codes.400",
+                ("get.api.v1.suggest.timing", None),
+                (
+                    "get.api.v1.suggest.status_codes.400",
+                    {"browser": "Firefox(103.0)", "form_factor": "desktop", "os_family": "macos"},
+                ),
+                (
+                    "response.status_codes.400",
+                    {"browser": "Firefox(103.0)", "form_factor": "desktop", "os_family": "macos"},
+                ),
             ],
         ),
     ],
@@ -373,10 +385,20 @@ def test_suggest_metrics(
     """
     report = mocker.patch.object(aiodogstatsd.Client, "_report")
 
-    client.get(url)
+    client.get(
+        url=url,
+        headers={
+            "User-Agent": (
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 11.2; rv:85.0) "
+                "Gecko/20100101 Firefox/103.0"
+            ),
+        },
+    )
 
     # TODO: Remove reliance on internal details of aiodogstatsd
-    metric_keys: list[str] = [call.args[0] for call in report.call_args_list]
+    metric_keys: list[tuple[str, dict]] = [
+        (call.args[0], call.args[3]) for call in report.call_args_list
+    ]
     assert metric_keys == expected_metric_keys
 
 


### PR DESCRIPTION
## References

JIRA: [DISCO-3209](https://mozilla-hub.atlassian.net/browse/DISCO-3209)

## Description
Adding tags to metrics so that we can separate by user agent



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3209]: https://mozilla-hub.atlassian.net/browse/DISCO-3209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ