### PR TITLE
[DISCO-3524] feat: Categorize AMP suggestions via SERP categories

### DIFF
--- a/merino/jobs/utils/domain_category_mapping.py
+++ b/merino/jobs/utils/domain_category_mapping.py
@@ -3,14 +3,17 @@
 from merino.configs import settings
 from merino.providers.suggest.base import Category
 
+_mapping: dict[str, list[Category]]
 if settings.env_for_dynaconf in ["testing", "ci"]:
-    DOMAIN_MAPPING = {
+    _mapping = {
+        # "testserpcategories.com"
+        "3hcN3vfGxlXjlaHR2TGGDA==": [Category.Education],
         "mqzeM3Cm0XLuAd0kKwCttg==": [Category.Sports],
         "g01iNP2/b7ehY5hQXQRP1g==": [Category.Sports, Category.News],
         "uQX8/1Xq/Q9wZOXXGogCaQ==": [Category.Inconclusive],
     }
 else:
-    DOMAIN_MAPPING = {
+    _mapping = {
         "BPNrX9JDOSGaN/1l4qozIg==": [Category.Home],
         "fH/ay2trYCtgO1liGcnqKA==": [Category.Home],
         "FpvYfZ+lFeup4Zppijee6g==": [Category.Travel],
@@ -34163,3 +34166,5 @@ else:
         "WEx15bXkR7627I7kK0WfTQ==": [Category.Business],
         "wSUqisCPuYgiPI2lqvD0Ug==": [Category.Tech],
     }
+
+DOMAIN_MAPPING: dict[str, list[Category]] = _mapping

--- a/merino/providers/suggest/adm/provider.py
+++ b/merino/providers/suggest/adm/provider.py
@@ -1,16 +1,23 @@
 """AdM integration that uses the remote-settings provided data."""
 
 import asyncio
+import base64
 import logging
+import functools
+import hashlib
 import time
 from enum import Enum, unique
 from typing import Any, Final
 
+import tldextract
+
 from pydantic import HttpUrl
+from tldextract.tldextract import ExtractResult
 
 from merino.utils import cron
+from merino.jobs.utils.domain_category_mapping import DOMAIN_MAPPING
 from merino.providers.suggest.adm.backends.protocol import AdmBackend, SuggestionContent
-from merino.providers.suggest.base import BaseProvider, BaseSuggestion, SuggestionRequest
+from merino.providers.suggest.base import BaseProvider, BaseSuggestion, Category, SuggestionRequest
 
 logger = logging.getLogger(__name__)
 
@@ -130,6 +137,28 @@ class Provider(BaseProvider):
         """Convert a query string to lowercase and remove trailing spaces."""
         return query.strip().lower()
 
+    @staticmethod
+    @functools.lru_cache(maxsize=100)
+    def serp_categories(domain: str) -> list[Category]:
+        """Query SERP categories for a given domain.
+
+        Note that to leverage caching and be consistent with SERP Categories,
+        passing in a domain instead of a URL. For example, for the URL
+        "https://www.foo.com/bar", you should pass in "foo.com".
+
+        This function is sped up via caching ("memoization"). The LRU cache
+        size is determined by the fact that there are normally no more than
+        100 unique domains for AMP suggestions.
+
+        Params:
+            `domain`: the domain of a URL.
+        Returns a list of SERP categories if any or else an empty list.
+        """
+        hash = base64.b64encode(
+            hashlib.md5(domain.encode(), usedforsecurity=False).digest()
+        ).decode()
+        return DOMAIN_MAPPING.get(hash, [])
+
     async def query(self, srequest: SuggestionRequest) -> list[BaseSuggestion]:
         """Provide suggestion for a given query."""
         q: str = srequest.query
@@ -138,11 +167,15 @@ class Provider(BaseProvider):
             res = self.suggestion_content.results[results_id]
             is_sponsored = res.get("iab_category") == IABCategory.SHOPPING
 
+            url: str = res["url"]
+            e: ExtractResult = tldextract.extract(url)
+            categories: list[Category] = Provider.serp_categories(domain=f"{e.domain}.{e.suffix}")
             suggestion_dict: dict[str, Any] = {
                 "block_id": res.get("id"),
                 "full_keyword": self.suggestion_content.full_keywords[fkw_id],
                 "title": res.get("title"),
-                "url": res.get("url"),
+                "url": url,
+                "categories": categories,
                 "impression_url": res.get("impression_url"),
                 "click_url": res.get("click_url"),
                 "provider": self.name,

--- a/tests/unit/providers/suggest/adm/test_provider.py
+++ b/tests/unit/providers/suggest/adm/test_provider.py
@@ -12,6 +12,7 @@ from pytest import LogCaptureFixture
 
 from merino.providers.suggest.adm.backends.protocol import SuggestionContent
 from merino.providers.suggest.adm.provider import NonsponsoredSuggestion, Provider
+from merino.providers.suggest.base import Category
 from tests.types import FilterCaplogFixture
 from tests.unit.types import SuggestionRequestFixture
 
@@ -123,6 +124,7 @@ async def test_query_success(
             full_keyword="firefox accounts",
             title="Mozilla Firefox Accounts",
             url=HttpUrl("https://example.org/target/mozfirefoxaccounts"),
+            categories=[],
             impression_url=HttpUrl("https://example.org/impression/mozilla"),
             click_url=HttpUrl("https://example.org/click/mozilla"),
             provider="adm",
@@ -140,3 +142,18 @@ async def test_query_with_missing_key(srequest: SuggestionRequestFixture, adm: P
     await adm.initialize()
 
     assert await adm.query(srequest("nope")) == []
+
+
+@pytest.mark.parametrize(
+    ["domain", "expected"],
+    [
+        ("testserpcategories.com", [Category.Education]),
+        ("nocategories.com", []),
+    ],
+)
+@pytest.mark.asyncio
+async def test_query_serp_categories(adm: Provider, domain: str, expected: list[Category]) -> None:
+    """Test for the serp_categories() method of the adM provider."""
+    categories = adm.serp_categories(domain)
+
+    assert categories == expected


### PR DESCRIPTION
## References

JIRA: [DISCO-3524](https://mozilla-hub.atlassian.net/browse/DISCO-3524)

## Description
This categorizes AMP suggestions via SERP categories to prepare for the R2D2 experiment for AMP. To minimize the ingestion overhead, the suggestion categorization is done (and cached) at query time.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3524]: https://mozilla-hub.atlassian.net/browse/DISCO-3524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ