### PR TITLE
[DISCO-3393] Suggest: return 204 for no weather

### DIFF
--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -224,6 +224,9 @@ async def suggest(
 
     emit_suggestions_per_metrics(metrics_client, suggestions, search_from)
 
+    if request_type == "weather" and len(suggestions) == 0:
+        return ORJSONResponse(content=None, status_code=204)
+
     response = SuggestResponse(
         suggestions=suggestions,
         request_id=correlation_id.get(),

--- a/tests/integration/api/v1/suggest/test_suggest_weather.py
+++ b/tests/integration/api/v1/suggest/test_suggest_weather.py
@@ -246,18 +246,13 @@ def test_suggest_without_weather_report(client: TestClient, backend_mock: Any) -
     """Test that the suggest endpoint response is as expected when the Weather provider
     cannot supply a suggestion.
     """
-    expected_suggestion: list[Suggestion] = []
     backend_mock.get_weather_report.return_value = None
 
     response = client.get("/api/v1/suggest?q=weather&request_type=weather")
 
-    assert response.status_code == 200
-    assert (
-        response.headers["Cache-Control"]
-        == f"private, max-age={DEFAULT_SUGGESTIONS_RESPONSE_TTL_SEC}"
-    )
+    assert response.status_code == 204
     result = response.json()
-    assert result["suggestions"] == expected_suggestion
+    assert result is None
 
 
 def test_suggest_weather_with_missing_request_type_query_parameter(client: TestClient) -> None:
@@ -458,7 +453,7 @@ async def test_suggest_weather_with_custom_location(
 
     assert geolocation_scope[ScopeKey.GEOLOCATION] == expected_initial_location
 
-    response = client.get(
+    client.get(
         "/api/v1/suggest",
         params={
             "q": "",
@@ -479,5 +474,3 @@ async def test_suggest_weather_with_custom_location(
             query="", geolocation=expected_geolocation, request_type="weather", languages=["en-US"]
         )
     )
-
-    assert response.status_code == 200


### PR DESCRIPTION
## References

JIRA: [DISCO-3393](https://mozilla-hub.atlassian.net/browse/DISCO-3393)

## Description
When weather doesn't return any suggestions, we want to return a 204 instead



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3393]: https://mozilla-hub.atlassian.net/browse/DISCO-3393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ