### PR TITLE
add GCP token file to dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -24,3 +24,6 @@ profile.json
 workspace/
 dev/local_data/
 local_data/
+
+# Ignore generated credentials from google-github-actions/auth
+gha-creds-*.json


### PR DESCRIPTION
## References

Preventing the same issue reported in this bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1959182
