### PR TITLE
MC-1702: get_icon_url returns valid urls or None

### DIFF
--- a/merino/providers/manifest/provider.py
+++ b/merino/providers/manifest/provider.py
@@ -110,12 +110,12 @@ class Provider:
 
             idx = self.domain_lookup_table.get(base_domain, -1)
             if idx >= 0 and self.manifest_data is not None:
-                icon = self.manifest_data.domains[idx].icon
+                icon_url = self.manifest_data.domains[idx].icon
                 try:
-                    return HttpUrl(icon)
+                    return HttpUrl(icon_url)
                 except ValidationError:
-                    # As of April 2025, some icon URLs are empty strings, which are not valid URLs.
-                    logger.warning(f"Invalid icon URL for domain {base_domain}: '{icon}'")
+                    # [DISCO-3441] Some icon URLs are empty strings, which are not valid URLs.
+                    logger.warning(f"Invalid icon URL for domain {base_domain}: '{icon_url}'")
         except Exception as e:
             logger.warning(f"Error getting icon for URL {url}: {e}")
         return None

--- a/merino/providers/manifest/provider.py
+++ b/merino/providers/manifest/provider.py
@@ -5,7 +5,7 @@ import time
 import logging
 from urllib.parse import urlparse
 
-from pydantic import HttpUrl
+from pydantic import HttpUrl, ValidationError
 
 from merino.providers.manifest.backends.filemanager import GetManifestResultCode
 from merino.utils import cron
@@ -92,7 +92,7 @@ class Provider:
         """Return manifest data"""
         return self.manifest_data
 
-    def get_icon_url(self, url: str | HttpUrl) -> str | None:
+    def get_icon_url(self, url: str | HttpUrl) -> HttpUrl | None:
         """Get icon URL for a domain.
 
         Args:
@@ -110,8 +110,12 @@ class Provider:
 
             idx = self.domain_lookup_table.get(base_domain, -1)
             if idx >= 0 and self.manifest_data is not None:
-                return self.manifest_data.domains[idx].icon
-
+                icon = self.manifest_data.domains[idx].icon
+                try:
+                    return HttpUrl(icon)
+                except ValidationError:
+                    # As of April 2025, some icon URLs are empty strings, which are not valid URLs.
+                    logger.warning(f"Invalid icon URL for domain {base_domain}: '{icon}'")
         except Exception as e:
             logger.warning(f"Error getting icon for URL {url}: {e}")
         return None

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -102,6 +102,15 @@ def fixture_blob_json() -> str:
                     "icon": "https://merino-images.services.mozilla.com/favicons"
                     "/e673f8818103a583c9a98ee38aa7892d58969ec2a8387deaa46ef6d94e8a3796_4535.png",
                 },
+                {
+                    "rank": 4,
+                    "domain": "bbc",
+                    "categories": ["News"],
+                    "serp_categories": [0],
+                    "url": "https://www.bbc.co.uk/",
+                    "title": "BBC Home - Breaking News",
+                    "icon": "https://merino-images.services.mozilla.com/favicons/bbciconhash_12345.png",
+                },
             ]
         }
     )

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -111,6 +111,15 @@ def fixture_blob_json() -> str:
                     "title": "BBC Home - Breaking News",
                     "icon": "https://merino-images.services.mozilla.com/favicons/bbciconhash_12345.png",
                 },
+                {
+                    "rank": 5,
+                    "domain": "cnn",
+                    "categories": ["News"],
+                    "serp_categories": [0],
+                    "url": "https://edition.cnn.com/2025/04/09/entertainment/aimee-lou-wood-teeth-talk-intl-scli/index.html",
+                    "title": "‘White Lotus’ star Aimee Lou Wood doesn’t love all the talk about her teeth | CNN",
+                    "icon": "https://merino-images.services.mozilla.com/favicons/cnniconhash_98765.png",
+                },
             ]
         }
     )

--- a/tests/unit/providers/manifest/backends/test_filemanager.py
+++ b/tests/unit/providers/manifest/backends/test_filemanager.py
@@ -23,7 +23,7 @@ async def test_get_file_async(
     assert get_file_result_code is GetManifestResultCode.SUCCESS
     assert isinstance(result, ManifestData)
     assert result.domains
-    assert len(result.domains) == 3
+    assert len(result.domains) == 4
     assert result.domains[0].domain == "google"
 
     # assert correct success log is emitted

--- a/tests/unit/providers/manifest/backends/test_filemanager.py
+++ b/tests/unit/providers/manifest/backends/test_filemanager.py
@@ -23,7 +23,7 @@ async def test_get_file_async(
     assert get_file_result_code is GetManifestResultCode.SUCCESS
     assert isinstance(result, ManifestData)
     assert result.domains
-    assert len(result.domains) == 4
+    assert len(result.domains) == 5
     assert result.domains[0].domain == "google"
 
     # assert correct success log is emitted

--- a/tests/unit/providers/manifest/backends/test_manifest.py
+++ b/tests/unit/providers/manifest/backends/test_manifest.py
@@ -25,7 +25,7 @@ async def test_fetch_manifest_data(backend: ManifestBackend, fixture_filemanager
         assert get_file_result_code is GetManifestResultCode.SUCCESS
         assert result is not None
         assert result.domains is not None
-        assert len(result.domains) == 3
+        assert len(result.domains) == 4
         assert result.domains[1].domain == "microsoft"
 
 
@@ -61,5 +61,5 @@ async def test_fetch(backend: ManifestBackend, fixture_filemanager) -> None:
         assert get_file_result_code is GetManifestResultCode.SUCCESS
         assert result is not None
         assert result.domains is not None
-        assert len(result.domains) == 3
+        assert len(result.domains) == 4
         assert result.domains[2].domain == "facebook"

--- a/tests/unit/providers/manifest/backends/test_manifest.py
+++ b/tests/unit/providers/manifest/backends/test_manifest.py
@@ -25,7 +25,7 @@ async def test_fetch_manifest_data(backend: ManifestBackend, fixture_filemanager
         assert get_file_result_code is GetManifestResultCode.SUCCESS
         assert result is not None
         assert result.domains is not None
-        assert len(result.domains) == 4
+        assert len(result.domains) == 5
         assert result.domains[1].domain == "microsoft"
 
 
@@ -61,5 +61,5 @@ async def test_fetch(backend: ManifestBackend, fixture_filemanager) -> None:
         assert get_file_result_code is GetManifestResultCode.SUCCESS
         assert result is not None
         assert result.domains is not None
-        assert len(result.domains) == 4
+        assert len(result.domains) == 5
         assert result.domains[2].domain == "facebook"

--- a/tests/unit/providers/manifest/test_get_icon_url.py
+++ b/tests/unit/providers/manifest/test_get_icon_url.py
@@ -32,6 +32,7 @@ MS_ICON = HttpUrl(
     "90cdaf487716184e4034000935c605d1633926d348116d198f355a98b8c6cd21_17174.oct"
 )
 BBC_ICON = HttpUrl("https://merino-images.services.mozilla.com/favicons/bbciconhash_12345.png")
+# CNN_ICON = HttpUrl("https://merino-images.services.mozilla.com/favicons/cnniconhash_98765.png")
 
 
 @pytest.mark.asyncio
@@ -45,6 +46,12 @@ BBC_ICON = HttpUrl("https://merino-images.services.mozilla.com/favicons/bbciconh
         ("https://www.microsoft.com/en-us/", MS_ICON),
         ("https://bbc.co.uk/news", BBC_ICON),
         ("https://www.bbc.co.uk/sport", BBC_ICON),
+        # DISCO-3447: URLs with subdomains aren't handled correctly yet.
+        # (
+        #     "https://edition.cnn.com/2025/04/09/entertainment/aimee-lou-wood-teeth-talk-intl-scli/"
+        #     "index.html?utm_source=firefox-newtab-en-us",
+        #     CNN_ICON,
+        # ),
     ],
 )
 async def test_get_icon_url_domain_variants(

--- a/tests/unit/providers/manifest/test_get_icon_url.py
+++ b/tests/unit/providers/manifest/test_get_icon_url.py
@@ -1,5 +1,7 @@
 """Unit tests for the get_icon_url method of the manifest provider."""
 
+import logging
+
 import pytest
 from pydantic import HttpUrl
 
@@ -25,26 +27,32 @@ async def test_domain_lookup_table_initialization(
             assert domain.domain in manifest_provider.domain_lookup_table
 
 
-@pytest.mark.asyncio
-async def test_get_icon_url_success(
-    manifest_provider: Provider, manifest_data: ManifestData, cleanup
-):
-    """Test successful icon URL retrieval for known domains."""
-    with patch(
-        "merino.providers.manifest.backends.manifest.ManifestBackend.fetch",
-        return_value=(GetManifestResultCode.SUCCESS, manifest_data),
-    ):
-        await manifest_provider.initialize()
-        await cleanup(manifest_provider)
-
-        # Test with Google domain which exists in fixture
-        google_icon = manifest_provider.get_icon_url("https://www.google.com/search")
-        assert google_icon == ""  # Google has empty icon in fixture
+MS_ICON = HttpUrl(
+    "https://merino-images.services.mozilla.com/favicons/"
+    "90cdaf487716184e4034000935c605d1633926d348116d198f355a98b8c6cd21_17174.oct"
+)
+BBC_ICON = HttpUrl("https://merino-images.services.mozilla.com/favicons/bbciconhash_12345.png")
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "test_url, expected_icon",
+    [
+        ("https://google.com/search", None),  # Google icon fixture is empty
+        ("http://www.google.com", None),
+        ("https://google.com", None),
+        ("http://google.com/maps", None),
+        ("https://www.microsoft.com/en-us/", MS_ICON),
+        ("https://bbc.co.uk/news", BBC_ICON),
+        ("https://www.bbc.co.uk/sport", BBC_ICON),
+    ],
+)
 async def test_get_icon_url_domain_variants(
-    manifest_provider: Provider, manifest_data: ManifestData, cleanup
+    manifest_provider: Provider,
+    manifest_data: ManifestData,
+    cleanup,
+    test_url,
+    expected_icon,
 ):
     """Test icon URL retrieval with different domain format variants."""
     with patch(
@@ -54,16 +62,7 @@ async def test_get_icon_url_domain_variants(
         await manifest_provider.initialize()
         await cleanup(manifest_provider)
 
-        test_cases = [
-            "https://google.com/search",
-            "http://www.google.com",
-            "https://google.com",
-            "http://google.com/maps",
-        ]
-
-        for url in test_cases:
-            result = manifest_provider.get_icon_url(url)
-            assert result == ""  # Google has empty icon in fixture
+        assert manifest_provider.get_icon_url(test_url) == expected_icon
 
 
 @pytest.mark.asyncio
@@ -117,18 +116,41 @@ async def test_get_icon_url_with_pydantic_url(
         await cleanup(manifest_provider)
 
         url = HttpUrl("https://google.com/search")
-        assert manifest_provider.get_icon_url(url) == ""  # Google has empty icon
+        assert manifest_provider.get_icon_url(url) is None  # Google has empty icon
 
 
 @pytest.mark.asyncio
-async def test_get_icon_url_empty_manifest(manifest_provider: Provider, cleanup):
-    """Test icon URL retrieval with empty manifest data."""
-    empty_manifest = ManifestData(domains=[])
+@pytest.mark.parametrize(
+    "icon_value,expected_log_msg",
+    [
+        ("", "Invalid icon URL for domain google: ''"),
+        ("not-a-valid-url", "Invalid icon URL for domain google: 'not-a-valid-url'"),
+    ],
+)
+async def test_get_icon_url_invalid_icon_logged(
+    manifest_provider: Provider,
+    manifest_data: ManifestData,
+    cleanup,
+    icon_value: str,
+    expected_log_msg: str,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Test that invalid icon values log warnings and return None."""
+    # Override the Google icon value
+    for domain in manifest_data.domains:
+        if domain.domain == "google":
+            domain.icon = icon_value
+
     with patch(
         "merino.providers.manifest.backends.manifest.ManifestBackend.fetch",
-        return_value=(GetManifestResultCode.SUCCESS, empty_manifest),
+        return_value=(GetManifestResultCode.SUCCESS, manifest_data),
     ):
         await manifest_provider.initialize()
         await cleanup(manifest_provider)
 
-        assert manifest_provider.get_icon_url("https://google.com") is None
+        assert manifest_provider.get_icon_url("https://www.google.com") is None
+
+        assert any(
+            record.message == expected_log_msg and record.levelno == logging.WARNING
+            for record in caplog.records
+        )


### PR DESCRIPTION
## References

JIRA: [MC-1702](https://mozilla-hub.atlassian.net/browse/MC-1702)

## Description
Yesterday there was a brief outage on the curated-recommendations endpoint. I accidentally removed a truthy check on `get_icon_url`, which introduced HttpUrl validation errors when it returns empty strings. This PR changes `get_icon_url` to return a valid URL or None.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[MC-1702]: https://mozilla-hub.atlassian.net/browse/MC-1702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ