### PR TITLE
[DISCO 3512] fix: Remove the "request.summary"  logs

### DIFF
--- a/docs/data.md
+++ b/docs/data.md
@@ -43,10 +43,6 @@ log inspection interfaces.
   - `sequence_no` -  A client-side event counter (0-based) that records the query
     sequence within each search session.
 
-- `INFO request.summary` - The application request summary that follows the [MozLog][]
-  convention. This log is recorded for all incoming HTTP requests except for the
-  suggest API endpoint.
-
 [Mozlog]: https://wiki.mozilla.org/Firefox/Services/Logging
 
 - `ERROR dockerflow.error_endpoint` - The `__error__` endpoint of the server was

--- a/docs/testing/integration-tests.md
+++ b/docs/testing/integration-tests.md
@@ -43,25 +43,6 @@ def test_with_test_client_with_event(client_with_events: TestClient):
     response: Response = client_with_events.get("/api/v1/endpoint")
 ```
 
-### RequestSummaryLogDataFixture
-This fixture will extract the extra log data from a captured 'request.summary'
-LogRecord for verification
-
-_**Usage:**_
-```python
-def test_with_log_data(
-    caplog: LogCaptureFixture,
-    filter_caplog: FilterCaplogFixture,
-    extract_request_summary_log_data: LogDataFixture
-):
-    records: list[LogRecord] = filter_caplog(caplog.records, "request.summary")
-    assert len(records) == 1
-
-    record: LogRecord = records[0]
-    log_data: dict[str, Any] = extract_request_summary_log_data(record)
-    assert log_data == expected_log_data
-```
-
 ### InjectProvidersFixture & ProvidersFixture
 These fixture will setup and teardown given providers.
 

--- a/merino/configs/app_configs/config_logging.py
+++ b/merino/configs/app_configs/config_logging.py
@@ -62,11 +62,6 @@ def configure_logging() -> None:
                     "level": settings.logging.level,
                     "propagate": settings.logging.can_propagate,
                 },
-                "request.summary": {
-                    "handlers": handler,
-                    "level": settings.logging.level,
-                    "propagate": settings.logging.can_propagate,
-                },
                 "web.suggest.request": {
                     "handlers": handler,
                     "level": settings.logging.level,

--- a/merino/middleware/logging.py
+++ b/merino/middleware/logging.py
@@ -10,16 +10,12 @@ from starlette.requests import Request
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from merino.utils.log_data_creators import (
-    RequestSummaryLogDataModel,
     SuggestLogDataModel,
-    create_request_summary_log_data,
     create_suggest_log_data,
 )
 
 # web.suggest.request is used for logs coming from the /suggest endpoint
 suggest_request_logger = logging.getLogger("web.suggest.request")
-# all other requests will be logged to request.summary
-logger = logging.getLogger("request.summary")
 
 # The path pattern for the suggest API
 PATTERN: Pattern = re.compile(r"/api/v[1-9]\d*/suggest$")
@@ -51,11 +47,6 @@ class LoggingMiddleware:
                         request, message, dt
                     )
                     suggest_request_logger.info("", extra=suggest_log_data.model_dump())
-                else:
-                    request_log_data: RequestSummaryLogDataModel = create_request_summary_log_data(
-                        request, message, dt
-                    )
-                    logger.info("", extra=request_log_data.model_dump())
 
             await send(message)
 

--- a/merino/utils/log_data_creators.py
+++ b/merino/utils/log_data_creators.py
@@ -1,7 +1,6 @@
 """A utility module for log data creation"""
 
 from datetime import datetime
-from typing import Any
 
 from pydantic import BaseModel, field_serializer
 from starlette.datastructures import Headers
@@ -14,9 +13,7 @@ from merino.middleware.user_agent import UserAgent
 
 
 class LogDataModel(BaseModel):
-    """Shared generic log data model. These fields are shared between the Request Summary Logs
-    and the Suggest Logs.
-    """
+    """Shared generic log data model."""
 
     errno: int
     time: datetime
@@ -27,15 +24,6 @@ class LogDataModel(BaseModel):
     def serialize_time(self, v: datetime, **kwargs):
         """Return a datetime value as an iso formatted str."""
         return v.isoformat()
-
-
-class RequestSummaryLogDataModel(LogDataModel):
-    """Log metadata specific to Request Summary."""
-
-    agent: str | None = None
-    lang: str | None = None
-    querystring: dict[str, Any]
-    code: int
 
 
 class SuggestLogDataModel(LogDataModel):
@@ -56,22 +44,6 @@ class SuggestLogDataModel(LogDataModel):
     browser: str
     os_family: str
     form_factor: str
-
-
-def create_request_summary_log_data(
-    request: Request, message: Message, dt: datetime
-) -> RequestSummaryLogDataModel:
-    """Create log data for API endpoints."""
-    return RequestSummaryLogDataModel(
-        errno=0,
-        time=dt,
-        agent=request.headers.get("User-Agent"),
-        path=request.url.path,
-        method=request.method,
-        lang=request.headers.get("Accept-Language"),
-        querystring=dict(request.query_params),
-        code=message["status"],
-    )
 
 
 def create_suggest_log_data(

--- a/tests/integration/api/conftest.py
+++ b/tests/integration/api/conftest.py
@@ -4,7 +4,6 @@
 
 """Module for test configurations for the integration test directory."""
 
-from logging import LogRecord
 from typing import Iterator
 from unittest.mock import AsyncMock
 
@@ -18,8 +17,6 @@ from merino.providers.manifest.backends.protocol import GetManifestResultCode, M
 from merino.utils.gcs.gcs_uploader import GcsUploader
 from contextlib import nullcontext
 from merino.main import app
-from merino.utils.log_data_creators import RequestSummaryLogDataModel
-from tests.integration.api.types import RequestSummaryLogDataFixture
 
 
 class NoOpMetricsClient(AioDogstatsdClient):
@@ -67,29 +64,6 @@ def fixture_test_client_with_events() -> Iterator[TestClient]:
     """
     with TestClient(app) as client:
         yield client
-
-
-@pytest.fixture(name="extract_request_summary_log_data")
-def fixture_extract_request_summary_log_data() -> RequestSummaryLogDataFixture:
-    """Return a function that will extract the extra log data from a captured
-    "request.summary" log record
-    """
-
-    def extract_request_summary_log_data(
-        record: LogRecord,
-    ) -> RequestSummaryLogDataModel:
-        return RequestSummaryLogDataModel(
-            errno=record.__dict__["errno"],
-            time=record.__dict__["time"],
-            agent=record.__dict__["agent"],
-            path=record.__dict__["path"],
-            method=record.__dict__["method"],
-            lang=record.__dict__["lang"],
-            querystring=record.__dict__["querystring"],
-            code=record.__dict__["code"],
-        )
-
-    return extract_request_summary_log_data
 
 
 @pytest.fixture

--- a/tests/integration/api/test_error.py
+++ b/tests/integration/api/test_error.py
@@ -5,17 +5,12 @@
 """Integration tests for the Merino __error__ API endpoint."""
 
 import logging
-from datetime import datetime
-from logging import LogRecord
 
 import aiodogstatsd
 from fastapi.testclient import TestClient
-from freezegun import freeze_time
 from pytest import LogCaptureFixture
 from pytest_mock import MockerFixture
 
-from merino.utils.log_data_creators import RequestSummaryLogDataModel
-from tests.integration.api.types import RequestSummaryLogDataFixture
 from tests.types import FilterCaplogFixture
 
 
@@ -31,50 +26,6 @@ def test_error(
     records = filter_caplog(caplog.records, "merino.web.dockerflow")
     assert len(records) == 1
     assert records[0].message == "The __error__ endpoint was called"
-
-
-@freeze_time("1998-03-31")
-def test_error_request_log_data(
-    caplog: LogCaptureFixture,
-    filter_caplog: FilterCaplogFixture,
-    extract_request_summary_log_data: RequestSummaryLogDataFixture,
-    client: TestClient,
-) -> None:
-    """Test that the request log for the '__error__' endpoint contains the required
-    extra data.
-    """
-    caplog.set_level(logging.INFO)
-
-    expected_log_data: RequestSummaryLogDataModel = RequestSummaryLogDataModel(
-        agent=(
-            "Mozilla/5.0 (Macintosh; Intel Mac OS X 11.2; rv:85.0)" " Gecko/20100101 Firefox/103.0"
-        ),
-        path="/__error__",
-        method="GET",
-        lang="en-US",
-        querystring={},
-        errno=0,
-        code=500,
-        time=datetime(1998, 3, 31),
-    )
-
-    client.get(
-        "/__error__",
-        headers={
-            "accept-language": "en-US",
-            "User-Agent": (
-                "Mozilla/5.0 (Macintosh; Intel Mac OS X 11.2; rv:85.0) "
-                "Gecko/20100101 Firefox/103.0"
-            ),
-        },
-    )
-
-    records: list[LogRecord] = filter_caplog(caplog.records, "request.summary")
-    assert len(records) == 1
-
-    record: LogRecord = records[0]
-    log_data: RequestSummaryLogDataModel = extract_request_summary_log_data(record)
-    assert log_data == expected_log_data
 
 
 def test_error_metrics(mocker: MockerFixture, client: TestClient) -> None:

--- a/tests/integration/api/test_heartbeat.py
+++ b/tests/integration/api/test_heartbeat.py
@@ -4,18 +4,8 @@
 
 """Integration tests for the Merino __heartbeat__ and __lbheartbeat__ API endpoints."""
 
-import logging
-from datetime import datetime
-from logging import LogRecord
-
 import pytest
-from _pytest.logging import LogCaptureFixture
 from fastapi.testclient import TestClient
-from freezegun import freeze_time
-
-from merino.utils.log_data_creators import RequestSummaryLogDataModel
-from tests.integration.api.types import RequestSummaryLogDataFixture
-from tests.types import FilterCaplogFixture
 
 
 @pytest.mark.parametrize("endpoint", ["__heartbeat__", "__lbheartbeat__"])
@@ -24,49 +14,3 @@ def test_heartbeats(client: TestClient, endpoint: str) -> None:
     response = client.get(f"/{endpoint}")
 
     assert response.status_code == 200
-
-
-@freeze_time("1998-03-31")
-@pytest.mark.parametrize("endpoint", ["__heartbeat__", "__lbheartbeat__"])
-def test_heartbeat_request_log_data(
-    caplog: LogCaptureFixture,
-    filter_caplog: FilterCaplogFixture,
-    extract_request_summary_log_data: RequestSummaryLogDataFixture,
-    client: TestClient,
-    endpoint: str,
-) -> None:
-    """Test that the request log for the '__heartbeat__' and '__lbheartbeat__'
-    endpoints contain the required extra data
-    """
-    caplog.set_level(logging.INFO)
-
-    expected_log_data: RequestSummaryLogDataModel = RequestSummaryLogDataModel(
-        agent=(
-            "Mozilla/5.0 (Macintosh; Intel Mac OS X 11.2; rv:85.0)" " Gecko/20100101 Firefox/103.0"
-        ),
-        path=f"/{endpoint}",
-        method="GET",
-        lang="en-US",
-        querystring={},
-        errno=0,
-        code=200,
-        time=datetime(1998, 3, 31),
-    )
-
-    client.get(
-        f"/{endpoint}",
-        headers={
-            "accept-language": "en-US",
-            "User-Agent": (
-                "Mozilla/5.0 (Macintosh; Intel Mac OS X 11.2; rv:85.0) "
-                "Gecko/20100101 Firefox/103.0"
-            ),
-        },
-    )
-
-    records: list[LogRecord] = filter_caplog(caplog.records, "request.summary")
-    assert len(records) == 1
-
-    record: LogRecord = records[0]
-    log_data: RequestSummaryLogDataModel = extract_request_summary_log_data(record)
-    assert log_data == expected_log_data

--- a/tests/integration/api/test_version.py
+++ b/tests/integration/api/test_version.py
@@ -4,19 +4,10 @@
 
 """Integration tests for the Merino __version__ API endpoint."""
 
-import logging
 import pathlib
-from datetime import datetime
-from logging import LogRecord
 
 from fastapi.testclient import TestClient
-from freezegun import freeze_time
-from pytest import LogCaptureFixture
 from pytest_mock import MockerFixture
-
-from merino.utils.log_data_creators import RequestSummaryLogDataModel
-from tests.integration.api.types import RequestSummaryLogDataFixture
-from tests.types import FilterCaplogFixture
 
 
 def test_version(client: TestClient) -> None:
@@ -41,47 +32,3 @@ def test_version_error(mocker: MockerFixture, client: TestClient) -> None:
 
     assert response.status_code == 500
     assert response.json() == {"detail": "Version file does not exist"}
-
-
-@freeze_time("1998-03-31")
-def test_version_request_log_data(
-    caplog: LogCaptureFixture,
-    filter_caplog: FilterCaplogFixture,
-    extract_request_summary_log_data: RequestSummaryLogDataFixture,
-    client: TestClient,
-) -> None:
-    """Test that the request log for the '__version__' endpoint contains the required
-    extra data.
-    """
-    caplog.set_level(logging.INFO)
-
-    expected_log_data: RequestSummaryLogDataModel = RequestSummaryLogDataModel(
-        agent=(
-            "Mozilla/5.0 (Macintosh; Intel Mac OS X 11.2; rv:85.0)" " Gecko/20100101 Firefox/103.0"
-        ),
-        path="/__version__",
-        method="GET",
-        lang="en-US",
-        querystring={},
-        errno=0,
-        code=200,
-        time=datetime(1998, 3, 31),
-    )
-
-    client.get(
-        "/__version__",
-        headers={
-            "accept-language": "en-US",
-            "User-Agent": (
-                "Mozilla/5.0 (Macintosh; Intel Mac OS X 11.2; rv:85.0) "
-                "Gecko/20100101 Firefox/103.0"
-            ),
-        },
-    )
-
-    records: list[LogRecord] = filter_caplog(caplog.records, "request.summary")
-    assert len(records) == 1
-
-    record: LogRecord = records[0]
-    log_data: RequestSummaryLogDataModel = extract_request_summary_log_data(record)
-    assert log_data == expected_log_data

--- a/tests/integration/api/types.py
+++ b/tests/integration/api/types.py
@@ -3,10 +3,3 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """Type definitions for the integration test modules."""
-
-from logging import LogRecord
-from typing import Callable
-
-from merino.utils.log_data_creators import RequestSummaryLogDataModel
-
-RequestSummaryLogDataFixture = Callable[[LogRecord], RequestSummaryLogDataModel]

--- a/tests/integration/api/v1/suggest/test_providers.py
+++ b/tests/integration/api/v1/suggest/test_providers.py
@@ -4,20 +4,11 @@
 
 """Integration tests for the Merino v1 providers API endpoint."""
 
-import logging
-from datetime import datetime
-from logging import LogRecord
-
 import pytest
 from fastapi.testclient import TestClient
-from freezegun import freeze_time
-from pytest import LogCaptureFixture
 
 from merino.providers.suggest import BaseProvider
-from merino.utils.log_data_creators import RequestSummaryLogDataModel
-from tests.integration.api.types import RequestSummaryLogDataFixture
 from tests.integration.api.v1.fake_providers import FakeProviderFactory
-from tests.types import FilterCaplogFixture
 
 
 @pytest.mark.parametrize(
@@ -114,48 +105,3 @@ def test_disabled_providers_setting(
 
     assert response.status_code == 200
     assert response.json() == expected_response
-
-
-@freeze_time("1998-03-31")
-@pytest.mark.parametrize("providers", [{}])
-def test_providers_request_log_data(
-    caplog: LogCaptureFixture,
-    filter_caplog: FilterCaplogFixture,
-    extract_request_summary_log_data: RequestSummaryLogDataFixture,
-    client: TestClient,
-) -> None:
-    """Test that the request log for the 'providers' endpoint contains the required
-    extra data
-    """
-    caplog.set_level(logging.INFO)
-
-    expected_log_data: RequestSummaryLogDataModel = RequestSummaryLogDataModel(
-        agent=(
-            "Mozilla/5.0 (Macintosh; Intel Mac OS X 11.2; rv:85.0)" " Gecko/20100101 Firefox/103.0"
-        ),
-        path="/api/v1/providers",
-        method="GET",
-        lang="en-US",
-        querystring={},
-        errno=0,
-        code=200,
-        time=datetime(1998, 3, 31),
-    )
-
-    client.get(
-        "/api/v1/providers",
-        headers={
-            "accept-language": "en-US",
-            "User-Agent": (
-                "Mozilla/5.0 (Macintosh; Intel Mac OS X 11.2; rv:85.0) "
-                "Gecko/20100101 Firefox/103.0"
-            ),
-        },
-    )
-
-    records: list[LogRecord] = filter_caplog(caplog.records, "request.summary")
-    assert len(records) == 1
-
-    record: LogRecord = records[0]
-    log_data: RequestSummaryLogDataModel = extract_request_summary_log_data(record)
-    assert log_data == expected_log_data

--- a/tests/integration/api/v1/suggest/test_suggest_weather.py
+++ b/tests/integration/api/v1/suggest/test_suggest_weather.py
@@ -7,7 +7,6 @@ provider.
 """
 
 import logging
-from datetime import datetime
 from logging import LogRecord
 from typing import Any
 from unittest.mock import AsyncMock
@@ -44,8 +43,6 @@ from merino.providers.suggest.weather.provider import (
     Provider,
     Suggestion,
 )
-from merino.utils.log_data_creators import RequestSummaryLogDataModel
-from tests.integration.api.types import RequestSummaryLogDataFixture
 from tests.integration.api.v1.types import Providers
 from tests.types import FilterCaplogFixture
 
@@ -376,33 +373,15 @@ def test_suggest_weather_with_missing_request_type_query_parameter(client: TestC
 def test_providers_request_log_data_weather(
     caplog: LogCaptureFixture,
     filter_caplog: FilterCaplogFixture,
-    extract_request_summary_log_data: RequestSummaryLogDataFixture,
     client: TestClient,
 ) -> None:
-    """Test that accuweather" provider logs using "request.summary"."""
+    """Test that accuweather" provider logs are not using "web.suggest.request"."""
     caplog.set_level(logging.INFO)
-
-    expected_log_data: RequestSummaryLogDataModel = RequestSummaryLogDataModel(
-        agent="testclient",
-        path="/api/v1/suggest",
-        method="GET",
-        querystring={"providers": "accuweather", "q": ""},
-        errno=0,
-        code=200,
-        time=datetime(1998, 3, 31),
-    )
 
     client.get("/api/v1/suggest?providers=accuweather&q=")
 
-    records: list[LogRecord] = filter_caplog(caplog.records, "request.summary")
-    assert len(records) == 1
-
     suggest_records: list[LogRecord] = filter_caplog(caplog.records, "web.suggest.request")
     assert len(suggest_records) == 0
-
-    record: LogRecord = records[0]
-    log_data: RequestSummaryLogDataModel = extract_request_summary_log_data(record)
-    assert log_data == expected_log_data
 
 
 def test_suggest_with_location_completion(

--- a/tests/integration/api/v1/test_unsupported.py
+++ b/tests/integration/api/v1/test_unsupported.py
@@ -4,63 +4,9 @@
 
 """Integration tests for unsupported Merino v1 API endpoints."""
 
-import logging
-from datetime import datetime
-from logging import LogRecord
-
 import aiodogstatsd
 from fastapi.testclient import TestClient
-from freezegun import freeze_time
-from pytest import LogCaptureFixture
 from pytest_mock import MockerFixture
-
-from merino.utils.log_data_creators import RequestSummaryLogDataModel
-from tests.integration.api.types import RequestSummaryLogDataFixture
-from tests.types import FilterCaplogFixture
-
-
-@freeze_time("1998-03-31")
-def test_unsupported_endpoint_request_log_data(
-    caplog: LogCaptureFixture,
-    filter_caplog: FilterCaplogFixture,
-    extract_request_summary_log_data: RequestSummaryLogDataFixture,
-    client: TestClient,
-) -> None:
-    """Test that the request log for unsupported endpoints contains the required extra
-    data.
-    """
-    caplog.set_level(logging.INFO)
-
-    expected_log_data: RequestSummaryLogDataModel = RequestSummaryLogDataModel(
-        agent=(
-            "Mozilla/5.0 (Macintosh; Intel Mac OS X 11.2; rv:85.0)" " Gecko/20100101 Firefox/103.0"
-        ),
-        path="/api/v1/unsupported",
-        method="GET",
-        lang="en-US",
-        querystring={},
-        errno=0,
-        code=404,
-        time=datetime(1998, 3, 31),
-    )
-
-    client.get(
-        "/api/v1/unsupported",
-        headers={
-            "accept-language": "en-US",
-            "User-Agent": (
-                "Mozilla/5.0 (Macintosh; Intel Mac OS X 11.2; rv:85.0) "
-                "Gecko/20100101 Firefox/103.0"
-            ),
-        },
-    )
-
-    records: list[LogRecord] = filter_caplog(caplog.records, "request.summary")
-    assert len(records) == 1
-
-    record: LogRecord = records[0]
-    log_data: RequestSummaryLogDataModel = extract_request_summary_log_data(record)
-    assert log_data == expected_log_data
 
 
 def test_unsupported_endpoint_metrics(mocker: MockerFixture, client: TestClient) -> None:

--- a/tests/unit/utils/test_log_data_creator.py
+++ b/tests/unit/utils/test_log_data_creator.py
@@ -17,57 +17,9 @@ from merino.middleware.geolocation import Location
 from merino.middleware.user_agent import UserAgent
 from merino.utils.log_data_creators import (
     LogDataModel,
-    RequestSummaryLogDataModel,
     SuggestLogDataModel,
-    create_request_summary_log_data,
     create_suggest_log_data,
 )
-
-
-@pytest.mark.parametrize(
-    ["headers", "expected_agent", "expected_lang"],
-    [
-        ([], None, None),
-        ([(b"user-agent", b"curl/7.84.0")], "curl/7.84.0", None),
-        ([(b"accept-language", b"en-US")], None, "en-US"),
-    ],
-    ids=["no_headers", "user_agent_header", "accept_language_header"],
-)
-def test_create_request_summary_log_data(
-    headers: list[tuple[bytes, bytes]],
-    expected_agent: str | None,
-    expected_lang: str | None,
-) -> None:
-    """Test that the create_request_summary_log_data method properly constructs log
-    data given different headers.
-    """
-    dt: datetime = datetime(1998, 3, 31)
-
-    expected_log_data: RequestSummaryLogDataModel = RequestSummaryLogDataModel(
-        errno=0,
-        time=dt,
-        agent=expected_agent,
-        path="/__heartbeat__",
-        method="GET",
-        lang=expected_lang,
-        querystring={},
-        code=200,
-    )
-
-    request: Request = Request(
-        scope={
-            "type": "http",
-            "headers": headers,
-            "method": "GET",
-            "path": "/__heartbeat__",
-            "query_string": "",
-        }
-    )
-    message: Message = {"type": "http.response.start", "status": "200"}
-
-    log_data: RequestSummaryLogDataModel = create_request_summary_log_data(request, message, dt)
-
-    assert log_data == expected_log_data
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## References

JIRA: [DISCO-3512](https://mozilla-hub.atlassian.net/browse/DISCO-3512)

## Description
See more details in the ticket. Let's see if this could save Merino's logging cost.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3512]: https://mozilla-hub.atlassian.net/browse/DISCO-3512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ