### PR TITLE
[DISCO-3210]: Async GCS client

### DIFF
--- a/merino/providers/manifest/backends/filemanager.py
+++ b/merino/providers/manifest/backends/filemanager.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 class ManifestRemoteFilemanager:
-    """Filemanager for fetching manifest data from GCS and storing only in memory."""
+    """Filemanager for fetching manifest data from GCS asynchronously and storing only in memory."""
 
     gcs_client: Storage
     blob_name: str

--- a/merino/providers/manifest/backends/filemanager.py
+++ b/merino/providers/manifest/backends/filemanager.py
@@ -1,14 +1,13 @@
 """A Filemanager to retrieve data for the Manifest Provider (Remote-Only)."""
 
-import json
+import orjson
 import logging
 
 from json import JSONDecodeError
-
 from pydantic import ValidationError
+from gcloud.aio.storage import Blob, Bucket, Storage
 
 from merino.providers.manifest.backends.protocol import ManifestData, GetManifestResultCode
-from merino.utils.gcs.gcs_uploader import GcsUploader
 from merino.utils.metrics import get_metrics_client
 
 logger = logging.getLogger(__name__)
@@ -17,53 +16,40 @@ logger = logging.getLogger(__name__)
 class ManifestRemoteFilemanager:
     """Filemanager for fetching manifest data from GCS and storing only in memory."""
 
-    gcs_client: GcsUploader
+    gcs_client: Storage
     blob_name: str
-    blob_generation: int
+    bucket: Bucket
 
-    def __init__(self, gcs_project_path: str, gcs_bucket_path: str, blob_name: str) -> None:
-        """:param gcs_project_path: Google Cloud project.
-        :param gcs_bucket_path: GCS bucket name to fetch from.
+    def __init__(self, gcs_bucket_path: str, blob_name: str) -> None:
+        """:param gcs_bucket_path: GCS bucket name to fetch from.
         :param blob_name: Name of the blob in the GCS bucket.
         """
-        self.gcs_client = GcsUploader(gcs_project_path, gcs_bucket_path, "")
+        self.gcs_storage_client = Storage()
         self.blob_name = blob_name
-        self.blob_generation = 0
+        self.bucket = Bucket(storage=self.gcs_storage_client, name=gcs_bucket_path)
 
-    def get_file(self) -> tuple[GetManifestResultCode, ManifestData | None]:
+    async def get_file(self) -> tuple[GetManifestResultCode, ManifestData | None]:
         """Fetch the remote manifest file from GCS"""
         metrics_client = get_metrics_client()
 
         try:
-            blob = self.gcs_client.get_file_by_name(self.blob_name, self.blob_generation)
+            blob: Blob = await self.bucket.get_blob(self.blob_name)
+            blob_data = await blob.download()
 
-            if blob is not None:
-                blob.reload()
-                metrics_client.gauge("manifest.size", value=blob.size)
+            metrics_client.gauge("manifest.size", value=blob.size)
 
-                blob_data = blob.download_as_text()
+            manifest_content = ManifestData.model_validate(orjson.loads(blob_data))
 
-                try:
-                    manifest_content = ManifestData.model_validate(json.loads(blob_data))
-                    metrics_client.gauge(
-                        "manifest.domains.count", value=len(manifest_content.domains)
-                    )
-                except JSONDecodeError as json_error:
-                    logger.error("Failed to decode manifest JSON: %s", json_error)
-                    return GetManifestResultCode.FAIL, None
-                except ValidationError as val_err:
-                    logger.error(f"Invalid manifest content: {val_err}")
-                    return GetManifestResultCode.FAIL, None
-
-                logger.info("Successfully loaded remote manifest file: %s", self.blob_name)
-                return GetManifestResultCode.SUCCESS, manifest_content
-
-            # If `get_file_by_name` returned None, that usually means no new generation (SKIP).
-            logger.info(
-                f"No new GCS generation for {self.blob_name}; returning SKIP or blob doesn't exist.",
-            )
-            return GetManifestResultCode.SKIP, None
-
+            metrics_client.gauge("manifest.domains.count", value=len(manifest_content.domains))
+        except JSONDecodeError as json_error:
+            logger.error("Failed to decode manifest JSON: %s", json_error)
+            return GetManifestResultCode.FAIL, None
+        except ValidationError as val_err:
+            logger.error(f"Invalid manifest content: {val_err}")
+            return GetManifestResultCode.FAIL, None
         except Exception as e:
             logger.error(f"Error fetching remote manifest file {self.blob_name}: {e}")
             return GetManifestResultCode.FAIL, None
+
+        logger.info("Successfully loaded remote manifest file: %s", self.blob_name)
+        return GetManifestResultCode.SUCCESS, manifest_content

--- a/merino/providers/manifest/backends/manifest.py
+++ b/merino/providers/manifest/backends/manifest.py
@@ -15,15 +15,14 @@ GCS_BLOB_NAME = "top_picks_latest.json"
 
 
 class ManifestBackend:
-    """A remote-only backend that fetches the manifest file from GCS, unmodified."""
+    """A remote-only backend that fetches the manifest file from GCS asynchronously, unmodified."""
 
     def __init__(self) -> None:
         """Initialize the Manifest backend."""
         pass
 
     async def fetch(self) -> tuple[GetManifestResultCode, ManifestData | None]:
-        """Fetch the manifest data from GCS, offloading the synchronous I/O
-        to a background thread.
+        """Fetch the manifest data from GCS asynchronously.
         Returns:
             (SUCCESS, ManifestData): If new data is fetched from GCS.
             (FAIL, None): If there's an error with fetching or parsing.

--- a/merino/providers/manifest/backends/manifest.py
+++ b/merino/providers/manifest/backends/manifest.py
@@ -1,6 +1,5 @@
 """A backend wrapper for the Manifest Provider I/O Interactions (Remote-Only)."""
 
-import asyncio
 import logging
 
 from merino.configs import settings
@@ -27,30 +26,15 @@ class ManifestBackend:
         to a background thread.
         Returns:
             (SUCCESS, ManifestData): If new data is fetched from GCS.
-            (SKIP, None): If there's no new generation (blob unchanged).
             (FAIL, None): If there's an error with fetching or parsing.
         """
-        return await asyncio.to_thread(self.fetch_manifest_data)
+        return await self.fetch_manifest_data()
 
-    def fetch_manifest_data(self) -> tuple[GetManifestResultCode, ManifestData | None]:
+    async def fetch_manifest_data(self) -> tuple[GetManifestResultCode, ManifestData | None]:
         """Fetch manifest data from GCS through the remote filemanager."""
         remote_filemanager = ManifestRemoteFilemanager(
-            gcs_project_path=settings.image_gcs.gcs_project,
             gcs_bucket_path=settings.image_gcs.gcs_bucket,
             blob_name=GCS_BLOB_NAME,
         )
 
-        result_code, manifest_data = remote_filemanager.get_file()
-
-        match GetManifestResultCode(result_code):
-            case GetManifestResultCode.SUCCESS:
-                logger.info("Manifest data loaded remotely from GCS.")
-                return result_code, manifest_data
-
-            case GetManifestResultCode.SKIP:
-                logger.info("Manifest data was not updated (SKIP).")
-                return result_code, None
-
-            case GetManifestResultCode.FAIL:
-                logger.error("Failed to fetch manifest from GCS (FAIL).")
-                return result_code, None
+        return await remote_filemanager.get_file()

--- a/merino/providers/manifest/backends/protocol.py
+++ b/merino/providers/manifest/backends/protocol.py
@@ -18,7 +18,6 @@ class GetManifestResultCode(Enum):
 
     SUCCESS = 0
     FAIL = 1
-    SKIP = 2
 
 
 class Domain(BaseModel):

--- a/merino/providers/manifest/provider.py
+++ b/merino/providers/manifest/provider.py
@@ -75,9 +75,6 @@ class Provider:
                     }
                     self.last_fetch_at = time.time()
 
-                case GetManifestResultCode.SKIP:
-                    return None
-
                 case GetManifestResultCode.FAIL:
                     logger.error("Failed to fetch data from Manifest backend.")
                     return None

--- a/merino/providers/manifest/provider.py
+++ b/merino/providers/manifest/provider.py
@@ -1,4 +1,4 @@
-"""Provider for the Manifest data, fetched from GCS and stored in memory."""
+"""Provider for the Manifest data, fetched from GCS asynchronously and stored in memory."""
 
 import asyncio
 import time

--- a/tests/unit/providers/manifest/test_provider.py
+++ b/tests/unit/providers/manifest/test_provider.py
@@ -54,22 +54,6 @@ async def test_get_manifest_data(
 
 
 @pytest.mark.asyncio
-async def test_get_manifest_data_empty_data(manifest_provider: Provider, cleanup) -> None:
-    """Test get_manifest_data method returns empty manifest data object if backend returns SKIP"""
-    with patch(
-        "merino.providers.manifest.backends.manifest.ManifestBackend.fetch",
-        return_value=(GetManifestResultCode.SKIP, None),
-    ):
-        await manifest_provider.initialize()
-        await cleanup(manifest_provider)
-
-        manifest_data = manifest_provider.get_manifest_data()
-
-        assert manifest_data is not None
-        assert manifest_data.domains == []
-
-
-@pytest.mark.asyncio
 async def test_should_fetch_true(
     manifest_provider: Provider, manifest_data: ManifestData, cleanup
 ) -> None:
@@ -127,23 +111,6 @@ async def test_fetch_data_success(
 
         assert manifest_provider.manifest_data is not None
         assert manifest_provider.manifest_data == manifest_data
-
-
-@pytest.mark.asyncio
-async def test_fetch_data_skip(manifest_provider: Provider, cleanup) -> None:
-    """Test fetch_data method does not set manifest data on SKIP"""
-    with patch(
-        "merino.providers.manifest.backends.manifest.ManifestBackend.fetch",
-        return_value=(GetManifestResultCode.SKIP, None),
-    ):
-        await manifest_provider.initialize()
-        await cleanup(manifest_provider)
-
-        await manifest_provider._fetch_data()
-
-        # manifest data remains empty ManifestData instance after initialization
-        assert manifest_provider.manifest_data is not None
-        assert manifest_provider.manifest_data.domains == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## References

JIRA: [DISCO-3210](https://mozilla-hub.atlassian.net/browse/DISCO-3210)

## Description
Implement the async gcs client. Opened in lieu of: https://github.com/mozilla-services/merino-py/pull/793 

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3210]: https://mozilla-hub.atlassian.net/browse/DISCO-3210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ