### PR TITLE
[DISCO-3482] Fix failing wiki job - first run

### DIFF
--- a/merino/jobs/wikipedia_indexer/settings/v1.py
+++ b/merino/jobs/wikipedia_indexer/settings/v1.py
@@ -184,7 +184,7 @@ EN_INDEX_SETTINGS: dict = {
             "accentfolding": {"type": "icu_folding"},
         },
         "analyzer": {
-            "stop_analyzer": {
+            "stop_analyzer_en": {
                 "filter": [
                     "icu_normalizer",
                     "stop_filter",
@@ -195,19 +195,19 @@ EN_INDEX_SETTINGS: dict = {
                 "type": "custom",
                 "tokenizer": "standard",
             },
-            "plain_search": {
+            "plain_search_en": {
                 "filter": ["remove_empty", "token_limit", "lowercase"],
                 "char_filter": ["word_break_helper"],
                 "type": "custom",
                 "tokenizer": "whitespace",
             },
-            "plain": {
+            "plain_en": {
                 "filter": ["remove_empty", "token_limit", "lowercase"],
                 "char_filter": ["word_break_helper"],
                 "type": "custom",
                 "tokenizer": "whitespace",
             },
-            "stop_analyzer_search": {
+            "stop_analyzer_search_en": {
                 "filter": [
                     "icu_normalizer",
                     "accentfolding",

--- a/tests/unit/jobs/wikipedia_indexer/test_filemanager.py
+++ b/tests/unit/jobs/wikipedia_indexer/test_filemanager.py
@@ -246,6 +246,37 @@ def test_stream_latest_dump_when_gcs_empty(mock_get_latest_gcs, mock_get_latest_
     assert returned_blob.name == "BlobMock"
 
 
+@patch("merino.jobs.wikipedia_indexer.filemanager.requests.get")
+@patch("merino.jobs.wikipedia_indexer.filemanager.Client")
+def test_get_latest_dump_when_gcs_is_none(mock_storage_client, mock_requests_get):
+    """Returns remote dump URL on first run when no GCS file exists."""
+    html = """
+    <html>
+      <body>
+        <a href="dewiki-20250512-cirrussearch-content.json.gz">dewiki-20250512-cirrussearch-content.json.gz</a>
+      </body>
+    </html>
+    """
+    mock_response = MagicMock()
+    mock_response.content = html
+    mock_requests_get.return_value = mock_response
+
+    mock_client_instance = MagicMock()
+    mock_storage_client.return_value = mock_client_instance
+
+    # --- FileManager setup
+    fm = FileManager(
+        gcs_bucket="gcs-bucket",
+        gcs_project="gcs-project",
+        export_base_url="http://mock-url/",
+        language="de",
+    )
+
+    result = fm.get_latest_dump(latest_gcs=None)
+
+    assert result == "http://mock-url/dewiki-20250512-cirrussearch-content.json.gz"
+
+
 def test_parse_date_returns_correct_datetime():
     """Parses and returns the correct datetime from a valid filename."""
     mock_client = MagicMock()


### PR DESCRIPTION
## References

JIRA: [DISCO-3482](https://mozilla-hub.atlassian.net/browse/DISCO-3482)

## Description
- This PR updates the `stream_latest_dump_to_gcs()` method to handle the scenario where the target file in the GCS bucket initially doesn't exist (i.e., no Wikipedia dump files are present yet). Previously, the method would raise a `RuntimeError` when no matching dump file was found in GCS, causing the first run of the `copy_export` job to fail.

- This Pr also updates the english index. The `en` suffix was missing from the english analyzers causing a mismatch with the mapping. 



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3482]: https://mozilla-hub.atlassian.net/browse/DISCO-3482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1723)
