### PR TITLE
fix: process records in top picks if source field is not available

### DIFF
--- a/merino/providers/suggest/top_picks/backends/top_picks.py
+++ b/merino/providers/suggest/top_picks/backends/top_picks.py
@@ -88,8 +88,11 @@ class TopPicksBackend:
         query_max: int = self.query_char_limit
 
         for record in domain_list["domains"]:
-            # Filter to only include domains with source="top-picks"
-            if record.get("source") != "top-picks":
+            # Filter to only include domains with source="top-picks" (if exists)
+            # if the source field is not present, ignore and add the record
+            # TODO: Once the updated manifest is published, remove "is not None"
+            source = record.get("source")
+            if source is not None and source != "top-picks":
                 continue
 
             index_key: int = len(results)

--- a/tests/unit/jobs/navigational_suggestions/test_init.py
+++ b/tests/unit/jobs/navigational_suggestions/test_init.py
@@ -4,7 +4,16 @@
 
 """Unit tests for navigational_suggestions __init__.py module."""
 
-from merino.jobs.navigational_suggestions import _construct_top_picks
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from merino.jobs.navigational_suggestions import (
+    _construct_partner_manifest,
+    _construct_top_picks,
+    _write_xcom_file,
+    prepare_domain_metadata,
+)
 
 
 def test_construct_top_picks_source_field():
@@ -43,3 +52,294 @@ def test_construct_top_picks_source_field():
     assert result["domains"][1]["url"] == "https://amazon.ca"
     assert result["domains"][1]["title"] == "Amazon"
     assert result["domains"][1]["icon"] == "icon2"
+
+
+def test_construct_top_picks_missing_source_field():
+    """Test that _construct_top_picks handles missing source field correctly."""
+    # Mock input data with missing source field
+    domain_data = [
+        {"rank": 1, "categories": ["web"]},  # No source field
+    ]
+
+    domain_metadata = [
+        {
+            "domain": "example.com",
+            "url": "https://example.com",
+            "title": "Example",
+            "icon": "icon1",
+        },
+    ]
+
+    result = _construct_top_picks(domain_data, domain_metadata)
+
+    # Check if source field defaults to "top-picks"
+    assert "domains" in result
+    assert len(result["domains"]) == 1
+    assert result["domains"][0]["source"] == "top-picks"
+
+
+def test_construct_partner_manifest():
+    """Test the _construct_partner_manifest function."""
+    partner_favicon_source = [
+        {
+            "domain": "partner1.com",
+            "url": "https://partner1.com",
+            "icon": "https://partner1.com/favicon.ico",
+        },
+        {
+            "domain": "partner2.com",
+            "url": "https://partner2.com",
+            "icon": "https://partner2.com/favicon.ico",
+        },
+    ]
+
+    uploaded_favicons = [
+        "https://cdn.example.com/partner1-favicon.ico",
+        "https://cdn.example.com/partner2-favicon.ico",
+    ]
+
+    result = _construct_partner_manifest(partner_favicon_source, uploaded_favicons)
+
+    assert "partners" in result
+    assert len(result["partners"]) == 2
+
+    assert result["partners"][0]["domain"] == "partner1.com"
+    assert result["partners"][0]["url"] == "https://partner1.com"
+    assert result["partners"][0]["original_icon_url"] == "https://partner1.com/favicon.ico"
+    assert result["partners"][0]["gcs_icon_url"] == "https://cdn.example.com/partner1-favicon.ico"
+
+    assert result["partners"][1]["domain"] == "partner2.com"
+    assert result["partners"][1]["url"] == "https://partner2.com"
+    assert result["partners"][1]["original_icon_url"] == "https://partner2.com/favicon.ico"
+    assert result["partners"][1]["gcs_icon_url"] == "https://cdn.example.com/partner2-favicon.ico"
+
+
+def test_construct_partner_manifest_length_mismatch():
+    """Test _construct_partner_manifest with mismatched input lengths."""
+    partner_favicon_source = [
+        {
+            "domain": "partner1.com",
+            "url": "https://partner1.com",
+            "icon": "https://partner1.com/favicon.ico",
+        },
+        {
+            "domain": "partner2.com",
+            "url": "https://partner2.com",
+            "icon": "https://partner2.com/favicon.ico",
+        },
+    ]
+
+    uploaded_favicons = [
+        "https://cdn.example.com/partner1-favicon.ico",
+        # Missing second favicon URL
+    ]
+
+    with pytest.raises(
+        ValueError, match="Mismatch: The number of favicons and GCS URLs must be the same."
+    ):
+        _construct_partner_manifest(partner_favicon_source, uploaded_favicons)
+
+
+def test_write_xcom_file():
+    """Test _write_xcom_file function."""
+    test_data = {"key": "value", "numbers": [1, 2, 3]}
+
+    # Create a mock file object instead of using a real temporary file
+    mock_file = MagicMock()
+
+    with patch("builtins.open", return_value=mock_file):
+        _write_xcom_file(test_data)
+
+        # Verify that json.dump was called with our test data to the file
+        mock_file.__enter__.return_value.write.assert_called()
+        # We can verify that open was called with the right path
+        open.assert_called_once_with("/airflow/xcom/return.json", "w")
+
+
+@patch("merino.jobs.navigational_suggestions.DomainDataDownloader")
+@patch("merino.jobs.navigational_suggestions.DomainMetadataUploader")
+@patch("merino.jobs.navigational_suggestions.DomainMetadataExtractor")
+@patch("merino.jobs.navigational_suggestions.GcsUploader")
+@patch("merino.jobs.navigational_suggestions.AsyncFaviconDownloader")
+@patch("merino.jobs.navigational_suggestions.DomainDiff")
+@patch(
+    "merino.jobs.navigational_suggestions.PARTNER_FAVICONS",
+    [
+        {
+            "domain": "partner.com",
+            "url": "https://partner.com",
+            "icon": "https://partner.com/favicon.ico",
+        }
+    ],
+)
+def test_prepare_domain_metadata(
+    mock_domain_diff_class,
+    mock_favicon_downloader,
+    mock_gcs_uploader,
+    mock_extractor_class,
+    mock_uploader_class,
+    mock_downloader_class,
+):
+    """Test prepare_domain_metadata function."""
+    # Setup mocks
+    mock_downloader = MagicMock()
+    mock_downloader_class.return_value = mock_downloader
+    mock_downloader.download_data.return_value = [
+        {"rank": 1, "categories": ["web"], "source": "top-picks"}
+    ]
+
+    mock_uploader = MagicMock()
+    mock_uploader_class.return_value = mock_uploader
+    mock_uploader.get_latest_file_for_diff.return_value = None
+    mock_uploader.upload_favicons.return_value = ["https://cdn.example.com/partner-favicon.ico"]
+
+    mock_blob = MagicMock()
+    mock_blob.name = "top_picks.json"
+    mock_blob.public_url = "https://cdn.example.com/top_picks.json"
+    mock_uploader.upload_top_picks.return_value = mock_blob
+
+    mock_extractor = MagicMock()
+    mock_extractor_class.return_value = mock_extractor
+    mock_extractor.process_domain_metadata.return_value = [
+        {
+            "domain": "example.com",
+            "url": "https://example.com",
+            "title": "Example",
+            "icon": "https://cdn.example.com/favicon.ico",
+        }
+    ]
+
+    mock_domain_diff = MagicMock()
+    mock_domain_diff_class.return_value = mock_domain_diff
+    mock_domain_diff.compare_top_picks.return_value = (10, 5, 3)
+    mock_domain_diff.create_diff.return_value = {"unchanged": 10, "added": 5, "url_changes": 3}
+
+    # Call the function
+    with patch("merino.jobs.navigational_suggestions._write_xcom_file") as mock_write_xcom:
+        prepare_domain_metadata(
+            source_gcp_project="source-project",
+            destination_gcp_project="dest-project",
+            destination_gcs_bucket="dest-bucket",
+            destination_cdn_hostname="cdn.example.com",
+            force_upload=True,
+            write_xcom=True,
+            min_favicon_width=48,
+        )
+
+    # Verify calls
+    mock_downloader_class.assert_called_once_with("source-project")
+    mock_downloader.download_data.assert_called_once()
+
+    mock_gcs_uploader.assert_called_once_with("dest-project", "dest-bucket", "cdn.example.com")
+
+    mock_extractor_class.assert_called_once()
+    mock_extractor.process_domain_metadata.assert_called_once_with(
+        [{"rank": 1, "categories": ["web"], "source": "top-picks"}], 48, uploader=mock_uploader
+    )
+
+    mock_uploader.upload_favicons.assert_called_once_with(["https://partner.com/favicon.ico"])
+
+    mock_uploader.get_latest_file_for_diff.assert_called_once()
+
+    mock_domain_diff_class.assert_called_once()
+    mock_domain_diff.compare_top_picks.assert_called_once()
+    mock_domain_diff.create_diff.assert_called_once_with(
+        file_name="top_picks.json", unchanged=10, domains=5, urls=3
+    )
+
+    mock_write_xcom.assert_called_once_with(
+        {
+            "top_pick_url": "https://cdn.example.com/top_picks.json",
+            "diff": {"unchanged": 10, "added": 5, "url_changes": 3},
+        }
+    )
+
+
+@patch("merino.jobs.navigational_suggestions.DomainDataDownloader")
+@patch("merino.jobs.navigational_suggestions.DomainMetadataUploader")
+@patch("merino.jobs.navigational_suggestions.DomainMetadataExtractor")
+@patch("merino.jobs.navigational_suggestions.GcsUploader")
+@patch("merino.jobs.navigational_suggestions.AsyncFaviconDownloader")
+@patch("merino.jobs.navigational_suggestions.DomainDiff")
+@patch(
+    "merino.jobs.navigational_suggestions.PARTNER_FAVICONS",
+    [
+        {
+            "domain": "partner.com",
+            "url": "https://partner.com",
+            "icon": "https://partner.com/favicon.ico",
+        }
+    ],
+)
+def test_prepare_domain_metadata_with_existing_file(
+    mock_domain_diff_class,
+    mock_favicon_downloader,
+    mock_gcs_uploader,
+    mock_extractor_class,
+    mock_uploader_class,
+    mock_downloader_class,
+):
+    """Test prepare_domain_metadata function with an existing top picks file."""
+    # Setup mocks
+    mock_downloader = MagicMock()
+    mock_downloader_class.return_value = mock_downloader
+    mock_downloader.download_data.return_value = [
+        {"rank": 1, "categories": ["web"], "source": "top-picks"}
+    ]
+
+    mock_uploader = MagicMock()
+    mock_uploader_class.return_value = mock_uploader
+
+    # Return existing data for diff
+    mock_uploader.get_latest_file_for_diff.return_value = {
+        "domains": [
+            {
+                "rank": 1,
+                "domain": "example.com",
+                "url": "https://example.com",
+                "title": "Example",
+                "icon": "old-icon-url",
+                "categories": ["web"],
+                "source": "top-picks",
+            }
+        ]
+    }
+
+    mock_uploader.upload_favicons.return_value = ["https://cdn.example.com/partner-favicon.ico"]
+
+    mock_blob = MagicMock()
+    mock_blob.name = "top_picks.json"
+    mock_blob.public_url = "https://cdn.example.com/top_picks.json"
+    mock_uploader.upload_top_picks.return_value = mock_blob
+
+    mock_extractor = MagicMock()
+    mock_extractor_class.return_value = mock_extractor
+    mock_extractor.process_domain_metadata.return_value = [
+        {
+            "domain": "example.com",
+            "url": "https://example.com",
+            "title": "Example",
+            "icon": "https://cdn.example.com/favicon.ico",
+        }
+    ]
+
+    mock_domain_diff = MagicMock()
+    mock_domain_diff_class.return_value = mock_domain_diff
+    mock_domain_diff.compare_top_picks.return_value = (10, 5, 3)
+    mock_domain_diff.create_diff.return_value = {"unchanged": 10, "added": 5, "url_changes": 3}
+
+    # Call the function without write_xcom
+    prepare_domain_metadata(
+        source_gcp_project="source-project",
+        destination_gcp_project="dest-project",
+        destination_gcs_bucket="dest-bucket",
+        destination_cdn_hostname="cdn.example.com",
+        force_upload=True,
+        write_xcom=False,  # No XCom writing in this test
+        min_favicon_width=48,
+    )
+
+    # Verify the domain diff was created with the correct data
+    mock_domain_diff_class.assert_called_once()
+    # Confirm compare_top_picks was called with both old and new data
+    mock_domain_diff.compare_top_picks.assert_called_once()

--- a/tests/unit/providers/suggest/top_picks/backends/test_top_picks.py
+++ b/tests/unit/providers/suggest/top_picks/backends/test_top_picks.py
@@ -303,3 +303,59 @@ def test_source_field_filtering(top_picks_backend: TopPicksBackend, mocker) -> N
 
     assert top_pick_prefix in result.primary_index
     assert custom_prefix not in result.primary_index
+
+
+def test_missing_source_field(top_picks_backend: TopPicksBackend, mocker) -> None:
+    """Test that domains with missing source field are included in build_index."""
+    # Create mock domain list with a domain missing the source field
+    mock_domain_list = {
+        "domains": [
+            {
+                "domain": "toppick.com",
+                "title": "Top Pick Domain",
+                "url": "https://toppick.com",
+                "icon": "icon1",
+                "source": "top-picks",
+                "categories": ["web"],
+                "serp_categories": [1],
+            },
+            {
+                "domain": "nosource.com",
+                "title": "No Source Domain",
+                "url": "https://nosource.com",
+                "icon": "icon3",
+                "categories": ["web"],
+                "serp_categories": [1],
+            },
+            {
+                "domain": "custom.com",
+                "title": "Custom Domain",
+                "url": "https://custom.com",
+                "icon": "icon2",
+                "source": "custom-domains",
+                "categories": ["web"],
+                "serp_categories": [1],
+            },
+        ]
+    }
+
+    # Use the real build_index method with our mock data
+    result = top_picks_backend.build_index(mock_domain_list)
+
+    # Check that the top-picks domain and the one without source are included
+    all_domains = []
+    for index_value in result.results:
+        all_domains.append(index_value["url"])
+
+    assert "https://toppick.com" in all_domains
+    assert "https://nosource.com" in all_domains
+    assert "https://custom.com" not in all_domains
+
+    # Verify the domains appear in the indices
+    top_pick_prefix = "toppick"[: top_picks_backend.query_char_limit]
+    no_source_prefix = "nosource"[: top_picks_backend.query_char_limit]
+    custom_prefix = "custom"[: top_picks_backend.query_char_limit]
+
+    assert top_pick_prefix in result.primary_index
+    assert no_source_prefix in result.primary_index
+    assert custom_prefix not in result.primary_index


### PR DESCRIPTION
## References

Process records also if the `source` field does not exist inside the Top Picks provider. The current manifest doesn't contain the `source` field yet. This is a backwards compatible fix, which can be removed after the next successful navigational suggestion job run.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
