### PR TITLE
HNT-656: Map IAB category codes to Section

### DIFF
--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -41,12 +41,12 @@ logger = logging.getLogger(__name__)
 
 
 def map_topic_to_iab_categories(topic: Topic) -> list[str]:
-    """Map an IAB category code to a Section. Source:
+    """Map a topic to IAB category code(s). Source:
     https://docs.google.com/spreadsheets/d/1R0wzDYgrFkLjo6sxTFvVYThJ4uKz-YVDkYMegbGK9XA/edit?gid=1439764175#gid
     =1439764175
 
     Args:
-        topic: The topic for which to get the IAB category codes.
+        topic: The topic for which to get IAB category code(s).
 
     Returns:
         Array of IAB codes for given section_topic.

--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -10,6 +10,8 @@ from merino.curated_recommendations.corpus_backends.protocol import (
     SurfaceId,
     CorpusSection,
     CorpusItem,
+    Topic,
+    IABMetadata,
 )
 from merino.curated_recommendations.layouts import (
     layout_4_medium,
@@ -36,6 +38,38 @@ from merino.curated_recommendations.rankers import (
 from merino.curated_recommendations.utils import is_enrolled_in_experiment
 
 logger = logging.getLogger(__name__)
+
+
+def map_iab_categories_to_section(section_topic: Topic) -> list[str]:
+    """Map an IAB category code to a Section. Source:
+    https://docs.google.com/spreadsheets/d/1R0wzDYgrFkLjo6sxTFvVYThJ4uKz-YVDkYMegbGK9XA/edit?gid=1439764175#gid
+    =1439764175
+
+    Args:
+        section_topic: The section topic to get the IAB category codes.
+
+    Returns:
+        Array of IAB codes for given section_topic.
+    """
+    section_iab_category_mapping = {
+        Topic.BUSINESS: ["52"],  # IAB -  Business and Finance
+        Topic.CAREER: ["123"],  # IAB -  Careers
+        Topic.EDUCATION: ["132"],  # IAB -  Education
+        Topic.ARTS: ["JLBCU7"],  # IAB -  Entertainment
+        Topic.FOOD: ["210"],  # IAB -  Food & Drink
+        Topic.HEALTH_FITNESS: ["223"],  # IAB -  Healthy Living
+        Topic.HOME: ["274"],  # IAB -  Home & Garden
+        Topic.PERSONAL_FINANCE: ["391"],  # IAB -  Personal Finance
+        Topic.POLITICS: ["386"],  # IAB -  Politics
+        Topic.SPORTS: ["483"],  # IAB -  Sports
+        Topic.TECHNOLOGY: ["596"],  # IAB -  Technology & Computing
+        Topic.TRAVEL: ["653"],  # IAB -  Travel
+        Topic.GAMING: ["596"],  # IAB -  Technology & Computing
+        Topic.PARENTING: ["192"],  # IAB -  Parenting
+        Topic.SCIENCE: ["464"],  # IAB -  Science
+        Topic.SELF_IMPROVEMENT: ["186"],  # IAB -  Family and Relationships
+    }
+    return section_iab_category_mapping.get(section_topic) or []
 
 
 def map_section_item_to_recommendation(
@@ -186,6 +220,7 @@ def create_sections_from_items_by_topic(
                     receivedFeedRank=idx,
                     recommendations=[],
                     title=get_translation(surface_id, rec.topic, sid),
+                    iab=IABMetadata(categories=map_iab_categories_to_section(rec.topic)),
                     layout=deepcopy(layout_cycle[idx % len(layout_cycle)]),
                 )
             sec = sections[sid]

--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -40,18 +40,18 @@ from merino.curated_recommendations.utils import is_enrolled_in_experiment
 logger = logging.getLogger(__name__)
 
 
-def map_iab_categories_to_section(section_topic: Topic) -> list[str]:
+def map_topic_to_iab_categories(topic: Topic) -> list[str]:
     """Map an IAB category code to a Section. Source:
     https://docs.google.com/spreadsheets/d/1R0wzDYgrFkLjo6sxTFvVYThJ4uKz-YVDkYMegbGK9XA/edit?gid=1439764175#gid
     =1439764175
 
     Args:
-        section_topic: The section topic to get the IAB category codes.
+        topic: The topic for which to get the IAB category codes.
 
     Returns:
         Array of IAB codes for given section_topic.
     """
-    section_iab_category_mapping = {
+    topic_iab_category_mapping = {
         Topic.BUSINESS: ["52"],  # IAB -  Business and Finance
         Topic.CAREER: ["123"],  # IAB -  Careers
         Topic.EDUCATION: ["132"],  # IAB -  Education
@@ -69,7 +69,7 @@ def map_iab_categories_to_section(section_topic: Topic) -> list[str]:
         Topic.SCIENCE: ["464"],  # IAB -  Science
         Topic.SELF_IMPROVEMENT: ["186"],  # IAB -  Family and Relationships
     }
-    return section_iab_category_mapping.get(section_topic) or []
+    return topic_iab_category_mapping.get(topic) or []
 
 
 def map_section_item_to_recommendation(
@@ -220,7 +220,7 @@ def create_sections_from_items_by_topic(
                     receivedFeedRank=idx,
                     recommendations=[],
                     title=get_translation(surface_id, rec.topic, sid),
-                    iab=IABMetadata(categories=map_iab_categories_to_section(rec.topic)),
+                    iab=IABMetadata(categories=map_topic_to_iab_categories(rec.topic)),
                     layout=deepcopy(layout_cycle[idx % len(layout_cycle)]),
                 )
             sec = sections[sid]

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -1299,6 +1299,10 @@ class TestSections:
                 assert data["feeds"]["arts"]["isFollowed"]
                 # assert followed section ARTS comes after top-stories and before unfollowed sections (education).
                 assert data["feeds"]["arts"]["receivedFeedRank"] in [1, 2]
+                assert data["feeds"]["arts"]["iab"] == {
+                    "taxonomy": "IAB-3.0",
+                    "categories": ["JLBCU7"],
+                }
             if data["feeds"].get("education") is not None:
                 assert not data["feeds"]["education"]["isFollowed"]
                 assert data["feeds"]["education"]["isBlocked"]
@@ -1306,6 +1310,10 @@ class TestSections:
                 assert data["feeds"]["sports"]["isFollowed"]
                 # assert followed section SPORTS comes after top-stories and before unfollowed sections (education).
                 assert data["feeds"]["sports"]["receivedFeedRank"] in [1, 2]
+                assert data["feeds"]["sports"]["iab"] == {
+                    "taxonomy": "IAB-3.0",
+                    "categories": ["483"],
+                }
 
             # Assert no errors were logged
             errors = [r for r in caplog.records if r.levelname == "ERROR"]

--- a/tests/unit/curated_recommendations/test_sections.py
+++ b/tests/unit/curated_recommendations/test_sections.py
@@ -38,7 +38,7 @@ from merino.curated_recommendations.sections import (
     get_corpus_sections,
     map_corpus_section_to_section,
     map_section_item_to_recommendation,
-    map_iab_categories_to_section,
+    map_topic_to_iab_categories,
 )
 from tests.unit.curated_recommendations.fixtures import (
     generate_recommendations,
@@ -382,7 +382,7 @@ class TestGetCorpusSections:
 
 
 class TestMapIABCategoriesToSection:
-    """Tests for map_iab_categories_to_section."""
+    """Tests for map_topic_to_iab_categories."""
 
     @pytest.mark.parametrize(
         "section_id,expected_iab_codes",
@@ -408,4 +408,4 @@ class TestMapIABCategoriesToSection:
     )
     def test_mapping_works(self, section_id, expected_iab_codes):
         """Map a valid section_ids to IAB category code(s)."""
-        assert map_iab_categories_to_section(section_id) == expected_iab_codes
+        assert map_topic_to_iab_categories(section_id) == expected_iab_codes

--- a/tests/unit/curated_recommendations/test_sections.py
+++ b/tests/unit/curated_recommendations/test_sections.py
@@ -38,6 +38,7 @@ from merino.curated_recommendations.sections import (
     get_corpus_sections,
     map_corpus_section_to_section,
     map_section_item_to_recommendation,
+    map_iab_categories_to_section,
 )
 from tests.unit.curated_recommendations.fixtures import (
     generate_recommendations,
@@ -252,8 +253,10 @@ class TestCreateSectionsFromItemsByTopic:
         food = sections[Topic.FOOD.value]
         assert sci.receivedFeedRank == 0
         assert sci.layout == layout_6_tiles
+        assert sci.iab.categories == ["464"]
         assert food.receivedFeedRank == 1
         assert food.layout == layout_4_large
+        assert food.iab.categories == ["210"]
         assert sci.recommendations[0].receivedRank == 0
         assert food.recommendations[0].receivedRank == 0
 
@@ -376,3 +379,33 @@ class TestGetCorpusSections:
         section = result["secA"]
         assert section.receivedFeedRank == 5
         assert len(section.recommendations) == 2
+
+
+class TestMapIABCategoriesToSection:
+    """Tests for map_iab_categories_to_section."""
+
+    @pytest.mark.parametrize(
+        "section_id,expected_iab_codes",
+        [
+            (Topic.BUSINESS, ["52"]),
+            (Topic.CAREER, ["123"]),
+            (Topic.EDUCATION, ["132"]),
+            (Topic.ARTS, ["JLBCU7"]),
+            (Topic.FOOD, ["210"]),
+            (Topic.HEALTH_FITNESS, ["223"]),
+            (Topic.HOME, ["274"]),
+            (Topic.PERSONAL_FINANCE, ["391"]),
+            (Topic.POLITICS, ["386"]),
+            (Topic.SPORTS, ["483"]),
+            (Topic.TECHNOLOGY, ["596"]),
+            (Topic.TRAVEL, ["653"]),
+            (Topic.GAMING, ["596"]),
+            (Topic.PARENTING, ["192"]),
+            (Topic.SCIENCE, ["464"]),
+            (Topic.SELF_IMPROVEMENT, ["186"]),
+            ("section_id_not_found", []),  # return empty array if section_id not found in mapping
+        ],
+    )
+    def test_mapping_works(self, section_id, expected_iab_codes):
+        """Map a valid section_ids to IAB category code(s)."""
+        assert map_iab_categories_to_section(section_id) == expected_iab_codes


### PR DESCRIPTION
## References

JIRA: https://mozilla-hub.atlassian.net/browse/HNT-656

## Description
Non-ML topic feeds need IAB metadata. 
Creating a mapping between non-ML topic feeds & IAB category codes (see [source for mapping](https://docs.google.com/spreadsheets/d/1R0wzDYgrFkLjo6sxTFvVYThJ4uKz-YVDkYMegbGK9XA/edit?gid=1439764175#gid=1439764175))


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
