### PR TITLE
DISCO-3441 Filter out empty favicon entries from custom-domains

### DIFF
--- a/merino/jobs/navigational_suggestions/__init__.py
+++ b/merino/jobs/navigational_suggestions/__init__.py
@@ -116,6 +116,12 @@ def _construct_top_picks(
     # This prevents IndexError when domain_metadata is shorter than domain_data
     for domain, metadata in zip(domain_data, domain_metadata):
         if metadata["url"]:
+            # We don't want to add custom-domains to the manifest file if they don't
+            # have a valid favicon. We keep the "top-picks" ones (from BigQuery) because
+            # they are used in Search & Suggest in the browser
+            if metadata["icon"] == "" and domain.get("source") != "top-picks":
+                continue
+
             domain_url = metadata["url"]
             result.append(
                 {

--- a/tests/integration/jobs/navigational_suggestions/test_init.py
+++ b/tests/integration/jobs/navigational_suggestions/test_init.py
@@ -45,6 +45,15 @@ def mock_domain_data():
             "categories": ["search", "tech"],
             "source": "custom-domains",
         },
+        {
+            "rank": 3,
+            "domain": "no-favicon.org",
+            "host": "no-favicon.org",
+            "origin": "http://no-favicon.org",
+            "suffix": "org",
+            "categories": ["search", "tech"],
+            "source": "custom-domains",
+        },
     ]
 
 
@@ -63,6 +72,12 @@ def mock_domain_metadata():
             "url": "https://test.org",
             "title": "Test Website",
             "icon": "https://cdn.test.org/favicon.ico",
+        },
+        {
+            "domain": "no-favicon",
+            "url": "https://no-favicon.org",
+            "title": "No Favicon",
+            "icon": "",
         },
     ]
 


### PR DESCRIPTION
## References

JIRA: [DISCO-3441](https://mozilla-hub.atlassian.net/browse/DISCO-3441)

## Description
We don't want to store domains in the Manifest file when they:
- don't have a valid favicon url (we couldn't find one)
- AND are from the `custom_domains.py` file

We keep empty favicon url entries from the top-sites (BigQuery), because they are used for Search & Suggest.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3441]: https://mozilla-hub.atlassian.net/browse/DISCO-3441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ