### PR TITLE
DISCO-3362: Exclude the custom domains from the top-picks provider

### DIFF
--- a/merino/jobs/navigational_suggestions/__init__.py
+++ b/merino/jobs/navigational_suggestions/__init__.py
@@ -98,6 +98,7 @@ def _construct_top_picks(
                     "url": domain_url,
                     "title": domain_metadata[index]["title"],
                     "icon": favicons[index],
+                    "source": domain.get("source", "top-picks"),
                 }
             )
     return {"domains": result}

--- a/merino/jobs/navigational_suggestions/custom_domains.py
+++ b/merino/jobs/navigational_suggestions/custom_domains.py
@@ -1,6 +1,6 @@
 """Custom domains data for navigational suggestions"""
 
-CUSTOM_DOMAINS = [
+CUSTOM_DOMAINS: list[str] = [
     # "01net.com",
     # "11freunde.de",
     # "19thnews.org",

--- a/merino/providers/suggest/top_picks/backends/top_picks.py
+++ b/merino/providers/suggest/top_picks/backends/top_picks.py
@@ -88,6 +88,10 @@ class TopPicksBackend:
         query_max: int = self.query_char_limit
 
         for record in domain_list["domains"]:
+            # Filter to only include domains with source="top-picks"
+            if record.get("source") != "top-picks":
+                continue
+
             index_key: int = len(results)
             domain: str = record["domain"].strip().lower()
 

--- a/tests/data/top_picks.json
+++ b/tests/data/top_picks.json
@@ -10,6 +10,7 @@
                 "web-browser"
             ],
             "serp_categories": [0],
+            "source": "top-picks",
             "similars": [
                 "exxample",
                 "exampple",
@@ -26,6 +27,7 @@
                 "web-browser"
             ],
             "serp_categories": [18],
+            "source": "top-picks",
             "similars": [
                 "firefoxx",
                 "foyerfox",
@@ -44,6 +46,7 @@
                 "web-browser"
             ],
             "serp_categories": [18],
+            "source": "top-picks",
             "similars": [
                 "mozzilla",
                 "mozila"
@@ -59,6 +62,7 @@
                 "web-browser"
             ],
             "serp_categories": [0],
+            "source": "top-picks",
             "similars": [
                 "aa",
                 "ab",
@@ -77,6 +81,7 @@
                 "web-browser"
             ],
             "serp_categories": [0],
+            "source": "top-picks",
             "similars": [
                 "bad",
                 "badd"
@@ -91,6 +96,7 @@
             "categories": [
                 "web-browser"
             ],
+            "source": "top-picks",
             "similars": [
                 "pineappel",
                 "pinnapple",

--- a/tests/unit/jobs/navigational_suggestions/test_domain_data_downloader.py
+++ b/tests/unit/jobs/navigational_suggestions/test_domain_data_downloader.py
@@ -36,7 +36,9 @@ def test_download_data(mock_bigquery_client):
 
     mock_bigquery_client.query.assert_called_once()
     mock_bigquery_client.query.return_value.result.assert_called_once()
-    assert domains == [{"x": "a", "y": "b"}]
+    assert domains[0]["x"] == "a"
+    assert domains[0]["y"] == "b"
+    assert domains[0]["source"] == "top-picks"  # Test source field for BigQuery domains
 
 
 def test_custom_domains(mock_bigquery_client):
@@ -68,6 +70,10 @@ def test_custom_domains(mock_bigquery_client):
         assert isinstance(domain, dict), f"Domain should be a dict, got {type(domain)}"
         assert "domain" in domain, f"Missing 'domain' in {domain}"
         assert "categories" in domain, f"Missing 'categories' in {domain}"
+        assert "source" in domain, f"Missing 'source' in {domain}"
+        assert (
+            domain["source"] == "custom-domains"
+        ), f"Expected source to be 'custom-domains', got {domain['source']}"
         assert isinstance(domain["categories"], list), f"Categories should be a list in {domain}"
         assert all(
             isinstance(cat, str) for cat in domain["categories"]

--- a/tests/unit/jobs/navigational_suggestions/test_init.py
+++ b/tests/unit/jobs/navigational_suggestions/test_init.py
@@ -1,0 +1,42 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Unit tests for navigational_suggestions __init__.py module."""
+
+from merino.jobs.navigational_suggestions import _construct_top_picks
+
+
+def test_construct_top_picks_source_field():
+    """Test that _construct_top_picks includes the source field in the output JSON data."""
+    # Mock input data
+    domain_data = [
+        {"rank": 1, "categories": ["web"], "source": "top-picks"},
+        {"rank": 2, "categories": ["shopping"], "source": "custom-domains"},
+    ]
+
+    favicons = ["icon1", "icon2"]
+
+    domain_metadata = [
+        {"domain": "example.com", "url": "https://example.com", "title": "Example"},
+        {"domain": "amazon.ca", "url": "https://amazon.ca", "title": "Amazon"},
+    ]
+
+    result = _construct_top_picks(domain_data, favicons, domain_metadata)
+
+    # Check if source field is included correctly in the results
+    assert "domains" in result
+    assert len(result["domains"]) == 2
+    assert result["domains"][0]["source"] == "top-picks"
+    assert result["domains"][1]["source"] == "custom-domains"
+
+    # Check other fields
+    assert result["domains"][0]["domain"] == "example.com"
+    assert result["domains"][0]["url"] == "https://example.com"
+    assert result["domains"][0]["title"] == "Example"
+    assert result["domains"][0]["icon"] == "icon1"
+
+    assert result["domains"][1]["domain"] == "amazon.ca"
+    assert result["domains"][1]["url"] == "https://amazon.ca"
+    assert result["domains"][1]["title"] == "Amazon"
+    assert result["domains"][1]["icon"] == "icon2"

--- a/tests/unit/jobs/navigational_suggestions/test_navigational_suggestions.py
+++ b/tests/unit/jobs/navigational_suggestions/test_navigational_suggestions.py
@@ -33,6 +33,7 @@ def test_prepare_domain_metadata_top_picks_construction(mocker):
             "origin": "https://www.dummy_domain.com",
             "suffix": "com",
             "categories": ["Search Engines"],
+            "source": "top-picks",
         },
         {
             "rank": 2,
@@ -41,6 +42,7 @@ def test_prepare_domain_metadata_top_picks_construction(mocker):
             "origin": "https://www.dummy_unreachable_domain.com",
             "suffix": "com",
             "categories": ["Search Engines"],
+            "source": "top-picks",
         },
     ]
 
@@ -85,6 +87,7 @@ def test_prepare_domain_metadata_top_picks_construction(mocker):
                 "url": "dummy_url.com",
                 "title": "dummy_title",
                 "icon": "dummy_uploaded_favicon_url",
+                "source": "top-picks",
             }
         ]
     }
@@ -114,6 +117,7 @@ def test_prepare_domain_metadata_partner_manifest(mocker):
             "origin": "https://www.dummy_domain.com",
             "suffix": "com",
             "categories": ["Search Engines"],
+            "source": "top-picks",
         }
     ]
 
@@ -206,6 +210,7 @@ def test_prepare_domain_metadata_partner_manifest(mocker):
                 "url": "dummy_url.com",
                 "title": "dummy_title",
                 "icon": "dummy_uploaded_favicon_url",
+                "source": "top-picks",
             }
         ],
         "partners": expected_partner_manifest["partners"],


### PR DESCRIPTION
## References

JIRA: [DISCO-3362](https://mozilla-hub.atlassian.net/browse/DISCO-3362)

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3362]: https://mozilla-hub.atlassian.net/browse/DISCO-3362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ