### PR TITLE
[DISCO-3528] fix: Add logs for http 400 errors

### DIFF
--- a/merino/providers/suggest/weather/provider.py
+++ b/merino/providers/suggest/weather/provider.py
@@ -144,6 +144,7 @@ class Provider(BaseProvider):
     def validate(self, srequest: SuggestionRequest) -> None:
         """Validate the suggestion request."""
         if srequest.query and not srequest.request_type:
+            logger.warning("HTTP 400: invalid query parameters: `request_type` is missing")
             raise HTTPException(
                 status_code=400,
                 detail="Invalid query parameters: `request_type` is missing",

--- a/merino/utils/api/query_params.py
+++ b/merino/utils/api/query_params.py
@@ -1,12 +1,15 @@
 """A utility module for merino API query params."""
 
 import functools
+import logging
 from typing import Optional
 
 from fastapi import HTTPException, Request
 
 from merino.middleware import ScopeKey
 from merino.middleware.geolocation import Location
+
+logger = logging.getLogger(__name__)
 
 
 @functools.lru_cache(maxsize=1000)
@@ -35,6 +38,9 @@ def validate_suggest_custom_location_params(
     city: Optional[str], region: Optional[str], country: Optional[str]
 ):
     """Validate that city, region & country params are either all present or all omitted."""
+    logger.warning(
+        "HTTP 400: invalid query parameters: `city`, `region`, and `country` are either all present or all omitted."
+    )
     if any([country, region, city]) and not all([country, region, city]):
         raise HTTPException(
             status_code=400,

--- a/tests/unit/providers/suggest/weather/test_provider.py
+++ b/tests/unit/providers/suggest/weather/test_provider.py
@@ -186,17 +186,27 @@ async def test_query_no_weather_report_returned(
 
 
 def test_query_with_no_request_type_param_returns_http_400(
-    provider: Provider, geolocation: Location
+    provider: Provider,
+    geolocation: Location,
+    caplog: pytest.LogCaptureFixture,
+    filter_caplog: FilterCaplogFixture,
 ) -> None:
     """Test that the query method throws a http 400 error when `q` param is provided but no
     `request_type` param is provided
     """
+    caplog.set_level(logging.WARNING)
+
     with pytest.raises(HTTPException) as accuweather_error:
         provider.validate(SuggestionRequest(query="weather", geolocation=geolocation))
 
     expected_error_message = "400: Invalid query parameters: `request_type` is missing"
 
     assert expected_error_message == str(accuweather_error.value)
+
+    records = filter_caplog(caplog.records, "merino.providers.suggest.weather.provider")
+
+    assert len(records) == 1
+    assert records[0].message == "HTTP 400: invalid query parameters: `request_type` is missing"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## References

JIRA: [DISCO-3528](https://mozilla-hub.atlassian.net/browse/DISCO-3528)

## Description
Log all HTTP 400 errors.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3528]: https://mozilla-hub.atlassian.net/browse/DISCO-3528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ