### PR TITLE
HNT-463: curated-recs: return surfaceId

### DIFF
--- a/merino/curated_recommendations/protocol.py
+++ b/merino/curated_recommendations/protocol.py
@@ -8,7 +8,11 @@ import logging
 
 from pydantic import Field, field_validator, model_validator, BaseModel, ValidationInfo
 
-from merino.curated_recommendations.corpus_backends.protocol import CorpusItem, Topic
+from merino.curated_recommendations.corpus_backends.protocol import (
+    CorpusItem,
+    Topic,
+    ScheduledSurfaceId,
+)
 from merino.curated_recommendations.fakespot_backend.protocol import FakespotFeed
 
 logger = logging.getLogger(__name__)
@@ -306,6 +310,7 @@ class CuratedRecommendationsResponse(BaseModel):
     """Response schema for a list of curated recommendations"""
 
     recommendedAt: int
+    surfaceId: ScheduledSurfaceId
     data: list[CuratedRecommendation]
     feeds: CuratedRecommendationsFeed | None = None
     interestPicker: InterestPicker | None = None

--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -470,7 +470,9 @@ class CuratedRecommendationsProvider:
             fakespot_feed = self.get_fakespot_feed(self.fakespot_backend, surface_id)
 
         # Construct the base response
-        response = CuratedRecommendationsResponse(recommendedAt=self.time_ms(), data=general_feed)
+        response = CuratedRecommendationsResponse(
+            recommendedAt=self.time_ms(), surfaceId=surface_id, data=general_feed
+        )
 
         # If we have feeds to return, add those to the response
         if need_to_know_feed or fakespot_feed:

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -44,6 +44,7 @@ from merino.curated_recommendations.protocol import (
     Layout,
     CuratedRecommendationsFeed,
     Section,
+    Locale,
 )
 from merino.curated_recommendations.protocol import CuratedRecommendation
 from merino.main import app
@@ -219,6 +220,9 @@ async def test_curated_recommendations(repeat):
         # Check if the mock response is valid
         assert response.status_code == 200
 
+        # Check surfaceId is returned (should be NEW_TAB_EN_US for en-US locale)
+        assert data["surfaceId"] == ScheduledSurfaceId.NEW_TAB_EN_US
+
         corpus_items = data["data"]
         # assert total of 80 items returned
         assert len(corpus_items) == 80
@@ -269,29 +273,31 @@ class TestCuratedRecommendationsRequestParameters:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        "locale",
+        "locale,surface_id",
         [
-            "fr",
-            "fr-FR",
-            "es",
-            "es-ES",
-            "it",
-            "it-IT",
-            "en",
-            "en-CA",
-            "en-GB",
-            "en-US",
-            "de",
-            "de-DE",
-            "de-AT",
-            "de-CH",
+            (Locale.EN, ScheduledSurfaceId.NEW_TAB_EN_US),
+            (Locale.EN_CA, ScheduledSurfaceId.NEW_TAB_EN_US),
+            (Locale.EN_US, ScheduledSurfaceId.NEW_TAB_EN_US),
+            (Locale.EN_GB, ScheduledSurfaceId.NEW_TAB_EN_GB),
+            (Locale.DE, ScheduledSurfaceId.NEW_TAB_DE_DE),
+            (Locale.DE_DE, ScheduledSurfaceId.NEW_TAB_DE_DE),
+            (Locale.DE_AT, ScheduledSurfaceId.NEW_TAB_DE_DE),
+            (Locale.DE_CH, ScheduledSurfaceId.NEW_TAB_DE_DE),
+            (Locale.FR, ScheduledSurfaceId.NEW_TAB_FR_FR),
+            (Locale.FR_FR, ScheduledSurfaceId.NEW_TAB_FR_FR),
+            (Locale.ES, ScheduledSurfaceId.NEW_TAB_ES_ES),
+            (Locale.ES_ES, ScheduledSurfaceId.NEW_TAB_ES_ES),
+            (Locale.IT, ScheduledSurfaceId.NEW_TAB_IT_IT),
+            (Locale.IT_IT, ScheduledSurfaceId.NEW_TAB_IT_IT),
         ],
     )
-    async def test_curated_recommendations_locales(self, locale):
-        """Test the curated recommendations endpoint accepts valid locales."""
+    async def test_curated_recommendations_locales(self, locale, surface_id):
+        """Test the curated recommendations endpoint accepts valid locales & returns correct surfaceId."""
         async with AsyncClient(app=app, base_url="http://test") as ac:
             response = await ac.post("/api/v1/curated-recommendations", json={"locale": locale})
             assert response.status_code == 200, f"{locale} resulted in {response.status_code}"
+            data = response.json()
+            assert data["surfaceId"] == surface_id
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(


### PR DESCRIPTION
## References

JIRA: https://mozilla-hub.atlassian.net/browse/HNT-463

## Description
Returning the scheduled surface id as `surfaceId` in the curated recs response.

Example response:
```
{
	"recommendedAt": 1742243411507,
	"surfaceId": "NEW_TAB_FR_FR",
	"data": [...]
}
```


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
