### PR TITLE
[DISCO-3393] Suggest: Weather 204 when there's no weather for location

### DIFF
--- a/merino/configs/testing.toml
+++ b/merino/configs/testing.toml
@@ -45,6 +45,7 @@ url_base = "test://test"
 
 [testing.providers.accuweather]
 enabled_by_default = false
+backend="test_weather"
 
 [testing.providers.adm]
 # Whether or not this provider is enabled by default.

--- a/merino/providers/suggest/weather/backends/accuweather/errors.py
+++ b/merino/providers/suggest/weather/backends/accuweather/errors.py
@@ -4,6 +4,7 @@ AccuweatherError class to format and wrap them as a BackendError child object
 
 from enum import Enum
 from merino.exceptions import BackendError
+from merino.middleware.geolocation import Location
 
 
 class AccuweatherErrorMessages(Enum):
@@ -38,3 +39,10 @@ class AccuweatherError(BackendError):
         # Use the `format_message` method to get the formatted error message
         message = error_type.format_message(**kwargs)
         super().__init__(message)
+
+
+class MissingLocationKeyError(BackendError):
+    """Error when Accuweather api does not find a location key."""
+
+    def __init__(self, location: Location | None = None):
+        super().__init__(f"AccuWeatherError.missing_location_key for location: {location}")

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -224,14 +224,8 @@ async def suggest(
             for task in completed_tasks
         )
     )
-    if (
-        request_type == "weather"
-        and len(suggestions) == 1
-        and suggestions[0] is NO_LOCATION_KEY_SUGGESTION
-    ):
+    if len(suggestions) == 1 and suggestions[0] is NO_LOCATION_KEY_SUGGESTION:
         return Response(status_code=204)
-
-    suggestions = [s for s in suggestions if s is not NO_LOCATION_KEY_SUGGESTION]
 
     emit_suggestions_per_metrics(metrics_client, suggestions, search_from)
 

--- a/tests/integration/api/v1/suggest/test_suggest_weather.py
+++ b/tests/integration/api/v1/suggest/test_suggest_weather.py
@@ -20,6 +20,7 @@ from pydantic import HttpUrl, TypeAdapter
 from pytest import LogCaptureFixture
 from pytest_mock import MockerFixture
 
+from merino.exceptions import BackendError
 from merino.middleware import ScopeKey
 from merino.middleware.geolocation import GeolocationMiddleware, Location, Coordinates
 from merino.providers.suggest.base import SuggestionRequest
@@ -67,7 +68,7 @@ def fixture_providers(backend_mock: Any, statsd_mock: Any) -> Providers:
             backend=backend_mock,
             metrics_client=statsd_mock,
             score=0.3,
-            name="weather",
+            name="test_weather",
             query_timeout_sec=0.2,
             enabled_by_default=True,
             cron_interval_sec=100,
@@ -220,7 +221,7 @@ def test_suggest_with_weather_report(client: TestClient, backend_mock: Any) -> N
                 "http://www.accuweather.com/en/us/milton-wa/98354/current-weather/"
                 "41512_pc?lang=en-us"
             ),
-            provider="weather",
+            provider="test_weather",
             is_sponsored=False,
             score=0.3,
             icon=None,
@@ -246,16 +247,23 @@ def test_suggest_without_weather_report(client: TestClient, backend_mock: Any) -
     """Test that the suggest endpoint response is as expected when the Weather provider
     cannot supply a suggestion.
     """
-    expected_suggestion: list[Suggestion] = []
     backend_mock.get_weather_report.return_value = None
 
     response = client.get("/api/v1/suggest?q=weather&request_type=weather")
 
+    assert response.status_code == 204
+
+
+def test_suggest_error_weather_report_returns_empty(client: TestClient, backend_mock: Any) -> None:
+    """Test that the suggest endpoint response is as expected when the Weather provider
+    cannot supply a suggestion.
+    """
+    expected_suggestion: list[Suggestion] = []
+    backend_mock.get_weather_report.side_effect = BackendError()
+
+    response = client.get("/api/v1/suggest?q=weather&request_type=weather")
+
     assert response.status_code == 200
-    assert (
-        response.headers["Cache-Control"]
-        == f"private, max-age={DEFAULT_SUGGESTIONS_RESPONSE_TTL_SEC}"
-    )
     result = response.json()
     assert result["suggestions"] == expected_suggestion
 
@@ -330,7 +338,7 @@ def test_suggest_with_location_completion(
         LocationCompletionSuggestion(
             title="Location completions",
             url=HttpUrl(url="https://merino.services.mozilla.com/"),
-            provider="weather",
+            provider="test_weather",
             is_sponsored=False,
             score=0.3,
             icon=None,
@@ -480,4 +488,4 @@ async def test_suggest_weather_with_custom_location(
         )
     )
 
-    assert response.status_code == 200
+    assert response.status_code == 204


### PR DESCRIPTION
## References

JIRA: [DISCO-3393](https://mozilla-hub.atlassian.net/browse/DISCO-3393)

## Description
When no weather report isn't returned in the event that we don't get anything from accuweather we want to return 204.
If no weather report is returned due to a BackendError we want to return 200. 
This way, there's a way to differentiate diff scenarios so that clients can retry for the latter case.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3393]: https://mozilla-hub.atlassian.net/browse/DISCO-3393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ