### PR TITLE
DISCO-3330 Add shared http client to IconProcessor

### DIFF
--- a/merino/providers/suggest/manager.py
+++ b/merino/providers/suggest/manager.py
@@ -122,6 +122,9 @@ def _create_provider(provider_id: str, setting: Settings) -> BaseProvider:
                             gcs_project=settings.image_gcs.gcs_project,
                             gcs_bucket=settings.image_gcs.gcs_bucket,
                             cdn_hostname=settings.image_gcs.cdn_hostname,
+                            http_client=create_http_client(
+                                request_timeout=settings.icon.http_timeout,
+                            ),
                         ),
                     )
                     if setting.backend == "remote-settings"

--- a/tests/integration/providers/suggest/adm/backends/test_remotesettings_icon.py
+++ b/tests/integration/providers/suggest/adm/backends/test_remotesettings_icon.py
@@ -2,7 +2,7 @@
 
 import hashlib
 from typing import Optional
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, AsyncMock
 
 import httpx
 import kinto_http
@@ -154,11 +154,15 @@ class MockImageProcessor(IconProcessor):
 
     def __init__(self) -> None:
         """Initialize the mock processor."""
+        # Create a mock http client
+        mock_http_client = MagicMock()
+
         # Call parent constructor with dummy values
         super().__init__(
             gcs_project="test-project",
             gcs_bucket="test-bucket",
             cdn_hostname="test-cdn.mozilla.net",
+            http_client=mock_http_client,
         )
 
         # Override uploader with a mock
@@ -279,11 +283,15 @@ async def test_remotesettings_with_gcs_integration(
         mock_settings.icon.favicons_root = "favicons"
         mock_settings.icon.http_timeout = 5
 
+        # Create a mock HTTP client
+        mock_http_client = AsyncMock()
+
         # Create a real IconProcessor using the test GCS client/bucket
         icon_processor = IconProcessor(
             gcs_project=gcs_storage_client.project,
             gcs_bucket=gcs_storage_bucket.name,
             cdn_hostname=settings.image_gcs.cdn_hostname,
+            http_client=mock_http_client,
         )
 
         # Replace the GCS client with our test client

--- a/tests/load/locustfiles/locustfile.py
+++ b/tests/load/locustfiles/locustfile.py
@@ -42,6 +42,7 @@ from merino.curated_recommendations.protocol import (
     CuratedRecommendationsResponse,
 )
 from merino.utils.icon_processor import IconProcessor
+from merino.utils.http_client import create_http_client
 from merino.configs import settings
 
 # Type definitions
@@ -180,10 +181,16 @@ def get_adm_queries(server: str | None, collection: str | None, bucket: str | No
                     empty.
         BackendError: Failed request to Remote Settings.
     """
+    # Create HTTP client for IconProcessor
+    http_client = create_http_client(
+        request_timeout=settings.icon.http_timeout,
+    )
+
     icon_processor = IconProcessor(
         gcs_project=settings.image_gcs.gcs_project,
         gcs_bucket=settings.image_gcs.gcs_bucket,
         cdn_hostname=settings.image_gcs.cdn_hostname,
+        http_client=http_client,
     )
     backend: RemoteSettingsBackend = RemoteSettingsBackend(
         server, collection, bucket, icon_processor


### PR DESCRIPTION
## References

JIRA: [DISCO-3330](https://mozilla-hub.atlassian.net/browse/DISCO-3330)


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3330]: https://mozilla-hub.atlassian.net/browse/DISCO-3330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ