### PR TITLE
[DISCO 2053] feat: Add a circuit breaker for the AccuWeather provider

### DIFF
--- a/merino/cache/redis.py
+++ b/merino/cache/redis.py
@@ -10,7 +10,12 @@ from merino.exceptions import CacheAdapterError
 
 
 def create_redis_clients(
-    primary: str, replica: str, max_connections: int, db: int = 0
+    primary: str,
+    replica: str,
+    max_connections: int,
+    socket_connect_timeout: int,
+    socket_timeout: int,
+    db: int = 0,
 ) -> tuple[Redis, Redis]:
     """Create redis clients for the primary and replica severs.
     When `replica` is the same as `primary`, the returned clients are the same.
@@ -19,17 +24,31 @@ def create_redis_clients(
         - `primary`: the URL to the Redis primary endpoint.
         - `replica`: the URL to the Redis replica endpoint.
         - `max_connections`: the maximum connections allowed in the connection pool.
+        - `socket_connect_timeout`: the timeout in seconds to connect to the Redis server.
+        - `socket_timeout`: the timeout in seconds to interact with the Redis server.
         - `db`: the ID (`SELECT db`) of the DB to which the clients connect.
     Returns:
         - A tuple of two clients, the first for the primary server and the second for the replica endpoint.
           When `primary` is the same as `replica`, the two share the same underlying client.
     """
-    client_primary: Redis = Redis.from_url(primary, db=db, max_connections=max_connections)
+    client_primary: Redis = Redis.from_url(
+        primary,
+        db=db,
+        max_connections=max_connections,
+        socket_connect_timeout=socket_connect_timeout,
+        socket_timeout=socket_timeout,
+    )
     client_replica: Redis
     if primary == replica:
         client_replica = client_primary
     else:
-        client_replica = Redis.from_url(replica, db=db, max_connections=max_connections)
+        client_replica = Redis.from_url(
+            replica,
+            db=db,
+            max_connections=max_connections,
+            socket_connect_timeout=socket_connect_timeout,
+            socket_timeout=socket_timeout,
+        )
 
     return client_primary, client_replica
 

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -283,7 +283,7 @@ cron_interval_sec = 21600 # 6 hours
 circuit_breaker_failure_threshold = 10
 
 # MERINO_PROVIDERS__ACCUWEATHER__CIRCUIT_BREAKER_RECOVER_TIMEOUT_SEC
-# The circuit breaker will stay open for this period of time until the next revoery attempt.
+# The circuit breaker will stay open for this period of time until the next recovery attempt.
 circuit_breaker_recover_timeout_sec = 30
 
 [default.providers.accuweather.cache_ttls]

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -188,6 +188,13 @@ replica = "redis://localhost:6379"
 # To override the default max_conns of Redis-py: 2 ** 31.
 max_connections = 500
 
+# MERINO_REDIS__SOCKET_CONNECT_TIMEOUT_SEC
+# Timeout to connect to Redis in seconds
+socket_connect_timeout_sec = 3
+
+# MERINO_REDIS__SOCKET_TIMEOUT_SEC
+# Timeout to interact with Redis in seconds
+socket_timeout_sec = 3
 
 [default.sentry]
 # MERINO_SENTRY__MODE

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -278,6 +278,14 @@ connect_timeout_sec = 3.0
 # MERINO_PROVIDERS__ACCUWEATHER__CRON_INTERVAL_SEC
 cron_interval_sec = 21600 # 6 hours
 
+# MERINO_PROVIDERS__ACCUWEATHER__CIRCUIT_BREAKER_FAILURE_THRESHOLD
+# The circuit breaker will open when the failure is over this threshold.
+circuit_breaker_failure_threshold = 10
+
+# MERINO_PROVIDERS__ACCUWEATHER__CIRCUIT_BREAKER_RECOVER_TIMEOUT_SEC
+# The circuit breaker will stay open for this period of time until the next revoery attempt.
+circuit_breaker_recover_timeout_sec = 30
+
 [default.providers.accuweather.cache_ttls]
 # Cache TTLs for weather data.
 

--- a/merino/configs/testing.toml
+++ b/merino/configs/testing.toml
@@ -46,6 +46,8 @@ url_base = "test://test"
 [testing.providers.accuweather]
 enabled_by_default = false
 backend="test_weather"
+circuit_breaker_failure_threshold = 1
+circuit_breaker_recover_timeout_sec = 3
 
 [testing.providers.adm]
 # Whether or not this provider is enabled by default.

--- a/merino/governance/__init__.py
+++ b/merino/governance/__init__.py
@@ -1,0 +1,1 @@
+"""The module for service governance."""

--- a/merino/governance/circuitbreakers.py
+++ b/merino/governance/circuitbreakers.py
@@ -1,0 +1,51 @@
+"""This module defines all the circuit breakers for Merino.
+
+
+Circuit breakers can be used to monitor the "integration points" and react to
+integration anomalies in Merino. External integrations (e.g. calling an external API endpoint)
+and cloud dependencies (e.g. a database or a cache) are good candidates to be put
+behind circuit breakers to guard Merino against integration interruptions.
+
+To better manage circuit breakers for Merino, new breakers can be defined in this module.
+Each breaker can be defined as follows:
+  - Create a subclass of `CircuitBreaker` with the following class constants:
+    - `FAILURE_THRESHOLD` {int}: A failure threshold for the breaker, when the failure count
+      is greater or equal to it, the breaker state will transition from `closed` to `open`.
+    - `RECOVERY_TIMEOUT` {int}: The recovery timeout in seconds for an opened breaker. During
+      this window, all the subsequent calls to your integration point will be ignored and a
+      `circuitbreaker.CircuitBreakerError` will be raised.
+    - `EXPECTED_EXCEPTION` [{exception} | iter(exceptions)]: The expected exception(s) that
+      the breaker cares about. Only these specific exception(s) will be listened and update
+      the state of the breaker.
+    - `FALLBACK_FUNCTION` {callable}: Optionally, a fullback function (or async function) can
+      be called instead when the breaker is open. If this is specified, the
+      `circuitbreaker.CircuitBreakerError` will no longer be raised as mentioned above.
+  - You can create an instance of this circuit breaker class and attach it to a function
+    or an async function, i.e. the integration point, as a new circuit breaker. Make sure
+    you specify `name` in the constructor, this will be the ID of this breaker which can
+    be used for monitoring later.
+"""
+
+from circuitbreaker import CircuitBreaker
+
+from merino.configs import settings
+from merino.exceptions import BackendError
+from merino.providers.suggest.weather.backends.accuweather.errors import AccuweatherError
+from merino.providers.suggest.base import BaseSuggestion
+
+
+async def _suggest_provider_fallback_fn(*args, **kwargs) -> list[BaseSuggestion]:
+    """Define a fallback function that returns an empty list when the circuit breaker is open."""
+    return []
+
+
+class WeatherCircuitBreaker(CircuitBreaker):
+    """Circuit Breaker for the weather provider."""
+
+    FAILURE_THRESHOLD = settings.providers.accuweather.circuit_breaker_failure_threshold
+    RECOVERY_TIMEOUT = settings.providers.accuweather.circuit_breaker_recover_timeout_sec
+    # This breaker only cares about these two errors, which would cover both Redis errors
+    # and AccuWeather API errors.
+    EXPECTED_EXCEPTION = (AccuweatherError, BackendError)
+    # When the breaker is open, use this to simply return an empty suggestion list to the caller.
+    FALLBACK_FUNCTION = _suggest_provider_fallback_fn

--- a/merino/governance/circuitbreakers.py
+++ b/merino/governance/circuitbreakers.py
@@ -17,7 +17,7 @@ Each breaker can be defined as follows:
     - `EXPECTED_EXCEPTION` [{exception} | iter(exceptions)]: The expected exception(s) that
       the breaker cares about. Only these specific exception(s) will be listened and update
       the state of the breaker.
-    - `FALLBACK_FUNCTION` {callable}: Optionally, a fullback function (or async function) can
+    - `FALLBACK_FUNCTION` {callable}: Optionally, a fallback function (or async function) can
       be called instead when the breaker is open. If this is specified, the
       `circuitbreaker.CircuitBreakerError` will no longer be raised as mentioned above.
   - You can create an instance of this circuit breaker class and attach it to a function

--- a/merino/providers/suggest/base.py
+++ b/merino/providers/suggest/base.py
@@ -169,6 +169,16 @@ class BaseProvider(ABC):
         """
         ...
 
+    def validate(self, srequest: SuggestionRequest) -> None:  # pragma: no cover
+        """Validate the request. Raise an `HTTPException` for any validation errors.
+
+        Args:
+          - `srequest`: the suggestion request.
+        Raise:
+          - `HTTPException` for any validation errors.
+        """
+        return
+
     def normalize_query(self, query: str) -> str:  # pragma: no cover
         """Normalize the query string when passed to the provider.
         Each provider can extend this class given its requirements. Can be used to

--- a/merino/providers/suggest/manager.py
+++ b/merino/providers/suggest/manager.py
@@ -57,6 +57,8 @@ def _create_provider(provider_id: str, setting: Settings) -> BaseProvider:
                         settings.redis.server,
                         settings.redis.replica,
                         settings.redis.max_connections,
+                        settings.redis.socket_connect_timeout_sec,
+                        settings.redis.socket_timeout_sec,
                     )
                 )
                 if setting.cache == "redis"

--- a/merino/providers/suggest/weather/backends/accuweather/backend.py
+++ b/merino/providers/suggest/weather/backends/accuweather/backend.py
@@ -532,7 +532,10 @@ class AccuweatherBackend:
         except CacheAdapterError as exc:
             logger.error(f"Failed to fetch weather report from Redis: {exc}")
             self.metrics_client.increment("accuweather.cache.fetch-via-location-key.error")
-            return None
+            # Propagate the error for circuit breaking.
+            raise AccuweatherError(
+                AccuweatherErrorMessages.CACHE_READ_ERROR, exception=exc
+            ) from exc
 
         self.emit_cache_fetch_metrics(cached_data, skip_location_key=True)
         cached_report = self.parse_cached_data(cached_data)
@@ -613,7 +616,10 @@ class AccuweatherBackend:
         except CacheAdapterError as exc:
             logger.error(f"Failed to fetch weather report from Redis: {exc}")
             self.metrics_client.increment("accuweather.cache.fetch.error")
-            return None
+            # Propagate the error for circuit breaking.
+            raise AccuweatherError(
+                AccuweatherErrorMessages.CACHE_READ_ERROR, exception=exc
+            ) from exc
 
         if is_skipped:
             raise MissingLocationKeyError(geolocation)

--- a/merino/providers/suggest/weather/backends/accuweather/errors.py
+++ b/merino/providers/suggest/weather/backends/accuweather/errors.py
@@ -11,6 +11,7 @@ class AccuweatherErrorMessages(Enum):
     """Enum variables with string values representing error messages"""
 
     CACHE_WRITE_ERROR = "Something went wrong with storing to cache. Did not update cache."
+    CACHE_READ_ERROR = "Failed to read from cache: {exception}"
     FAILED_WEATHER_REPORT = "Failed to fetch weather report: {exceptions}"
     HTTP_UNEXPECTED_LOCATION_RESPONSE = (
         "Unexpected location response from: {url_path}, city: {city}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "gcloud-aio-storage>=9.3.0,<10",
     "ua-parser>=1.0,<2.0",
     "redis[hiredis]>=5.2.1,<6",
+    "circuitbreaker>=2.1.3",
 ]
 
 [project.scripts]

--- a/tests/integration/api/v1/suggest/test_suggest.py
+++ b/tests/integration/api/v1/suggest/test_suggest.py
@@ -400,26 +400,3 @@ def test_suggest_metrics(
         (call.args[0], call.args[3]) for call in report.call_args_list
     ]
     assert metric_keys == expected_metric_keys
-
-
-@pytest.mark.parametrize("providers", [{"corrupt": FakeProviderFactory.corrupt()}])
-def test_suggest_metrics_500(mocker: MockerFixture, client: TestClient) -> None:
-    """Test that 500 status codes are recorded as metrics."""
-    error_msg = "test"
-    expected_metric_keys = [
-        "providers.corrupted.query",
-        "get.api.v1.suggest.timing",
-        "get.api.v1.suggest.status_codes.500",
-        "response.status_codes.500",
-    ]
-
-    report = mocker.patch.object(aiodogstatsd.Client, "_report")
-
-    with pytest.raises(RuntimeError) as excinfo:
-        client.get(f"/api/v1/suggest?q={error_msg}")
-
-    # TODO: Remove reliance on internal details of aiodogstatsd
-    metric_keys: list[str] = [call.args[0] for call in report.call_args_list]
-    assert metric_keys == expected_metric_keys
-
-    assert str(excinfo.value) == error_msg

--- a/tests/unit/providers/suggest/weather/backends/test_accuweather.py
+++ b/tests/unit/providers/suggest/weather/backends/test_accuweather.py
@@ -1294,7 +1294,7 @@ async def test_get_weather_report_with_cache_fetch_error(
     caplog: LogCaptureFixture,
     filter_caplog: FilterCaplogFixture,
 ) -> None:
-    """Test that it should return None on the cache bulk fetch error."""
+    """Test that it should raise an exception on the cache bulk fetch error."""
     caplog.set_level(logging.ERROR)
 
     redis_mock = mocker.AsyncMock(spec=Redis)
@@ -1312,11 +1312,9 @@ async def test_get_weather_report_with_cache_fetch_error(
     )
     client_mock: AsyncMock = cast(AsyncMock, accuweather.http_client)
 
-    report: Optional[WeatherReport] = await accuweather.get_weather_report(
-        weather_context_without_location_key
-    )
+    with pytest.raises(AccuweatherError):
+        _ = await accuweather.get_weather_report(weather_context_without_location_key)
 
-    assert report is None
     client_mock.get.assert_not_called()
 
     metrics_called = [call_arg[0][0] for call_arg in statsd_mock.increment.call_args_list]

--- a/tests/unit/providers/suggest/weather/test_provider.py
+++ b/tests/unit/providers/suggest/weather/test_provider.py
@@ -185,15 +185,14 @@ async def test_query_no_weather_report_returned(
     assert suggestions == expected_suggestions
 
 
-@pytest.mark.asyncio
-async def test_query_with_no_request_type_param_returns_http_400(
+def test_query_with_no_request_type_param_returns_http_400(
     provider: Provider, geolocation: Location
 ) -> None:
     """Test that the query method throws a http 400 error when `q` param is provided but no
     `request_type` param is provided
     """
     with pytest.raises(HTTPException) as accuweather_error:
-        await provider.query(SuggestionRequest(query="weather", geolocation=geolocation))
+        provider.validate(SuggestionRequest(query="weather", geolocation=geolocation))
 
     expected_error_message = "400: Invalid query parameters: `request_type` is missing"
 

--- a/tests/unit/utils/test_cache_redis.py
+++ b/tests/unit/utils/test_cache_redis.py
@@ -21,6 +21,8 @@ async def test_adapter_in_standalone_mode(mocker: MockerFixture) -> None:
             primary="redis://localhost:6379",
             replica="redis://localhost:6379",
             max_connections=1,
+            socket_connect_timeout=1,
+            socket_timeout=1,
             db=0,
         )
     )

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.13, <4"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -135,7 +136,7 @@ name = "bandit"
 version = "1.8.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "pyyaml" },
     { name = "rich" },
     { name = "stevedore" },
@@ -268,11 +269,20 @@ wheels = [
 ]
 
 [[package]]
+name = "circuitbreaker"
+version = "2.1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/ac/de7a92c4ed39cba31fe5ad9203b76a25ca67c530797f6bb420fff5f65ccb/circuitbreaker-2.1.3.tar.gz", hash = "sha256:1a4baee510f7bea3c91b194dcce7c07805fe96c4423ed5594b75af438531d084", size = 10787 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/34/15f08edd4628f65217de1fc3c1a27c82e46fe357d60c217fc9881e12ebcc/circuitbreaker-2.1.3-py3-none-any.whl", hash = "sha256:87ba6a3ed03fdc7032bc175561c2b04d52ade9d5faf94ca2b035fbdc5e6b1dd1", size = 7737 },
+]
+
+[[package]]
 name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
 wheels = [
@@ -1132,6 +1142,7 @@ source = { editable = "." }
 dependencies = [
     { name = "aiodogstatsd" },
     { name = "asgi-correlation-id" },
+    { name = "circuitbreaker" },
     { name = "dockerflow" },
     { name = "dynaconf" },
     { name = "elasticsearch", extra = ["async"] },
@@ -1193,6 +1204,7 @@ load = [
 requires-dist = [
     { name = "aiodogstatsd", specifier = ">=0.16.0,<0.17" },
     { name = "asgi-correlation-id", specifier = ">=4.3.4,<5" },
+    { name = "circuitbreaker", specifier = ">=2.1.3" },
     { name = "dockerflow", specifier = ">=2022.7.0,<2023" },
     { name = "dynaconf", specifier = ">=3.2.4,<4" },
     { name = "elasticsearch", extras = ["async"], specifier = ">=8.5.0,<9" },
@@ -1884,7 +1896,7 @@ dependencies = [
     { name = "cloudpickle" },
     { name = "jinja2" },
     { name = "numpy" },
-    { name = "nvidia-ml-py", marker = "platform_system != 'Darwin'" },
+    { name = "nvidia-ml-py", marker = "sys_platform != 'darwin'" },
     { name = "psutil" },
     { name = "pydantic" },
     { name = "rich" },


### PR DESCRIPTION
## References

JIRA: [DISCO-2053](https://mozilla-hub.atlassian.net/browse/DISCO-2053)

## Description
This adds a circuit breaker to the AccuWeather provider which guards against two potential integration failures:
- Redis
- The AccuWeather endpoint

With this, should any of the above experiences interruptions (e.g. service downtime or high latency), the circuit breaker will help Merino to gracefully handle those without affecting the rest of the service. I've done some local benchmarks, the overhead is negligible. We will see how it performs in load tests and production.

Please see in-source documents for more implementation details. The patch was split into several smaller commits to facilitate the code review.

Will do a follow up to add metrics monitoring the circuit break status.     



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-2053]: https://mozilla-hub.atlassian.net/browse/DISCO-2053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ