### PR TITLE
HNT-429: Adjust ad display in sections

### DIFF
--- a/merino/curated_recommendations/layouts.py
+++ b/merino/curated_recommendations/layouts.py
@@ -3,7 +3,7 @@
 When changing or adding a new layout, put the change behind a Nimbus experiment, such that
 front-end engineering, product, and design can QA the layout before it reaches users.
 
-Tile order should be based on horizontal stacking. You can try this our in the Mozilla Playground:
+Tile order should be based on horizontal stacking. You can try this out in the Mozilla Playground:
 https://developer.mozilla.org/en-US/play?id=zWYUe3xC5v60fEuN8USHE24l7Q7tR2Vghi08O6KT9DAZz9cv%2B%2F0s0H8F7vJBWRVCnQgSHYWR%2BadDY4zA
 """
 

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -1145,7 +1145,7 @@ class TestSections:
         ],
     )
     async def test_sections_layouts(self, sections_payload, experiment_payload):
-        """Test that the correct layout are returned along with sections."""
+        """Test that the correct layouts & ads are returned along with sections."""
         async with AsyncClient(app=app, base_url="http://test") as ac:
             response = await ac.post(
                 "/api/v1/curated-recommendations",
@@ -1180,6 +1180,20 @@ class TestSections:
             for section in sections.values():
                 if section["receivedFeedRank"] != 1:
                     assert section["layout"]["name"] != "7-double-row-3-ad"
+
+            # Assert only sections 1,2,3,5,7,9 (ranks: 0,1,2,4,6,8) have ads
+            expected_section_ranks_with_ads = {0, 1, 2, 4, 6, 8}
+            for section in sections.values():
+                tiles_with_ads = [
+                    tile
+                    for layout in section["layout"]["responsiveLayouts"]
+                    for tile in layout["tiles"]
+                    if tile["hasAd"]
+                ]
+                if section["receivedFeedRank"] in expected_section_ranks_with_ads:
+                    assert tiles_with_ads
+                else:
+                    assert not tiles_with_ads
 
     @pytest.mark.asyncio
     async def test_curated_recommendations_with_sections_feed_boost_followed_sections(

--- a/tests/unit/curated_recommendations/fixtures.py
+++ b/tests/unit/curated_recommendations/fixtures.py
@@ -2,6 +2,7 @@
 
 import random
 import uuid
+from copy import deepcopy
 
 from pydantic import HttpUrl
 
@@ -50,7 +51,7 @@ def generate_sections_feed(section_count: int, followed_count: int = 0) -> dict[
             receivedFeedRank=0,
             recommendations=[],  # Dummy recommendations.
             title="Top Stories",
-            layout=layout_4_medium,
+            layout=deepcopy(layout_4_medium),
         )
     }
 
@@ -61,7 +62,7 @@ def generate_sections_feed(section_count: int, followed_count: int = 0) -> dict[
             receivedFeedRank=i + 1,  # Ranks start after top_stories_section.
             recommendations=[],
             title=f"{topic.value.title()} Section",
-            layout=layout_4_medium,
+            layout=deepcopy(layout_4_medium),
             isFollowed=(i < followed_count),
         )
 


### PR DESCRIPTION
## References

JIRA: https://mozilla-hub.atlassian.net/browse/HNT-429

## Description
Only display Ads in sections: 1,2,3,5,7,9 (`receivedFeedRank: {0,1,2,4,6,8}`) and then no more.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
