### PR TITLE
fix: reduce logs for nav-suggestions job

### DIFF
--- a/merino/jobs/navigational_suggestions/domain_metadata_uploader.py
+++ b/merino/jobs/navigational_suggestions/domain_metadata_uploader.py
@@ -64,7 +64,6 @@ class DomainMetadataUploader:
 
         data = most_recent.download_as_text()
         file_contents: dict = json.loads(data)
-        logger.info(f"Domain file {most_recent.name} acquired.")
         return file_contents
 
     def upload_favicon(self, favicon_url: str) -> str:
@@ -90,10 +89,9 @@ class DomainMetadataUploader:
                 dst_favicon_public_url = self.uploader.upload_image(
                     favicon_image, dst_favicon_name, forced_upload=self.force_upload
                 )
-                logger.info(f"Favicon uploaded: {dst_favicon_public_url}")
                 return dst_favicon_public_url
             except Exception as e:
-                logger.info(f"Exception {e} occurred while uploading favicon")
+                logger.debug(f"Failed to upload favicon: {e}")
 
         return ""
 
@@ -151,7 +149,6 @@ class DomainMetadataUploader:
             case "image/gif":
                 extension = ".gif"
             case _:
-                logger.info(f"Couldn't find a match for {favicon_image.content_type}")
                 extension = ".oct"
 
         return f"{self.DESTINATION_FAVICONS_ROOT}/{content_hex_digest}_{content_len}{extension}"

--- a/merino/jobs/navigational_suggestions/utils.py
+++ b/merino/jobs/navigational_suggestions/utils.py
@@ -49,8 +49,7 @@ class AsyncFaviconDownloader:
         try:
             response = await self.session.get(url, headers=REQUEST_HEADERS, follow_redirects=True)
             return response if response.status_code == 200 else None
-        except Exception as e:
-            logger.info(f"Exception {e} while getting response from {url}")
+        except Exception:
             return None
 
     async def download_favicon(self, url: str) -> Optional[Image]:
@@ -71,8 +70,7 @@ class AsyncFaviconDownloader:
                     content_type=str(content_type),
                 )
             return None
-        except Exception as e:
-            logger.info(f"Exception {e} while downloading favicon {url}")
+        except Exception:
             return None
 
     async def download_multiple_favicons(self, urls: List[str]) -> List[Optional[Image]]:
@@ -90,8 +88,7 @@ class AsyncFaviconDownloader:
             try:
                 async with semaphore:
                     return await self.download_favicon(url)
-            except Exception as e:
-                logger.warning(f"Unhandled exception in download_with_semaphore: {e}")
+            except Exception:
                 return None
 
         # Create tasks with semaphore control

--- a/tests/unit/jobs/navigational_suggestions/test_domain_metadata_extractor.py
+++ b/tests/unit/jobs/navigational_suggestions/test_domain_metadata_extractor.py
@@ -1011,14 +1011,8 @@ async def test_scraper_get_default_favicon() -> None:
     scraper.request_client.requests_get.reset_mock()
     scraper.request_client.requests_get.side_effect = Exception("Connection error")
 
-    with patch(
-        "merino.jobs.navigational_suggestions.domain_metadata_extractor.logger"
-    ) as mock_logger:
-        result = await scraper.get_default_favicon("https://example.com")
-
-        assert result is None
-        mock_logger.info.assert_called_once()
-        assert "Connection error" in mock_logger.info.call_args[0][0]
+    result = await scraper.get_default_favicon("https://example.com")
+    assert result is None
 
 
 @pytest.mark.asyncio
@@ -1068,8 +1062,8 @@ async def test_scraper_scrape_favicons_from_manifest() -> None:
         result = await scraper.scrape_favicons_from_manifest("https://example.com/manifest.json")
 
         assert result == []
-        mock_logger.warning.assert_called_once()
-        assert "Connection error" in mock_logger.warning.call_args[0][0]
+        mock_logger.debug.assert_called_once()
+        assert "Connection error" in mock_logger.debug.call_args[0][0]
 
     # Test exception during JSON parsing
     scraper.request_client.requests_get.reset_mock()
@@ -1085,8 +1079,8 @@ async def test_scraper_scrape_favicons_from_manifest() -> None:
         result = await scraper.scrape_favicons_from_manifest("https://example.com/manifest.json")
 
         assert result == []
-        mock_logger.warning.assert_called_once()
-        assert "Invalid JSON" in mock_logger.warning.call_args[0][0]
+        mock_logger.debug.assert_called_once()
+        assert "Failed to parse manifest JSON" in mock_logger.debug.call_args[0][0]
 
 
 def test_scraper_scrape_title() -> None:
@@ -1110,28 +1104,16 @@ def test_scraper_scrape_title() -> None:
     # Test exception - missing head tag
     scraper.browser.find.return_value = None
 
-    with patch(
-        "merino.jobs.navigational_suggestions.domain_metadata_extractor.logger"
-    ) as mock_logger:
-        result = scraper.scrape_title()
-
-        assert result is None
-        mock_logger.info.assert_called_once()
-        assert "while scraping title" in mock_logger.info.call_args[0][0]
+    result = scraper.scrape_title()
+    assert result is None
 
     # Test exception - missing title tag
     head_mock = Mock()
     head_mock.find.return_value = None
     scraper.browser.find.return_value = head_mock
 
-    with patch(
-        "merino.jobs.navigational_suggestions.domain_metadata_extractor.logger"
-    ) as mock_logger:
-        result = scraper.scrape_title()
-
-        assert result is None
-        mock_logger.info.assert_called_once()
-        assert "while scraping title" in mock_logger.info.call_args[0][0]
+    result = scraper.scrape_title()
+    assert result is None
 
 
 @pytest.mark.asyncio
@@ -1150,10 +1132,10 @@ async def test_extract_favicons_with_exception() -> None:
         # Should return empty list but not fail
         assert result == []
         # Check for the specific error log call
-        assert mock_logger.info.call_count >= 1
+        assert mock_logger.error.call_count >= 1
         exception_log_call = False
-        for call_args in mock_logger.info.call_args_list:
-            if "Test exception" in call_args[0][0]:
+        for call_args in mock_logger.error.call_args_list:
+            if "extracting favicons" in call_args[0][0]:
                 exception_log_call = True
                 break
         assert exception_log_call, "Expected log message with exception not found"
@@ -1211,7 +1193,7 @@ async def test_upload_best_favicon_with_exception(mock_domain_metadata_uploader)
             # Should not raise exception but return empty string
             assert result == ""
             mock_logger.warning.assert_called_once()
-            assert "Test exception" in mock_logger.warning.call_args[0][0]
+            assert "Exception for favicon at position" in mock_logger.warning.call_args[0][0]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/jobs/navigational_suggestions/test_domain_metadata_uploader.py
+++ b/tests/unit/jobs/navigational_suggestions/test_domain_metadata_uploader.py
@@ -418,8 +418,7 @@ def test_get_latest_file_for_diff(
     assert result["domains"]
     assert len(result["domains"]) == 6
 
-    assert len(records) == 1
-    assert records[0].message.startswith(f"Domain file {remote_blob_newest.name} acquired.")
+    assert len(records) == 0
 
 
 def test_get_latest_file_for_diff_when_no_file_is_returned_by_the_uploader(

--- a/tests/unit/jobs/navigational_suggestions/test_navigational_suggestions_utils.py
+++ b/tests/unit/jobs/navigational_suggestions/test_navigational_suggestions_utils.py
@@ -99,7 +99,6 @@ async def test_requests_get_exception(mocker, caplog):
 
     # Verify the result
     assert response is None
-    assert "Exception Test error while getting response from http://example.com" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -183,5 +182,4 @@ async def test_favicon_downloader_handles_exception(
     favicon = await downloader.download_favicon("http://icon")
 
     assert favicon is None
-    assert len(caplog.messages) == 1
-    assert caplog.messages[0] == "Exception Bad Request while downloading favicon http://icon"
+    assert len(caplog.messages) == 0


### PR DESCRIPTION
## References

Reduce the amount of logs we accumulate to not to overload the Kubernetes pod.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
