### PR TITLE
[DISCO-3507] temp fix ignore UK region when specified in weather request

### DIFF
--- a/merino/utils/api/query_params.py
+++ b/merino/utils/api/query_params.py
@@ -61,7 +61,11 @@ def refine_geolocation_for_suggestion(
     geolocation: Location = request.scope[ScopeKey.GEOLOCATION].model_copy()
     if country and region and city:
         geolocation = request.scope[ScopeKey.GEOLOCATION].model_copy(
-            update={"city": city, "regions": [region], "country": country}
+            # temp measure as FX is not providing the expected region for GB. [DISCO-3507]
+            update={
+                "city": city,
+                "regions": [region if country.casefold() != "gb" else None],
+                "country": country,
+            }
         )
-
     return geolocation


### PR DESCRIPTION
## References

JIRA: [DISCO-3507](https://mozilla-hub.atlassian.net/browse/DISCO-3507)

## Description
As a temp measure, we're going to ignore the region if the weather request is made with the parameters, country, city and region and the country is "GB".  Will remove, once we have the correct mapping for the UK region that accuweather expects.

This should not affect other ways that weather is requested


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3507]: https://mozilla-hub.atlassian.net/browse/DISCO-3507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ