### PR TITLE
DISCO-3541 - Add custom favicons to icon fetching

### DIFF
--- a/merino/jobs/navigational_suggestions/custom_favicons.py
+++ b/merino/jobs/navigational_suggestions/custom_favicons.py
@@ -1,0 +1,24 @@
+"""Custom favicon URLs for domains that block scrapers or have unreliable favicon detection"""
+
+# Mapping of domain names to their direct favicon URLs
+CUSTOM_FAVICONS: dict[str, str] = {
+    "axios.com": "https://static.axios.com/icons/favicon.svg",
+    "ign.com": "https://kraken.ignimgs.com/favicon.ico",
+    "infobae.com": "https://www.infobae.com/pf/resources/favicon/favicon-32x32.png?d=3209",
+    "reuters.com": "https://www.reuters.com/pf/resources/images/reuters/favicon/tr_kinesis_v2.svg?d=287",
+    "si.com": "https://images2.minutemediacdn.com/image/upload/v1713365891/shape/cover/sport/SI-f87ae31620c381274a85426b5c4f1341.ico",
+    "yahoo.com": "https://s.yimg.com/rz/l/favicon.ico",
+    "espn.com": "https://a.espncdn.com/favicon.ico",
+}
+
+
+def get_custom_favicon_url(domain: str) -> str:
+    """Get the custom favicon URL for a given domain.
+
+    Args:
+        domain: The domain name to look up
+
+    Returns:
+        The custom favicon URL if found, empty string otherwise
+    """
+    return CUSTOM_FAVICONS.get(domain, "")

--- a/tests/integration/jobs/navigational_suggestions/test_local_mode.py
+++ b/tests/integration/jobs/navigational_suggestions/test_local_mode.py
@@ -146,3 +146,152 @@ def test_local_domain_data_provider():
     assert "categories" in domain_data
     assert "source" in domain_data
     assert domain_data["categories"] == ["Local_Testing"]
+
+
+class TestLocalModeCustomFavicons:
+    """Test custom favicon tracking in local mode"""
+
+    def test_local_metrics_collector_with_custom_favicon_tracking(self, temp_dir):
+        """Test LocalMetricsCollector tracks custom favicon usage"""
+        collector = LocalMetricsCollector(temp_dir)
+
+        # Test result that used custom favicon
+        custom_favicon_result = {
+            "url": "https://axios.com",
+            "title": "Axios",
+            "icon": "https://cdn.example.com/axios_favicon.svg",
+            "domain": "axios",
+        }
+        collector.record_domain_result("axios.com", custom_favicon_result, used_custom=True)
+
+        # Test result that used scraped favicon
+        scraped_favicon_result = {
+            "url": "https://example.com",
+            "title": "Example",
+            "icon": "https://cdn.example.com/example_favicon.ico",
+            "domain": "example",
+        }
+        collector.record_domain_result("example.com", scraped_favicon_result, used_custom=False)
+
+        # Test failed result
+        failed_result = {"url": None, "title": None, "icon": None, "domain": None}
+        collector.record_domain_result("failed.com", failed_result, used_custom=False)
+
+        # Verify counts
+        assert collector.domains_processed == 3
+        assert collector.favicons_found == 2
+        assert collector.custom_favicons_used == 1
+        assert collector.scraped_favicons_used == 1
+
+        # Verify domain records include custom favicon tracking
+        assert len(collector.domain_records) == 3
+        assert collector.domain_records[0]["used_custom_favicon"] is True
+        assert collector.domain_records[1]["used_custom_favicon"] is False
+        assert collector.domain_records[2]["used_custom_favicon"] is False
+
+    @freeze_time("2023-01-01 12:00:00")
+    def test_local_metrics_collector_custom_favicon_report(self, temp_dir):
+        """Test that custom favicon metrics are included in the saved report"""
+        collector = LocalMetricsCollector(temp_dir)
+
+        # Add mixed results
+        custom_result = {
+            "url": "https://axios.com",
+            "title": "Axios",
+            "icon": "https://cdn.example.com/axios.svg",
+            "domain": "axios",
+        }
+        scraped_result = {
+            "url": "https://example.com",
+            "title": "Example",
+            "icon": "https://cdn.example.com/example.ico",
+            "domain": "example",
+        }
+
+        collector.record_domain_result("axios.com", custom_result, used_custom=True)
+        collector.record_domain_result("example.com", scraped_result, used_custom=False)
+
+        # Save report
+        collector.save_report()
+
+        # Check file content includes custom favicon metrics
+        output_files = list(Path(temp_dir).glob("metrics_*.json"))
+        with open(output_files[0], "r") as f:
+            report = json.load(f)
+
+        assert report["custom_favicons_used"] == 1
+        assert report["scraped_favicons_used"] == 1
+        assert report["custom_favicon_rate"] == 0.5  # 1 custom out of 2 total favicons
+
+    def test_local_domain_data_provider_with_custom_favicon_domains(self):
+        """Test that LocalDomainDataProvider can include domains with custom favicons"""
+        # Create test domains that include some with custom favicons
+        test_domains = [
+            "axios.com",  # Has custom favicon
+            "reuters.com",  # Has custom favicon
+            "example.com",  # No custom favicon
+            "test.com",  # No custom favicon
+        ]
+
+        provider = LocalDomainDataProvider(test_domains, 4)
+        data = provider.get_domain_data()
+
+        assert len(data) == 4
+
+        # Verify all domains are included
+        domain_names = [d["domain"] for d in data]
+        assert "axios.com" in domain_names
+        assert "reuters.com" in domain_names
+        assert "example.com" in domain_names
+        assert "test.com" in domain_names
+
+        # Verify structure is correct for all domains
+        for domain_data in data:
+            assert "rank" in domain_data
+            assert "domain" in domain_data
+            assert "source" in domain_data
+            assert domain_data["source"] == "local-test"
+
+    def test_local_metrics_progress_logging_with_custom_favicons(self, temp_dir, caplog):
+        """Test that progress logging includes custom favicon success rate"""
+        import logging
+
+        caplog.set_level(logging.INFO)
+
+        collector = LocalMetricsCollector(temp_dir)
+
+        # Add 10 domains with mix of custom and scraped favicons
+        for i in range(10):
+            if i < 3:  # First 3 use custom favicons
+                result = {
+                    "url": f"https://custom{i}.com",
+                    "title": f"Custom {i}",
+                    "icon": f"https://cdn.example.com/custom{i}.svg",
+                    "domain": f"custom{i}",
+                }
+                collector.record_domain_result(f"custom{i}.com", result, used_custom=True)
+            elif i < 7:  # Next 4 use scraped favicons
+                result = {
+                    "url": f"https://scraped{i}.com",
+                    "title": f"Scraped {i}",
+                    "icon": f"https://cdn.example.com/scraped{i}.ico",
+                    "domain": f"scraped{i}",
+                }
+                collector.record_domain_result(f"scraped{i}.com", result, used_custom=False)
+            else:  # Last 3 fail to get favicons
+                result = {"url": None, "title": None, "icon": None, "domain": None}
+                collector.record_domain_result(f"failed{i}.com", result, used_custom=False)
+
+        # Check that progress logging includes custom favicon rate
+        # The progress logging happens every 10 domains, so it should trigger
+        progress_logs = [
+            record.message for record in caplog.records if "Progress:" in record.message
+        ]
+
+        if progress_logs:
+            # Should include success rate and custom favicon rate
+            latest_log = progress_logs[-1]
+            assert "Success rate:" in latest_log
+            assert (
+                "Custom:" in latest_log or "70.0%" in latest_log
+            )  # 3 custom out of 7 successful favicons


### PR DESCRIPTION
## References

JIRA: [DISCO-3541](https://mozilla-hub.atlassian.net/browse/DISCO-3541)

## Description
Some domains block us from fetching favicons, and sometimes the Navigational Suggestion job doesn't provide the "right" favicon. 

We can certainly improve the job in the long term. But in the short term, we have the option to add hardcoded locations (URLs) for a domain. We prefer fetching from this hardcoded url rather than the one the Navigational Suggestions finds in the HTML.

For this to work, the domain also has to be in the `custom_domains.py` list. Reasons are two-fold:

- Every domain we want to fetch should be there (or in the BigQuery table)
- The custom favicon is just to tell the job, when the domain comes along, we already have a location for the favicon, so no reason to scrape the HTML.

The complexity would be much higher to:
- Maintain two sources (custom_domains and custom_favicons) for possible domains
- The business logic would increase even further


Therefore this "simple" solution.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3541]: https://mozilla-hub.atlassian.net/browse/DISCO-3541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1732)
