### PR TITLE
Introduce business subjects for Yelp suggestion

### DIFF
--- a/merino/jobs/csv_rs_uploader/yelp.py
+++ b/merino/jobs/csv_rs_uploader/yelp.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel
 from merino.jobs.csv_rs_uploader.base import BaseSuggestion
 
 FIELD_SUBJECTS = "subjects"
+FIELD_BUSINESS_SUBJECTS = "business-subjects"
 FIELD_PRE_MODIFIERS = "pre-modifiers"
 FIELD_POST_MODIFIERS = "post-modifiers"
 FIELD_LOCATION_MODIFIERS = "location-modifiers"
@@ -35,6 +36,7 @@ class Suggestion(BaseSuggestion):
     """
 
     subjects: list[str]
+    businessSubjects: list[str]
     preModifiers: list[str]
     postModifiers: list[str]
     locationSigns: list[LocationSign]
@@ -45,6 +47,7 @@ class Suggestion(BaseSuggestion):
     def csv_to_suggestions(cls, csv_reader) -> list["Suggestion"]:
         """Convert CSV content to Yelp Suggestions."""
         subjects = []
+        business_subjects = []
         pre_modifiers = []
         post_modifiers = []
         location_signs = []
@@ -54,6 +57,10 @@ class Suggestion(BaseSuggestion):
             subject = row[FIELD_SUBJECTS]
             if subject:
                 subjects.append(subject)
+
+            business_subject = row[FIELD_BUSINESS_SUBJECTS]
+            if business_subject:
+                business_subjects.append(business_subject)
 
             pre_modifier = row[FIELD_PRE_MODIFIERS]
             if pre_modifier:
@@ -78,6 +85,7 @@ class Suggestion(BaseSuggestion):
         return [
             Suggestion(
                 subjects=subjects,
+                businessSubjects=business_subjects,
                 preModifiers=pre_modifiers,
                 postModifiers=post_modifiers,
                 locationSigns=location_signs,

--- a/tests/unit/jobs/csv_rs_uploader/test_yelp.py
+++ b/tests/unit/jobs/csv_rs_uploader/test_yelp.py
@@ -10,6 +10,7 @@ from merino.jobs.csv_rs_uploader.yelp import (
     FIELD_POST_MODIFIERS,
     FIELD_PRE_MODIFIERS,
     FIELD_SUBJECTS,
+    FIELD_BUSINESS_SUBJECTS,
     FIELD_YELP_MODIFIERS,
     ICON_ID,
 )
@@ -26,6 +27,7 @@ def test_upload(mocker):
         csv_rows=[
             {
                 FIELD_SUBJECTS: "subject-1",
+                FIELD_BUSINESS_SUBJECTS: "business-subject-1",
                 FIELD_PRE_MODIFIERS: "pre-modifier-1",
                 FIELD_POST_MODIFIERS: "post-modifier-1",
                 FIELD_LOCATION_MODIFIERS: "location-modifier-1",
@@ -34,6 +36,7 @@ def test_upload(mocker):
             },
             {
                 FIELD_SUBJECTS: "subject-2",
+                FIELD_BUSINESS_SUBJECTS: "business-subject-2",
                 FIELD_PRE_MODIFIERS: "pre-modifier-2",
                 FIELD_POST_MODIFIERS: "post-modifier-2",
                 FIELD_LOCATION_MODIFIERS: "location-modifier-2",
@@ -99,6 +102,10 @@ def test_upload(mocker):
                     "subject-5",
                     "subject-6",
                     "subject-7",
+                ],
+                "businessSubjects": [
+                    "business-subject-1",
+                    "business-subject-2",
                 ],
                 "preModifiers": [
                     "pre-modifier-1",


### PR DESCRIPTION
## References

JIRA: [SNG-2374](https://mozilla-hub.atlassian.net/browse/SNG-2374)

## Description
We need to show a prefix to the title of Yelp suggestion if the subject indicates a service.
To realize it, we want to register new data that are business subjects in Remote Settings.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[SNG-2374]: https://mozilla-hub.atlassian.net/browse/SNG-2374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ