### PR TITLE
[DISCO-3509] Add language to wikipedia provider

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -570,9 +570,27 @@ es_url = "http://localhost:9200"
 # The base64 key used to authenticate on the Elasticsearch cluster specified by `es_cloud_id`.
 es_api_key = ""
 
-# MERINO_PROVIDERS__WIKIPEDIA__ES_INDEX
-#  The index identifier of Wikipedia in Elasticsearch.
-es_index = "enwiki-v1"
+es_index = "enwiki-v1" # TODO temporarily leaving this here for backward compatibility with load tests
+
+# MERINO_PROVIDERS__WIKIPEDIA__EN_ES_INDEX
+#  The english index identifier of Wikipedia in Elasticsearch.
+en_es_index = "enwiki-v1"
+
+# MERINO_PROVIDERS__WIKIPEDIA__FR_ES_INDEX
+#  The french index identifier of Wikipedia in Elasticsearch.
+fr_es_index = "frwiki-v1"
+
+# MERINO_PROVIDERS__WIKIPEDIA__DE_ES_INDEX
+#  The german index identifier of Wikipedia in Elasticsearch.
+de_es_index = "dewiki-v1"
+
+# MERINO_PROVIDERS__WIKIPEDIA__IT_ES_INDEX
+#  The italian index identifier of Wikipedia in Elasticsearch.
+it_es_index = "itwiki-v1"
+
+# MERINO_PROVIDERS__WIKIPEDIA__PL_ES_INDEX
+#  The polish index identifier of Wikipedia in Elasticsearch.
+pl_es_index = "plwiki-v1"
 
 # MERINO_PROVIDERS__WIKIPEDIA__ES_MAX_SUGGESTIONS
 # The maximum suggestions for each search request to Elasticsearch.

--- a/merino/providers/suggest/wikipedia/backends/fake_backends.py
+++ b/merino/providers/suggest/wikipedia/backends/fake_backends.py
@@ -13,7 +13,7 @@ class FakeWikipediaBackend:  # pragma: no cover
         """Nothing to shut down."""
         return None
 
-    async def search(self, _: str) -> list[dict[str, Any]]:
+    async def search(self, _: str, language_code: str) -> list[dict[str, Any]]:
         """Return an empty list."""
         return []
 
@@ -25,13 +25,13 @@ class FakeEchoWikipediaBackend:
         """Nothing to shut down."""
         return None
 
-    async def search(self, q: str) -> list[dict[str, Any]]:
+    async def search(self, q: str, language_code: str) -> list[dict[str, Any]]:
         """Echoing the query as the single suggestion."""
         return [
             {
                 "full_keyword": q,
                 "title": q,
-                "url": f"""https://en.wikipedia.org/wiki/{quote(q.replace(" ", "_"))}""",
+                "url": f"""https://{language_code}.wikipedia.org/wiki/{quote(q.replace(" ", "_"))}""",
             }
         ]
 
@@ -43,6 +43,6 @@ class FakeExceptionWikipediaBackend:  # pragma: no cover
         """Nothing to shut down."""
         return None
 
-    async def search(self, q: str) -> list[dict[str, Any]]:
+    async def search(self, q: str, language_code: str) -> list[dict[str, Any]]:
         """Echoing the query as the single suggestion."""
         raise BackendError("A backend failure")

--- a/merino/providers/suggest/wikipedia/backends/protocol.py
+++ b/merino/providers/suggest/wikipedia/backends/protocol.py
@@ -15,8 +15,8 @@ class WikipediaBackend(Protocol):
         """Shut down connection to the backend"""
         ...
 
-    async def search(self, q: str) -> list[dict[str, Any]]:  # pragma: no cover
-        """Search Wikipedia and return articles relevant to the given query.
+    async def search(self, q: str, language_code: str) -> list[dict[str, Any]]:  # pragma: no cover
+        """Search Wikipedia and return articles relevant to the given query using the language-specific index.
 
         Raises:
             BackendError: Category of error specific to provider backends.

--- a/merino/providers/suggest/wikipedia/backends/utils.py
+++ b/merino/providers/suggest/wikipedia/backends/utils.py
@@ -1,0 +1,14 @@
+"""Utilities for the Wikipedia backend."""
+
+from merino.configs import settings
+
+SUPPORTED_LANGUAGES: frozenset = frozenset(settings.suggest_supported_languages)
+
+
+def get_language_code(requested_languages: list[str]) -> str:
+    """Return the first supported base language code from the input list, or fall back to 'en'."""
+    for lang in requested_languages:
+        base = lang.lower().split("-")[0]
+        if base in SUPPORTED_LANGUAGES:
+            return base
+    return "en"

--- a/merino/providers/suggest/wikipedia/provider.py
+++ b/merino/providers/suggest/wikipedia/provider.py
@@ -9,6 +9,7 @@ from merino.configs import settings
 from merino.exceptions import BackendError
 from merino.providers.suggest.base import BaseProvider, BaseSuggestion, SuggestionRequest, Category
 from merino.providers.suggest.wikipedia.backends.protocol import WikipediaBackend
+from merino.providers.suggest.wikipedia.backends.utils import get_language_code
 
 # The Wikipedia icon backed by Merino's image CDN.
 # TODO: Use a better way to fetch this icon URL instead of hardcoding it here.
@@ -74,7 +75,9 @@ class Provider(BaseProvider):
     async def query(self, srequest: SuggestionRequest) -> list[BaseSuggestion]:
         """Provide suggestion for a given query."""
         try:
-            suggestions = await self.backend.search(srequest.query)
+            languages: list[str] = srequest.languages if srequest.languages else []
+            language_code = get_language_code(languages)
+            suggestions = await self.backend.search(srequest.query, language_code)
         except BackendError as e:
             logger.warning(f"{e}")
             return []

--- a/tests/unit/providers/suggest/wikipedia/backends/test_utils.py
+++ b/tests/unit/providers/suggest/wikipedia/backends/test_utils.py
@@ -1,0 +1,21 @@
+"""Unit tests for the Wiki Backend Utilities."""
+
+import pytest
+from merino.providers.suggest.wikipedia.backends.utils import get_language_code
+
+
+@pytest.mark.parametrize(
+    "input_languages,expected",
+    [
+        (["en-US"], "en"),
+        (["fr-FR"], "fr"),
+        (["de"], "de"),
+        (["it-IT"], "it"),
+        (["pl-PL"], "pl"),
+        ([], "en"),
+        (["es", "jp", "nl"], "en"),
+    ],
+)
+def test_get_language_code(input_languages, expected):
+    """Test that we return the correct language code based on the supported languages"""
+    assert get_language_code(input_languages) == expected


### PR DESCRIPTION
## References

JIRA: [DISCO-3509](https://mozilla-hub.atlassian.net/browse/DISCO-3509)

## Description
This PR updates the wikipedia suggest provider to support multilingual queries by dynamically selecting the appropriate elasticsearch index and wikipedia domain based on the request’s `accept-language` header.

### Changes
- Updated the Wikipedia provider to extract the language code from the request header and use it to determine the correct elasticsearch index alias (e.g., frwiki-v1, dewiki-v1) to query
- Updated `build_article()` to generate wikipedia URLs based on language
    - URLs now point to `{language}.wikipedia.org/wiki/...` rather than always using english
- Added a utility function get_languag_code() that:
    - Parses the languages from the header and normalizes locale values (e.g., fr-FR → fr)
    - Defaults to english if unsupported or missing

### How to QA:
- Prerequisite: update `default.toml` with `es_url` and `es_api_key`
- Run merino locally - `make dev` and navigate to swagger docs - `http://localhost:8000`
- make a GET request to /api/v1/suggest
   - set providers to: wikipedia
   - set accept-language header to one of:
        - `fr-FR`,`de-DE`,`it-IT`, `pl-PL`, `en-US`
- input a search query under q
- execute and inspect response
- confirm title and url fields match expected language
- visit the returned urls to confirm the link resolves correctly

### Some sample queries (per language)
- French (fr-FR)
   - tour e → Tour Eiffel
   - révolution → Révolution française
   - économie → Économie mondiale

- German (de-DE) 
   -  berl → Berliner Mauer, Berlin
   - gesellschaft → Gesellschaft für Informatik
   - groß → Großbritannien, Großstadt

- Italian (it-IT)
    - roma → Roma, Storia di Roma
    - città → Città del Vaticano
    - università → Università di Bologna

- Polish (pl-PL)
    - warszawa → Warszawa
    - piłka → Piłka nożna
    - język → Język polski

- English (en-US)
    - moon l → Moon landing
    - civil → Civil rights
    - wash → Washington, George Washington



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3509]: https://mozilla-hub.atlassian.net/browse/DISCO-3509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1717)
