### PR TITLE
[HNT-606] greedy ranking from inferred section interests

### DIFF
--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -137,6 +137,7 @@ class CuratedRecommendationsProvider:
                 request,
                 surface_id,
                 engagement_backend=self.engagement_backend,
+                personal_interests=request.inferredInterests,
                 prior_backend=self.prior_backend,
                 sections_backend=self.sections_backend,
                 region=derive_region(request.locale, request.region),

--- a/merino/curated_recommendations/rankers.py
+++ b/merino/curated_recommendations/rankers.py
@@ -169,16 +169,20 @@ def greedy_personalized_section_rank(
 
     ## order of personal preferences
     ptopics = [k for k, v in personal_interests.root.items() if isinstance(v, float)]
-    ordered_preferences = sorted(ptopics, key=lambda x: personal_interests.root[x])
+    ordered_preferences = sorted(ptopics, key=lambda x: personal_interests.root[x], reverse=True)
 
-    ## swap in preferences with probability 1-epsililon, lowest prefered score gets inserted first
-    for section_id in ordered_preferences:
-        if section_id in ordered_sections and np.random.choice([0, 1], p=[epsilon, 1 - epsilon]):
-            ordered_sections.remove(section_id)
-            ordered_sections.insert(0, section_id)
+    # decide once for each pref whether it “wins” (prob. 1-epsilon)
+    chosen = [
+        sec
+        for sec in ordered_preferences
+        if sec in ordered_sections and np.random.choice([0, 1], p=[epsilon, 1 - epsilon])
+    ]
 
-    ## reorder the sections according to the new ranking
-    ordered = [(sec, sections[sec]) for sec in ordered_sections if sec in sections]
+    # append the rest in original order
+    rest = [sec for sec in ordered_sections if sec not in chosen]
+
+    # reorder the sections according to the new ranking
+    ordered = [(sec, sections[sec]) for sec in chosen + rest]
     return renumber_sections(ordered)
 
 

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -34,6 +34,7 @@ from merino.curated_recommendations.legacy.protocol import (
     CuratedRecommendationsLegacyFx114Response,
 )
 from merino.middleware import ScopeKey
+from merino.middleware.user_agent import UserAgent
 from merino.providers.suggest import get_providers as get_suggest_providers
 from merino.providers.manifest import get_provider as get_manifest_provider
 from merino.providers.suggest.base import BaseProvider, SuggestionRequest
@@ -185,6 +186,7 @@ async def suggest(
     # enabled for this request by calling feature_flags.is_enabled("example").
     # feature_flags: FeatureFlags = request.scope[ScopeKey.FEATURE_FLAGS]
     metrics_client: Client = request.scope[ScopeKey.METRICS_CLIENT]
+    user_agent: UserAgent = request.scope[ScopeKey.USER_AGENT]
 
     active_providers, default_providers = sources
     if providers is not None:
@@ -211,6 +213,7 @@ async def suggest(
             geolocation=geolocation,
             request_type=request_type,
             languages=languages,
+            user_agent=user_agent,
         )
         p.validate(srequest)
         task = metrics_client.timeit_task(p.query(srequest), f"providers.{p.name}.query")
@@ -325,7 +328,6 @@ async def curated_content(
     - `count`: [Optional] The maximum number of recommendations to return. Defaults to 100.
     - `topics`: [Optional] A list of preferred [topics][curated-topics-doc].
     - `feeds`: [Optional] A list of sections.
-    - 'inferredInterests': [Optional] A dictionary defining user topic interests.
     - `experimentName`: [Optional] The Nimbus New Tab experiment name that the user is enrolled in.
         When an experiment _only_ requires backend changes, this allows us to run the experiments
         without waiting on the Firefox release cycle. When an experiment _does_ require changes in

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -328,7 +328,7 @@ async def curated_content(
     - `count`: [Optional] The maximum number of recommendations to return. Defaults to 100.
     - `topics`: [Optional] A list of preferred [topics][curated-topics-doc].
     - `feeds`: [Optional] A list of sections.
-    - inferredInterests: [Optional] A dictionary of topics with relative interest values.
+    - `inferredInterests`: [Optional] A dictionary of topics with relative interest values.
     - `experimentName`: [Optional] The Nimbus New Tab experiment name that the user is enrolled in.
         When an experiment _only_ requires backend changes, this allows us to run the experiments
         without waiting on the Firefox release cycle. When an experiment _does_ require changes in

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -34,7 +34,6 @@ from merino.curated_recommendations.legacy.protocol import (
     CuratedRecommendationsLegacyFx114Response,
 )
 from merino.middleware import ScopeKey
-from merino.middleware.user_agent import UserAgent
 from merino.providers.suggest import get_providers as get_suggest_providers
 from merino.providers.manifest import get_provider as get_manifest_provider
 from merino.providers.suggest.base import BaseProvider, SuggestionRequest
@@ -186,7 +185,6 @@ async def suggest(
     # enabled for this request by calling feature_flags.is_enabled("example").
     # feature_flags: FeatureFlags = request.scope[ScopeKey.FEATURE_FLAGS]
     metrics_client: Client = request.scope[ScopeKey.METRICS_CLIENT]
-    user_agent: UserAgent = request.scope[ScopeKey.USER_AGENT]
 
     active_providers, default_providers = sources
     if providers is not None:
@@ -213,7 +211,6 @@ async def suggest(
             geolocation=geolocation,
             request_type=request_type,
             languages=languages,
-            user_agent=user_agent,
         )
         p.validate(srequest)
         task = metrics_client.timeit_task(p.query(srequest), f"providers.{p.name}.query")
@@ -328,6 +325,7 @@ async def curated_content(
     - `count`: [Optional] The maximum number of recommendations to return. Defaults to 100.
     - `topics`: [Optional] A list of preferred [topics][curated-topics-doc].
     - `feeds`: [Optional] A list of sections.
+    - 'inferredInterests': [Optional] A dictionary defining user topic interests.
     - `experimentName`: [Optional] The Nimbus New Tab experiment name that the user is enrolled in.
         When an experiment _only_ requires backend changes, this allows us to run the experiments
         without waiting on the Firefox release cycle. When an experiment _does_ require changes in

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -328,6 +328,7 @@ async def curated_content(
     - `count`: [Optional] The maximum number of recommendations to return. Defaults to 100.
     - `topics`: [Optional] A list of preferred [topics][curated-topics-doc].
     - `feeds`: [Optional] A list of sections.
+    - inferredInterests: [Optional] A dictionary of topics with relative interest values.
     - `experimentName`: [Optional] The Nimbus New Tab experiment name that the user is enrolled in.
         When an experiment _only_ requires backend changes, this allows us to run the experiments
         without waiting on the Firefox release cycle. When an experiment _does_ require changes in

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -1704,17 +1704,17 @@ class TestSections:
             else:
                 assert local_model is None
 
-    @pytest.mark.asyncio    
+    @pytest.mark.asyncio
     async def test_sections_model_interest_vector_greedy_ranking(self, monkeypatch):
         """Test the curated recommendations endpoint ranks sections accorcding to inferredInterests"""
         # define interest vector
         interests = {
             "arts": 1.0,
-            "food": .8,
-            "government": .7,
-            "society": .00001,
-            "model_id": "fake_model_id"
-            }
+            "food": 0.8,
+            "government": 0.7,
+            "society": 0.00001,
+            "model_id": "fake_model_id",
+        }
         # make the api call
         async with AsyncClient(app=app, base_url="http://test") as ac:
             response = await ac.post(
@@ -1723,20 +1723,19 @@ class TestSections:
                     "locale": Locale.EN_US,
                     "feeds": ["sections"],
                     "inferredInterests": interests,
-                        },
+                },
             )
             data = response.json()
             # expect intests to be sorted by value
-            sorted_interests = sorted([k for k,v in interests.items()
-                                       if isinstance(v,float)],
-                                       key=interests.get)[::-1]
+            sorted_interests = sorted(
+                [k for k, v in interests.items() if isinstance(v, float)], key=interests.get
+            )[::-1]
             # expect top stories to be first
-            sorted_interests.insert(0,'top_stories_section')
+            sorted_interests.insert(0, "top_stories_section")
             # order is in receivedFeedRank
-            for i,sec in enumerate(sorted_interests):
-                assert data['feeds'][sec]['receivedFeedRank']==i
+            for i, sec in enumerate(sorted_interests):
+                assert data["feeds"][sec]["receivedFeedRank"] == i
 
-            
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "repeat",

--- a/tests/unit/curated_recommendations/test_rankers.py
+++ b/tests/unit/curated_recommendations/test_rankers.py
@@ -684,3 +684,17 @@ class TestGreedyPersonalizedSectionRanker:
         # the ranking should not have changed
         for sec in reranked_sections:
             assert reranked_sections[sec].receivedFeedRank == original_ranking[sec]
+
+    def test_fictional_interests(self):
+        """Interest vector keys that are not sections should not appear in section ranking"""
+        # get example section feed
+        sections = generate_sections_feed(section_count=16)
+        # inferredinterests is empty
+        bogus = "asflkjdfoij"
+        personal_interests = InferredInterests({bogus: 1.0})
+        # rerank the sections
+        reranked_sections = greedy_personalized_section_rank(
+            sections=sections, personal_interests=personal_interests, epsilon=0.0
+        )
+        # the sections should not include bogus
+        assert bogus not in reranked_sections

--- a/tests/unit/curated_recommendations/test_rankers.py
+++ b/tests/unit/curated_recommendations/test_rankers.py
@@ -649,13 +649,25 @@ class TestGreedyPersonalizedSectionRanker:
         sec_titles = [sec for sec in sections]
         personal_sections = [sec_titles[i] for i in [4, 10, 13, 15]]
         personal_interests = InferredInterests({k: i for i, k in enumerate(personal_sections)})
+        # store original order of sections not in inferredInterests
+        original_order = sorted(sections, key=lambda x: sections[x].receivedFeedRank)
+        original_order = [k for k in original_order if k not in personal_sections]
         # rerank the sections
         reranked_sections = greedy_personalized_section_rank(
             sections=sections, personal_interests=personal_interests, epsilon=0.0
         )
+        print("original order", original_order)
+        print("personal_sections", personal_sections)
+        print(
+            "new order",
+            sorted(reranked_sections, key=lambda x: reranked_sections[x].receivedFeedRank),
+        )
         # personal_interests should be at the top of reranked_sections, reversed
         for i, s in enumerate(personal_sections[::-1]):
             assert i == reranked_sections[s].receivedFeedRank
+        # original order should be preserved
+        for i, s in enumerate(original_order):
+            assert i + len(personal_sections) == reranked_sections[s].receivedFeedRank
 
     def test_empty_interests(self):
         """Empty inferredinterests should not affect the section ranking"""

--- a/tests/unit/curated_recommendations/test_rankers.py
+++ b/tests/unit/curated_recommendations/test_rankers.py
@@ -16,6 +16,7 @@ from merino.curated_recommendations.protocol import (
     MIN_TILE_ID,
     Section,
     SectionConfiguration,
+    InferredInterests,
 )
 from merino.curated_recommendations.rankers import (
     spread_publishers,
@@ -24,6 +25,7 @@ from merino.curated_recommendations.rankers import (
     is_section_recently_followed,
     renumber_recommendations,
     put_top_stories_first,
+    greedy_personalized_section_rank,
 )
 from tests.unit.curated_recommendations.fixtures import (
     generate_recommendations,
@@ -634,3 +636,39 @@ class TestPutTopStoriesFirst:
         # Should simply return the same dict
         updated = put_top_stories_first(feed)
         assert updated is feed
+
+
+class TestGreedyPersonalizedSectionRanker:
+    """Tests greedy use of inferred section ranker"""
+
+    def test_expected_ranking(self):
+        """Tests putting sections from inferred interests first"""
+        # get example section feed
+        sections = generate_sections_feed(section_count=16)
+        # extract titles and build InferredInterests
+        sec_titles = [sec for sec in sections]
+        personal_sections = [sec_titles[i] for i in [4, 10, 13, 15]]
+        personal_interests = InferredInterests({k: i for i, k in enumerate(personal_sections)})
+        # rerank the sections
+        reranked_sections = greedy_personalized_section_rank(
+            sections=sections, personal_interests=personal_interests, epsilon=0.0
+        )
+        # personal_interests should be at the top of reranked_sections, reversed
+        for i, s in enumerate(personal_sections[::-1]):
+            assert i == reranked_sections[s].receivedFeedRank
+
+    def test_empty_interests(self):
+        """Empty inferredinterests should not affect the section ranking"""
+        # get example section feed
+        sections = generate_sections_feed(section_count=16)
+        # store the original ranking
+        original_ranking = {sec: sections[sec].receivedFeedRank for sec in sections}
+        # inferredinterests is empty
+        personal_interests = InferredInterests({})
+        # rerank the sections
+        reranked_sections = greedy_personalized_section_rank(
+            sections=sections, personal_interests=personal_interests, epsilon=0.0
+        )
+        # the ranking should not have changed
+        for sec in reranked_sections:
+            assert reranked_sections[sec].receivedFeedRank == original_ranking[sec]


### PR DESCRIPTION
## References

JIRA: [HNT-606](https://mozilla-hub.atlassian.net/browse/DISCO-606)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [skip ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[HNT-606]: https://mozilla-hub.atlassian.net/browse/HNT-606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1730)


-----------------------------------------------------------------------------------------------------------------
Here is a curl for local testing

curl --location 'http://localhost:8000/api/v1/curated-recommendations' --header 'Content-Type: application/json' --data '{
    "locale": "en-US", "feeds": ["sections"], "inferredInterests": {
  "arts": 1,
  "finance": 0.6666666666666666,
  "food": 0.3333333333333333,
  "government": 0.3333333333333333,
  "society": 0.6666666666666666,
  "model_id": "fake_model_id"
} }'