### PR TITLE
HNT-574 inferred personalization to merino

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -592,6 +592,20 @@ bucket_name = ""
 gcp_project = ""
 
 
+[default.curated_recommendations.gcs.local_model]
+# MERINO__CURATED_RECOMMENDATIONS__GCS__LOCAL_MODEL__MAX_SIZE
+# The maximum size in bytes of the GCS local model file. If exceeded, an error will be logged.
+max_size = 10_000
+
+# MERINO__CURATED_RECOMMENDATIONS__GCS__LOCAL_MODEL__BLOB_PREFIX
+# GCS path of the priors JSON file.
+blob_name = "newtab-merino-exports/local_model/latest.json"
+
+# MERINO__CURATED_RECOMMENDATIONS__GCS__LOCAL_MODEL__CRON_INTERVAL_SECONDS
+# Interval in seconds at which the cron job checks if GCS contains updated model.
+# Model is checked every 1 hour.
+cron_interval_seconds = 3600
+
 [default.curated_recommendations.gcs.engagement]
 # MERINO__CURATED_RECOMMENDATIONS__GCS__ENGAGEMENT__MAX_SIZE
 # The maximum size in bytes of the GCS engagement blob. If exceeded, an error will be logged.

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -603,8 +603,8 @@ blob_name = "newtab-merino-exports/local_model/latest.json"
 
 # MERINO__CURATED_RECOMMENDATIONS__GCS__LOCAL_MODEL__CRON_INTERVAL_SECONDS
 # Interval in seconds at which the cron job checks if GCS contains updated model.
-# Model is checked every 1 hour.
-cron_interval_seconds = 3600
+# Model is checked every 10 minutes.
+cron_interval_seconds = 600
 
 [default.curated_recommendations.gcs.engagement]
 # MERINO__CURATED_RECOMMENDATIONS__GCS__ENGAGEMENT__MAX_SIZE

--- a/merino/curated_recommendations/__init__.py
+++ b/merino/curated_recommendations/__init__.py
@@ -39,6 +39,7 @@ _provider: CuratedRecommendationsProvider
 
 def init_local_model_backend() -> LocalModelBackend:
     """Initialize the GCS Local Model Backend."""
+    metrics_namespace = "recommendations.local_model"
     try:
         synced_gcs_blob = SyncedGcsBlob(
             storage_client=initialize_storage_client(
@@ -49,6 +50,8 @@ def init_local_model_backend() -> LocalModelBackend:
             max_size=settings.local_model.gcs.local_model.max_size,
             cron_interval_seconds=settings.local_model.gcs.local_model.cron_interval_seconds,
             cron_job_name="fetch_local_model",
+            metrics_client=get_metrics_client(),
+            metrics_namespace=metrics_namespace,
         )
         synced_gcs_blob.initialize()
 

--- a/merino/curated_recommendations/__init__.py
+++ b/merino/curated_recommendations/__init__.py
@@ -38,28 +38,9 @@ _provider: CuratedRecommendationsProvider
 
 
 def init_local_model_backend() -> LocalModelBackend:
-    """Initialize the GCS Local Model Backend."""
-    metrics_namespace = "recommendations.local_model"
-    try:
-        synced_gcs_blob = SyncedGcsBlob(
-            storage_client=initialize_storage_client(
-                destination_gcp_project=settings.local_model.gcs.gcp_project
-            ),
-            bucket_name=settings.local_model.gcs.bucket_name,
-            blob_name=settings.local_model.gcs.local_model.blob_name,
-            max_size=settings.local_model.gcs.local_model.max_size,
-            cron_interval_seconds=settings.local_model.gcs.local_model.cron_interval_seconds,
-            cron_job_name="fetch_local_model",
-            metrics_client=get_metrics_client(),
-            metrics_namespace=metrics_namespace,
-        )
-        synced_gcs_blob.initialize()
-
-        return GCSLocalModel(synced_gcs_blob=synced_gcs_blob)
-    except Exception as e:
-        logger.error(f"Failed to initialize GCS Local Model Backend: {e}")
-        # Return hard coded local model as degraded experience for testing
-        return FakeLocalModel()
+    """Initialize the Local Model Backend. This will be repaced with GCSLocal model
+    prior to production launch so we can dynamically update models."""
+    return FakeLocalModel()
 
 
 def init_engagement_backend() -> EngagementBackend:

--- a/merino/curated_recommendations/__init__.py
+++ b/merino/curated_recommendations/__init__.py
@@ -39,7 +39,8 @@ _provider: CuratedRecommendationsProvider
 
 def init_local_model_backend() -> LocalModelBackend:
     """Initialize the Local Model Backend. This will be repaced with GCSLocal model
-    prior to production launch so we can dynamically update models."""
+    prior to production launch so we can dynamically update models.
+    """
     return FakeLocalModel()
 
 

--- a/merino/curated_recommendations/__init__.py
+++ b/merino/curated_recommendations/__init__.py
@@ -40,7 +40,6 @@ _provider: CuratedRecommendationsProvider
 def init_local_model_backend() -> LocalModelBackend:
     """Initialize the GCS Local Model Backend."""
     try:
-        metrics_namespace = "recommendation.local_model"
         synced_gcs_blob = SyncedGcsBlob(
             storage_client=initialize_storage_client(
                 destination_gcp_project=settings.local_model.gcs.gcp_project
@@ -53,9 +52,7 @@ def init_local_model_backend() -> LocalModelBackend:
         )
         synced_gcs_blob.initialize()
 
-        return GCSLocalModel(
-            synced_gcs_blob=synced_gcs_blob
-        )
+        return GCSLocalModel(synced_gcs_blob=synced_gcs_blob)
     except Exception as e:
         logger.error(f"Failed to initialize GCS Local Model Backend: {e}")
         # Return hard coded local model as degraded experience for testing
@@ -137,13 +134,12 @@ def init_provider() -> None:
         manifest_provider=get_manifest_provider(),
     )
 
-
     _provider = CuratedRecommendationsProvider(
         scheduled_surface_backend=scheduled_surface_backend,
         engagement_backend=engagement_backend,
         prior_backend=init_prior_backend(),
         sections_backend=sections_backend,
-        local_model_backend=local_model_backend
+        local_model_backend=local_model_backend,
     )
 
 

--- a/merino/curated_recommendations/ml_backends/__init__.py
+++ b/merino/curated_recommendations/ml_backends/__init__.py
@@ -3,4 +3,3 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """Module dedicated to backends ML modeling, features and recommendations"""
-

--- a/merino/curated_recommendations/ml_backends/__init__.py
+++ b/merino/curated_recommendations/ml_backends/__init__.py
@@ -1,0 +1,6 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Module dedicated to backends ML modeling, features and recommendations"""
+

--- a/merino/curated_recommendations/ml_backends/fake_local_model.py
+++ b/merino/curated_recommendations/ml_backends/fake_local_model.py
@@ -1,22 +1,51 @@
-from merino.curated_recommendations.ml_backends.protocol import InferredLocalModel, LocalModelBackend
+"""Backup local model for testing and in case of GCS failure"""
+
+from merino.curated_recommendations.ml_backends.protocol import (
+    InferredLocalModel,
+    LocalModelBackend,
+)
 
 FAKE_MODEL_ID = "fake_model_id"
+SPECIAL_FEATURE_CLICK = "clicks"
+
+BASE_TOPICS = [
+    "arts",
+    "education",
+    "hobbies",
+    "society-parenting",
+    "business",
+    "education-science",
+    "finance",
+    "food",
+    "government",
+    "health",
+    "home",
+    "society",
+    "sports",
+    "tech",
+    "travel",
+]
+
+
+# Creates a simple model based on topics. Topic features are stored with a t_
+# in telemetry
 class FakeLocalModel(LocalModelBackend):
+    """Class that defines sample parameters on the local Firefox client for defining an interest
+    vector from interaction events
+    """
+
     def get(self, surface_id: str | None = None) -> InferredLocalModel | None:
-        """Fetch local model for the region """
-        SPECIAL_FEATURE_CLICK = "clicks"
-        topics = ["arts", "education", "business", "tech", "hobbies", "food", "home", "sports", "travel", "society-parenting",
-                  "government"]
+        """Fetch local model for the region"""
 
         def get_topic(topic):
             return {
-                "features": {topic: 1},
+                "features": {f"t_{topic}": 1},
                 "thresholds": [0.3, 0.4],
                 "diff_p": 0.75,
                 "diff_q": 0.25,
             }
 
-        category_fields = {a: get_topic(a) for a in topics}
+        category_fields = {a: get_topic(a) for a in BASE_TOPICS}
 
         model_data = {
             "model_type": "clicks",
@@ -35,5 +64,6 @@ class FakeLocalModel(LocalModelBackend):
                 },
             },
         }
-        print("RETURNING MODEL ****")
-        return InferredLocalModel(model_id=FAKE_MODEL_ID, surface_id=surface_id, model_data=model_data)
+        return InferredLocalModel(
+            model_id=FAKE_MODEL_ID, surface_id=surface_id, model_data=model_data
+        )

--- a/merino/curated_recommendations/ml_backends/fake_local_model.py
+++ b/merino/curated_recommendations/ml_backends/fake_local_model.py
@@ -1,6 +1,5 @@
 """Backup local model for testing and in case of GCS failure"""
 
-from typing import Any
 
 from merino.curated_recommendations.ml_backends.protocol import (
     InferredLocalModel,

--- a/merino/curated_recommendations/ml_backends/fake_local_model.py
+++ b/merino/curated_recommendations/ml_backends/fake_local_model.py
@@ -1,5 +1,7 @@
 """Backup local model for testing and in case of GCS failure"""
 
+from typing import Any
+
 from merino.curated_recommendations.ml_backends.protocol import (
     InferredLocalModel,
     LocalModelBackend,
@@ -37,7 +39,7 @@ class FakeLocalModel(LocalModelBackend):
     def get(self, surface_id: str | None = None) -> InferredLocalModel | None:
         """Fetch local model for the region"""
 
-        def get_topic(topic):
+        def get_topic(topic: str) -> dict[str, Any]:
             return {
                 "features": {f"t_{topic}": 1},
                 "thresholds": [0.3, 0.4],

--- a/merino/curated_recommendations/ml_backends/fake_local_model.py
+++ b/merino/curated_recommendations/ml_backends/fake_local_model.py
@@ -1,6 +1,5 @@
 """Backup local model for testing and in case of GCS failure"""
 
-
 from merino.curated_recommendations.ml_backends.protocol import (
     InferredLocalModel,
     LocalModelBackend,

--- a/merino/curated_recommendations/ml_backends/fake_local_model.py
+++ b/merino/curated_recommendations/ml_backends/fake_local_model.py
@@ -67,5 +67,5 @@ class FakeLocalModel(LocalModelBackend):
             },
         }
         return InferredLocalModel(
-            model_id=FAKE_MODEL_ID, surface_id=surface_id, model_data=model_data
+            model_id=FAKE_MODEL_ID, surface_id=surface_id, model_data=model_data, model_version=0
         )

--- a/merino/curated_recommendations/ml_backends/fake_local_model.py
+++ b/merino/curated_recommendations/ml_backends/fake_local_model.py
@@ -5,6 +5,10 @@ from typing import Any
 from merino.curated_recommendations.ml_backends.protocol import (
     InferredLocalModel,
     LocalModelBackend,
+    ModelData,
+    InterestVectorConfig,
+    ModelType,
+    DayTimeWeightingConfig,
 )
 
 FAKE_MODEL_ID = "fake_model_id"
@@ -39,33 +43,25 @@ class FakeLocalModel(LocalModelBackend):
     def get(self, surface_id: str | None = None) -> InferredLocalModel | None:
         """Fetch local model for the region"""
 
-        def get_topic(topic: str) -> dict[str, Any]:
-            return {
-                "features": {f"t_{topic}": 1},
-                "thresholds": [0.3, 0.4],
-                "diff_p": 0.75,
-                "diff_q": 0.25,
-            }
+        def get_topic(topic: str) -> InterestVectorConfig:
+            return InterestVectorConfig(
+                features={f"t_{topic}": 1},
+                thresholds=[0.3, 0.4],
+                diff_p=0.75,
+                diff_q=0.25,
+            )
 
-        category_fields = {a: get_topic(a) for a in BASE_TOPICS}
+        category_fields: dict[str, InterestVectorConfig] = {a: get_topic(a) for a in BASE_TOPICS}
+        model_data: ModelData = ModelData(
+            model_type=ModelType.CLICKS,
+            rescale=True,
+            day_time_weighting=DayTimeWeightingConfig(
+                days=[3, 14, 45],
+                relative_weight=[1, 1, 1],
+            ),
+            interest_vector=category_fields,
+        )
 
-        model_data = {
-            "model_type": "clicks",
-            "rescale": True,
-            "day_time_weighting": {
-                "days": [3, 14, 45],
-                "relative_weight": [1, 1, 1],
-            },
-            "interest_vector": {
-                **category_fields,
-                SPECIAL_FEATURE_CLICK: {
-                    "features": {"click": 1},
-                    "thresholds": [2, 8, 40],
-                    "diff_p": 0.9,
-                    "diff_q": 0.1,
-                },
-            },
-        }
         return InferredLocalModel(
             model_id=FAKE_MODEL_ID, surface_id=surface_id, model_data=model_data, model_version=0
         )

--- a/merino/curated_recommendations/ml_backends/fake_local_model.py
+++ b/merino/curated_recommendations/ml_backends/fake_local_model.py
@@ -1,0 +1,39 @@
+from merino.curated_recommendations.ml_backends.protocol import InferredLocalModel, LocalModelBackend
+
+FAKE_MODEL_ID = "fake_model_id"
+class FakeLocalModel(LocalModelBackend):
+    def get(self, surface_id: str | None = None) -> InferredLocalModel | None:
+        """Fetch local model for the region """
+        SPECIAL_FEATURE_CLICK = "clicks"
+        topics = ["arts", "education", "business", "tech", "hobbies", "food", "home", "sports", "travel", "society-parenting",
+                  "government"]
+
+        def get_topic(topic):
+            return {
+                "features": {topic: 1},
+                "thresholds": [0.3, 0.4],
+                "diff_p": 0.75,
+                "diff_q": 0.25,
+            }
+
+        category_fields = {a: get_topic(a) for a in topics}
+
+        model_data = {
+            "model_type": "clicks",
+            "rescale": True,
+            "day_time_weighting": {
+                "days": [3, 14, 45],
+                "relative_weight": [1, 1, 1],
+            },
+            "interest_vector": {
+                **category_fields,
+                SPECIAL_FEATURE_CLICK: {
+                    "features": {"click": 1},
+                    "thresholds": [2, 8, 40],
+                    "diff_p": 0.9,
+                    "diff_q": 0.1,
+                },
+            },
+        }
+        print("RETURNING MODEL ****")
+        return InferredLocalModel(model_id=FAKE_MODEL_ID, surface_id=surface_id, model_data=model_data)

--- a/merino/curated_recommendations/ml_backends/gcs_local_model.py
+++ b/merino/curated_recommendations/ml_backends/gcs_local_model.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+from typing import Any
 
 from merino.curated_recommendations.ml_backends.protocol import (
     LocalModelBackend,
@@ -24,7 +25,7 @@ class GCSLocalModel(LocalModelBackend):
         Args:
             synced_gcs_blob: Instance of SyncedGcsBlob that manages GCS synchronization.
         """
-        self._cache = {}
+        self._cache: dict[str | None, Any] = {}
         self.synced_blob = synced_gcs_blob
         self.synced_blob.set_fetch_callback(self._fetch_callback)
 

--- a/merino/curated_recommendations/ml_backends/gcs_local_model.py
+++ b/merino/curated_recommendations/ml_backends/gcs_local_model.py
@@ -1,0 +1,56 @@
+"""Wrapper for engagement data from Google Cloud Storage."""
+
+import json
+import logging
+
+from merino.curated_recommendations.engagement_backends.protocol import (
+    Engagement,
+    EngagementBackend,
+)
+from merino.curated_recommendations.ml_backends.protocol import LocalModelBackend, InferredLocalModel
+from merino.utils.synced_gcs_blob import SyncedGcsBlob
+
+logger = logging.getLogger(__name__)
+
+
+class GCSLocalModel(LocalModelBackend):
+    """Backend that caches and periodically retrieves model information from GCS"""
+
+    def __init__(
+        self,
+        synced_gcs_blob: SyncedGcsBlob,
+    ) -> None:
+        """Initialize the GcsEngagement backend.
+
+        Args:
+            synced_gcs_blob: Instance of SyncedGcsBlob that manages GCS synchronization.
+        """
+        self._cache = {}
+        self.synced_blob = synced_gcs_blob
+        self.synced_blob.set_fetch_callback(self._fetch_callback)
+
+    def get(self, surface_id: str | None = None) -> InferredLocalModel | None:
+        """Get cached click and impression counts from the last 24h for the corpus item id
+
+        Args:
+            surface_id: Return model for a given surface (e.g. 'EN_US').
+
+        Returns:
+            Engagement: Engagement data for the specified id if it exists in cache, otherwise None.
+        """
+        return self._cache.get(surface_id)
+
+    @property
+    def update_count(self) -> int:
+        """Return the number of times the model data has been updated."""
+        return self.synced_blob.update_count
+
+    def _fetch_callback(self, data: str) -> None:
+        """Process the raw model blob data and update the cache.
+
+        Args:
+            data: The engagement blob string data, with an array of Engagement objects.
+        """
+        parsed_data = [InferredLocalModel(**item) for item in json.loads(data)]
+        self._cache = {d.surface_id: d for d in parsed_data}
+

--- a/merino/curated_recommendations/ml_backends/gcs_local_model.py
+++ b/merino/curated_recommendations/ml_backends/gcs_local_model.py
@@ -1,13 +1,12 @@
-"""Wrapper for engagement data from Google Cloud Storage."""
+"""Wrapper for local model data from Google Cloud Storage."""
 
 import json
 import logging
 
-from merino.curated_recommendations.engagement_backends.protocol import (
-    Engagement,
-    EngagementBackend,
+from merino.curated_recommendations.ml_backends.protocol import (
+    LocalModelBackend,
+    InferredLocalModel,
 )
-from merino.curated_recommendations.ml_backends.protocol import LocalModelBackend, InferredLocalModel
 from merino.utils.synced_gcs_blob import SyncedGcsBlob
 
 logger = logging.getLogger(__name__)
@@ -36,7 +35,7 @@ class GCSLocalModel(LocalModelBackend):
             surface_id: Return model for a given surface (e.g. 'EN_US').
 
         Returns:
-            Engagement: Engagement data for the specified id if it exists in cache, otherwise None.
+            Inferred local model
         """
         return self._cache.get(surface_id)
 
@@ -53,4 +52,3 @@ class GCSLocalModel(LocalModelBackend):
         """
         parsed_data = [InferredLocalModel(**item) for item in json.loads(data)]
         self._cache = {d.surface_id: d for d in parsed_data}
-

--- a/merino/curated_recommendations/ml_backends/protocol.py
+++ b/merino/curated_recommendations/ml_backends/protocol.py
@@ -1,12 +1,14 @@
 """Protocol and Pydantic models for the Local Model provider backend."""
 
 from enum import Enum
-from typing import Protocol, Any
-from pydantic import BaseModel, ConfigDict
+from typing import Protocol
+from pydantic import BaseModel
 
 
 # Define the model type enum
 class ModelType(str, Enum):
+    """Type of model. Indicates source of data, such as whether we are working with clicks or include impressions"""
+
     CLICKS = "clicks"
     CLICK_IMP_PAIR = "click_impression_pair"
 

--- a/merino/curated_recommendations/ml_backends/protocol.py
+++ b/merino/curated_recommendations/ml_backends/protocol.py
@@ -1,6 +1,6 @@
 """Protocol and Pydantic models for the Local Model provider backend."""
 
-from typing import Protocol, Dict, Any
+from typing import Protocol, Any
 from pydantic import BaseModel, ConfigDict
 
 
@@ -11,7 +11,7 @@ class InferredLocalModel(BaseModel):
 
     model_id: str
     surface_id: str
-    model_data: Dict[str, Any]
+    model_data: dict[str, Any]
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 

--- a/merino/curated_recommendations/ml_backends/protocol.py
+++ b/merino/curated_recommendations/ml_backends/protocol.py
@@ -1,0 +1,21 @@
+"""Protocol and Pydantic models for the Local Model provider backend."""
+
+from typing import Protocol
+from pydantic import BaseModel, ConfigDict
+
+
+class InferredLocalModel(BaseModel):
+    model_id: str
+    surface_id: str
+    model_data: [dict, any]
+
+    class Config:
+        arbitrary_types_allowed = True
+
+
+class LocalModelBackend(Protocol):
+    """Protocol for Engagement backend that the provider depends on."""
+
+    def get(self, surface_id: str | None = None) -> InferredLocalModel | None:
+        """Fetch local model for the region """
+        ...

--- a/merino/curated_recommendations/ml_backends/protocol.py
+++ b/merino/curated_recommendations/ml_backends/protocol.py
@@ -13,6 +13,8 @@ class ModelType(str, Enum):
 
 # Interest vector category configuration
 class InterestVectorConfig(BaseModel):
+    """Class that defines the mapping of several article features (that were impressed, clicked etc) to an output feature"""
+
     # features that are added together to form the output value
     features: dict[str, float]
 
@@ -26,12 +28,15 @@ class InterestVectorConfig(BaseModel):
 
 # Top-level model config
 class DayTimeWeightingConfig(BaseModel):
-    # day ranges and relative weights. Each list must have the same length
+    """Day ranges and relative weights. 1 is no special weighting. Each list (days and relative_weight) must have the same length"""
+
     days: list[int]
     relative_weight: list[float]
 
 
 class ModelData(BaseModel):
+    """Data defining a model that maps interactions over many features to an interest vector of smaller number of dimensions"""
+
     model_type: ModelType
     # Whether to rescale the values based on 1 max value
     rescale: bool

--- a/merino/curated_recommendations/ml_backends/protocol.py
+++ b/merino/curated_recommendations/ml_backends/protocol.py
@@ -1,7 +1,43 @@
 """Protocol and Pydantic models for the Local Model provider backend."""
 
+from enum import Enum
 from typing import Protocol, Any
 from pydantic import BaseModel, ConfigDict
+
+
+# Define the model type enum
+class ModelType(str, Enum):
+    CLICKS = "clicks"
+    CLICK_IMP_PAIR = "click_impression_pair"
+
+
+# Interest vector category configuration
+class InterestVectorConfig(BaseModel):
+    # features that are added together to form the output value
+    features: dict[str, float]
+
+    # Threshold ranges for forming a coarse integer value (0, 1, 2, etc.)
+    thresholds: list[float]
+
+    # Differential privacy p and q values for unary encoding
+    diff_p: float
+    diff_q: float
+
+
+# Top-level model config
+class DayTimeWeightingConfig(BaseModel):
+    # day ranges and relative weights. Each list must have the same length
+    days: list[int]
+    relative_weight: list[float]
+
+
+class ModelData(BaseModel):
+    model_type: ModelType
+    # Whether to rescale the values based on 1 max value
+    rescale: bool
+    day_time_weighting: DayTimeWeightingConfig
+    # Output key, and inputs for how fields affect it
+    interest_vector: dict[str, InterestVectorConfig]
 
 
 class InferredLocalModel(BaseModel):
@@ -9,15 +45,13 @@ class InferredLocalModel(BaseModel):
     events
     """
 
-    # Id of model
     model_id: str
+
     # Schema version
     model_version: int
-
     surface_id: str
-    model_data: dict[str, Any]
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)
+    model_data: ModelData
 
 
 class LocalModelBackend(Protocol):

--- a/merino/curated_recommendations/ml_backends/protocol.py
+++ b/merino/curated_recommendations/ml_backends/protocol.py
@@ -1,21 +1,24 @@
 """Protocol and Pydantic models for the Local Model provider backend."""
 
-from typing import Protocol
+from typing import Protocol, Dict, Any
 from pydantic import BaseModel, ConfigDict
 
 
 class InferredLocalModel(BaseModel):
+    """Class that defines parameters on the local Firefox client for defining an interest vector from interaction
+    events
+    """
+
     model_id: str
     surface_id: str
-    model_data: [dict, any]
+    model_data: Dict[str, Any]
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 class LocalModelBackend(Protocol):
-    """Protocol for Engagement backend that the provider depends on."""
+    """Protocol for local model that is applied to New Tab article interactions on the client."""
 
     def get(self, surface_id: str | None = None) -> InferredLocalModel | None:
-        """Fetch local model for the region """
+        """Fetch local model for the region"""
         ...

--- a/merino/curated_recommendations/ml_backends/protocol.py
+++ b/merino/curated_recommendations/ml_backends/protocol.py
@@ -9,7 +9,11 @@ class InferredLocalModel(BaseModel):
     events
     """
 
+    # Id of model
     model_id: str
+    # Schema version
+    model_version: int
+
     surface_id: str
     model_data: dict[str, Any]
 

--- a/merino/curated_recommendations/protocol.py
+++ b/merino/curated_recommendations/protocol.py
@@ -13,7 +13,6 @@ from pydantic import (
     BaseModel,
     ValidationInfo,
     RootModel,
-    ConfigDict,
 )
 
 from merino.curated_recommendations.corpus_backends.protocol import (
@@ -97,10 +96,8 @@ MAX_TILE_ID = (1 << 53) - 1
 MIN_TILE_ID = 10000000
 
 
-class InferredInterests(RootModel[dict[str, float]]):
+class InferredInterests(RootModel[dict[str, float | str]]):
     """Inferred general interests from New Tab article interactions"""
-
-    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 class SectionConfiguration(BaseModel):

--- a/merino/curated_recommendations/protocol.py
+++ b/merino/curated_recommendations/protocol.py
@@ -6,7 +6,15 @@ from typing import Annotated
 import logging
 from datetime import datetime
 
-from pydantic import Field, field_validator, model_validator, BaseModel, ValidationInfo, RootModel
+from pydantic import (
+    Field,
+    field_validator,
+    model_validator,
+    BaseModel,
+    ValidationInfo,
+    RootModel,
+    ConfigDict,
+)
 
 from merino.curated_recommendations.corpus_backends.protocol import (
     CorpusItem,
@@ -90,8 +98,9 @@ MIN_TILE_ID = 10000000
 
 
 class InferredInterests(RootModel[dict[str, float]]):
-    class Config:
-        arbitrary_types_allowed = True
+    """Inferred general interests from New Tab article interactions"""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 class SectionConfiguration(BaseModel):
@@ -103,7 +112,7 @@ class SectionConfiguration(BaseModel):
     followedAt: datetime | None = Field(
         default=None,
         description="Timestamp when the section was followed. Must be in ISO 8601 format with timezone, "
-                    "e.g. '2024-03-24T12:34:56Z' or '2024-03-24T14:34:56+02:00'.",
+        "e.g. '2024-03-24T12:34:56Z' or '2024-03-24T14:34:56+02:00'.",
     )
 
     @field_validator("followedAt", mode="before")
@@ -137,7 +146,7 @@ class CuratedRecommendation(CorpusItem):
     features: dict[str, float] = Field(
         default_factory=dict,
         description="Maps feature names to weights, which the client "
-                    "can use to create a coarse interest vector.",
+        "can use to create a coarse interest vector.",
     )
 
     @model_validator(mode="before")
@@ -286,7 +295,7 @@ class Section(BaseModel):
     followedAt: datetime | None = Field(
         default=None,
         description="Timestamp when the section was followed. Must be in ISO 8601 format with timezone, "
-                    "e.g. '2024-03-24T12:34:56Z' or '2024-03-24T14:34:56+02:00'.",
+        "e.g. '2024-03-24T12:34:56Z' or '2024-03-24T14:34:56+02:00'.",
     )
     isInitiallyVisible: bool = True
 

--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -126,7 +126,10 @@ class CuratedRecommendationsProvider:
         sections_feeds = None
         general_feed = []
         is_sections_experiment = self.is_sections_experiment(request, surface_id)
-        inferred_p13n_enabled = is_sections_experiment and request.inferredInterests
+
+        inferred_local_model = None
+        if is_sections_experiment and request.inferredInterests:
+            inferred_local_model = self.local_model_backend.get(surface_id)
 
         if is_sections_experiment:
             sections_feeds = await get_sections(
@@ -145,9 +148,7 @@ class CuratedRecommendationsProvider:
             surfaceId=surface_id,
             data=general_feed,
             feeds=sections_feeds,
-            inferredLocalModel=self.local_model_backend.get(surface_id)
-            if inferred_p13n_enabled
-            else None,
+            inferredLocalModel=inferred_local_model,
         )
 
         if request.enableInterestPicker and response.feeds:

--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -109,7 +109,6 @@ class CuratedRecommendationsProvider:
     ) -> CuratedRecommendationsResponse:
         """Provide curated recommendations."""
         surface_id = get_recommendation_surface_id(locale=request.locale, region=request.region)
-
         corpus_items = await self.scheduled_surface_backend.fetch(surface_id)
         recommendations = [
             CuratedRecommendation(

--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -46,7 +46,7 @@ class CuratedRecommendationsProvider:
         engagement_backend: EngagementBackend,
         prior_backend: PriorBackend,
         sections_backend: SectionsProtocol,
-        local_model_backend: LocalModelBackend
+        local_model_backend: LocalModelBackend,
     ) -> None:
         self.scheduled_surface_backend = scheduled_surface_backend
         self.engagement_backend = engagement_backend
@@ -119,7 +119,7 @@ class CuratedRecommendationsProvider:
                 # interest vector. Data science work shows that using the topics as features
                 # is effective as a first pass at personalization.
                 # https://mozilla-hub.atlassian.net/wiki/x/FoV5Ww
-                features={item.topic.value: 1.0} if item.topic else {},
+                features={f"t_{item.topic.value}": 1.0} if item.topic else {},
             )
             for rank, item in enumerate(corpus_items)
         ]
@@ -146,7 +146,9 @@ class CuratedRecommendationsProvider:
             surfaceId=surface_id,
             data=general_feed,
             feeds=sections_feeds,
-            inferredLocalModel=self.local_model_backend.get(surface_id) if inferred_p13n_enabled else None
+            inferredLocalModel=self.local_model_backend.get(surface_id)
+            if inferred_p13n_enabled
+            else None,
         )
 
         if request.enableInterestPicker and response.feeds:

--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -53,12 +53,17 @@ def map_section_item_to_recommendation(
     Returns:
         A CuratedRecommendation.
     """
+    # We use a feature prefix of "t_" for topics and "s_" for sections
+    features = {f"s_{section_id}": 1.0}
+    if item.topic is not None:
+        features[f"t_{item.topic}"] = 1.0
+
     return CuratedRecommendation(
         **item.model_dump(),
         receivedRank=rank,
         # Treat the section’s externalId as a weight-1.0 feature so the client can aggregate a
         # coarse interest vector. See also https://mozilla-hub.atlassian.net/wiki/x/FoV5Ww
-        features={section_id: 1.0},
+        features=features,
     )
 
 

--- a/tests/integration/api/v1/curated_recommendations/ml_backends/test_gcs_local_model.py
+++ b/tests/integration/api/v1/curated_recommendations/ml_backends/test_gcs_local_model.py
@@ -1,0 +1,110 @@
+"""Tests loading local model data from Google Cloud Storage."""
+
+import asyncio
+import json
+import time
+from typing import Callable
+
+import pytest
+from aiodogstatsd import Client as StatsdClient
+from google.cloud.storage import Client, Bucket
+
+from merino.configs import settings
+from merino.curated_recommendations import GCSLocalModel
+from merino.curated_recommendations.ml_backends.protocol import InferredLocalModel
+from merino.utils.synced_gcs_blob import SyncedGcsBlob
+
+TEST_SURFACE_ID = "AA"
+TEST_MODEL_ID = "BB"
+
+
+@pytest.fixture(scope="function")
+def gcs_bucket(gcs_storage_client):
+    """Create a test bucket in the fake GCS server."""
+    bucket = gcs_storage_client.create_bucket(settings.curated_recommendations.gcs.bucket_name)
+    yield bucket
+    bucket.delete(force=True)
+
+
+def create_gcs_local_model(
+    gcs_storage_client: Client, gcs_bucket: Bucket, metrics_client: StatsdClient
+) -> GCSLocalModel:
+    """Return an initialized GcsEngagement instance using the fake GCS server."""
+    synced_gcs_blob = SyncedGcsBlob(
+        storage_client=gcs_storage_client,
+        bucket_name=gcs_bucket.name,
+        blob_name=settings.curated_recommendations.gcs.local_model.blob_name,
+        metrics_client=metrics_client,
+        metrics_namespace="recommendation.local_model",
+        max_size=settings.curated_recommendations.gcs.local_model.max_size,
+        cron_interval_seconds=0.01,
+        cron_job_name="fetch_local_model",
+    )
+    # Call initialize to start the cron job in the same event loop
+    synced_gcs_blob.initialize()
+
+    return GCSLocalModel(synced_gcs_blob=synced_gcs_blob)
+
+
+def create_blob(bucket, data):
+    """Create a blob with given data."""
+    blob = bucket.blob(settings.curated_recommendations.gcs.local_model.blob_name)
+    blob.upload_from_string(json.dumps(data))
+    return blob
+
+
+async def wait(until: Callable[[], bool]):
+    """Wait for some time to pass, until the given condition is true."""
+    max_wait_time_sec = 2
+    start_time = time.time()
+    while time.time() - start_time < max_wait_time_sec:
+        if until():
+            break
+        await asyncio.sleep(0.01)  # sleep for 10ms
+
+
+async def wait_until_engagement_is_updated(backend: GCSLocalModel):
+    """Wait for some time to pass to update engagement."""
+    await wait(until=lambda: backend.update_count > 0)
+
+
+@pytest.fixture
+def blob(gcs_bucket):
+    """Create a blob with region data."""
+    return create_blob(
+        gcs_bucket,
+        [{"surface_id": TEST_SURFACE_ID, "model_id": TEST_MODEL_ID, "model_data": {}}],
+    )
+
+
+@pytest.fixture(params=["stage", "prod", "dev"])
+def setting_environment(request):
+    """Fixture to run a test in the staging, production, and development environment."""
+    original_env = settings.current_env
+
+    # Set the desired environment.
+    settings.configure(FORCE_ENV_FOR_DYNACONF=request.param)
+    yield request.param  # Yield to run the test
+
+    # Reset to the original environment after the test
+    settings.configure(FORCE_ENV_FOR_DYNACONF=original_env)
+
+
+@pytest.mark.asyncio
+async def test_gcs_local_model_returns_none_for_missing_keys(
+    gcs_storage_client, gcs_bucket, metrics_client
+):
+    """Test that the backend returns None for keys not in the GCS blobs."""
+    gcs_engagement = create_gcs_local_model(gcs_storage_client, gcs_bucket, metrics_client)
+    assert gcs_engagement.get("missing_key") is None
+
+
+@pytest.mark.asyncio
+async def test_gcs_local_model_fetches_data(gcs_storage_client, gcs_bucket, metrics_client, blob):
+    """Test that the backend fetches data from GCS and returns engagement data."""
+    local_model = create_gcs_local_model(gcs_storage_client, gcs_bucket, metrics_client)
+    await wait_until_engagement_is_updated(local_model)
+
+    assert local_model.get(TEST_SURFACE_ID) == InferredLocalModel(
+        surface_id=TEST_SURFACE_ID, model_id=TEST_MODEL_ID, model_data={}
+    )

--- a/tests/integration/api/v1/curated_recommendations/ml_backends/test_gcs_local_model.py
+++ b/tests/integration/api/v1/curated_recommendations/ml_backends/test_gcs_local_model.py
@@ -73,7 +73,14 @@ def blob(gcs_bucket):
     """Create a blob with region data."""
     return create_blob(
         gcs_bucket,
-        [{"surface_id": TEST_SURFACE_ID, "model_id": TEST_MODEL_ID, "model_data": {}}],
+        [
+            {
+                "surface_id": TEST_SURFACE_ID,
+                "model_id": TEST_MODEL_ID,
+                "model_version": 0,
+                "model_data": {},
+            }
+        ],
     )
 
 
@@ -106,5 +113,5 @@ async def test_gcs_local_model_fetches_data(gcs_storage_client, gcs_bucket, metr
     await wait_until_engagement_is_updated(local_model)
 
     assert local_model.get(TEST_SURFACE_ID) == InferredLocalModel(
-        surface_id=TEST_SURFACE_ID, model_id=TEST_MODEL_ID, model_data={}
+        surface_id=TEST_SURFACE_ID, model_version=0, model_id=TEST_MODEL_ID, model_data={}
     )

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -19,7 +19,7 @@ from merino.curated_recommendations import (
     CuratedRecommendationsProvider,
     get_provider,
     ConstantPrior,
-    interest_picker,
+    interest_picker, LocalModelBackend,
 )
 from merino.curated_recommendations.corpus_backends.protocol import (
     Topic,
@@ -102,6 +102,7 @@ def provider(
     sections_backend: SectionsProtocol,
     engagement_backend: EngagementBackend,
     prior_backend: PriorBackend,
+    local_model_backend: LocalModelBackend
 ) -> CuratedRecommendationsProvider:
     """Mock curated recommendations provider."""
     return CuratedRecommendationsProvider(
@@ -109,6 +110,7 @@ def provider(
         engagement_backend=engagement_backend,
         prior_backend=prior_backend,
         sections_backend=sections_backend,
+        local_model_backend=local_model_backend
     )
 
 

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -82,7 +82,9 @@ class MockLocalModelBackend(LocalModelBackend):
 
     def get(self, surface_id: str | None = None) -> InferredLocalModel | None:
         """Return sample local model"""
-        return InferredLocalModel(model_id="fake", surface_id=surface_id, model_data={})
+        return InferredLocalModel(
+            model_id="fake", model_version=0, surface_id=surface_id, model_data={}
+        )
 
     def initialize(self) -> None:
         """Mock class must implement this method, but no initialization needs to happen."""

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -187,7 +187,7 @@ async def test_curated_recommendations(repeat):
             imageUrl="https://s3.us-east-1.amazonaws.com/pocket-curatedcorpusapi-prod-images/40e30ce2-a298-4b34-ab58-8f0f3910ee39.jpeg",
             receivedRank=0,
             tileId=301455520317019,
-            features={"food": 1.0},
+            features={"t_food": 1.0},
         )
         # Mock the endpoint
         response = await fetch_en_us(ac)

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -32,7 +32,12 @@ from merino.curated_recommendations.engagement_backends.protocol import (
     Engagement,
 )
 from merino.curated_recommendations.localization import LOCALIZED_SECTION_TITLES
-from merino.curated_recommendations.ml_backends.protocol import InferredLocalModel
+from merino.curated_recommendations.ml_backends.protocol import (
+    InferredLocalModel,
+    ModelData,
+    ModelType,
+    DayTimeWeightingConfig,
+)
 from merino.curated_recommendations.prior_backends.protocol import PriorBackend
 from merino.curated_recommendations.protocol import (
     ExperimentName,
@@ -82,8 +87,17 @@ class MockLocalModelBackend(LocalModelBackend):
 
     def get(self, surface_id: str | None = None) -> InferredLocalModel | None:
         """Return sample local model"""
+        model_data = ModelData(
+            model_type=ModelType.CLICKS,
+            rescale=True,
+            day_time_weighting=DayTimeWeightingConfig(
+                days=[3, 14, 45],
+                relative_weight=[1, 1, 1],
+            ),
+            interest_vector={},
+        )
         return InferredLocalModel(
-            model_id="fake", model_version=0, surface_id=surface_id, model_data={}
+            model_id="fake", model_version=0, surface_id=surface_id, model_data=model_data
         )
 
     def initialize(self) -> None:

--- a/tests/unit/curated_recommendations/ml_backends/test_fake_local_model.py
+++ b/tests/unit/curated_recommendations/ml_backends/test_fake_local_model.py
@@ -1,0 +1,25 @@
+"""Unit tests for fake local model"""
+
+import pytest
+from merino.curated_recommendations.ml_backends.fake_local_model import (
+    FakeLocalModel,
+    FAKE_MODEL_ID,
+)
+from merino.curated_recommendations.ml_backends.protocol import InferredLocalModel
+
+
+@pytest.fixture
+def model():
+    """Create fake model"""
+    return FakeLocalModel()
+
+
+def test_model_returns_inferred_local_model(model):
+    """Tests fake local model"""
+    surface_id = "test_surface"
+    result = model.get(surface_id)
+
+    assert isinstance(result, InferredLocalModel)
+    assert result.model_id == FAKE_MODEL_ID
+    assert result.surface_id == surface_id
+    assert isinstance(result.model_data, dict)

--- a/tests/unit/curated_recommendations/ml_backends/test_fake_local_model.py
+++ b/tests/unit/curated_recommendations/ml_backends/test_fake_local_model.py
@@ -23,4 +23,7 @@ def test_model_returns_inferred_local_model(model):
     assert result.model_id == FAKE_MODEL_ID
     assert result.surface_id == surface_id
     assert result.model_version == 0
-    assert isinstance(result.model_data, dict)
+    assert result.model_data is not None
+    assert len(result.model_data.interest_vector) > 0
+    assert len(result.model_data.day_time_weighting.days) > 0
+    assert len(result.model_data.day_time_weighting.relative_weight) > 0

--- a/tests/unit/curated_recommendations/ml_backends/test_fake_local_model.py
+++ b/tests/unit/curated_recommendations/ml_backends/test_fake_local_model.py
@@ -22,4 +22,5 @@ def test_model_returns_inferred_local_model(model):
     assert isinstance(result, InferredLocalModel)
     assert result.model_id == FAKE_MODEL_ID
     assert result.surface_id == surface_id
+    assert result.model_version == 0
     assert isinstance(result.model_data, dict)


### PR DESCRIPTION
## References

JIRA: [HNT-574](https://mozilla-hub.atlassian.net/browse/HNT-574)
https://mozilla-hub.atlassian.net/wiki/spaces/FPS/pages/1575092266/Personalization+v1+-+Section+Personalization

## Description
Merino serves some model metadata as part of the content response. This metadata is considered a 'local model' for aggregating features of interactions and clicks on articles in a certain way.

Key changes:
• Interest vector is received from the firefox content request and parsed (but not acted upon yet)
• Model is served when a non-null interest vector is sent from the client
• Section and topic names are included in the 'features' section with the 's_' and 't_' prefix respectively.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[HNT-574]: https://mozilla-hub.atlassian.net/browse/HNT-574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1719)
