### PR TITLE
[SNG-2523] Improve the remote settings uploader classes

### DIFF
--- a/merino/jobs/geonames_uploader/__init__.py
+++ b/merino/jobs/geonames_uploader/__init__.py
@@ -136,8 +136,8 @@ class GeonamesChunk(Chunk):
         """Convert the geoname to a JSON serializable object."""
         return geoname.to_json_serializable()
 
-    def __init__(self, start_index: int):
-        super().__init__(start_index)
+    def __init__(self, *args):
+        super().__init__(self, *args)
         self.max_alternate_name_length = 0
         self.max_alternate_name_word_count = 0
 
@@ -151,15 +151,12 @@ class GeonamesChunk(Chunk):
             if word_count > self.max_alternate_name_word_count:
                 self.max_alternate_name_word_count = word_count
 
-    def to_json_serializable(self) -> Any:
-        """Convert the chunk to a JSON serializable object that will be stored
-        in the chunk's attachment.
-
-        """
+    def to_attachment(self) -> Any:
+        """Create the attachment for the chunk."""
         return {
             "max_alternate_name_length": self.max_alternate_name_length,
             "max_alternate_name_word_count": self.max_alternate_name_word_count,
-            "geonames": self.items,
+            "geonames": [self.item_to_json_serializable(i) for i in self.items],
         }
 
 

--- a/merino/jobs/relevancy_uploader/chunked_rs_uploader.py
+++ b/merino/jobs/relevancy_uploader/chunked_rs_uploader.py
@@ -14,7 +14,7 @@ class RelevancyChunk(Chunk):
     uploader: "ChunkedRemoteSettingsRelevancyUploader"
 
     def to_record(self) -> dict[str, Any]:
-        """Create a record and attachment for a chunk."""
+        """Create the record for the chunk."""
         start, end = self.pretty_indexes()
         record_id = "-".join([self.uploader.category_name, start, end])
         return {

--- a/merino/jobs/relevancy_uploader/chunked_rs_uploader.py
+++ b/merino/jobs/relevancy_uploader/chunked_rs_uploader.py
@@ -1,18 +1,41 @@
 """Chunked remote settings uploader"""
 
-import io
-import json
 import logging
+from typing import Any
 
 from merino.jobs.utils.chunked_rs_uploader import Chunk, ChunkedRemoteSettingsUploader
 
 logger = logging.getLogger(__name__)
 
 
+class RelevancyChunk(Chunk):
+    """A chunk of items for the relevancy uploader."""
+
+    uploader: "ChunkedRemoteSettingsRelevancyUploader"
+
+    def to_record(self) -> dict[str, Any]:
+        """Create a record and attachment for a chunk."""
+        start, end = self.pretty_indexes()
+        record_id = "-".join([self.uploader.category_name, start, end])
+        return {
+            "id": record_id,
+            "type": self.uploader.record_type,
+            "record_custom_details": {
+                "category_to_domains": {
+                    "category": self.uploader.category_name.lower(),
+                    "category_code": self.uploader.category_code,
+                    "version": self.uploader.version,
+                }
+            },
+        }
+
+
 class ChunkedRemoteSettingsRelevancyUploader(ChunkedRemoteSettingsUploader):
     """A class that uploads relevancy data to remote settings."""
 
-    category: str
+    category_name: str
+    category_code: int
+    version: int
 
     def __init__(
         self,
@@ -38,6 +61,7 @@ class ChunkedRemoteSettingsRelevancyUploader(ChunkedRemoteSettingsUploader):
             server,
             dry_run,
             total_item_count,
+            chunk_cls=RelevancyChunk,
         )
         self.category_name = category_name
         self.category_code = category_code
@@ -48,54 +72,14 @@ class ChunkedRemoteSettingsRelevancyUploader(ChunkedRemoteSettingsUploader):
         `category_code`.
         """
         logger.info(f"Deleting records with type: {self.record_type}")
-        count = 0
-        for record in self.kinto.get_records():
-            record_details = record.get("record_custom_details", {})
-            cat_to_domains_details = record_details.get("category_to_domains", {})
-            if cat_to_domains_details.get("version") == self.version:
-                logger.info(f"Deleting record: {record['id']}")
-                if not self.dry_run:
-                    self.kinto.delete_record(id=record["id"])
-                    count += 1
+        deleted_records = self.uploader.delete_if(self._delete_if_predicate)
+        count = len(deleted_records)
         logger.info(f"Deleted {count} records")
 
-    def _upload_chunk(self, chunk: Chunk) -> None:
-        """Create a record and attachment for a chunk."""
-        # The record ID will be "{record_type}-{start}-{end}", where `start` and
-        # `end` are zero-padded based on the total suggestion count.
-        places = 0 if not self.total_item_count else len(str(self.total_item_count))
-        start = f"{chunk.start_index:0{places}}"
-        end = f"{chunk.start_index + chunk.size:0{places}}"
-        record_id = "-".join([self.category_name, start, end])
-        record = {
-            "id": record_id,
-            "type": self.record_type,
-            "record_custom_details": {
-                "category_to_domains": {
-                    "category": self.category_name.lower(),
-                    "category_code": self.category_code,
-                    "version": self.version,
-                }
-            },
-        }
-        attachment_json = json.dumps(chunk.to_json_serializable())
-
-        logger.info(f"Uploading record: {record}")
-        if not self.dry_run:
-            self.kinto.update_record(data=record)
-
-        logger.info(f"Uploading attachment json with {chunk.size} suggestions")
-        logger.debug(attachment_json)
-        if not self.dry_run:
-            self.kinto.session.request(
-                "post",
-                f"/buckets/{self.kinto.bucket_name}/collections/"
-                f"{self.kinto.collection_name}/records/{record_id}/attachment",
-                files={
-                    "attachment": (
-                        f"{record_id}.json",
-                        io.StringIO(attachment_json),
-                        "application/json",
-                    )
-                },
-            )
+    def _delete_if_predicate(self, record: dict[str, Any]) -> bool:
+        record_details = record.get("record_custom_details", {})
+        cat_to_domains_details = record_details.get("category_to_domains", {})
+        if cat_to_domains_details.get("version") == self.version:
+            logger.info(f"Deleting record: {record['id']}")
+            return True
+        return False

--- a/merino/jobs/utils/rs_uploader.py
+++ b/merino/jobs/utils/rs_uploader.py
@@ -1,0 +1,73 @@
+"""Remote settings uploader"""
+
+import json
+import logging
+import os
+from tempfile import TemporaryDirectory
+from typing import Any, Callable
+
+import kinto_http
+
+logger = logging.getLogger(__name__)
+
+
+class RemoteSettingsUploader:
+    """A class that uploads records and attachments to remote settings."""
+
+    kinto: kinto_http.Client
+
+    def __init__(
+        self,
+        auth: str,
+        bucket: str,
+        collection: str,
+        server: str,
+        dry_run: bool = False,
+    ):
+        """Initialize the uploader."""
+        self.kinto = kinto_http.Client(
+            server_url=server, bucket=bucket, collection=collection, auth=auth, dry_mode=dry_run
+        )
+
+    def upload(self, record: dict[str, Any], attachment: Any) -> None:
+        """Create or update a record and its attachment."""
+        record_id = record["id"]
+        logger.info(f"Uploading record: {record_id}")
+        logger.debug(json.dumps(record) + " ")
+
+        self.kinto.update_record(data=record)
+
+        attachment_json = json.dumps(attachment)
+        logger.debug(f"Uploading attachment: {record_id}")
+
+        # The logger apparently formats the message even when no args are
+        # passed, and if `attachment_json` is an object literal (as opposed to
+        # an array literal), the curly braces must confuse it because it ends up
+        # logging nothing at all. Adding a trailing space seems to prevent that.
+        logger.debug(attachment_json + " ")
+
+        # `kinto.add_attachment()` only takes a path to an actual file
+        # unfortunately, so create a temporary one.
+        with TemporaryDirectory() as tmp_dir_name:
+            path = os.path.join(tmp_dir_name, f"{record_id}.json")
+            with open(path, "w") as file:
+                file.write(attachment_json)
+            self.kinto.add_attachment(
+                id=record["id"],
+                filepath=path,
+                mimetype="application/json",
+            )
+
+    def delete_if(self, predicate: Callable[[dict[str, Any]], bool]) -> list[dict[str, Any]]:
+        """Delete records that match a predicate. The predicate function is
+        passed each record and should return True if it should be deleted. The
+        deleted records are returned.
+
+        """
+        deleted_records = []
+        for record in self.kinto.get_records():
+            if predicate(record):
+                deleted_records.append(record)
+                self.kinto.delete_record(id=record["id"])
+
+        return deleted_records

--- a/tests/unit/jobs/geonames_uploader/test_geonames_uploader.py
+++ b/tests/unit/jobs/geonames_uploader/test_geonames_uploader.py
@@ -165,8 +165,8 @@ def test_upload_multiple_countries(mocker):
     )
 
 
-def test_to_json_serializable():
-    """Test GeonamesChunk.to_json_serializable()"""
+def test_to_attachment():
+    """Test GeonamesChunk.to_attachment()"""
     chunk = GeonamesChunk(0)
     chunk.add_item(
         Geoname(
@@ -214,7 +214,7 @@ def test_to_json_serializable():
             alternates=[GeonameAlternate(3, long_name.lower())],
         )
     )
-    assert chunk.to_json_serializable() == {
+    assert chunk.to_attachment() == {
         "geonames": [
             {
                 "admin1_code": "AL",

--- a/tests/unit/jobs/utils/test_rs_uploader.py
+++ b/tests/unit/jobs/utils/test_rs_uploader.py
@@ -1,0 +1,306 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Unit tests for rs_uploader.py."""
+
+import json
+from typing import Any, Callable
+
+from requests_toolbelt.multipart.decoder import MultipartDecoder
+
+from merino.jobs.utils.rs_uploader import RemoteSettingsUploader
+
+TEST_UPLOADER_KWARGS: dict[str, Any] = {
+    "auth": "Bearer auth",
+    "bucket": "test-bucket",
+    "collection": "test-collection",
+    "dry_run": False,
+    "server": "http://localhost",
+}
+
+
+class Record:
+    """Encapsulates data for a remote settings record that should be created by
+    the uploader.
+    """
+
+    attachment: Any
+    attachment_url: str
+    data: dict[str, Any]
+    url: str
+
+    def __init__(
+        self,
+        data: dict[str, Any],
+        attachment: Any,
+        bucket: str = TEST_UPLOADER_KWARGS["bucket"],
+        collection: str = TEST_UPLOADER_KWARGS["collection"],
+        server: str = TEST_UPLOADER_KWARGS["server"],
+    ):
+        self.data = data
+        self.attachment = attachment
+        self.url = f"{server}/buckets/{bucket}/collections/{collection}/records/{self.id}"
+        self.attachment_url = f"{self.url}/attachment"
+
+    @property
+    def id(self) -> str:
+        """The record's ID."""
+        id: str = self.data["id"]
+        return id
+
+    @property
+    def expected_record_request(self) -> dict[str, Any]:
+        """A dict that describes the request that Kinto should receive when the
+        uploader uploads a record.
+        """
+        return {
+            "method": "PUT",
+            "url": self.url,
+            "data": self.data,
+        }
+
+    @property
+    def expected_attachment_request(self) -> dict[str, Any]:
+        """A dict that describes the request that Kinto should receive when the
+        uploader uploads an attachment.
+        """
+        return {
+            "method": "POST",
+            "url": self.attachment_url,
+            "attachment": self.attachment,
+            "headers": {
+                "Content-Disposition": f'form-data; name="attachment"; filename="{self.id}.json"',
+                "Content-Type": "application/json",
+            },
+        }
+
+    @property
+    def expected_delete_request(self) -> dict[str, Any]:
+        """A dict that describes the request that Kinto should receive when the
+        uploader deletes a record.
+        """
+        return {
+            "method": "DELETE",
+            "url": self.url,
+        }
+
+
+def check_request(actual, expected: dict[str, Any]) -> None:
+    """Assert an actual request matches an expected request."""
+    assert actual.url == expected["url"]
+    assert actual.method == expected["method"]
+    if "data" in expected:
+        assert json.loads(actual.text) == {"data": expected["data"]}
+    if "attachment" in expected:
+        boundary = actual.text.split("\r\n")[0]
+        mime = f'multipart/form-data; boundary="{boundary[2:]}"'
+        decoder = MultipartDecoder(actual.body, mime)
+        attachment = decoder.parts[0]
+        assert json.loads(attachment.text) == expected["attachment"]
+        if "headers" in expected:
+            actual_headers = {
+                name.decode(attachment.encoding): value.decode(attachment.encoding)
+                for name, value in attachment.headers.items()
+            }
+            assert actual_headers == expected["headers"]
+
+
+def check_upload_requests(actual_requests: list, records: list[Record]) -> None:
+    """Assert a list of actual requests matches expected upload requests for
+    some records. Each record should correspond to two requests, one for
+    uploading the record and one for uploading the attachment.
+
+    """
+    assert len(actual_requests) == 2 * len(records)
+    for r in records:
+        check_request(actual_requests.pop(0), r.expected_record_request)
+        check_request(actual_requests.pop(0), r.expected_attachment_request)
+
+
+def check_delete_requests(actual_requests: list, records: list[Record]) -> None:
+    """Assert a list of actual requests matches expected delete requests for
+    some records.
+
+    """
+    delete_requests = [r for r in actual_requests if r.method == "DELETE"]
+    assert len(delete_requests) == len(records)
+    for r in records:
+        check_request(delete_requests.pop(0), r.expected_delete_request)
+
+
+def do_upload_test(
+    requests_mock,
+    records: list[Record],
+    expected_records: list[Record] | None = None,
+    uploader_kwargs: dict[str, Any] = {},
+) -> None:
+    """Perform an upload test."""
+    for record in records:
+        requests_mock.put(record.url, json={})  # nosec
+        requests_mock.post(record.attachment_url, json={})  # nosec
+
+    uploader = RemoteSettingsUploader(**(TEST_UPLOADER_KWARGS | uploader_kwargs))
+    for record in records:
+        uploader.upload(record=record.data, attachment=record.attachment)
+
+    expected_records = expected_records if expected_records is not None else records
+    check_upload_requests(requests_mock.request_history, expected_records)
+
+
+def do_delete_if_test(
+    requests_mock,
+    predicate: Callable[[dict[str, Any]], bool],
+    expected_deleted_records: list[Record],
+    uploader_kwargs: dict[str, Any] = {},
+) -> None:
+    """Perform a delete_if test."""
+    records = [
+        Record(
+            data={"id": "test-0"},
+            attachment=["test-0-aaa", "test-0-bbb"],
+        ),
+        Record(
+            data={"id": "test-1", "type": "test-type-aaa"},
+            attachment=["test-1-aaa", "test-1-bbb"],
+        ),
+        Record(
+            data={"id": "test-2", "type": "test-type-bbb"},
+            attachment=["test-2-aaa", "test-2-bbb"],
+        ),
+        Record(
+            data={"id": "test-3", "type": "test-type-aaa"},
+            attachment=["test-3-aaa", "test-3-bbb"],
+        ),
+    ]
+
+    records_url = "/".join(
+        [
+            TEST_UPLOADER_KWARGS["server"],
+            "buckets",
+            TEST_UPLOADER_KWARGS["bucket"],
+            "collections",
+            TEST_UPLOADER_KWARGS["collection"],
+            "records",
+        ]
+    )
+    requests_mock.get(
+        records_url,
+        json={
+            "data": [r.data for r in records],
+        },
+    )
+
+    for record in records:
+        requests_mock.put(record.url, json={})  # nosec
+        requests_mock.post(record.attachment_url, json={})  # nosec
+        requests_mock.delete(record.url, json={"data": [{"deleted": True, "id": record.id}]})
+
+    uploader = RemoteSettingsUploader(**(TEST_UPLOADER_KWARGS | uploader_kwargs))
+    deleted_records = uploader.delete_if(predicate)
+    assert deleted_records == [r.data for r in expected_deleted_records]
+
+    check_delete_requests(requests_mock.request_history, expected_deleted_records)
+
+
+def test_upload(requests_mock):
+    """Basic upload test"""
+    do_upload_test(
+        requests_mock,
+        records=[
+            Record(
+                data={"id": "test-0"},
+                attachment={"foo": "bar"},
+            ),
+            Record(
+                data={"id": "test-1", "type": "test-type"},
+                attachment={"foo": "bar", "list": ["a", "b", "c"]},
+            ),
+        ],
+    )
+
+
+def test_upload_dry_run(requests_mock):
+    """An upload dry run shouldn't make any requests"""
+    do_upload_test(
+        requests_mock,
+        uploader_kwargs={
+            "dry_run": True,
+        },
+        records=[
+            Record(
+                data={"id": "test-0"},
+                attachment={"foo": "bar"},
+            ),
+            Record(
+                data={"id": "test-1", "type": "test-type"},
+                attachment={"foo": "bar", "list": ["a", "b", "c"]},
+            ),
+        ],
+        expected_records=[],
+    )
+
+
+def test_delete_if_none(requests_mock):
+    """Tests a delete_if that doesn't delete any records"""
+    do_delete_if_test(
+        requests_mock,
+        predicate=lambda r: False,
+        expected_deleted_records=[],
+    )
+
+
+def test_delete_if_some(requests_mock):
+    """Tests a delete_if that deletes some records"""
+    do_delete_if_test(
+        requests_mock,
+        predicate=lambda r: r.get("type") == "test-type-aaa",
+        expected_deleted_records=[
+            Record(
+                data={"id": "test-1", "type": "test-type-aaa"},
+                attachment=["test-1-aaa", "test-1-bbb"],
+            ),
+            Record(
+                data={"id": "test-3", "type": "test-type-aaa"},
+                attachment=["test-3-aaa", "test-3-bbb"],
+            ),
+        ],
+    )
+
+
+def test_delete_if_all(requests_mock):
+    """Tests a delete_if that deletes all records"""
+    do_delete_if_test(
+        requests_mock,
+        predicate=lambda r: True,
+        expected_deleted_records=[
+            Record(
+                data={"id": "test-0"},
+                attachment=["test-0-aaa", "test-0-bbb"],
+            ),
+            Record(
+                data={"id": "test-1", "type": "test-type-aaa"},
+                attachment=["test-1-aaa", "test-1-bbb"],
+            ),
+            Record(
+                data={"id": "test-2", "type": "test-type-bbb"},
+                attachment=["test-2-aaa", "test-2-bbb"],
+            ),
+            Record(
+                data={"id": "test-3", "type": "test-type-aaa"},
+                attachment=["test-3-aaa", "test-3-bbb"],
+            ),
+        ],
+    )
+
+
+def test_delete_if_dry_run(requests_mock):
+    """A delete_if dry run shouldn't make any requests"""
+    do_delete_if_test(
+        requests_mock,
+        uploader_kwargs={
+            "dry_run": True,
+        },
+        predicate=lambda r: True,
+        expected_deleted_records=[],
+    )


### PR DESCRIPTION
The main thing this does is factor out the core Kinto calls from `ChunkedRemoteSettingsUploader` into a new `RemoteSettingsUploader` class. For the geonames uploader changes I'm working on, I'm planning on not using chunking and instead just making one record per country.

Other changes:

Remove the staged-changes mechanism from `ChunkedRemoteSettingsUploader` and just upload/delete directly. It doesn't seem necessary?

Pass `dry_mode` to the Kinto API instead of managing that ourselves.

Use the Kinto `add_attachment()` API instead of making our own POST request.

Simplify `ChunkedRemoteSettingsRelevancyUploader` by subclassing `Chunk`.

Add some API to `Chunk` to make subclassing easier.

## References

https://mozilla-hub.atlassian.net/browse/SNG-2523

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1720)
