### PR TITLE
HNT-474: Change interest picker title & subtitle

### DIFF
--- a/merino/curated_recommendations/interest_picker.py
+++ b/merino/curated_recommendations/interest_picker.py
@@ -80,10 +80,6 @@ def _build_picker(
     picker_rank = _get_interest_picker_rank(sections)
     return InterestPicker(
         receivedFeedRank=picker_rank,
-        title="Follow topics to personalize your feed",
-        subtitle=(
-            "We will bring you personalized content, all while respecting your privacy. "
-            "You'll have powerful control over what content you see and what you don't."
-        ),
+        title="Follow topics to fine-tune your feed",
         sections=[InterestPickerSection(sectionId=s.ID) for s in picker_sections],
     )

--- a/merino/curated_recommendations/protocol.py
+++ b/merino/curated_recommendations/protocol.py
@@ -327,7 +327,7 @@ class InterestPicker(BaseModel):
 
     receivedFeedRank: int
     title: str
-    subtitle: str
+    subtitle: str | None = None
     sections: list[InterestPickerSection]
 
 

--- a/tests/unit/curated_recommendations/test_interest_picker.py
+++ b/tests/unit/curated_recommendations/test_interest_picker.py
@@ -54,6 +54,10 @@ def test_interest_picker_is_created(followed_count: int):
     picker = create_interest_picker(sections)
     assert picker is not None
 
+    # Picker has expected title and subtitle strings.
+    assert picker.title == "Follow topics to fine-tune your feed"
+    assert picker.subtitle is None
+
     # Picker rank range depends on followed sections.
     min_picker_rank = 1 if followed_count == 0 else 2
     max_picker_rank = min_picker_rank + 2

--- a/tests/unit/curated_recommendations/test_interest_picker.py
+++ b/tests/unit/curated_recommendations/test_interest_picker.py
@@ -54,7 +54,7 @@ def test_interest_picker_is_created(followed_count: int):
     picker = create_interest_picker(sections)
     assert picker is not None
 
-    # Picker has expected title and subtitle strings.
+    # Picker has expected title string and no subtitle.
     assert picker.title == "Follow topics to fine-tune your feed"
     assert picker.subtitle is None
 


### PR DESCRIPTION
## References

JIRA: [HNT-474](https://mozilla-hub.atlassian.net/browse/HNT-474)

## Description
Update the Interest Picker title & subtitle:

- Change the headline: “Follow topics to fine-tune your feed”
- Removing the subtitle

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[HNT-474]: https://mozilla-hub.atlassian.net/browse/HNT-474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ