### PR TITLE
fix: enable top-picks in production [load test: skip]

### DIFF
--- a/merino/configs/production.toml
+++ b/merino/configs/production.toml
@@ -34,8 +34,6 @@ gcs_bucket = "merino-images-prodpy"
 cdn_hostname = "merino-images.services.mozilla.com"
 
 [production.providers.top_picks]
-# Temporarily disable it, see [DISCO-3453]
-enabled_by_default = false
 # MERINO_PROVIDERS__TOP_PICKS__DOMAIN_DATA_SOURCE
 # Enum of either `remote` or `local` that defines whether domain data
 # is remotely or locally acquired.


### PR DESCRIPTION
## References

The `top-picks.json` is producing domain titles again. We can re-enable the provider again.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
