### PR TITLE
[DISCO-3256] chore(ci): migrate the "upload-test-artifacts" and "upload-coverage-artifacts" steps from CircleCI to GH Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,9 +7,6 @@
 
 version: 2.1
 
-orbs:
-  gcp-cli: circleci/gcp-cli@3.3.0
-
 executors:
   image-build-executor:
     docker:
@@ -85,7 +82,6 @@ jobs:
     executor: python-executor
     steps:
       - checkout
-      - gcp-cli/setup
       - run:
           name: Create Workspace
           command: mkdir -p workspace
@@ -103,14 +99,6 @@ jobs:
           root: workspace
           paths:
             - test-results
-      - upload_to_gcs:
-          source: workspace/test-results
-          destination: gs://ecosystem-test-eng-metrics/merino-py/junit
-          extension: xml
-      - upload_to_gcs:
-          source: workspace/test-results
-          destination: gs://ecosystem-test-eng-metrics/merino-py/coverage
-          extension: json
   integration-tests:
     executor: ubuntu-executor
     steps:
@@ -118,7 +106,6 @@ jobs:
       - run:
           name: Create Workspace
           command: mkdir -p workspace
-      - gcp-cli/setup
       - setup-python-on-machine
       - run:
           name: Integration tests
@@ -134,14 +121,6 @@ jobs:
           root: workspace
           paths:
             - test-results
-      - upload_to_gcs:
-          source: workspace/test-results
-          destination: gs://ecosystem-test-eng-metrics/merino-py/junit
-          extension: xml
-      - upload_to_gcs:
-          source: workspace/test-results
-          destination: gs://ecosystem-test-eng-metrics/merino-py/coverage
-          extension: json
   test-coverage-check:
     executor: python-executor
     steps:
@@ -292,31 +271,6 @@ commands:
           command: |
             python3.12 --version
             poetry --version
-
-  upload_to_gcs:
-    parameters:
-      source:
-        type: string
-      destination:
-        type: string
-      extension:
-        type: enum
-        enum: ["xml", "json"]
-    steps:
-      - run:
-          name: Upload << parameters.source >> << parameters.extension >> Files to GCS
-          when: always # Ensure the step runs even if previous steps, like test runs, fail
-          command: |
-            if [ "$CIRCLE_BRANCH" = "main" ]; then
-              FILES=$(ls -1 << parameters.source>>/*.<< parameters.extension>> )
-              if [ -z "$FILES" ]; then
-                echo "No << parameters.extension >> files found in << parameters.source >>/"
-                exit 1
-              fi
-              gsutil cp $FILES << parameters.destination >>
-            else
-              echo "Skipping artifact upload, not on 'main' branch."
-            fi
 
   write-version:
     steps:

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -1,4 +1,4 @@
-name: Checks
+name: checks
 
 on:
   workflow_call:

--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -1,4 +1,4 @@
-name: Build Documentation
+name: docs-build
 
 on:
   workflow_call:

--- a/.github/workflows/docs-publish-github-pages.yaml
+++ b/.github/workflows/docs-publish-github-pages.yaml
@@ -1,4 +1,4 @@
-name: Publish Documentation
+name: docs-publish-github-pages
 
 on:
   workflow_call:

--- a/.github/workflows/main-workflow.yaml
+++ b/.github/workflows/main-workflow.yaml
@@ -1,4 +1,4 @@
-name: Production Deployment
+name: main-workflow  # The ETE Pipeline integration depends on this name
 
 on:
   push:
@@ -10,6 +10,20 @@ jobs:
     uses: ./.github/workflows/checks.yaml
   run-tests:
     uses: ./.github/workflows/tests.yaml
+  upload-test-artifacts:
+    needs: run-tests
+    if: always()  # Ensure the job runs even if previous jobs, like test runs, fail
+    uses: ./.github/workflows/upload-test-artifacts-to-gcs.yaml
+    with:
+      destination: "gs://ecosystem-test-eng-metrics/merino-py/junit"
+      extension: "xml"
+  upload-coverage-artifacts:
+    needs: run-tests
+    if: always()  # Ensure the job runs even if previous jobs, like test runs, fail
+    uses: ./.github/workflows/upload-test-artifacts-to-gcs.yaml
+    with:
+      destination: "gs://ecosystem-test-eng-metrics/merino-py/coverage"
+      extension: "json"
   run-docs-build:
     uses: ./.github/workflows/docs-build.yaml
   run-docs-publish-github-pages:

--- a/.github/workflows/pr-workflow.yaml
+++ b/.github/workflows/pr-workflow.yaml
@@ -1,4 +1,4 @@
-name: PR Checks Workflow
+name: pr-workflow
 
 on: pull_request
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,7 +1,13 @@
-name: Tests
+name: tests
 
 on:
   workflow_call:
+    inputs:
+      test_result_dir:
+        description: "Directory where test results should be output"
+        required: false
+        type: string
+        default: workspace/test-results
 
 jobs:
   unit-tests:
@@ -13,15 +19,19 @@ jobs:
       - name: Run unit tests
         run: make unit-tests
         env:
-          TEST_RESULTS_DIR: workspace/test-results
+          GITHUB_REPONAME: ${{ github.event.repository.name }}
+          TEST_RESULTS_DIR: ${{ inputs.test_result_dir }}
       - name: Generate Test Coverage
         run: make coverage-unit
+        env:
+          GITHUB_REPONAME: ${{ github.event.repository.name }}
+          TEST_RESULTS_DIR: ${{ inputs.test_result_dir }}
       - uses: actions/upload-artifact@v4
+        if: always()  # Ensure the artifacts upload even if tests fail
         with:
           name: unit-test-results
           include-hidden-files: true
-          path: |
-            workspace/test-results
+          path: ${{ inputs.test_result_dir }}
   integration-tests:
     runs-on: ubuntu-latest
     steps:
@@ -31,15 +41,19 @@ jobs:
       - name: Run Integration Tests
         run: make integration-tests
         env:
-          TEST_RESULTS_DIR: workspace/test-results
+          GITHUB_REPONAME: ${{ github.event.repository.name }}
+          TEST_RESULTS_DIR: ${{ inputs.test_result_dir }}
       - name: Generate Test Coverage
         run: make coverage-integration
+        env:
+          GITHUB_REPONAME: ${{ github.event.repository.name }}
+          TEST_RESULTS_DIR: ${{ inputs.test_result_dir }}
       - uses: actions/upload-artifact@v4
+        if: always()  # Ensure the artifacts upload even if tests fail
         with:
           name: integration-test-results
           include-hidden-files: true
-          path: |
-            workspace/test-results
+          path: ${{ inputs.test_result_dir }}
   test-coverage-checks:
     needs: [unit-tests, integration-tests]
     runs-on: ubuntu-latest
@@ -50,9 +64,9 @@ jobs:
       - name: Download All Artifacts
         uses: actions/download-artifact@v4
         with:
-          path: workspace/test-results/
+          path: ${{ inputs.test_result_dir }}
           merge-multiple: true
       - name: Evaluate Minimum Test Coverage
         run: make test-coverage-check
         env:
-          TEST_RESULTS_DIR: workspace/test-results
+          TEST_RESULTS_DIR: ${{ inputs.test_result_dir }}

--- a/.github/workflows/upload-test-artifacts-to-gcs.yaml
+++ b/.github/workflows/upload-test-artifacts-to-gcs.yaml
@@ -1,0 +1,59 @@
+name: upload-test-artifacts-to-gcs
+
+on:
+  workflow_call:
+    inputs:
+      service_account:
+        description: "Service account to use for authentication"
+        required: false
+        type: string
+        default: "merinopy-github@ecosystem-test-eng.iam.gserviceaccount.com"
+      source:
+        description: "Source directory containing test artifacts"
+        required: false
+        type: string
+        default: "workspace/test-results"
+      destination:
+        description: "GCS bucket destination for uploaded artifacts"
+        required: true
+        type: string
+      extension:
+        description: "File extension filter for artifacts"
+        required: false
+        type: string
+
+jobs:
+  upload-to-gcs:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - name: Set up Google Cloud Authentication
+        uses: google-github-actions/auth@v2
+        with:
+          service_account: ${{ inputs.service_account }}
+          workload_identity_provider: ${{ vars.GCPV2_GITHUB_WORKLOAD_IDENTITY_PROVIDER }}
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+      - name: Download Unit Test Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: unit-test-results
+          path: ${{ inputs.source }}
+      - name: Download Integration Test Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: integration-test-results
+          path: ${{ inputs.source }}
+      - name: Upload Artifacts to GCS
+        run: |
+          FILES="${{ inputs.source }}/*"
+          if [ -n "${{ inputs.extension }}" ]; then
+            FILES="${{ inputs.source }}/*.${{ inputs.extension }}"
+          fi
+          if ! ls -1 $FILES >/dev/null 2>&1; then
+            echo "No ${{ inputs.extension }} files found in ${{ inputs.source }}/"
+            exit 1
+          fi
+          gcloud storage cp $FILES ${{ inputs.destination }}/

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,9 @@ INSTALL_STAMP := .install.stamp
 POETRY := $(shell command -v poetry 2> /dev/null)
 
 # In order to be consumed by the ETE Test Metric Pipeline, files need to follow a strict naming
-# convention: {job_number}__{utc_epoch_datetime}__{workflow}__{test_suite}__results{-index}.xml
-WORKFLOW := main-workflow
+# convention: {job_number}__{utc_epoch_datetime}__{repository}__{workflow}__{test_suite}__results{-index}.xml
 EPOCH_TIME := $(shell date +"%s")
-TEST_FILE_PREFIX := $(if $(CIRCLECI),$(CIRCLE_BUILD_NUM)__$(EPOCH_TIME)__$(CIRCLE_PROJECT_REPONAME)__$(WORKFLOW)__)
+TEST_FILE_PREFIX := $(if $(GITHUB_ACTIONS),$(GITHUB_RUN_NUMBER)__$(EPOCH_TIME)__$(GITHUB_REPONAME)__$(GITHUB_WORKFLOW)__)
 UNIT_JUNIT_XML := $(TEST_RESULTS_DIR)/$(TEST_FILE_PREFIX)unit__results.xml
 UNIT_COVERAGE_JSON := $(TEST_RESULTS_DIR)/$(TEST_FILE_PREFIX)unit__coverage.json
 INTEGRATION_JUNIT_XML := $(TEST_RESULTS_DIR)/$(TEST_FILE_PREFIX)integration__results.xml

--- a/docs/testing/index.md
+++ b/docs/testing/index.md
@@ -10,9 +10,13 @@ Test code resides in the `tests` directory.
 Merino's test strategy requires that we do not go below a minimum test coverage percentage for unit
 and integration tests. Load tests cannot go below a minimum performance threshold.
 
+Functional tests push test artifacts, in the form of JUnit XMLs and Coverage JSONs to the 
+[ETE Test Metric Pipeline][ete_pipeline] for trending and monitoring. Results can be found on the 
+[Merino-py Test Metrics Looker Dashboard][looker_dashboard].
+
 Test documentation resides in the [/docs/testing/][test_docs_dir] directory.
 
-The functional test strategy is four-tiered, composed of:
+The test strategy is three-tiered, composed of:
 
 - [unit][unit_tests] - [documentation][unit_tests_docs]
 - [integration][integration_tests] - [documentation][integration_tests_docs]
@@ -21,11 +25,13 @@ The functional test strategy is four-tiered, composed of:
 See documentation and repositories in each given test area for specific details on running and
 maintaining tests.
 
-[test_dir]: https://github.com/mozilla-services/merino-py/tree/main/tests
-[test_docs_dir]: ./index.md
-[unit_tests]: https://github.com/mozilla-services/merino-py/tree/main/tests/unit
-[unit_tests_docs]: ./unit-tests.md
+[ete_pipeline]: https://mozilla.github.io/ecosystem-test-scripts/introduction.html
 [integration_tests]: https://github.com/mozilla-services/merino-py/tree/main/tests/integration
 [integration_tests_docs]: ./integration-tests.md
 [load_tests]: https://github.com/mozilla-services/merino-py/tree/main/tests/load
 [load_tests_docs]: ./load-tests.md
+[looker_dashboard]: https://mozilla.cloud.looker.com/dashboards/1976?Timestamp+Date=365+day
+[unit_tests]: https://github.com/mozilla-services/merino-py/tree/main/tests/unit
+[unit_tests_docs]: ./unit-tests.md
+[test_dir]: https://github.com/mozilla-services/merino-py/tree/main/tests
+[test_docs_dir]: ./index.md


### PR DESCRIPTION
## References

JIRA: [DISCO-3256](https://mozilla-hub.atlassian.net/browse/DISCO-3256)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->

* add a reusable workflow 'upload-test-artifacts-to-gcs' to GitHub actions
* incorporate 'upload-test-artifacts-to-gcs' in main-workflow GitHub action
* fix 'tests' workflow to upload test artifacts even when tests fail
* update Make to use github environment variables instead of CircleCI variables
* remove uploading test artifacts from CircleCI workflows
* update documentation

## Tests
In order to make sure the new action will behave as expected, the following tests were conducted:
1. Tests Pass, Uploads in main-workflow only (Base Case) - [PASS](https://github.com/mozilla-services/merino-py/actions/runs/13907790191)
2. Tests Pass, Upload result and coverage artifacts with filters to GCS - [PASS](https://github.com/mozilla-services/merino-py/actions/runs/13907997577/job/38915537971)
3. Tests Pass, Upload artifacts without filters to GCS - [PASS](https://github.com/mozilla-services/merino-py/actions/runs/13908205682/job/38916163684)
4. Tests Pass w no Artifacts, Upload fails - [PASS](https://github.com/mozilla-services/merino-py/actions/runs/13908353082/job/38916663196)
5. Tests Fail, Uploads result and coverage artifacts with filters to GCS  - [PASS](https://github.com/mozilla-services/merino-py/actions/runs/13909900106/job/38921624770)

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3256]: https://mozilla-hub.atlassian.net/browse/DISCO-3256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ