### PR TITLE
DISCO-3410 Improve fixing the urls of favicons with no proper url

### DIFF
--- a/tests/unit/jobs/navigational_suggestions/test_domain_metadata_extractor.py
+++ b/tests/unit/jobs/navigational_suggestions/test_domain_metadata_extractor.py
@@ -879,8 +879,8 @@ def test_fix_url() -> None:
     # Test with protocol-relative URLs - should add https: prefix (keeping // intact)
     assert extractor._fix_url("//example.com/icon.ico") == "https://example.com/icon.ico"
 
-    # Test with absolute paths - should add https: prefix (keeping / intact)
-    assert extractor._fix_url("/icon.ico") == "https:/icon.ico"
+    # Test with absolute paths - when no _current_base_url is set, should return empty string
+    assert extractor._fix_url("/icon.ico") == ""
 
     # Test with domain names without protocol - should add https:// prefix
     assert extractor._fix_url("example.com/icon.ico") == "https://example.com/icon.ico"


### PR DESCRIPTION
## References

JIRA: [DISCO-3410](https://mozilla-hub.atlassian.net/browse/DISCO-3410)

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3410]: https://mozilla-hub.atlassian.net/browse/DISCO-3410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ