### PR TITLE
[MC-1477] Enable topics for non-English locales

### DIFF
--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -196,15 +196,6 @@ class CuratedRecommendationsProvider:
             # Update received_rank now that recommendations have been ranked.
             rec.receivedRank = rank
 
-            # Topic labels are enabled only for en-US in Fx130. We are unsure about the quality of
-            # localized topic strings in Firefox. As a workaround, we decided to only send topics
-            # for New Tab en-US. This workaround should be removed once Fx131 is released on Oct 1.
-            if surface_id not in (
-                SurfaceId.NEW_TAB_EN_US,
-                SurfaceId.NEW_TAB_EN_GB,
-            ):
-                rec.topic = None
-
         return recommendations[: request.count]
 
     @staticmethod

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -369,30 +369,11 @@ class TestCuratedRecommendationsRequestParameters:
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "locale",
-        ["fr", "fr-FR", "es", "es-ES", "it", "it-IT", "de", "de-DE", "de-AT", "de-CH"],
-    )
-    @pytest.mark.parametrize("topics", [None, ["arts", "finance"]])
-    async def test_curated_recommendations_non_en_topic_is_null(self, locale, topics):
-        """Test that topic is missing/null for non-English locales."""
-        async with AsyncClient(app=app, base_url="http://test") as ac:
-            response = await ac.post(
-                "/api/v1/curated-recommendations", json={"locale": locale, "topics": topics}
-            )
-            data = response.json()
-            corpus_items = data["data"]
-
-            assert len(corpus_items) > 0
-            # Assert that the topic is None for all items in non-en-US locales.
-            assert all(item["topic"] is None for item in corpus_items)
-
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize(
-        "locale",
-        ["en-US", "en-GB"],
+        ["en-US", "en-GB", "fr-FR", "es-ES", "it-IT", "de-DE"],
     )
     @pytest.mark.parametrize("topics", [None, ["arts", "finance"]])
     async def test_curated_recommendations_en_topic(self, locale, topics):
-        """Test that topic is present for English locales."""
+        """Test that topic is present."""
         async with AsyncClient(app=app, base_url="http://test") as ac:
             response = await ac.post(
                 "/api/v1/curated-recommendations", json={"locale": locale, "topics": topics}


### PR DESCRIPTION
## References

JIRA: [MC-1477](https://mozilla-hub.atlassian.net/browse/MC-1477)
[Recent Slack thread](https://mozilla.slack.com/archives/C058SAB9F0Q/p1743464155135359) confirming that translations are available

## Description
Re-enable topics on New Tab recommendations for all locales. We disabled topics for non-English locales in the past because the translations weren't ready yet, and re-enabling them well off our radar.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[MC-1477]: https://mozilla-hub.atlassian.net/browse/MC-1477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ