### PR TITLE
DISCO-3527 Remove failed url logger from manifest provider, add metrics

### DIFF
--- a/docs/data.md
+++ b/docs/data.md
@@ -195,6 +195,7 @@ When requesting a manifest file, we record the following metrics.
 - `manifest.gcs.fetch_time` - A timer for how long it took to download the latest manifest file from the Google Cloud bucket.
 - `manifest.request.no_manifest` - A counter to measure how many times we didn't find the latest manifest file.
 - `manifest.request.error` - A counter to measure how many times we could not provide a valid JSON manifest file.
+- `manifest.invalid_icon_url` - A counter to measure how many requests the Manifest provider gets for domains where we don't have a valid icon Url (with tags).
 
 ### Service Governance
 


### PR DESCRIPTION
## References

JIRA: [DISCO-3527](https://mozilla-hub.atlassian.net/browse/DISCO-3527)

## Description
Remove the logging of failed url lookups from the manifest provider, and replaced it with metrics and a domain tag.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3527]: https://mozilla-hub.atlassian.net/browse/DISCO-3527?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ