### PR TITLE
HNT-472: Roll out double row layout to sections experiment

### DIFF
--- a/merino/curated_recommendations/protocol.py
+++ b/merino/curated_recommendations/protocol.py
@@ -64,8 +64,6 @@ class ExperimentName(str, Enum):
     EXTENDED_EXPIRATION_EXPERIMENT = "new-tab-extend-content-duration"
     # Experiment where we apply a modified prior to reduce exploration
     MODIFIED_PRIOR_EXPERIMENT = "new-tab-feed-reduce-exploration"
-    # Experiment where the layout of the second section has two rows.
-    DOUBLE_ROW_LAYOUT_EXPERIMENT = "new-tab-double-row-layout"
 
 
 # Maximum tileId that Firefox can support. Firefox uses Javascript to store this value. The max

--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -182,13 +182,6 @@ class CuratedRecommendationsProvider:
         )
 
     @staticmethod
-    def is_double_row_layout_experiment(request: CuratedRecommendationsRequest) -> bool:
-        """Check if the double row layout experiment is enabled."""
-        return CuratedRecommendationsProvider.is_enrolled_in_experiment(
-            request, ExperimentName.DOUBLE_ROW_LAYOUT_EXPERIMENT.value, "treatment"
-        )
-
-    @staticmethod
     def is_fakespot_experiment(request, surface_id) -> bool:
         """Check if the 'Fakespot' experiment is enabled."""
         return (
@@ -416,8 +409,7 @@ class CuratedRecommendationsProvider:
             feeds = boost_followed_sections(request.sections, feeds)
 
         # Set the layout of the second section to have 3 ads, to match the number of ads in control.
-        if self.is_double_row_layout_experiment(request):
-            self.set_double_row_layout(feeds)
+        self.set_double_row_layout(feeds)
 
         return feeds
 

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -1361,46 +1361,6 @@ class TestSections:
             # All sections have a layout.
             assert all(Layout(**section["layout"]) for section in sections.values())
 
-            # Find the first section by their receivedFeedRank.
-            first_section = next(
-                (s for s in sections.values() if s["receivedFeedRank"] == 0), None
-            )
-            assert first_section is not None
-
-            # Assert layout of the first section.
-            assert first_section["layout"]["name"] == "4-large-small-medium-1-ad"
-            # Assert that none of the sections have the layout "7-double-row-3-ad".
-            for section in sections.values():
-                assert section["layout"]["name"] != "7-double-row-3-ad"
-
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize(
-        "sections_payload",
-        [
-            None,
-            [{"sectionId": "sports", "isFollowed": True, "isBlocked": False}],
-        ],
-    )
-    async def test_sections_layouts_double_row_experiment(self, sections_payload):
-        """Test that the correct layout are returned along with sections."""
-        async with AsyncClient(app=app, base_url="http://test") as ac:
-            payload = {
-                "locale": "en-US",
-                "feeds": ["sections"],
-                "experimentName": "new-tab-double-row-layout",
-                "experimentBranch": "treatment",
-            }
-            if sections_payload is not None:
-                payload["sections"] = sections_payload
-            response = await ac.post("/api/v1/curated-recommendations", json=payload)
-            assert response.status_code == 200
-            data = response.json()
-            feeds = data["feeds"]
-            sections = {name: section for name, section in feeds.items() if section is not None}
-
-            # All sections have a layout.
-            assert all(Layout(**section["layout"]) for section in sections.values())
-
             # Find the first and second sections by their receivedFeedRank.
             first_section = next(
                 (s for s in sections.values() if s["receivedFeedRank"] == 0), None


### PR DESCRIPTION
## References

- JIRA: [HNT-472](https://mozilla-hub.atlassian.net/browse/HNT-472)
- [QA Slack thread](https://mozilla.slack.com/archives/C058SAB9F0Q/p1742339555276329)
- [Figma](https://www.figma.com/design/VdghooQZTLiXYO8hF5pAuS/Feed?node-id=6259-53439&p=f&t=RfS6kHqg3izXJ29e-0)

## Description
The new double row layout with 3 ads has successfully been QA'ed by FE, design, and PM. This PR rolls it out to all users who receive sections.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[HNT-472]: https://mozilla-hub.atlassian.net/browse/HNT-472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ