### PR TITLE
[DISCO-3227] Fix gcp client auth error in staging

### DIFF
--- a/merino/configs/__init__.py
+++ b/merino/configs/__init__.py
@@ -8,6 +8,13 @@ _validators = [
         "runtime.disabled_providers",
         is_type_of=list,
     ),
+    Validator(
+        "runtime.skip_gcp_client_auth",
+        is_type_of=bool,
+        must_exist=True,
+        eq=True,
+        env=["production", "stage"],
+    ),
     Validator("deployment.canary", is_type_of=bool),
     Validator("logging.format", is_in=["mozlog", "pretty"]),
     Validator("logging.level", is_in=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]),

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -51,6 +51,12 @@ default_suggestions_response_ttl_sec = 300 # 5 mins
 # ensuring reasonably fresh data.
 default_manifest_response_ttl_sec = 28800 # 8 hours
 
+# MERINO_RUNTIME__SKIP_GCP_CLIENT_AUTH
+# Skip providing explicit `credentials` parameter to the gcp Client instance constructor.
+# In production and staging environments, the auth credentials are automatically picked up
+# from the ADC file in the GCP Project. For dev & testing envs, we use anonymous credentials.
+skip_gcp_client_auth = false
+
 [default.logging]
 # MERINO_LOGGING__LEVEL
 # Minimum level of logs that should be reported.

--- a/merino/configs/production.toml
+++ b/merino/configs/production.toml
@@ -10,6 +10,13 @@
 # settings. This enables merge for the entire `production` environment.
 dynaconf_merge = true
 
+[production.runtime]
+# MERINO_RUNTIME__SKIP_GCP_CLIENT_AUTH
+# Skip providing explicit `credentials` parameter to the gcp Client instance constructor.
+# In production and staging environments, the auth credentials are automatically picked up
+# from the ADC file in the GCP Project. For dev & testing envs, we use anonymous credentials.
+skip_gcp_client_auth = true
+
 [production.accuweather]
 url_base = "https://api.accuweather.com"
 

--- a/merino/configs/stage.toml
+++ b/merino/configs/stage.toml
@@ -10,6 +10,13 @@
 # settings. This enables merge for the entire `stage` environment.
 dynaconf_merge = true
 
+[stage.runtime]
+# MERINO_RUNTIME__SKIP_GCP_CLIENT_AUTH
+# Skip providing explicit `credentials` parameter to the gcp Client instance constructor.
+# In production and staging environments, the auth credentials are automatically picked up
+# from the ADC file in the GCP Project. For dev & testing envs, we use anonymous credentials.
+skip_gcp_client_auth = true
+
 [stage.accuweather]
 url_base = "https://api.accuweather.com"
 

--- a/merino/utils/gcs/gcs_uploader.py
+++ b/merino/utils/gcs/gcs_uploader.py
@@ -1,7 +1,7 @@
 """Uploads Content to GCS"""
 
 import logging
-from merino.configs import settings as config
+from merino.configs import settings
 from typing import Callable
 from urllib.parse import urljoin
 
@@ -104,10 +104,11 @@ class GcsUploader(BaseContentUploader):
         return None
 
     def _initialize_storage_client(self, destination_gcp_project: str) -> Client:
-        """Initialize a Google Cloud Storage client with production or anonymous credentials if in non-production environment"""
-        if config.current_env == "production":
-            # for production env we don't have to explicitly pass the credentials as it picks up the ADC file automatically
+        """Initialize a Google Cloud Storage client with production or anonymous credentials if in non-production/staging environment"""
+        if settings.runtime.skip_gcp_client_auth:
+            # for production and staging envs we don't have to explicitly pass the credentials
+            #  as it picks up the ADC file automatically
             return Client(destination_gcp_project)
         else:
-            # if not using anonymous credentials in non-prod env, this will throw
+            # if not using anonymous credentials in dev & testing envs, this will throw
             return Client(destination_gcp_project, credentials=AnonymousCredentials())  # type: ignore


### PR DESCRIPTION
## References

JIRA: [DISCO-3227](https://mozilla-hub.atlassian.net/browse/DISCO-3227)

## Description
Fix logic branch to set default auth credentials in staging environment too.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3227]: https://mozilla-hub.atlassian.net/browse/DISCO-3227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ