### PR TITLE
GENAI-1208 fix - section TS with region 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,6 +157,7 @@ workspace/
 # VS Code configuration files
 .vscode/*
 !.vscode/launch.json
+.vscode/
 
 # Emacs autosave files
 *~

--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -139,6 +139,7 @@ class CuratedRecommendationsProvider:
                 engagement_backend=self.engagement_backend,
                 prior_backend=self.prior_backend,
                 sections_backend=self.sections_backend,
+                region=derive_region(request.locale, request.region),
             )
         else:
             general_feed = self.rank_recommendations(recommendations, request)


### PR DESCRIPTION
GENAI-1208 fix - section TS with region in args

## References

JIRA: [GENAI-1208](https://mozilla-hub.atlassian.net/browse/GENAI-1208)

## Description
While analyzing the below experiment result we noticed that the treatment arm had lower CTR and the reason was due to the top section was getting different set of items as region was missed in the section ranker. 

This is to fix that behavior
Added test for region presence in args

How to test this 
```
COVERAGE_FILE="workspace/test-results"/.coverage.integration \                                                                     
MERINO_ENV=testing \
/Users/cgopal/.local/bin/uv run pytest \
  tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py \
  -k test_sections_pass_region_to_engagement_backend \
  --junit-xml="workspace/test-results"/sections_region__results.xml \
  -s
```


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[GENAI-1208]: https://mozilla-hub.atlassian.net/browse/GENAI-1208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1727)
