### PR TITLE
[DISCO-3178] Replace robobrowser with mechanicalsoup

### DIFF
--- a/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
+++ b/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
@@ -9,7 +9,6 @@ from urllib.parse import urljoin, urlparse
 import requests
 from pydantic import BaseModel
 from mechanicalsoup import StatefulBrowser
-from typing import cast
 
 from merino.jobs.navigational_suggestions.domain_metadata_uploader import DomainMetadataUploader
 from merino.utils.gcs.models import Image

--- a/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
+++ b/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
@@ -133,6 +133,14 @@ class Scraper:
             logger.info(f"Exception: {e} while scraping title")
             return None
 
+    def close(self) -> None:
+        """Close the scraper browser session"""
+        try:
+            self.browser.close()
+        except Exception as ex:
+            logger.warning(f"Error ocurred when closing scraper session: {ex}")
+            return None
+
 
 class DomainMetadataExtractor:
     """Extract domain metadata from domain data"""
@@ -488,6 +496,9 @@ class DomainMetadataExtractor:
                         logger.error(f"Unexpected result type: {result}")
                         continue
                     filtered_results.append(result)
+
+        # Close the scraper browser session
+        self.scraper.close()
 
         return filtered_results
 

--- a/merino/jobs/utils/domain_tester.py
+++ b/merino/jobs/utils/domain_tester.py
@@ -109,6 +109,7 @@ def test_domain(domain: str, min_width: int) -> DomainTestResult:
             # all URLs are absolute, just like in production
             raw_favicon_data.links = processed_links
 
+            raw_favicon_data = scraper.scrape_favicon_data()
             favicon_data = raw_favicon_data.model_dump()
             favicon_urls = set()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,9 +47,9 @@ omit = [
 
 [dependency-groups]
 jobs = [
-    "robobro>=0.5.3,<0.6",
     "typer>=0.11.0,<0.15",
     "tldextract>=3.4.4,<4",
+    "mechanicalsoup>=1.3.0",
 ]
 load = [
     "faker>=20.0.0,<21",

--- a/tests/unit/jobs/navigational_suggestions/test_domain_metadata_extractor.py
+++ b/tests/unit/jobs/navigational_suggestions/test_domain_metadata_extractor.py
@@ -973,9 +973,9 @@ def test_scraper_init() -> None:
     # Verify that the session headers are correctly set
     assert scraper.browser.session.headers.get("User-Agent") == REQUEST_HEADERS.get("User-Agent")
 
-    # Verify that the browser is properly configured
-    assert scraper.browser.parser == "html.parser"
-    assert scraper.browser.allow_redirects is True
+    # These properties are set as class properties in the Scraper class
+    assert scraper.parser == "html.parser"
+    assert scraper.ALLOW_REDIRECTS is True
 
     # Verify that the request client is properly initialized
     assert isinstance(scraper.request_client, AsyncFaviconDownloader)
@@ -1096,13 +1096,13 @@ def test_scraper_scrape_title() -> None:
     head_mock.find.return_value = title_mock
 
     # Mock the find method on the browser
-    scraper.browser.find.return_value = head_mock
+    scraper.browser.page.find.return_value = head_mock
 
     result = scraper.scrape_title()
     assert result == "Example Website"
 
     # Test exception - missing head tag
-    scraper.browser.find.return_value = None
+    scraper.browser.page.find.return_value = None
 
     result = scraper.scrape_title()
     assert result is None

--- a/uv.lock
+++ b/uv.lock
@@ -1042,6 +1042,31 @@ wheels = [
 ]
 
 [[package]]
+name = "lxml"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/f6/c15ca8e5646e937c148e147244817672cf920b56ac0bf2cc1512ae674be8/lxml-5.3.1.tar.gz", hash = "sha256:106b7b5d2977b339f1e97efe2778e2ab20e99994cbb0ec5e55771ed0795920c8", size = 3678591 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/1c/724931daa1ace168e0237b929e44062545bf1551974102a5762c349c668d/lxml-5.3.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c093c7088b40d8266f57ed71d93112bd64c6724d31f0794c1e52cc4857c28e0e", size = 8171881 },
+    { url = "https://files.pythonhosted.org/packages/67/0c/857b8fb6010c4246e66abeebb8639eaabba60a6d9b7c606554ecc5cbf1ee/lxml-5.3.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b0884e3f22d87c30694e625b1e62e6f30d39782c806287450d9dc2fdf07692fd", size = 4440394 },
+    { url = "https://files.pythonhosted.org/packages/61/72/c9e81de6a000f9682ccdd13503db26e973b24c68ac45a7029173237e3eed/lxml-5.3.1-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1637fa31ec682cd5760092adfabe86d9b718a75d43e65e211d5931809bc111e7", size = 5037860 },
+    { url = "https://files.pythonhosted.org/packages/24/26/942048c4b14835711b583b48cd7209bd2b5f0b6939ceed2381a494138b14/lxml-5.3.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a364e8e944d92dcbf33b6b494d4e0fb3499dcc3bd9485beb701aa4b4201fa414", size = 4782513 },
+    { url = "https://files.pythonhosted.org/packages/e2/65/27792339caf00f610cc5be32b940ba1e3009b7054feb0c4527cebac228d4/lxml-5.3.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:779e851fd0e19795ccc8a9bb4d705d6baa0ef475329fe44a13cf1e962f18ff1e", size = 5305227 },
+    { url = "https://files.pythonhosted.org/packages/18/e1/25f7aa434a4d0d8e8420580af05ea49c3e12db6d297cf5435ac0a054df56/lxml-5.3.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c4393600915c308e546dc7003d74371744234e8444a28622d76fe19b98fa59d1", size = 4829846 },
+    { url = "https://files.pythonhosted.org/packages/fe/ed/faf235e0792547d24f61ee1448159325448a7e4f2ab706503049d8e5df19/lxml-5.3.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:673b9d8e780f455091200bba8534d5f4f465944cbdd61f31dc832d70e29064a5", size = 4949495 },
+    { url = "https://files.pythonhosted.org/packages/e5/e1/8f572ad9ed6039ba30f26dd4c2c58fb90f79362d2ee35ca3820284767672/lxml-5.3.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:2e4a570f6a99e96c457f7bec5ad459c9c420ee80b99eb04cbfcfe3fc18ec6423", size = 4773415 },
+    { url = "https://files.pythonhosted.org/packages/a3/75/6b57166b9d1983dac8f28f354e38bff8d6bcab013a241989c4d54c72701b/lxml-5.3.1-cp313-cp313-manylinux_2_28_ppc64le.whl", hash = "sha256:71f31eda4e370f46af42fc9f264fafa1b09f46ba07bdbee98f25689a04b81c20", size = 5337710 },
+    { url = "https://files.pythonhosted.org/packages/cc/71/4aa56e2daa83bbcc66ca27b5155be2f900d996f5d0c51078eaaac8df9547/lxml-5.3.1-cp313-cp313-manylinux_2_28_s390x.whl", hash = "sha256:42978a68d3825eaac55399eb37a4d52012a205c0c6262199b8b44fcc6fd686e8", size = 4897362 },
+    { url = "https://files.pythonhosted.org/packages/65/10/3fa2da152cd9b49332fd23356ed7643c9b74cad636ddd5b2400a9730d12b/lxml-5.3.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:8b1942b3e4ed9ed551ed3083a2e6e0772de1e5e3aca872d955e2e86385fb7ff9", size = 4977795 },
+    { url = "https://files.pythonhosted.org/packages/de/d2/e1da0f7b20827e7b0ce934963cb6334c1b02cf1bb4aecd218c4496880cb3/lxml-5.3.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:85c4f11be9cf08917ac2a5a8b6e1ef63b2f8e3799cec194417e76826e5f1de9c", size = 4858104 },
+    { url = "https://files.pythonhosted.org/packages/a5/35/063420e1b33d3308f5aa7fcbdd19ef6c036f741c9a7a4bd5dc8032486b27/lxml-5.3.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:231cf4d140b22a923b1d0a0a4e0b4f972e5893efcdec188934cc65888fd0227b", size = 5416531 },
+    { url = "https://files.pythonhosted.org/packages/c3/83/93a6457d291d1e37adfb54df23498101a4701834258c840381dd2f6a030e/lxml-5.3.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:5865b270b420eda7b68928d70bb517ccbe045e53b1a428129bb44372bf3d7dd5", size = 5273040 },
+    { url = "https://files.pythonhosted.org/packages/39/25/ad4ac8fac488505a2702656550e63c2a8db3a4fd63db82a20dad5689cecb/lxml-5.3.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dbf7bebc2275016cddf3c997bf8a0f7044160714c64a9b83975670a04e6d2252", size = 5050951 },
+    { url = "https://files.pythonhosted.org/packages/82/74/f7d223c704c87e44b3d27b5e0dde173a2fcf2e89c0524c8015c2b3554876/lxml-5.3.1-cp313-cp313-win32.whl", hash = "sha256:d0751528b97d2b19a388b302be2a0ee05817097bab46ff0ed76feeec24951f78", size = 3485357 },
+    { url = "https://files.pythonhosted.org/packages/80/83/8c54533b3576f4391eebea88454738978669a6cad0d8e23266224007939d/lxml-5.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:91fb6a43d72b4f8863d21f347a9163eecbf36e76e2f51068d59cd004c506f332", size = 3814484 },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1085,6 +1110,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/58/cdb1a7c18a1946ad006657b52cb499e489d2b28a62490fd5aee14b356a55/maxminddb-2.6.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6eb23f842a72ab3096f9f9b1c292f4feb55a8d758567cb6d77637c2257a3187c", size = 92126 },
     { url = "https://files.pythonhosted.org/packages/39/94/4b37ffa77f8921a549805a62ce62f6fa453ea3c59c0dfcd584770fc59a8c/maxminddb-2.6.3-cp313-cp313-win32.whl", hash = "sha256:acf46e20709a27d2b519669888e3f53a37bc4204b98a0c690664c48ff8cb1364", size = 34751 },
     { url = "https://files.pythonhosted.org/packages/1e/af/638811134e1a33cf75c2d2be1b0b9b90dd1f43216a4ef1f24e223f646b46/maxminddb-2.6.3-cp313-cp313-win_amd64.whl", hash = "sha256:3015afb00e6168837938dbe5fda40ace37442c22b292ccee27c1690fbf6078ed", size = 36790 },
+]
+
+[[package]]
+name = "mechanicalsoup"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "lxml" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/37/11/61d95339e23b5e6fe3b6bbf2782fd65394eac2af79c42b49c13e216f2bed/MechanicalSoup-1.3.0.tar.gz", hash = "sha256:38e8748f62fd9455a0818701a9e2dbfa549639d09f829f3fdd03665c825e7ce1", size = 50826 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/26/e48f1499547475659c49d4d8143b26b9488a0358997bfba13617d4e7dbe7/MechanicalSoup-1.3.0-py3-none-any.whl", hash = "sha256:83dfc23bbbcaafb62dd43e0f12aee3202e780650b4612d999b54324558980114", size = 19963 },
 ]
 
 [[package]]
@@ -1140,7 +1179,7 @@ dev = [
     { name = "types-requests" },
 ]
 jobs = [
-    { name = "robobro" },
+    { name = "mechanicalsoup" },
     { name = "tldextract" },
     { name = "typer" },
 ]
@@ -1200,7 +1239,7 @@ dev = [
     { name = "types-requests", specifier = ">=2.28.10,<3" },
 ]
 jobs = [
-    { name = "robobro", specifier = ">=0.5.3,<0.6" },
+    { name = "mechanicalsoup", specifier = ">=1.3.0" },
     { name = "tldextract", specifier = ">=3.4.4,<4" },
     { name = "typer", specifier = ">=0.11.0,<0.15" },
 ]
@@ -1798,21 +1837,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/11/23/814edf09ec6470d52022b9e95c23c1bef77f0bc451761e1504ebd09606d3/rich-12.6.0.tar.gz", hash = "sha256:ba3a3775974105c221d31141f2c116f4fd65c5ceb0698657a11e9f295ec93fd0", size = 220114 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/60/81ac2e7d1e3b861ab478a72e3b20fc91c4302acd2274822e493758941829/rich-12.6.0-py3-none-any.whl", hash = "sha256:a4eb26484f2c82589bd9a17c73d32a010b1e29d89f1604cd9bf3a2097b81bb5e", size = 237505 },
-]
-
-[[package]]
-name = "robobro"
-version = "0.5.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "beautifulsoup4" },
-    { name = "requests" },
-    { name = "six" },
-    { name = "werkzeug" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b3/a1/5b4022270c10ddb3dd10af8d515f40459f928469d407dff9656645bb1739/robobro-0.5.3.tar.gz", hash = "sha256:a2f0771042a3118d854e91556da111c112fa9735765b362587dd5c80e85d869e", size = 16170 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/ac/29d3ab1ab83b791d3b4f06017ed51c791420f5b61bf1271de9ff5770d815/robobro-0.5.3-py3-none-any.whl", hash = "sha256:cd0ae9cadc95498bfb4382cfb36f6aeb86fccd3dbe82e494162ac8feb6a19e7f", size = 16384 },
 ]
 
 [[package]]


### PR DESCRIPTION
## References

JIRA: [DISCO-3178](https://mozilla-hub.atlassian.net/browse/DISCO-3178)

## Description
Replacing the older, unsupported `robobrowser` package in lieu of more actively maintained `mechanicalsoup` package.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3178]: https://mozilla-hub.atlassian.net/browse/DISCO-3178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ