### PR TITLE
[DISCO-3447] Fix: handle subdomains for icon_url

### DIFF
--- a/merino/providers/manifest/provider.py
+++ b/merino/providers/manifest/provider.py
@@ -3,7 +3,6 @@
 import asyncio
 import time
 import logging
-from urllib.parse import urlparse
 
 import tldextract
 from pydantic import HttpUrl, ValidationError

--- a/merino/providers/manifest/provider.py
+++ b/merino/providers/manifest/provider.py
@@ -5,6 +5,7 @@ import time
 import logging
 from urllib.parse import urlparse
 
+import tldextract
 from pydantic import HttpUrl, ValidationError
 
 from merino.providers.manifest.backends.filemanager import GetManifestResultCode
@@ -103,10 +104,8 @@ class Provider:
         """
         try:
             url_str = str(url)
-            # Remove www. and get the domain
-            domain = urlparse(url_str).netloc.replace("www.", "")
-            # Strip TLD by taking first part of domain
-            base_domain = domain.split(".")[0] if "." in domain else domain
+            # Use tldextract to correctly handle all domain patterns
+            base_domain = tldextract.extract(url_str).domain
 
             idx = self.domain_lookup_table.get(base_domain, -1)
             if idx >= 0 and self.manifest_data is not None:

--- a/tests/unit/providers/manifest/test_get_icon_url.py
+++ b/tests/unit/providers/manifest/test_get_icon_url.py
@@ -32,7 +32,7 @@ MS_ICON = HttpUrl(
     "90cdaf487716184e4034000935c605d1633926d348116d198f355a98b8c6cd21_17174.oct"
 )
 BBC_ICON = HttpUrl("https://merino-images.services.mozilla.com/favicons/bbciconhash_12345.png")
-# CNN_ICON = HttpUrl("https://merino-images.services.mozilla.com/favicons/cnniconhash_98765.png")
+CNN_ICON = HttpUrl("https://merino-images.services.mozilla.com/favicons/cnniconhash_98765.png")
 
 
 @pytest.mark.asyncio
@@ -46,12 +46,11 @@ BBC_ICON = HttpUrl("https://merino-images.services.mozilla.com/favicons/bbciconh
         ("https://www.microsoft.com/en-us/", MS_ICON),
         ("https://bbc.co.uk/news", BBC_ICON),
         ("https://www.bbc.co.uk/sport", BBC_ICON),
-        # DISCO-3447: URLs with subdomains aren't handled correctly yet.
-        # (
-        #     "https://edition.cnn.com/2025/04/09/entertainment/aimee-lou-wood-teeth-talk-intl-scli/"
-        #     "index.html?utm_source=firefox-newtab-en-us",
-        #     CNN_ICON,
-        # ),
+        (
+            "https://edition.cnn.com/2025/04/09/entertainment/aimee-lou-wood-teeth-talk-intl-scli/"
+            "index.html?utm_source=firefox-newtab-en-us",
+            CNN_ICON,
+        ),
     ],
 )
 async def test_get_icon_url_domain_variants(


### PR DESCRIPTION
## References

JIRA: [DISCO-3447](https://mozilla-hub.atlassian.net/browse/DISCO-3447)

## Description
Correctly return an icon_url for urls with subdomains, such as `https://edition.cnn.com/2025/04/09/entertainment/aimee-lou-wood-teeth-talk-intl-scli`.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3447]: https://mozilla-hub.atlassian.net/browse/DISCO-3447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ