### PR TITLE
HNT-455: Sections layout update

### DIFF
--- a/merino/curated_recommendations/layouts.py
+++ b/merino/curated_recommendations/layouts.py
@@ -1,9 +1,10 @@
 """The layouts below control how tiles are displayed in the sections experiment.
 
+When changing or adding a new layout, put the change behind a Nimbus experiment, such that
+front-end engineering, product, and design can QA the layout before it reaches users.
+
 Tile order should be based on horizontal stacking. You can try this our in the Mozilla Playground:
 https://developer.mozilla.org/en-US/play?id=zWYUe3xC5v60fEuN8USHE24l7Q7tR2Vghi08O6KT9DAZz9cv%2B%2F0s0H8F7vJBWRVCnQgSHYWR%2BadDY4zA
-
-TODO: HNT-252 will document the QA process for layout changes. PR review suffices while we're in nightly.
 """
 
 from merino.curated_recommendations.protocol import Layout, ResponsiveLayout, Tile, TileSize
@@ -140,6 +141,61 @@ layout_6_tiles = Layout(
                 Tile(size=TileSize.SMALL, position=3, hasAd=False, hasExcerpt=False),
                 Tile(size=TileSize.SMALL, position=4, hasAd=False, hasExcerpt=False),
                 Tile(size=TileSize.SMALL, position=5, hasAd=False, hasExcerpt=False),
+            ],
+        ),
+    ],
+)
+
+# Layout 4: Layout with 7 tiles, intended to show the same number of ads as in the control branch.
+layout_3_ads = Layout(
+    name="7-double-row-3-ad",
+    responsiveLayouts=[
+        ResponsiveLayout(
+            columnCount=4,
+            tiles=[
+                Tile(size=TileSize.MEDIUM, position=0, hasAd=False, hasExcerpt=True),
+                Tile(size=TileSize.MEDIUM, position=1, hasAd=True, hasExcerpt=True),
+                Tile(size=TileSize.MEDIUM, position=2, hasAd=False, hasExcerpt=True),
+                Tile(size=TileSize.MEDIUM, position=3, hasAd=True, hasExcerpt=True),
+                Tile(size=TileSize.LARGE, position=4, hasAd=False, hasExcerpt=True),
+                Tile(size=TileSize.MEDIUM, position=5, hasAd=True, hasExcerpt=True),
+                Tile(size=TileSize.MEDIUM, position=6, hasAd=False, hasExcerpt=True),
+            ],
+        ),
+        ResponsiveLayout(
+            columnCount=3,
+            tiles=[
+                Tile(size=TileSize.MEDIUM, position=0, hasAd=False, hasExcerpt=True),
+                Tile(size=TileSize.MEDIUM, position=1, hasAd=True, hasExcerpt=True),
+                Tile(size=TileSize.SMALL, position=2, hasAd=False, hasExcerpt=False),
+                Tile(size=TileSize.SMALL, position=4, hasAd=False, hasExcerpt=False),
+                Tile(size=TileSize.MEDIUM, position=3, hasAd=True, hasExcerpt=True),
+                Tile(size=TileSize.MEDIUM, position=6, hasAd=False, hasExcerpt=True),
+                Tile(size=TileSize.MEDIUM, position=5, hasAd=True, hasExcerpt=True),
+            ],
+        ),
+        ResponsiveLayout(
+            columnCount=2,
+            tiles=[
+                Tile(size=TileSize.MEDIUM, position=0, hasAd=False, hasExcerpt=True),
+                Tile(size=TileSize.MEDIUM, position=1, hasAd=True, hasExcerpt=True),
+                Tile(size=TileSize.MEDIUM, position=3, hasAd=True, hasExcerpt=True),
+                Tile(size=TileSize.MEDIUM, position=2, hasAd=False, hasExcerpt=True),
+                Tile(size=TileSize.LARGE, position=4, hasAd=False, hasExcerpt=True),
+                Tile(size=TileSize.MEDIUM, position=5, hasAd=True, hasExcerpt=True),
+                Tile(size=TileSize.MEDIUM, position=6, hasAd=False, hasExcerpt=True),
+            ],
+        ),
+        ResponsiveLayout(
+            columnCount=1,
+            tiles=[
+                Tile(size=TileSize.MEDIUM, position=1, hasAd=True, hasExcerpt=True),
+                Tile(size=TileSize.SMALL, position=0, hasAd=False, hasExcerpt=False),
+                Tile(size=TileSize.SMALL, position=2, hasAd=False, hasExcerpt=False),
+                Tile(size=TileSize.MEDIUM, position=3, hasAd=True, hasExcerpt=True),
+                Tile(size=TileSize.MEDIUM, position=4, hasAd=False, hasExcerpt=True),
+                Tile(size=TileSize.MEDIUM, position=5, hasAd=True, hasExcerpt=True),
+                Tile(size=TileSize.MEDIUM, position=6, hasAd=False, hasExcerpt=True),
             ],
         ),
     ],

--- a/merino/curated_recommendations/protocol.py
+++ b/merino/curated_recommendations/protocol.py
@@ -64,6 +64,8 @@ class ExperimentName(str, Enum):
     EXTENDED_EXPIRATION_EXPERIMENT = "new-tab-extend-content-duration"
     # Experiment where we apply a modified prior to reduce exploration
     MODIFIED_PRIOR_EXPERIMENT = "new-tab-feed-reduce-exploration"
+    # Experiment where the layout of the second section has two rows.
+    DOUBLE_ROW_LAYOUT_EXPERIMENT = "new-tab-double-row-layout"
 
 
 # Maximum tileId that Firefox can support. Firefox uses Javascript to store this value. The max

--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -19,7 +19,8 @@ from merino.curated_recommendations.interest_picker import create_interest_picke
 from merino.curated_recommendations.layouts import (
     layout_4_medium,
     layout_4_large,
-    layout_6_tiles, layout_3_ads,
+    layout_6_tiles,
+    layout_3_ads,
 )
 from merino.curated_recommendations.localization import get_translation, LOCALIZED_SECTION_TITLES
 from merino.curated_recommendations.prior_backends.protocol import PriorBackend
@@ -425,7 +426,9 @@ class CuratedRecommendationsProvider:
 
         # Set the layout of the second section to have 3 ads, to match the number of ads in control.
         if self.is_double_row_layout_experiment(request):
-            second_section = next((s for s, _ in feeds.get_sections() if s.receivedFeedRank == 1), None)
+            second_section = next(
+                (s for s, _ in feeds.get_sections() if s.receivedFeedRank == 1), None
+            )
             if second_section:
                 second_section.layout = layout_3_ads
 

--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -188,6 +188,13 @@ class CuratedRecommendationsProvider:
         )
 
     @staticmethod
+    def is_double_row_layout_experiment(request: CuratedRecommendationsRequest) -> bool:
+        """Check if the double row layout experiment is enabled."""
+        return CuratedRecommendationsProvider.is_enrolled_in_experiment(
+            request, ExperimentName.DOUBLE_ROW_LAYOUT_EXPERIMENT.value, "treatment"
+        )
+
+    @staticmethod
     def is_fakespot_experiment(request, surface_id) -> bool:
         """Check if the 'Fakespot' experiment is enabled."""
         return (
@@ -417,9 +424,10 @@ class CuratedRecommendationsProvider:
             feeds = boost_followed_sections(request.sections, feeds)
 
         # Set the layout of the second section to have 3 ads, to match the number of ads in control.
-        second_section = next((s for s, _ in feeds.get_sections() if s.receivedFeedRank == 1), None)
-        if second_section:
-            second_section.layout = layout_3_ads
+        if self.is_double_row_layout_experiment(request):
+            second_section = next((s for s, _ in feeds.get_sections() if s.receivedFeedRank == 1), None)
+            if second_section:
+                second_section.layout = layout_3_ads
 
         return feeds
 

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -1400,6 +1400,44 @@ class TestSections:
             # All sections have a layout.
             assert all(Layout(**section["layout"]) for section in sections.values())
 
+            # Find the first section by their receivedFeedRank.
+            first_section = next((s for s in sections.values() if s["receivedFeedRank"] == 0), None)
+            assert first_section is not None
+
+            # Assert layout of the first section.
+            assert first_section["layout"]["name"] == "4-large-small-medium-1-ad"
+            # Assert that none of the sections have the layout "7-double-row-3-ad".
+            for section in sections.values():
+                assert section["layout"]["name"] != "7-double-row-3-ad"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "sections_payload",
+        [
+            None,
+            [{"sectionId": "sports", "isFollowed": True, "isBlocked": False}],
+        ],
+    )
+    async def test_sections_layouts_double_row_experiment(self, sections_payload):
+        """Test that the correct layout are returned along with sections."""
+        async with AsyncClient(app=app, base_url="http://test") as ac:
+            payload = {
+                "locale": "en-US",
+                "feeds": ["sections"],
+                "experimentName": "new-tab-double-row-layout",
+                "experimentBranch": "treatment",
+            }
+            if sections_payload is not None:
+                payload["sections"] = sections_payload
+            response = await ac.post("/api/v1/curated-recommendations", json=payload)
+            assert response.status_code == 200
+            data = response.json()
+            feeds = data["feeds"]
+            sections = {name: section for name, section in feeds.items() if section is not None}
+
+            # All sections have a layout.
+            assert all(Layout(**section["layout"]) for section in sections.values())
+
             # Find the first and second sections by their receivedFeedRank.
             first_section = next((s for s in sections.values() if s["receivedFeedRank"] == 0), None)
             second_section = next((s for s in sections.values() if s["receivedFeedRank"] == 1), None)

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -1401,7 +1401,9 @@ class TestSections:
             assert all(Layout(**section["layout"]) for section in sections.values())
 
             # Find the first section by their receivedFeedRank.
-            first_section = next((s for s in sections.values() if s["receivedFeedRank"] == 0), None)
+            first_section = next(
+                (s for s in sections.values() if s["receivedFeedRank"] == 0), None
+            )
             assert first_section is not None
 
             # Assert layout of the first section.
@@ -1439,8 +1441,12 @@ class TestSections:
             assert all(Layout(**section["layout"]) for section in sections.values())
 
             # Find the first and second sections by their receivedFeedRank.
-            first_section = next((s for s in sections.values() if s["receivedFeedRank"] == 0), None)
-            second_section = next((s for s in sections.values() if s["receivedFeedRank"] == 1), None)
+            first_section = next(
+                (s for s in sections.values() if s["receivedFeedRank"] == 0), None
+            )
+            second_section = next(
+                (s for s in sections.values() if s["receivedFeedRank"] == 1), None
+            )
             assert first_section is not None
             assert second_section is not None
 

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -1367,9 +1367,6 @@ class TestSections:
             # and therefore the number of recs per topics is non-deterministic.
             assert len(sections) >= 4
 
-            # All sections have a layout
-            assert all(Layout(**section["layout"]) for section in sections.values())
-
             # Section receivedFeedRank should be numbered 0, 1, 2, ..., len(sections) - 1.
             assert {s["receivedFeedRank"] for s in sections.values()} == set(range(len(sections)))
             # Recommendation receivedRank should be numbered 0, 1, 2, ..., len(recommendations) - 1.
@@ -1379,6 +1376,44 @@ class TestSections:
 
             # Ensure all topics are present and are named according to the Topic Enum value.
             assert all(topic.value in feeds for topic in Topic)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "sections_payload",
+        [
+            None,
+            [{"sectionId": "sports", "isFollowed": True, "isBlocked": False}],
+        ],
+    )
+    async def test_sections_layouts(self, sections_payload):
+        """Test that the correct layout are returned along with sections."""
+        async with AsyncClient(app=app, base_url="http://test") as ac:
+            payload = {"locale": "en-US", "feeds": ["sections"]}
+            if sections_payload is not None:
+                payload["sections"] = sections_payload
+            response = await ac.post("/api/v1/curated-recommendations", json=payload)
+            assert response.status_code == 200
+            data = response.json()
+            feeds = data["feeds"]
+            sections = {name: section for name, section in feeds.items() if section is not None}
+
+            # All sections have a layout.
+            assert all(Layout(**section["layout"]) for section in sections.values())
+
+            # Find the first and second sections by their receivedFeedRank.
+            first_section = next((s for s in sections.values() if s["receivedFeedRank"] == 0), None)
+            second_section = next((s for s in sections.values() if s["receivedFeedRank"] == 1), None)
+            assert first_section is not None
+            assert second_section is not None
+
+            # Assert layout of the first section.
+            assert first_section["layout"]["name"] == "4-large-small-medium-1-ad"
+            # Assert layout of the second section.
+            assert second_section["layout"]["name"] == "7-double-row-3-ad"
+            # Assert that none of the other sections have the layout "7-double-row-3-ad".
+            for section in sections.values():
+                if section["receivedFeedRank"] != 1:
+                    assert section["layout"]["name"] != "7-double-row-3-ad"
 
     @pytest.mark.asyncio
     async def test_curated_recommendations_with_sections_feed_boost_followed_sections(


### PR DESCRIPTION
## References

- JIRA: [HNT-455](https://mozilla-hub.atlassian.net/browse/HNT-455)
- [Figma spec](https://www.figma.com/design/VdghooQZTLiXYO8hF5pAuS/Feed?node-id=10976-209386&t=5TeGb0b5ClpQl8zA-0)

## Description
Changes the layout of the second section two be 2 rows with 3 ads, to make the number of ads the same between the sections experiment, and whats shown in the control branch.

The new layout is only shown behind a Nimbus experiment, which our team can enroll in to QA the new layout before it's shown to users.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[HNT-455]: https://mozilla-hub.atlassian.net/browse/HNT-455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ