### PR TITLE
[DISCO-3253] Fix gcs client auth error for curated recommendations

### DIFF
--- a/merino/curated_recommendations/__init__.py
+++ b/merino/curated_recommendations/__init__.py
@@ -27,6 +27,7 @@ from merino.utils.http_client import create_http_client
 from merino.utils.synced_gcs_blob import SyncedGcsBlob
 
 from merino.providers.manifest import get_provider as get_manifest_provider
+from merino.utils.gcs import initialize_storage_client
 
 logger = logging.getLogger(__name__)
 
@@ -38,7 +39,9 @@ def init_engagement_backend() -> EngagementBackend:
     try:
         metrics_namespace = "recommendation.engagement"
         synced_gcs_blob = SyncedGcsBlob(
-            storage_client=Client(settings.curated_recommendations.gcs.gcp_project),
+            storage_client=initialize_storage_client(
+                destination_gcp_project=settings.curated_recommendations.gcs.gcp_project
+            ),
             metrics_client=get_metrics_client(),
             metrics_namespace=metrics_namespace,
             bucket_name=settings.curated_recommendations.gcs.bucket_name,
@@ -65,7 +68,9 @@ def init_prior_backend() -> PriorBackend:
     """Initialize the GCS Prior Backend, falling back to ConstantPrior if GCS Prior cannot be initialized."""
     try:
         synced_gcs_blob = SyncedGcsBlob(
-            storage_client=Client(settings.curated_recommendations.gcs.gcp_project),
+            storage_client=initialize_storage_client(
+                destination_gcp_project=settings.curated_recommendations.gcs.gcp_project
+            ),
             metrics_client=get_metrics_client(),
             metrics_namespace="recommendation.prior",
             bucket_name=settings.curated_recommendations.gcs.bucket_name,

--- a/merino/utils/gcs/__init__.py
+++ b/merino/utils/gcs/__init__.py
@@ -1,1 +1,16 @@
 """Module designed to handle file (image) uploads to google cloud storage"""
+
+from merino.configs import settings
+from google.auth.credentials import AnonymousCredentials
+from google.cloud.storage import Client
+
+
+def initialize_storage_client(*, destination_gcp_project: str) -> Client:
+    """Initialize a Google Cloud Storage client with production or anonymous credentials if in non-production/staging environment"""
+    if settings.runtime.skip_gcp_client_auth:
+        # for production and staging envs we don't have to explicitly pass the credentials
+        #  as it picks up the ADC file automatically
+        return Client(destination_gcp_project)
+    else:
+        # if not using anonymous credentials in dev & testing envs, this will throw
+        return Client(destination_gcp_project, credentials=AnonymousCredentials())  # type: ignore


### PR DESCRIPTION
## References

JIRA: [DISCO-3253](https://mozilla-hub.atlassian.net/browse/DISCO-3253)

## Description
We were seeing errors about the gcs client initializing failing to find any credentials. We fixed this error in the `gcs_uploader.py` module. The reason this occurs is that it is looking for an explicit `credentials` argument but if none is passed, it tries to pull the ADC file from the google project. However, when running locally, we don't have an ADC file hence adding this check.

<img width="990" alt="Screenshot 2025-04-17 at 11 37 18 AM" src="https://github.com/user-attachments/assets/e1cfbb86-64f1-4839-ae07-8c75d2988db9" />




## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3253]: https://mozilla-hub.atlassian.net/browse/DISCO-3253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ