### PR TITLE
HNT-503: Add coarse OS and timezone request params

### DIFF
--- a/merino/curated_recommendations/protocol.py
+++ b/merino/curated_recommendations/protocol.py
@@ -52,6 +52,19 @@ class Locale(str, Enum):
         return Locale._value2member_map_
 
 
+# New Enum for coarse_os
+@unique
+class CoarseOS(str, Enum):
+    """Supported operating systems at a coarse granularity."""
+
+    MAC = "mac"
+    WIN = "win"
+    LINUX = "linux"
+    ANDROID = "android"
+    IOS = "ios"
+    OTHER = "other"
+
+
 @unique
 class ExperimentName(str, Enum):
     """List of Nimbus experiment names on New Tab. This list is NOT meant to be exhaustive.
@@ -143,6 +156,8 @@ class CuratedRecommendationsRequest(BaseModel):
 
     locale: Locale
     region: str | None = None
+    coarseOs: CoarseOS | None = None
+    utcOffset: Annotated[int, Field(ge=0, le=24)] | None = None
     count: int = 100
     topics: list[Topic | str] | None = None
     feeds: list[str] | None = None

--- a/merino/curated_recommendations/protocol.py
+++ b/merino/curated_recommendations/protocol.py
@@ -52,7 +52,6 @@ class Locale(str, Enum):
         return Locale._value2member_map_
 
 
-# New Enum for coarse_os
 @unique
 class CoarseOS(str, Enum):
     """Supported operating systems at a coarse granularity."""

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -287,14 +287,9 @@ class TestCuratedRecommendationsRequestParameters:
         async with AsyncClient(app=app, base_url="http://test") as ac:
             response = await ac.post(
                 "/api/v1/curated-recommendations",
-                json={
-                    "locale": Locale.EN_US,
-                    "coarse_os": coarse_os,
-                },
+                json={"locale": Locale.EN_US, "coarse_os": coarse_os},
             )
-            assert (
-                response.status_code == 200
-            ), f"coarse_os {coarse_os} resulted in {response.status_code}"
+            assert response.status_code == 200
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("coarse_os", ["", "windows11"])
@@ -316,7 +311,7 @@ class TestCuratedRecommendationsRequestParameters:
         async with AsyncClient(app=app, base_url="http://test") as ac:
             response = await ac.post(
                 "/api/v1/curated-recommendations",
-                json={"locale": Locale.EN_US, "utc_offset": utc_offset},
+                json={"locale": Locale.EN_US, "utcOffset": utc_offset},
             )
             assert response.status_code == 200
 
@@ -327,11 +322,9 @@ class TestCuratedRecommendationsRequestParameters:
         async with AsyncClient(app=app, base_url="http://test") as ac:
             response = await ac.post(
                 "/api/v1/curated-recommendations",
-                json={"locale": Locale.EN_US, "utc_offset": utc_offset},
+                json={"locale": Locale.EN_US, "utcOffset": utc_offset},
             )
-            assert (
-                response.status_code == 400
-            ), f"utc_offset {utc_offset} should fail, got {response.status_code}"
+            assert response.status_code == 400
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("count", [10, 50, 100])

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -35,7 +35,8 @@ from merino.curated_recommendations.prior_backends.protocol import PriorBackend
 from merino.curated_recommendations.protocol import (
     ExperimentName,
     Layout,
-    Locale, CoarseOS,
+    Locale,
+    CoarseOS,
 )
 from merino.curated_recommendations.protocol import CuratedRecommendation
 from merino.main import app
@@ -284,35 +285,39 @@ class TestCuratedRecommendationsRequestParameters:
     async def test_curated_recommendations_valid_os(self, coarse_os):
         """Test the curated recommendations endpoint accepts valid coarse_os values."""
         async with AsyncClient(app=app, base_url="http://test") as ac:
-            response = await ac.post("/api/v1/curated-recommendations", json={
-                "locale": Locale.EN_US,
-                "coarse_os": coarse_os,
-            })
-            assert response.status_code == 200, f"coarse_os {coarse_os} resulted in {response.status_code}"
+            response = await ac.post(
+                "/api/v1/curated-recommendations",
+                json={
+                    "locale": Locale.EN_US,
+                    "coarse_os": coarse_os,
+                },
+            )
+            assert (
+                response.status_code == 200
+            ), f"coarse_os {coarse_os} resulted in {response.status_code}"
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("coarse_os", ["", "windows11"])
     async def test_curated_recommendations_invalid_os(self, coarse_os):
         """Test the curated recommendations endpoint rejects invalid coarse_os values."""
         async with AsyncClient(app=app, base_url="http://test") as ac:
-            response = await ac.post("/api/v1/curated-recommendations", json={
-                "locale": Locale.EN_US,
-                "coarseOs": coarse_os
-            })
+            response = await ac.post(
+                "/api/v1/curated-recommendations",
+                json={"locale": Locale.EN_US, "coarseOs": coarse_os},
+            )
             assert response.status_code == 400
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("utc_offset", [0, 12, 24])
     async def test_curated_recommendations_valid_utc_offset(self, utc_offset):
-        """
-        Test the curated recommendations endpoint accepts valid utc_offset values.
+        """Test the curated recommendations endpoint accepts valid utc_offset values.
         This includes values that require rounding (e.g., 3.7 should be rounded to 4).
         """
         async with AsyncClient(app=app, base_url="http://test") as ac:
-            response = await ac.post("/api/v1/curated-recommendations", json={
-                "locale": Locale.EN_US,
-                "utc_offset": utc_offset
-            })
+            response = await ac.post(
+                "/api/v1/curated-recommendations",
+                json={"locale": Locale.EN_US, "utc_offset": utc_offset},
+            )
             assert response.status_code == 200
 
     @pytest.mark.asyncio
@@ -320,11 +325,13 @@ class TestCuratedRecommendationsRequestParameters:
     async def test_curated_recommendations_invalid_utc_offset(self, utc_offset):
         """Test the curated recommendations endpoint rejects invalid utc_offset values."""
         async with AsyncClient(app=app, base_url="http://test") as ac:
-            response = await ac.post("/api/v1/curated-recommendations", json={
-                "locale": Locale.EN_US,
-                "utc_offset": utc_offset
-            })
-            assert response.status_code == 400, f"utc_offset {utc_offset} should fail, got {response.status_code}"
+            response = await ac.post(
+                "/api/v1/curated-recommendations",
+                json={"locale": Locale.EN_US, "utc_offset": utc_offset},
+            )
+            assert (
+                response.status_code == 400
+            ), f"utc_offset {utc_offset} should fail, got {response.status_code}"
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("count", [10, 50, 100])

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -35,7 +35,7 @@ from merino.curated_recommendations.prior_backends.protocol import PriorBackend
 from merino.curated_recommendations.protocol import (
     ExperimentName,
     Layout,
-    Locale,
+    Locale, CoarseOS,
 )
 from merino.curated_recommendations.protocol import CuratedRecommendation
 from merino.main import app
@@ -268,6 +268,63 @@ class TestCuratedRecommendationsRequestParameters:
         async with AsyncClient(app=app, base_url="http://test") as ac:
             response = await ac.post("/api/v1/curated-recommendations", json={"locale": locale})
             assert response.status_code == 400
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "coarse_os",
+        [
+            CoarseOS.MAC,
+            CoarseOS.WIN,
+            CoarseOS.LINUX,
+            CoarseOS.ANDROID,
+            CoarseOS.IOS,
+            CoarseOS.OTHER,
+        ],
+    )
+    async def test_curated_recommendations_valid_os(self, coarse_os):
+        """Test the curated recommendations endpoint accepts valid coarse_os values."""
+        async with AsyncClient(app=app, base_url="http://test") as ac:
+            response = await ac.post("/api/v1/curated-recommendations", json={
+                "locale": Locale.EN_US,
+                "coarse_os": coarse_os,
+            })
+            assert response.status_code == 200, f"coarse_os {coarse_os} resulted in {response.status_code}"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("coarse_os", ["", "windows11"])
+    async def test_curated_recommendations_invalid_os(self, coarse_os):
+        """Test the curated recommendations endpoint rejects invalid coarse_os values."""
+        async with AsyncClient(app=app, base_url="http://test") as ac:
+            response = await ac.post("/api/v1/curated-recommendations", json={
+                "locale": Locale.EN_US,
+                "coarseOs": coarse_os
+            })
+            assert response.status_code == 400
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("utc_offset", [0, 12, 24])
+    async def test_curated_recommendations_valid_utc_offset(self, utc_offset):
+        """
+        Test the curated recommendations endpoint accepts valid utc_offset values.
+        This includes values that require rounding (e.g., 3.7 should be rounded to 4).
+        """
+        async with AsyncClient(app=app, base_url="http://test") as ac:
+            response = await ac.post("/api/v1/curated-recommendations", json={
+                "locale": Locale.EN_US,
+                "utc_offset": utc_offset
+            })
+            assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("utc_offset", [-1, 11.5, 25, "Z"])
+    async def test_curated_recommendations_invalid_utc_offset(self, utc_offset):
+        """Test the curated recommendations endpoint rejects invalid utc_offset values."""
+        async with AsyncClient(app=app, base_url="http://test") as ac:
+            response = await ac.post("/api/v1/curated-recommendations", json={
+                "locale": Locale.EN_US,
+                "utc_offset": utc_offset
+            })
+            assert response.status_code == 400, f"utc_offset {utc_offset} should fail, got {response.status_code}"
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("count", [10, 50, 100])


### PR DESCRIPTION
## References

JIRA: [HNT-503](https://mozilla-hub.atlassian.net/browse/HNT-503)
[BugZilla #1960999](https://bugzilla.mozilla.org/show_bug.cgi?id=1960999)

## Description
Add a `coarseOs` and `utcOffset` parameter to the request for New Tab recommendations. For now, these parameters will not be used by the backend. Eventually, they may allow us to deliver more relevant recommendations to users, in a privacy-preserving way.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[HNT-503]: https://mozilla-hub.atlassian.net/browse/HNT-503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ