### PR TITLE
[DISCO-3479] Switch Merino to use quicksuggest-amp collection

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -159,7 +159,7 @@ bucket = "main"
 # MERINO_REMOTE_SETTINGS__COLLECTION
 # The collection to use for Remote Settings providers if not specified in provider config.
 # Ex: "quicksuggest".
-collection = "quicksuggest"
+collection = "quicksuggest-amp"
 
 # The collection to use for uploading fakespot suggestions if not specified on the command line
 collection_fakespot = "fakespot-suggest-products"
@@ -179,6 +179,10 @@ dry_run = false
 # MERINO_REMOTE_SETTINGS__SCORE
 # Default score to set in suggestions uploaded to remote settings.
 score = 0.25
+
+# MERINO_REMOTE_SETTINGS__COUNTRIES
+# Default countries used to filter out records from remote settings.
+countries = ["US"]
 
 # Global Redis settings. The weather provider optionally uses Redis to cache weather suggestions.
 [default.redis]

--- a/tests/integration/providers/suggest/adm/backends/test_remotesettings_icon.py
+++ b/tests/integration/providers/suggest/adm/backends/test_remotesettings_icon.py
@@ -25,7 +25,7 @@ def fixture_rs_parameters() -> dict[str, str]:
     return {
         "server": "test://test",
         "bucket": "main",
-        "collection": "quicksuggest",
+        "collection": "quicksuggest-amp",
     }
 
 
@@ -34,13 +34,15 @@ def fixture_rs_records() -> list[dict]:
     """Return fake records data for testing."""
     return [
         {
-            "type": "data",
+            "type": "amp",
             "schema": 123,
+            "country": "US",
+            "form_factor": "desktop",
             "attachment": {
                 "hash": "abcd",
                 "size": 1,
                 "filename": "data-01.json",
-                "location": "main-workspace/quicksuggest/attachmment-01.json",
+                "location": "main-workspace/quicksuggest-amp/attachmment-01.json",
                 "mimetype": "application/octet-stream",
             },
             "id": "data-01",
@@ -54,7 +56,7 @@ def fixture_rs_records() -> list[dict]:
                 "hash": "efghabcasd",
                 "size": 1,
                 "filename": "icon-01",
-                "location": "main-workspace/quicksuggest/icon-01",
+                "location": "main-workspace/quicksuggest-amp/icon-01",
                 "mimetype": "application/octet-stream",
             },
             "content_type": "image/png",
@@ -69,7 +71,7 @@ def fixture_rs_records() -> list[dict]:
                 "hash": "iconhash2",
                 "size": 1,
                 "filename": "icon-02",
-                "location": "main-workspace/quicksuggest/icon-02",
+                "location": "main-workspace/quicksuggest-amp/icon-02",
                 "mimetype": "application/octet-stream",
             },
             "content_type": "image/jpeg",
@@ -114,7 +116,7 @@ def fixture_rs_attachment_response(rs_attachment: KintoSuggestion) -> httpx.Resp
         request=httpx.Request(
             method="GET",
             url=(
-                "attachment-host/main-workspace/quicksuggest/"
+                "attachment-host/main-workspace/quicksuggest-amp/"
                 "6129d437-b3c1-48b5-b343-535e045d341a.json"
             ),
         ),
@@ -211,7 +213,7 @@ async def test_remotesettings_with_icon_processor(
         assert "test-cdn.mozilla.net/favicons" in icon_url
 
         # The original URLs should have been passed to the processor
-        original_url = f"attachment-host/main-workspace/quicksuggest/icon-{icon_id}"
+        original_url = f"attachment-host/main-workspace/quicksuggest-amp/icon-{icon_id}"
         assert original_url in mock_processor.processed_urls
 
 
@@ -256,10 +258,10 @@ async def test_remotesettings_icon_processor_error_handling(
 
     # Check that each icon URL is the original attachment URL
     for icon_id, icon_url in suggestion_content.icons.items():
-        assert icon_url == f"attachment-host/main-workspace/quicksuggest/icon-{icon_id}"
+        assert icon_url == f"attachment-host/main-workspace/quicksuggest-amp/icon-{icon_id}"
 
         # Verify the URL was processed (attempt was made)
-        original_url = f"attachment-host/main-workspace/quicksuggest/icon-{icon_id}"
+        original_url = f"attachment-host/main-workspace/quicksuggest-amp/icon-{icon_id}"
         assert original_url in mock_processor.processed_urls
 
 

--- a/tests/unit/providers/suggest/adm/backends/test_remotesettings.py
+++ b/tests/unit/providers/suggest/adm/backends/test_remotesettings.py
@@ -91,6 +91,21 @@ def fixture_rs_records() -> list[dict[str, Any]]:
             "last_modified": 123,
         },
         {
+            "type": "amp",
+            "country": "US",
+            "form_factor": "desktop",
+            "schema": 123,
+            "attachment": {
+                "hash": "abcd",
+                "size": 1,
+                "filename": "data-01.json",
+                "location": "main-workspace/quicksuggest/attachmment-01.json",
+                "mimetype": "application/octet-stream",
+            },
+            "id": "data-01",
+            "last_modified": 123,
+        },
+        {
             "type": "icon",
             "schema": 456,
             "attachment": {
@@ -299,6 +314,33 @@ async def test_fetch_no_adm_wikipedia_result(
     suggestion_content: SuggestionContent = await rs_backend.fetch()
 
     assert suggestion_content.results == []
+
+
+@pytest.mark.asyncio
+async def test_filter_amp_records(
+    rs_records: list[dict[str, Any]],
+    rs_backend: RemoteSettingsBackend,
+) -> None:
+    """Test that the filter_records method returns the proper records."""
+    suggestion_content = rs_backend.filter_records("amp", rs_records)
+
+    assert suggestion_content == [
+        {
+            "type": "amp",
+            "country": "US",
+            "form_factor": "desktop",
+            "schema": 123,
+            "attachment": {
+                "hash": "abcd",
+                "size": 1,
+                "filename": "data-01.json",
+                "location": "main-workspace/quicksuggest/attachmment-01.json",
+                "mimetype": "application/octet-stream",
+            },
+            "id": "data-01",
+            "last_modified": 123,
+        }
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## References

JIRA: [DISCO-3479](https://mozilla-hub.atlassian.net/browse/DISCO-3479)

## Description
This should move merino to fetch records from the new collection and should keep existing functionality all the same. This would help us half way to getting merino to support multi country and form factor



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3479]: https://mozilla-hub.atlassian.net/browse/DISCO-3479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ