### PR TITLE
DISCO-3411 Save resources on parsing favicons in the nav-suggestion job

### DIFF
--- a/docs/operations/jobs/navigational_suggestions.md
+++ b/docs/operations/jobs/navigational_suggestions.md
@@ -61,22 +61,32 @@ This is meant to troubleshoot domains locally and iterate over the functionality
 
 Example output:
 ```bash
-$ poetry run probe-images mozilla.org
+$ uv run probe-images mozilla.org wikipedia.org
 
 Testing domain: mozilla.org
 ✅ Success!
  Title           Mozilla - Internet for people, not profit (UK)
- Best Icon       https://www.mozilla.org/media/img/favicons/mozilla/m24/favicon-196x196.e143075360ea.png
+ Best Icon       https://dummy-cdn.example.com/favicons/bd67680f7da3564bace91b2be87feab16d5e9e6266355b8f082e21f8159…
+ Total Favicons  4
+
+All favicons found:
+- https://www.mozilla.org/media/img/favicons/mozilla/apple-touch-icon.05aa000f6748.png (rel=apple-touch-icon
+size=180x180 type=image/png)
+- https://www.mozilla.org/media/img/favicons/mozilla/favicon-196x196.e143075360ea.png (rel=icon size=196x196
+type=image/png)
+- https://www.mozilla.org/media/img/favicons/mozilla/favicon.d0be64e474b1.ico (rel=shortcut,icon)
+
+Testing domain: wikipedia.org
+✅ Success!
+ Title           Wikipedia
+ Best Icon       https://dummy-cdn.example.com/favicons/4c8bf96d667fa2e9f072bdd8e9f25c8ba6ba2ad55df1af7d9ea0dd575c1…
  Total Favicons  3
 
 All favicons found:
-- https://www.mozilla.org/media/img/favicons/mozilla/m24/apple-touch-icon.05aa000f6748.png (rel=apple-touch-icon
-size=180x180 type=image/png)
-- https://www.mozilla.org/media/img/favicons/mozilla/m24/favicon-196x196.e143075360ea.png (rel=icon size=196x196
-type=image/png)
-- https://www.mozilla.org/media/img/favicons/mozilla/m24/favicon.d0be64e474b1.ico (rel=shortcut,icon)
+- https://www.wikipedia.org/static/apple-touch/wikipedia.png (rel=apple-touch-icon)
+- https://www.wikipedia.org/static/favicon/wikipedia.ico (rel=shortcut,icon)
 
-Summary: 1/1 domains processed successfully
+Summary: 2/2 domains processed successfully
 ```
 
 ## Adding new domains

--- a/tests/unit/jobs/navigational_suggestions/conftest.py
+++ b/tests/unit/jobs/navigational_suggestions/conftest.py
@@ -116,3 +116,14 @@ def mock_favicon_downloader(mocker, mock_async_client_session):
         return downloader
 
     return _create_downloader
+
+
+@pytest.fixture
+def mock_domain_metadata_uploader(mocker):
+    """Create a mock DomainMetadataUploader for testing."""
+    uploader = mocker.MagicMock()
+
+    uploader.upload_image.return_value = "https://cnd.mozilla.com/uploaded-favicon.ico"
+    uploader.destination_favicon_name.return_value = "favicons/12345_100.ico"
+
+    return uploader

--- a/tests/unit/jobs/navigational_suggestions/test_domain_metadata_extractor_improved.py
+++ b/tests/unit/jobs/navigational_suggestions/test_domain_metadata_extractor_improved.py
@@ -1,0 +1,255 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Additional tests for the domain metadata extractor to improve coverage."""
+
+import io
+import pytest
+from PIL import Image as PILImage
+from unittest.mock import AsyncMock
+
+from merino.jobs.navigational_suggestions.domain_metadata_extractor import (
+    DomainMetadataExtractor,
+    FaviconData,
+)
+from merino.utils.gcs.models import Image
+
+
+@pytest.mark.asyncio
+async def test_is_problematic_favicon_url():
+    """Test the _is_problematic_favicon_url method with various URLs."""
+    extractor = DomainMetadataExtractor(set())
+
+    # Test data URLs (should be problematic)
+    assert extractor._is_problematic_favicon_url("data:image/png;base64,ABC123") is True
+
+    # Test manifest JSON base64 marker URLs (should be problematic)
+    assert (
+        extractor._is_problematic_favicon_url("something/application/manifest+json;base64,xyz")
+        is True
+    )
+
+    # Test normal URLs (should not be problematic)
+    assert extractor._is_problematic_favicon_url("https://example.com/favicon.ico") is False
+    assert extractor._is_problematic_favicon_url("/favicon.ico") is False
+
+
+@pytest.mark.asyncio
+async def test_fix_url():
+    """Test the _fix_url method with various URLs."""
+    extractor = DomainMetadataExtractor(set())
+
+    # Empty URL or single slash
+    assert extractor._fix_url("") == ""
+    assert extractor._fix_url("/") == ""
+
+    # Protocol-relative URLs
+    assert extractor._fix_url("//example.com/favicon.ico") == "https://example.com/favicon.ico"
+
+    # URLs without protocol
+    assert extractor._fix_url("example.com/favicon.ico") == "https://example.com/favicon.ico"
+
+    # Absolute paths with base URL context
+    extractor._current_base_url = "https://example.com"
+    assert extractor._fix_url("/favicon.ico") == "https://example.com/favicon.ico"
+
+    # Absolute paths without base URL context
+    delattr(extractor, "_current_base_url")
+    assert extractor._fix_url("/favicon.ico") == ""
+
+    # URLs that already have a protocol
+    assert (
+        extractor._fix_url("https://example.com/favicon.ico") == "https://example.com/favicon.ico"
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_favicon_smallest_dimension():
+    """Test the _get_favicon_smallest_dimension method."""
+    extractor = DomainMetadataExtractor(set())
+
+    # Create a test image that will return specific dimensions
+    img_data = io.BytesIO()
+    test_image = PILImage.new("RGB", (100, 50))
+    test_image.save(img_data, format="PNG")
+    img_data.seek(0)
+
+    # Create an Image object with methods that mock PIL's behavior
+    test_image_obj = Image(content=img_data.getvalue(), content_type="image/png")
+
+    # Test the smallest dimension (should be 50)
+    assert extractor._get_favicon_smallest_dimension(test_image_obj) == 50
+
+    # Test with a square image
+    img_data = io.BytesIO()
+    test_image = PILImage.new("RGB", (75, 75))
+    test_image.save(img_data, format="PNG")
+    img_data.seek(0)
+    test_image_obj = Image(content=img_data.getvalue(), content_type="image/png")
+
+    # Both dimensions are the same, so it should return 75
+    assert extractor._get_favicon_smallest_dimension(test_image_obj) == 75
+
+
+@pytest.mark.asyncio
+async def test_extract_favicons_with_default_favicon_url(mocker):
+    """Test _extract_favicons method when a default favicon URL is found."""
+    extractor = DomainMetadataExtractor(set())
+
+    # Mock favicon data with no links, metas, or manifests
+    favicon_data = FaviconData(links=[], metas=[], manifests=[])
+    mocker.patch.object(extractor.scraper, "scrape_favicon_data", return_value=favicon_data)
+
+    # Mock the default favicon URL
+    default_favicon_url = "https://example.com/favicon.ico"
+    mocker.patch.object(
+        extractor.scraper, "get_default_favicon", AsyncMock(return_value=default_favicon_url)
+    )
+
+    # Call the method
+    results = await extractor._extract_favicons("https://example.com")
+
+    # Should include the default favicon
+    assert len(results) == 1
+    assert results[0]["href"] == default_favicon_url
+
+
+@pytest.mark.asyncio
+async def test_extract_favicons_error_handling(mocker):
+    """Test error handling in _extract_favicons method."""
+    extractor = DomainMetadataExtractor(set())
+
+    # Make scrape_favicon_data raise an exception
+    mocker.patch.object(
+        extractor.scraper, "scrape_favicon_data", side_effect=Exception("Test exception")
+    )
+
+    # Call the method - it should handle the exception and return an empty list
+    results = await extractor._extract_favicons("https://example.com")
+
+    # Should return an empty list
+    assert len(results) == 0
+
+
+@pytest.mark.asyncio
+async def test_upload_best_favicon_with_svg(mocker, mock_domain_metadata_uploader):
+    """Test _upload_best_favicon method with an SVG favicon."""
+    extractor = DomainMetadataExtractor(set())
+
+    # Create test favicons list with an SVG
+    favicons = [{"href": "https://example.com/icon.svg", "rel": "icon"}]
+
+    # Mock download_multiple_favicons to return an SVG image
+    svg_image = Image(content=b"<svg></svg>", content_type="image/svg+xml")
+    mocker.patch.object(
+        extractor.favicon_downloader,
+        "download_multiple_favicons",
+        AsyncMock(return_value=[svg_image]),
+    )
+
+    # Mock uploader methods
+    mock_domain_metadata_uploader.destination_favicon_name.return_value = "favicons/svg_icon.svg"
+    mock_domain_metadata_uploader.upload_image.return_value = (
+        "https://cdn.example.com/favicons/svg_icon.svg"
+    )
+
+    # Call the method
+    result = await extractor._upload_best_favicon(favicons, 16, mock_domain_metadata_uploader)
+
+    # Should return the uploaded SVG URL
+    assert result == "https://cdn.example.com/favicons/svg_icon.svg"
+
+    # Verify uploader was called correctly
+    mock_domain_metadata_uploader.upload_image.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_upload_best_favicon_svg_upload_error(mocker, mock_domain_metadata_uploader):
+    """Test _upload_best_favicon method with an SVG favicon that fails to upload."""
+    extractor = DomainMetadataExtractor(set())
+
+    # Create test favicons list with an SVG
+    favicons = [{"href": "https://example.com/icon.svg", "rel": "icon"}]
+
+    # Mock download_multiple_favicons to return an SVG image
+    svg_image = Image(content=b"<svg></svg>", content_type="image/svg+xml")
+    mocker.patch.object(
+        extractor.favicon_downloader,
+        "download_multiple_favicons",
+        AsyncMock(return_value=[svg_image]),
+    )
+
+    # Mock uploader to throw an exception
+    mock_domain_metadata_uploader.upload_image.side_effect = Exception("Upload failed")
+
+    # Call the method
+    result = await extractor._upload_best_favicon(favicons, 16, mock_domain_metadata_uploader)
+
+    # Should fall back to the original URL
+    assert result == "https://example.com/icon.svg"
+
+
+@pytest.mark.asyncio
+async def test_upload_best_favicon_bitmap_upload_error(mocker, mock_domain_metadata_uploader):
+    """Test _upload_best_favicon method with a bitmap favicon that fails to upload."""
+    extractor = DomainMetadataExtractor(set())
+
+    # Create test favicons list with a PNG
+    favicons = [{"href": "https://example.com/icon.png", "rel": "icon"}]
+
+    # Create a mock image
+    img_data = io.BytesIO()
+    test_image = PILImage.new("RGB", (32, 32))
+    test_image.save(img_data, format="PNG")
+    img_data.seek(0)
+
+    # Mock download_multiple_favicons to return a PNG image
+    png_image = Image(content=img_data.getvalue(), content_type="image/png")
+    mocker.patch.object(
+        extractor.favicon_downloader,
+        "download_multiple_favicons",
+        AsyncMock(return_value=[png_image]),
+    )
+
+    # Mock uploader to throw an exception
+    mock_domain_metadata_uploader.upload_image.side_effect = Exception("Upload failed")
+
+    # Mock _get_favicon_smallest_dimension
+    mocker.patch.object(extractor, "_get_favicon_smallest_dimension", return_value=32)
+
+    # Call the method
+    result = await extractor._upload_best_favicon(favicons, 16, mock_domain_metadata_uploader)
+
+    # Should fall back to the original URL
+    assert result == "https://example.com/icon.png"
+
+
+@pytest.mark.asyncio
+async def test_process_favicon(mocker, mock_domain_metadata_uploader):
+    """Test the _process_favicon method."""
+    extractor = DomainMetadataExtractor(set())
+
+    # Mock _extract_favicons
+    favicons = [{"href": "https://example.com/favicon.ico"}]
+    mocker.patch.object(extractor, "_extract_favicons", AsyncMock(return_value=favicons))
+
+    # Mock _upload_best_favicon
+    expected_url = "https://cdn.example.com/favicons/uploaded.ico"
+    mocker.patch.object(extractor, "_upload_best_favicon", AsyncMock(return_value=expected_url))
+
+    # Call the method
+    result = await extractor._process_favicon(
+        "https://example.com", 16, mock_domain_metadata_uploader
+    )
+
+    # Should return the result of _upload_best_favicon
+    assert result == expected_url
+
+    # Verify _extract_favicons was called with the correct parameters
+    extractor._extract_favicons.assert_called_once_with("https://example.com", max_icons=5)
+
+    # Verify _upload_best_favicon was called with the correct parameters
+    extractor._upload_best_favicon.assert_called_once_with(
+        favicons, 16, mock_domain_metadata_uploader
+    )

--- a/tests/unit/jobs/navigational_suggestions/test_init.py
+++ b/tests/unit/jobs/navigational_suggestions/test_init.py
@@ -15,14 +15,17 @@ def test_construct_top_picks_source_field():
         {"rank": 2, "categories": ["shopping"], "source": "custom-domains"},
     ]
 
-    favicons = ["icon1", "icon2"]
-
     domain_metadata = [
-        {"domain": "example.com", "url": "https://example.com", "title": "Example"},
-        {"domain": "amazon.ca", "url": "https://amazon.ca", "title": "Amazon"},
+        {
+            "domain": "example.com",
+            "url": "https://example.com",
+            "title": "Example",
+            "icon": "icon1",
+        },
+        {"domain": "amazon.ca", "url": "https://amazon.ca", "title": "Amazon", "icon": "icon2"},
     ]
 
-    result = _construct_top_picks(domain_data, favicons, domain_metadata)
+    result = _construct_top_picks(domain_data, domain_metadata)
 
     # Check if source field is included correctly in the results
     assert "domains" in result

--- a/tests/unit/jobs/navigational_suggestions/test_navigational_suggestions.py
+++ b/tests/unit/jobs/navigational_suggestions/test_navigational_suggestions.py
@@ -46,7 +46,7 @@ def test_prepare_domain_metadata_top_picks_construction(mocker):
         },
     ]
 
-    mock_domain_metadata_extractor.get_domain_metadata.return_value = [
+    mock_domain_metadata_extractor.process_domain_metadata.return_value = [
         {
             "url": "dummy_url.com",
             "title": "dummy_title",
@@ -86,7 +86,7 @@ def test_prepare_domain_metadata_top_picks_construction(mocker):
                 "serp_categories": [0],
                 "url": "dummy_url.com",
                 "title": "dummy_title",
-                "icon": "dummy_uploaded_favicon_url",
+                "icon": "dummy_icon",
                 "source": "top-picks",
             }
         ]
@@ -121,7 +121,7 @@ def test_prepare_domain_metadata_partner_manifest(mocker):
         }
     ]
 
-    mock_domain_metadata_extractor.get_domain_metadata.return_value = [
+    mock_domain_metadata_extractor.process_domain_metadata.return_value = [
         {
             "url": "dummy_url.com",
             "title": "dummy_title",
@@ -209,7 +209,7 @@ def test_prepare_domain_metadata_partner_manifest(mocker):
                 "serp_categories": [0],
                 "url": "dummy_url.com",
                 "title": "dummy_title",
-                "icon": "dummy_uploaded_favicon_url",
+                "icon": "dummy_icon",
                 "source": "top-picks",
             }
         ],


### PR DESCRIPTION
## References

JIRA: [DISCO-3411](https://mozilla-hub.atlassian.net/browse/DISCO-3411)

This PR re-writes how the Navigational Suggestion job works. We recently started adding more custom domains to the already existing domains we query each week inside BigQuery. The custom domains (https://github.com/mozilla-services/merino-py/blob/main/merino/jobs/navigational_suggestions/custom_domains.py) grew to over 1.5k entries.

This caused the job to error out on Airflow, most likely due to increased resource consumption. The old way was to query all domains for all possible favicons, download and compare the quality of these favicons for each side, and at the end of the run, upload them and create the `top-picks.json` file and upload it to a Google Cloud bucket.

We then introduced an async version of this job with this PR: https://github.com/mozilla-services/merino-py/pull/846 Which sped up the processing, but still used the same in-memory resources.

This PR tries to address these issues by:
- Don't query the domains for all possible favicons, but limit it to 5 (because we download and compare all of them)
- Upload the favicon right away to Google Cloud instead of keeping them in memory
- Delete all fetched favicons after uploading them to Google Cloud right away

Therefore, this PR replaces the methods where we get a list of favicons, and downloading all of them before uploading them to GCS, and uploading a good fit right away (https://github.com/mozilla-services/merino-py/pull/866/files#diff-3f65e67d8441adc349f59daf0c480b0b16b2826ffd35c0dd993a151326c34c94L77-L93).

Instead of `get_best_favicon`, we have now the method `_process_favicon` (https://github.com/mozilla-services/merino-py/pull/866/files#diff-d9ccfdf46db463d509aaf3ae5dee144bc11d765352784192d49d81e27f4ffeafL316) where we extract possible links of the fetched HTML of the queried domain, do the same quality and type comparison, and upload a match right away.

This PR doesn't change how we find favicons or compare them, and implements a more streamlined approach to storing and uploading them to save memory resources.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3411]: https://mozilla-hub.atlassian.net/browse/DISCO-3411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ