### PR TITLE
[DISCO-3482] Add Language Support to Wiki Indexer Job

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -245,7 +245,7 @@ cdn_hostname = ""
 # Subdirectory within bucket for favicons
 favicons_root = "favicons"
 # Maximum size of files to process (in bytes)
-max_size = 16777216  # 16MB
+max_size = 16777216 # 16MB
 # HTTP timeout for favicon downloads (in seconds)
 http_timeout = 5
 
@@ -406,7 +406,7 @@ default_languages = [
     "ur",
     "vi",
     "zh-CN",
-    "zh-TW"
+    "zh-TW",
 ]
 
 
@@ -649,8 +649,24 @@ es_url = ""
 es_api_key = ""
 
 # MERINO_JOBS__WIKIPEDIA_INDEXER__ES_ALIAS
-# Elasticsearch alias value for indexing job.
-es_alias = "enwiki-{version}"
+# Elasticsearch english alias value for indexing job.
+en_es_alias = "enwiki-{version}"
+
+# MERINO_JOBS__WIKIPEDIA_INDEXER__FR__ES_ALIAS
+# Elasticsearch french alias value for indexing job.
+fr_es_alias = "frwiki-{version}"
+
+# MERINO_JOBS__WIKIPEDIA_INDEXER__DE__ES_ALIAS
+# Elasticsearch german alias value for indexing job.
+de_es_alias = "dewiki-{version}"
+
+# MERINO_JOBS__WIKIPEDIA_INDEXER__IT__ES_ALIAS
+# Elasticsearch italian alias value for indexing job.
+it_es_alias = "itwiki-{version}"
+
+# MERINO_JOBS__WIKIPEDIA_INDEXER__PL__ES_ALIAS
+# Elasticsearch polish alias value for indexing job.
+pl_es_alias = "plwiki-{version}"
 
 # MERINO_JOBS__WIKIPEDIA_INDEXER__INDEX_VERSION
 # Index version that will be written.

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -24,6 +24,8 @@
 [default]
 debug = false
 
+suggest_supported_languages = ["en", "fr", "de", "it", "pl"]
+
 
 [default.runtime]
 # MERINO_RUNTIME__QUERY_TIMEOUT_SEC

--- a/merino/jobs/wikipedia_indexer/filemanager.py
+++ b/merino/jobs/wikipedia_indexer/filemanager.py
@@ -19,6 +19,8 @@ from google.api_core.exceptions import GoogleAPIError
 
 logger = logging.getLogger(__name__)
 
+VALID_LANGUAGES = {"en", "fr", "de", "it", "pl"}
+
 
 class DirectoryParser(HTMLParser):
     """Parse the directory listing to find the specified file."""
@@ -53,11 +55,22 @@ class FileManager:
     object_prefix: str
     file_pattern: Pattern
     client: Client
+    language: str
 
-    def __init__(self, gcs_bucket: str, gcs_project: str, export_base_url: str) -> None:
-        self.file_pattern = re.compile(r"(?:.*/|^)enwiki-(\d+)-cirrussearch-content.json.gz")
+    def __init__(
+        self, gcs_bucket: str, gcs_project: str, export_base_url: str, language: str
+    ) -> None:
+        if language not in VALID_LANGUAGES:
+            raise ValueError(
+                f"Unsupported language '{language}'. Must be one of: {', '.join(VALID_LANGUAGES)}"
+            )
+
+        self.file_pattern = re.compile(
+            rf"(?:.*/|^){language}wiki-(\d+)-cirrussearch-content.json.gz"
+        )
         self.client = Client(gcs_project)
         self.base_url = export_base_url
+        self.language = language
         if "/" in gcs_bucket:
             self.gcs_bucket, self.object_prefix = gcs_bucket.split("/", 1)
         else:
@@ -91,9 +104,16 @@ class FileManager:
         return dt(1, 1, 1)
 
     def get_latest_gcs(self) -> Blob:
-        """Find the most recent file on GCS"""
+        """Find the most recent file on GCS that matches the language-specific pattern"""
         bucket = self.client.bucket(self.gcs_bucket)
-        blobs: list[Blob] = [b for b in bucket.list_blobs(prefix=self.object_prefix)]
+        blobs: list[Blob] = [
+            b
+            for b in bucket.list_blobs(prefix=self.object_prefix)
+            if self.file_pattern.match(b.name)
+        ]
+        if not blobs:
+            raise RuntimeError(f"No matching dump files found for pattern: {self.file_pattern}")
+
         blobs.sort(key=lambda b: self._parse_date(str(b.name)))
         return blobs[-1]
 

--- a/merino/jobs/wikipedia_indexer/filemanager.py
+++ b/merino/jobs/wikipedia_indexer/filemanager.py
@@ -7,6 +7,8 @@ from gzip import GzipFile
 from html.parser import HTMLParser
 from typing import Generator, Optional, Pattern
 from urllib.parse import urljoin
+from merino.configs import settings
+
 
 import requests
 from google.cloud.storage import Blob, Client
@@ -19,7 +21,7 @@ from google.api_core.exceptions import GoogleAPIError
 
 logger = logging.getLogger(__name__)
 
-VALID_LANGUAGES = {"en", "fr", "de", "it", "pl"}
+SUPPORTED_LANGUAGES = set(settings.suggest_supported_languages)
 
 
 class DirectoryParser(HTMLParser):
@@ -60,9 +62,9 @@ class FileManager:
     def __init__(
         self, gcs_bucket: str, gcs_project: str, export_base_url: str, language: str
     ) -> None:
-        if language not in VALID_LANGUAGES:
+        if language not in SUPPORTED_LANGUAGES:
             raise ValueError(
-                f"Unsupported language '{language}'. Must be one of: {', '.join(VALID_LANGUAGES)}"
+                f"Unsupported language '{language}'. Must be one of: {', '.join(SUPPORTED_LANGUAGES)}"
             )
 
         self.file_pattern = re.compile(

--- a/merino/jobs/wikipedia_indexer/settings/v1.py
+++ b/merino/jobs/wikipedia_indexer/settings/v1.py
@@ -1,6 +1,6 @@
 """Version 1 of the index mapping & settings"""
 
-SUGGEST_MAPPING = {
+SUGGEST_MAPPING_EN = {
     "dynamic": False,
     "properties": {
         "batch_id": {"type": "long"},
@@ -27,7 +27,7 @@ SUGGEST_MAPPING = {
 }
 
 
-SUGGEST_SETTINGS = {
+SUGGEST_SETTINGS_EN = {
     "number_of_replicas": "1",
     "refresh_interval": "-1",
     "number_of_shards": "2",

--- a/tests/integration/jobs/wikipedia_indexer/test_filemanager.py
+++ b/tests/integration/jobs/wikipedia_indexer/test_filemanager.py
@@ -68,7 +68,7 @@ def test_directory_parser():
 )
 def test_parse_date(file_name, expected_datetime):
     """Test parse date regexp properly converts to a valid or sentinel datetime"""
-    file_manager = FileManager("foo/bar", "a-project", "http://foo/")
+    file_manager = FileManager("foo/bar", "a-project", "http://foo/", "en")
 
     parsed_date = file_manager._parse_date(file_name)
 
@@ -86,7 +86,7 @@ def test_parse_date(file_name, expected_datetime):
 )
 def test_parse_gcs_bucket(gcs_bucket, expected_bucket, expected_prefix):
     """Test gcs bucket path parsing"""
-    file_manager = FileManager(gcs_bucket, "a-project", "http://foo/")
+    file_manager = FileManager(gcs_bucket, "a-project", "http://foo/", "en")
 
     assert file_manager.gcs_bucket == expected_bucket
     assert file_manager.object_prefix == expected_prefix
@@ -116,7 +116,7 @@ def test_get_latest_dump(requests_mock, file_date, gcs_date, expected):
     html_directory = f"<a href='{file_name}' />"
     requests_mock.get(base_url, text=html_directory)  # nosec
 
-    file_manager = FileManager("foo/bar", "a-project", base_url)
+    file_manager = FileManager("foo/bar", "a-project", base_url, "en")
 
     latest_dump_url = file_manager.get_latest_dump(latest_gcs)
 
@@ -131,7 +131,7 @@ def test_get_latest_gcs(mock_gcs_client):
     mock_bucket = mock_gcs_client.bucket.return_value
     mock_bucket.list_blobs.return_value = [blob1, blob2]
 
-    file_manager = FileManager("foo/bar", "a-project", "")
+    file_manager = FileManager("foo/bar", "a-project", "", "en")
     latest_gcs = file_manager.get_latest_gcs()
 
     assert latest_gcs == blob1
@@ -159,7 +159,7 @@ def test_stream_dump_to_gcs_success(mock_requests, mock_gcs_client, mock_wiki_ht
     mock_blob.open.return_value.__enter__.return_value = mock_blob_writer
     mock_blob.open.return_value.__exit__.return_value = None
 
-    file_manager = FileManager(mock_bucket, "a-project", base_url)
+    file_manager = FileManager(mock_bucket, "a-project", base_url, "en")
     file_manager._stream_dump_to_gcs(dump_url)
 
     mock_blob.open.assert_called_once_with("wb")
@@ -197,7 +197,7 @@ def test_stream_dump_to_gcs_blob_deletion(mock_requests, mock_gcs_client, mock_w
     # raise an exception during streaming
     mock_blob_writer.write.side_effect = Exception("failed to write chunk")
 
-    file_manager = FileManager(mock_bucket, "a-project", base_url)
+    file_manager = FileManager(mock_bucket, "a-project", base_url, "en")
 
     with pytest.raises(WikipediaFilemanagerError, match="Failed to stream dump to GCS"):
         file_manager._stream_dump_to_gcs(dump_url)

--- a/tests/integration/jobs/wikipedia_indexer/test_indexer.py
+++ b/tests/integration/jobs/wikipedia_indexer/test_indexer.py
@@ -102,12 +102,13 @@ def test_index_from_export_no_exports_available(
 ):
     """Test that RuntimeError is emitted."""
     file_manager.get_latest_gcs.return_value = Blob("", "bucket")
+    file_manager.language = "en"
     es_client.indices.exists.return_value = False
     indexer = Indexer("v1", category_blocklist, title_blocklist, file_manager, es_client)
     with pytest.raises(RuntimeError) as exc_info:
         indexer.index_from_export(100, "fake_alias")
 
-    assert exc_info.value.args[0] == "No exports available on GCS"
+    assert exc_info.value.args[0] == "No exports available on GCS for en"
 
 
 def test_index_from_export_fail_on_existing_index(

--- a/tests/unit/jobs/wikipedia_indexer/test_filemanager.py
+++ b/tests/unit/jobs/wikipedia_indexer/test_filemanager.py
@@ -1,0 +1,251 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Unit tests for the wikipedia indexer filemanager module."""
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+from requests import HTTPError
+from merino.jobs.wikipedia_indexer.filemanager import FileManager, WikipediaFilemanagerError
+
+
+def test_get_latest_gcs_returns_latest_blob():
+    """Returns the most recent matching blob for a given language."""
+    mock_client = MagicMock()
+    mock_bucket = MagicMock()
+
+    mock_blob_old = MagicMock()
+    mock_blob_old.name = "frwiki-20240101-cirrussearch-content.json.gz"
+
+    mock_blob_new = MagicMock()
+    mock_blob_new.name = "frwiki-20240401-cirrussearch-content.json.gz"
+
+    mock_bucket.list_blobs.return_value = [mock_blob_old, mock_blob_new]
+    mock_client.bucket.return_value = mock_bucket
+
+    with patch("merino.jobs.wikipedia_indexer.filemanager.Client", return_value=mock_client):
+        fm = FileManager("gcs-bucket", "gcs-project", "", language="fr")
+        latest_blob = fm.get_latest_gcs()
+
+    assert latest_blob == mock_blob_new
+
+
+def test_get_latest_gcs_filters_by_language():
+    """Filters out blobs not matching the current language pattern."""
+    mock_client = MagicMock()
+    mock_bucket = MagicMock()
+
+    fr_blob = MagicMock()
+    fr_blob.name = "frwiki-20240301-cirrussearch-content.json.gz"
+
+    en_blob = MagicMock()
+    en_blob.name = "enwiki-20240301-cirrussearch-content.json.gz"
+
+    random_blob = MagicMock()
+    random_blob.name = "unrelated-file.txt"
+
+    mock_bucket.list_blobs.return_value = [fr_blob, en_blob, random_blob]
+    mock_client.bucket.return_value = mock_bucket
+
+    with patch("merino.jobs.wikipedia_indexer.filemanager.Client", return_value=mock_client):
+        fm = FileManager("gcs-bucket", "gcs-project", "", language="fr")
+        result = fm.get_latest_gcs()
+
+    # the frwiki blob should match and be returned
+    assert result == fr_blob
+
+
+def test_get_latest_gcs_raises_runtime_error_if_no_matches():
+    """Raises RuntimeError when no blobs match the language-specific pattern."""
+    mock_client = MagicMock()
+    mock_bucket = MagicMock()
+
+    en_blob = MagicMock()
+    en_blob.name = "enwiki-20240301-cirrussearch-content.json.gz"
+
+    unrelated_blob = MagicMock()
+    unrelated_blob.name = "somefile.txt"
+
+    mock_bucket.list_blobs.return_value = [en_blob, unrelated_blob]
+    mock_client.bucket.return_value = mock_bucket
+
+    with patch("merino.jobs.wikipedia_indexer.filemanager.Client", return_value=mock_client):
+        fm = FileManager("gcs-bucket", "gcs-project", "", language="fr")
+
+        with pytest.raises(RuntimeError, match="No matching dump files found"):
+            fm.get_latest_gcs()
+
+
+@patch("requests.get")
+def test_get_latest_dump_returns_url_if_newer(mock_get):
+    """Returns a full download URL if the dump is newer than the one in GCS."""
+    mock_client = MagicMock()
+    # HTML content with a single matching link
+    html = '<a href="frwiki-20240401-cirrussearch-content.json.gz">download</a>'
+    mock_get.return_value.content = html
+
+    mock_blob = MagicMock()
+    mock_blob.name = "frwiki-20240301-cirrussearch-content.json.gz"  # older GCS file
+
+    with patch("merino.jobs.wikipedia_indexer.filemanager.Client", return_value=mock_client):
+        fm = FileManager("gcs-bucket", "gcs-project", "http://mock-url/", "fr")
+        result = fm.get_latest_dump(mock_blob)
+
+    assert result == "http://mock-url/frwiki-20240401-cirrussearch-content.json.gz"
+
+
+@patch("requests.get")
+def test_get_latest_dump_returns_none_if_not_newer(mock_get):
+    """Returns None when the latest dump in GCS is up to date or newer."""
+    mock_client = MagicMock()
+    # File in HTML is same date or older
+    html = '<a href="frwiki-20240301-cirrussearch-content.json.gz">download</a>'
+    mock_get.return_value.content = html
+
+    mock_blob = MagicMock()
+    mock_blob.name = "frwiki-20240301-cirrussearch-content.json.gz"  # same date
+
+    with patch("merino.jobs.wikipedia_indexer.filemanager.Client", return_value=mock_client):
+        fm = FileManager("gcs-bucket", "gcs-project", "http://mock-url/", "fr")
+        result = fm.get_latest_dump(mock_blob)
+
+    assert result is None
+
+
+@patch("requests.get")
+def test_stream_dump_to_gcs_success(mock_get):
+    """Streams and writes a remote dump to GCS successfully."""
+    mock_chunk = b"x" * 1024
+
+    mock_response = MagicMock()
+    mock_response.__enter__.return_value = mock_response
+    mock_response.iter_content.return_value = [mock_chunk, mock_chunk]
+    mock_response.headers = {"Content-Length": str(len(mock_chunk) * 2)}
+    mock_response.raise_for_status.return_value = None
+    mock_get.return_value = mock_response
+
+    mock_writer = MagicMock()
+    mock_writer.write.side_effect = lambda chunk: len(chunk)
+
+    mock_blob = MagicMock()
+    mock_blob.open.return_value.__enter__.return_value = mock_writer
+
+    mock_bucket = MagicMock()
+    mock_bucket.blob.return_value = mock_blob
+
+    mock_client = MagicMock()
+    mock_client.bucket.return_value = mock_bucket
+
+    with patch("merino.jobs.wikipedia_indexer.filemanager.Client", return_value=mock_client):
+        fm = FileManager("gcs-bucket", "gcs-project", "http://mock-url/", "fr")
+        fm._stream_dump_to_gcs("http://mock-url/frwiki-20240501-cirrussearch-content.json.gz")
+
+    # Assertions
+    mock_writer.write.assert_called()
+    assert mock_writer.write.call_count == 2
+    mock_blob.open.assert_called_once()
+    mock_get.assert_called_once_with(
+        "http://mock-url/frwiki-20240501-cirrussearch-content.json.gz", stream=True
+    )
+
+
+@patch("requests.get")
+def test_stream_dump_to_gcs_handles_stream_failure_and_deletes_blob(mock_get):
+    """Handles stream failure by deleting the partial GCS blob and raising an error."""
+    mock_response = MagicMock()
+    mock_response.__enter__.return_value = mock_response
+    mock_response.raise_for_status.side_effect = HTTPError("Simulated HTTP error")
+
+    mock_get.return_value = mock_response
+
+    mock_blob = MagicMock()
+    mock_blob.exists.return_value = True
+
+    mock_bucket = MagicMock()
+    mock_bucket.blob.return_value = mock_blob
+
+    mock_client = MagicMock()
+    mock_client.bucket.return_value = mock_bucket
+
+    with patch("merino.jobs.wikipedia_indexer.filemanager.Client", return_value=mock_client):
+        fm = FileManager("gcs-bucket", "gcs-project", "http://mock-url/", "fr")
+
+        with pytest.raises(WikipediaFilemanagerError, match="Failed to stream dump to GCS"):
+            fm._stream_dump_to_gcs("http://mock-url/frwiki-20240501-cirrussearch-content.json.gz")
+
+    mock_blob.exists.assert_called_once()
+    mock_blob.delete.assert_called_once()
+
+
+@patch.object(FileManager, "_stream_dump_to_gcs")
+@patch.object(FileManager, "get_latest_dump")
+@patch.object(FileManager, "get_latest_gcs")
+def test_stream_latest_dump_triggers_stream(
+    mock_get_latest_gcs, mock_get_latest_dump, mock_stream
+):
+    """Triggers dump streaming when a newer remote dump is available."""
+    mock_client = MagicMock()
+    mock_blob = MagicMock()
+    mock_get_latest_gcs.return_value = mock_blob
+    mock_get_latest_dump.return_value = "http://mock-url/frwiki-latest.json.gz"
+
+    with patch("merino.jobs.wikipedia_indexer.filemanager.Client", return_value=mock_client):
+        fm = FileManager("gcs-bucket", "gcs-project", "http://mock-url/", "fr")
+        returned_blob = fm.stream_latest_dump_to_gcs()
+
+    mock_stream.assert_called_once_with("http://mock-url/frwiki-latest.json.gz")
+    assert returned_blob == mock_blob
+
+
+@patch.object(FileManager, "_stream_dump_to_gcs")
+@patch.object(FileManager, "get_latest_dump")
+@patch.object(FileManager, "get_latest_gcs")
+def test_stream_latest_dump_skips_if_up_to_date(
+    mock_get_latest_gcs, mock_get_latest_dump, mock_stream
+):
+    """Skips dump streaming when no newer dump is available."""
+    mock_client = MagicMock()
+    mock_blob = MagicMock()
+    mock_get_latest_gcs.return_value = mock_blob
+    mock_get_latest_dump.return_value = None  # No newer dump
+
+    with patch("merino.jobs.wikipedia_indexer.filemanager.Client", return_value=mock_client):
+        fm = FileManager("gcs-bucket", "gcs-project", "http://mock-url/", "fr")
+        returned_blob = fm.stream_latest_dump_to_gcs()
+
+    mock_stream.assert_not_called()
+    assert returned_blob == mock_blob
+
+
+def test_parse_date_returns_correct_datetime():
+    """Parses and returns the correct datetime from a valid filename."""
+    mock_client = MagicMock()
+    with patch("merino.jobs.wikipedia_indexer.filemanager.Client", return_value=mock_client):
+        fm = FileManager("gcs-bucket", "gcs-project", "http://mock-url/", "fr")
+
+        filename = "frwiki-20240501-cirrussearch-content.json.gz"
+        result = fm._parse_date(filename)
+
+        assert isinstance(result, datetime)
+        assert result == datetime(2024, 5, 1)
+
+
+def test_parse_date_returns_default_on_invalid_filename():
+    """Returns the default fallback datetime when the filename is invalid."""
+    mock_client = MagicMock()
+    with patch("merino.jobs.wikipedia_indexer.filemanager.Client", return_value=mock_client):
+        fm = FileManager("gcs-bucket", "gcs-project", "http://mock-url/", "fr")
+
+        filename = "invalid-file-name.txt"
+        result = fm._parse_date(filename)
+
+        assert result == datetime(1, 1, 1)
+
+
+def test_filemanager_rejects_invalid_language():
+    """Raises ValueError if FileManager is initialized with an unsupported language."""
+    with pytest.raises(ValueError, match="Unsupported language 'es'"):
+        FileManager("gcs-bucket", "gcs-project", "http://mock-url", language="es")


### PR DESCRIPTION
## References

JIRA: [DISCO-3482](https://mozilla-hub.atlassian.net/browse/DISCO-3482)

## Description
This PR adds the initial changes to support multi-language Wikipedia indexing, beginning with English (en) only. The goal is to ensure that the job can run successfully with a language-aware setup before expanding to additional languages (e.g., fr, de, it, pl).

Changes
* Updated the job CLI to iterate over a list of languages (["en"] for now)
* Modified the `FileManager` to accept a language argument and apply language-specific filename filtering
* Added validation to ensure only supported languages are accepted
* Added Elasticsearch index settings and mappings specific to English
* Extended the toml config to include a per-language alias (`en_es_alias`)
* Updated index creation logic to dynamically select language-specific settings
* Added unit tests

Next Steps (Not included in this PR)
* Update Airflow DAG to define one task per language
* Expand language support to fr, de, it, and pl - add analyzers, blocklists 
* Add per-language analyzers and mappings



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3482]: https://mozilla-hub.atlassian.net/browse/DISCO-3482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ