### PR TITLE
DISCO-3440 Fix wrong title in manifest production

### DIFF
--- a/tests/integration/jobs/navigational_suggestions/conftest.py
+++ b/tests/integration/jobs/navigational_suggestions/conftest.py
@@ -1,0 +1,40 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Fixtures for navigational_suggestions tests."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from merino.jobs.navigational_suggestions.domain_metadata_extractor import Scraper
+
+
+@pytest.fixture
+def mock_scraper_context():
+    """Fixture that provides a mock Scraper context manager.
+
+    Returns a tuple containing:
+    1. The mock Scraper class to patch with
+    2. The shared scraper instance (accessible for modifying behavior)
+    """
+    # Create shared instance that all mocks will reference
+    shared_scraper = AsyncMock(spec=Scraper)
+    shared_scraper.open.return_value = "https://example.com"
+    shared_scraper.scrape_title.return_value = "Example Website"
+
+    # Create a context manager mock that will return our shared scraper
+    class MockScraperContextManager:
+        async def __aenter__(self):
+            return shared_scraper
+
+        async def __aexit__(self, exc_type, exc_val, exc_tb):
+            return False
+
+    # Create a mock class for Scraper that returns our context manager
+    class MockScraper:
+        def __new__(cls, *args, **kwargs):
+            return MockScraperContextManager()
+
+    return MockScraper, shared_scraper

--- a/tests/unit/jobs/navigational_suggestions/conftest.py
+++ b/tests/unit/jobs/navigational_suggestions/conftest.py
@@ -4,11 +4,17 @@
 
 """Fixtures for navigational_suggestions tests."""
 
+from unittest.mock import MagicMock
+
 import httpx
 from typing import Dict
 
 import pytest
 
+from merino.jobs.navigational_suggestions.domain_metadata_extractor import (
+    current_scraper,
+    Scraper,
+)
 from merino.jobs.navigational_suggestions.utils import AsyncFaviconDownloader
 
 
@@ -127,3 +133,27 @@ def mock_domain_metadata_uploader(mocker):
     uploader.destination_favicon_name.return_value = "favicons/12345_100.ico"
 
     return uploader
+
+
+@pytest.fixture(name="mock_scraper_context")
+def fixture_mock_scraper_context():
+    """Create a mock Scraper class that uses the contextvar."""
+    shared_scraper = MagicMock(spec=Scraper)
+
+    # Create a class that will set the contextvar when instantiated
+    class MockScraper:
+        def __init__(self):
+            # For synchronous methods
+            pass
+
+        async def __aenter__(self):
+            # Set the context variable and store the token
+            self.token = current_scraper.set(shared_scraper)
+            return shared_scraper
+
+        async def __aexit__(self, exc_type, exc_val, exc_tb):
+            # Reset the context variable
+            current_scraper.reset(self.token)
+            return False
+
+    return MockScraper, shared_scraper


### PR DESCRIPTION
## References

JIRA: [DISCO-3440](https://mozilla-hub.atlassian.net/browse/DISCO-3440)

## Description
We were facing race conditions in the `top-picks` file creation. When getting the title from the scraper in each batch, the one domain which was processed last was overwriting the previous domains. So each batch just hat one `title` - the one from the last domain processed in that batch.

This didn't happen for all the batches though.

This PR is:
- removing the global scraper inside `_process_domains`
- creating a local `Scraper()` for each `_process_single_domain` task
- Is reducing the batch size from`50` to `25` to be able to clean up resources more often and keep the RAM down

The maximum RAM used (locally) is around 650MB. 


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3440]: https://mozilla-hub.atlassian.net/browse/DISCO-3440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ