### PR TITLE
New AMP Suggestion storage structures

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -159,7 +159,7 @@ bucket = "main"
 # MERINO_REMOTE_SETTINGS__COLLECTION
 # The collection to use for Remote Settings providers if not specified in provider config.
 # Ex: "quicksuggest".
-collection = "quicksuggest"
+collection = "quicksuggest-amp"
 
 # The collection to use for uploading fakespot suggestions if not specified on the command line
 collection_fakespot = "fakespot-suggest-products"
@@ -179,6 +179,10 @@ dry_run = false
 # MERINO_REMOTE_SETTINGS__SCORE
 # Default score to set in suggestions uploaded to remote settings.
 score = 0.25
+
+# MERINO_REMOTE_SETTINGS__COUNTRIES
+# Default countries used to filter out records from remote settings.
+countries = ["US"]
 
 # Global Redis settings. The weather provider optionally uses Redis to cache weather suggestions.
 [default.redis]

--- a/merino/providers/suggest/adm/backends/protocol.py
+++ b/merino/providers/suggest/adm/backends/protocol.py
@@ -1,25 +1,22 @@
 """Protocol for the AdM provider backends."""
 
 from typing import Any, Protocol
-
 from pydantic import BaseModel
 
 
 class SuggestionContent(BaseModel):
-    """Class that holds the result from a fetch operation."""
+    """Class that holds subset of results from a fetch operation."""
 
-    # A dictionary keyed on suggestion keywords, each value stores an index
-    # (pointer) to one entry of the suggestion result list.
-    suggestions: dict[tuple[str, str], tuple[int, int]]
+    core_suggestions_data: dict[int, dict[str, Any]] = {}
+    overrides: dict[int, dict[str, Any]] = {}
+    full_keywords: dict[str, list] = {}
+    results: dict[str, tuple[int, int]] = {}
 
-    # A list of full keywords
-    full_keywords: list[str]
+class GlobalSuggestionContent(BaseModel):
+    """Class that holds all results from a fetch operation."""
 
-    # A list of suggestion results.
-    results: list[dict[str, Any]]
-
-    # A dictionary of icon IDs to icon URLs.
-    icons: dict[str, str]
+    suggestion_content: dict[str, SuggestionContent]
+    icons: dict[str, str] = {}
 
 
 class AdmBackend(Protocol):
@@ -30,6 +27,6 @@ class AdmBackend(Protocol):
     directly depend on.
     """
 
-    async def fetch(self) -> SuggestionContent:  # pragma: no cover
+    async def fetch(self) -> GlobalSuggestionContent:  # pragma: no cover
         """Get suggestion content from partner."""
         ...

--- a/merino/providers/suggest/adm/backends/protocol.py
+++ b/merino/providers/suggest/adm/backends/protocol.py
@@ -10,7 +10,7 @@ class SuggestionContent(BaseModel):
 
     # A dictionary keyed on suggestion keywords, each value stores an index
     # (pointer) to one entry of the suggestion result list.
-    suggestions: dict[str, tuple[int, int]]
+    suggestions: dict[tuple[str, str], tuple[int, int]]
 
     # A list of full keywords
     full_keywords: list[str]

--- a/merino/providers/suggest/adm/backends/remotesettings.py
+++ b/merino/providers/suggest/adm/backends/remotesettings.py
@@ -10,7 +10,6 @@ import logging
 import httpx
 import kinto_http
 from pydantic import BaseModel
-from pygments.lexer import default
 
 from merino.configs import settings
 from merino.exceptions import BackendError
@@ -111,7 +110,7 @@ class RemoteSettingsBackend:
                     for query in keywords[begin : begin + n]:
                         # Note that for adM suggestions, each keyword can only be
                         # mapped to a single suggestion.
-                        suggestions[(form_factor,query)] = (result_id, fkw_index)
+                        suggestions[(form_factor, query)] = (result_id, fkw_index)
                     begin += n
                     full_keywords.append(full_keyword)
                     fkw_index = len(full_keywords)

--- a/merino/providers/suggest/adm/provider.py
+++ b/merino/providers/suggest/adm/provider.py
@@ -133,7 +133,8 @@ class Provider(BaseProvider):
     async def query(self, srequest: SuggestionRequest) -> list[BaseSuggestion]:
         """Provide suggestion for a given query."""
         q: str = srequest.query
-        if (suggest_look_ups := self.suggestion_content.suggestions.get(q)) is not None:
+        form_factor = srequest.user_agent.form_factor
+        if (suggest_look_ups := self.suggestion_content.suggestions.get((form_factor,q))) is not None:
             results_id, fkw_id = suggest_look_ups
             res = self.suggestion_content.results[results_id]
             is_sponsored = res.get("iab_category") == IABCategory.SHOPPING

--- a/merino/providers/suggest/base.py
+++ b/merino/providers/suggest/base.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, Field, HttpUrl
 
 from merino.configs import settings
 from merino.middleware.geolocation import Location
+from merino.middleware.user_agent import UserAgent
 from merino.providers.suggest.custom_details import CustomDetails
 
 
@@ -20,6 +21,7 @@ class SuggestionRequest(BaseModel):
     city: str | None = None
     region: str | None = None
     country: str | None = None
+    user_agent: UserAgent | None = None
 
 
 class Category(Enum):

--- a/merino/utils/icon_processor.py
+++ b/merino/utils/icon_processor.py
@@ -61,7 +61,6 @@ class IconProcessor:
                     logger.info(f"Invalid image from {url}")
                     self.metrics_client.increment("icon_processor.invalid_images")
                     return url
-
                 # Generate content hash
                 content_hash = hashlib.sha256(favicon_image.content).hexdigest()
 
@@ -115,7 +114,6 @@ class IconProcessor:
     def _get_destination_path(self, favicon_image: Image, content_hash: str) -> str:
         """Generate GCS path based on content hash."""
         content_len = len(favicon_image.content)
-
         # Determine file extension from content type
         extension = ""
         match favicon_image.content_type:
@@ -156,7 +154,7 @@ class IconProcessor:
                         elif format == "ico":
                             favicon_image.content_type = "image/x-icon"
                 except Exception as e:
-                    logger.info(f"Exception detecting image type: {e}")
+                    logger.error(f"Exception detecting image type herrrr: {e}")
                     extension = ".png"  # Default to png
                     favicon_image.content_type = "image/png"
 

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -24,6 +24,7 @@ from merino.curated_recommendations.protocol import (
     CuratedRecommendationsResponse,
 )
 from merino.middleware import ScopeKey
+from merino.middleware.user_agent import UserAgent
 from merino.providers.suggest import get_providers as get_suggest_providers
 from merino.providers.manifest import get_provider as get_manifest_provider
 from merino.providers.suggest.base import BaseProvider, SuggestionRequest
@@ -175,7 +176,7 @@ async def suggest(
     # enabled for this request by calling feature_flags.is_enabled("example").
     # feature_flags: FeatureFlags = request.scope[ScopeKey.FEATURE_FLAGS]
     metrics_client: Client = request.scope[ScopeKey.METRICS_CLIENT]
-
+    user_agent: UserAgent = request.scope[ScopeKey.USER_AGENT]
     active_providers, default_providers = sources
     if providers is not None:
         # Set used to filter out possible duplicate providers passed in.
@@ -201,6 +202,7 @@ async def suggest(
             geolocation=geolocation,
             request_type=request_type,
             languages=languages,
+            user_agent=user_agent,
         )
         p.validate(srequest)
         task = metrics_client.timeit_task(p.query(srequest), f"providers.{p.name}.query")

--- a/tests/unit/providers/suggest/adm/backends/test_remotesettings.py
+++ b/tests/unit/providers/suggest/adm/backends/test_remotesettings.py
@@ -91,6 +91,21 @@ def fixture_rs_records() -> list[dict[str, Any]]:
             "last_modified": 123,
         },
         {
+            "type": "amp",
+            "country": "US",
+            "form_factor": "desktop",
+            "schema": 123,
+            "attachment": {
+                "hash": "abcd",
+                "size": 1,
+                "filename": "data-01.json",
+                "location": "main-workspace/quicksuggest/attachmment-01.json",
+                "mimetype": "application/octet-stream",
+            },
+            "id": "data-01",
+            "last_modified": 123,
+        },
+        {
             "type": "icon",
             "schema": 456,
             "attachment": {
@@ -299,6 +314,33 @@ async def test_fetch_no_adm_wikipedia_result(
     suggestion_content: SuggestionContent = await rs_backend.fetch()
 
     assert suggestion_content.results == []
+
+
+@pytest.mark.asyncio
+async def test_filter_amp_records(
+    rs_records: list[dict[str, Any]],
+    rs_backend: RemoteSettingsBackend,
+) -> None:
+    """Test that the filter_records method returns the proper records."""
+    suggestion_content = rs_backend.filter_records("amp", rs_records)
+
+    assert suggestion_content == [
+        {
+            "type": "amp",
+            "country": "US",
+            "form_factor": "desktop",
+            "schema": 123,
+            "attachment": {
+                "hash": "abcd",
+                "size": 1,
+                "filename": "data-01.json",
+                "location": "main-workspace/quicksuggest/attachmment-01.json",
+                "mimetype": "application/octet-stream",
+            },
+            "id": "data-01",
+            "last_modified": 123,
+        }
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description
Just thought I put up what I have so far.

After investigation: I found that suggestions across form-factors are quite similar. Aside from `click_url`, `impression_url` and `url`, but there are about ~40 suggestions that have differences in addition to those fields.

I thought it might be a good idea to store them like the following
```
core_suggestion_data = {
    123: {"id": "123", "title": "Item A", ....},
    ...
}

overrides = {
    456: {
        "desktop": {"url": "https://example.com/url", "click_url": "https://example.com/click_url"},
        "phone": {"url": "https://example.com/mobile-url", "click_url": "https://example.com/mobile-url"},
         ...
    },
 
    ...
}
```

Each query will be associated with an suggestion_id which then can be used to build the suggestion data, but retrieve the core components and then adding the overrides to it.

There are about ~30 suggestions with the same ID that have different keywords, and I think we could do the same with keywords too.

This may not be the most compressed way to store data, but if we're okay with this, we could iterate as we go

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
