### PR TITLE
DISCO-3543: Make upload_favicons async

### DIFF
--- a/merino/jobs/navigational_suggestions/__init__.py
+++ b/merino/jobs/navigational_suggestions/__init__.py
@@ -178,7 +178,7 @@ def _write_xcom_file(xcom_data: dict):
         json.dump(xcom_data, file)
 
 
-def _run_local_mode(
+async def _run_local_mode(
     local_sample_size: int, local_data_dir: str, min_favicon_width: int, enable_monitoring: bool
 ) -> None:
     """Run navigational suggestions in local mode"""
@@ -333,7 +333,7 @@ def _run_local_mode(
 
     # 5. Process partner favicons
     partner_favicons = [item["icon"] for item in PARTNER_FAVICONS]
-    uploaded_partner_favicons = domain_metadata_uploader.upload_favicons(partner_favicons)
+    uploaded_partner_favicons = await domain_metadata_uploader.upload_favicons(partner_favicons)
     logger.info("Partner favicons uploaded to GCS")
 
     # 6. Construct top picks content
@@ -396,7 +396,7 @@ def _run_local_mode(
     logger.info("=" * 40)
 
 
-def _run_normal_mode(
+async def _run_normal_mode(
     source_gcp_project: str,
     destination_gcp_project: str,
     destination_gcs_bucket: str,
@@ -437,7 +437,7 @@ def _run_normal_mode(
 
     # Process partner favicons
     partner_favicons = [item["icon"] for item in PARTNER_FAVICONS]
-    uploaded_partner_favicons = domain_metadata_uploader.upload_favicons(partner_favicons)
+    uploaded_partner_favicons = await domain_metadata_uploader.upload_favicons(partner_favicons)
     logger.info("partner favicons uploaded to GCS")
 
     # construct top pick contents. The `domain_metadata` already has the uploaded favicon URL in it
@@ -485,7 +485,7 @@ def _run_normal_mode(
 
 
 @navigational_suggestions_cmd.command()
-def prepare_domain_metadata(
+async def prepare_domain_metadata(
     source_gcp_project: str = source_gcp_project_option,
     destination_gcp_project: str = destination_gcp_project_option,
     destination_gcs_bucket: str = destination_gcs_bucket_option,
@@ -516,12 +516,12 @@ def prepare_domain_metadata(
         # Local mode for development and testing
         # This mode uses fake-gcs-server and custom domains
         # instead of connecting to Google Cloud
-        _run_local_mode(sample_size, data_dir, min_width, enable_monitoring)
+        await _run_local_mode(sample_size, data_dir, min_width, enable_monitoring)
     else:
         # Normal mode used in production
         # This connects to Google Cloud and processes custom_domains
         # AND domains from BigQuery
-        _run_normal_mode(
+        await _run_normal_mode(
             src_project,
             dst_project,
             dst_bucket,

--- a/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
+++ b/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
@@ -635,7 +635,7 @@ class DomainMetadataExtractor:
         custom_favicon_url = get_custom_favicon_url(normalized_domain)
         if custom_favicon_url:
             try:
-                favicon = uploader.upload_favicon(custom_favicon_url)
+                favicon = await uploader.upload_favicon(custom_favicon_url)
                 if favicon:
                     second_level_domain = self._get_second_level_domain(domain, suffix)
                     # For custom favicons, use the second level domain as title since we don't scrape

--- a/merino/jobs/navigational_suggestions/domain_metadata_uploader.py
+++ b/merino/jobs/navigational_suggestions/domain_metadata_uploader.py
@@ -1,6 +1,5 @@
 """Upload the domain metadata to GCS"""
 
-import asyncio
 import hashlib
 import json
 import logging
@@ -66,7 +65,7 @@ class DomainMetadataUploader:
         file_contents: dict = json.loads(data)
         return file_contents
 
-    def upload_favicon(self, favicon_url: str) -> str:
+    async def upload_favicon(self, favicon_url: str) -> str:
         """Upload a single favicon to GCS and return its public URL.
 
         Args:
@@ -82,8 +81,7 @@ class DomainMetadataUploader:
         if favicon_url and favicon_url.startswith(f"https://{self.uploader.cdn_hostname}"):
             return favicon_url
 
-        # Download the favicon
-        favicon_image = asyncio.run(self.async_favicon_downloader.download_favicon(favicon_url))
+        favicon_image = await self.async_favicon_downloader.download_favicon(favicon_url)
 
         # Process and upload the favicon
         if favicon_image:
@@ -115,7 +113,7 @@ class DomainMetadataUploader:
             favicon_image, dst_favicon_name, forced_upload=forced_upload
         )
 
-    def upload_favicons(self, src_favicons: list[str]) -> list[str]:
+    async def upload_favicons(self, src_favicons: list[str]) -> list[str]:
         """Upload multiple domain favicons to GCS using their source URLs.
 
         For backward compatibility with partner favicons.
@@ -128,7 +126,7 @@ class DomainMetadataUploader:
         """
         results = []
         for favicon_url in src_favicons:
-            result = self.upload_favicon(favicon_url)
+            result = await self.upload_favicon(favicon_url)
             # Ensure we always return a string, even for None or failed uploads
             results.append(result if isinstance(result, str) else "")
         return results

--- a/tests/integration/jobs/navigational_suggestions/test_domain_metadata_extractor.py
+++ b/tests/integration/jobs/navigational_suggestions/test_domain_metadata_extractor.py
@@ -846,7 +846,9 @@ class TestCustomFavicons:
         mock_get_custom_favicon.return_value = "https://static.axios.com/icons/favicon.svg"
 
         # Mock successful favicon upload - this should be synchronous and return a string
-        mock_uploader.upload_favicon.return_value = "https://cdn.example.com/axios_favicon.svg"
+        mock_uploader.upload_favicon = AsyncMock(
+            return_value="https://cdn.example.com/axios_favicon.svg"
+        )
 
         # Create extractor
         extractor = DomainMetadataExtractor(blocked_domains=set())
@@ -995,7 +997,7 @@ class TestCustomFavicons:
         mock_get_custom_favicon.side_effect = mock_custom_favicon_lookup
 
         # Mock successful custom favicon uploads - return actual strings, not coroutines
-        def mock_upload_favicon(url):
+        async def mock_upload_favicon(url):
             return f"https://cdn.example.com/{url.split('/')[-1]}"
 
         mock_uploader.upload_favicon.side_effect = mock_upload_favicon

--- a/tests/integration/jobs/navigational_suggestions/test_domain_metadata_uploader.py
+++ b/tests/integration/jobs/navigational_suggestions/test_domain_metadata_uploader.py
@@ -147,7 +147,8 @@ def test_upload_top_picks(gcs_storage_client, gcs_storage_bucket, mock_favicon_d
     assert top_picks_latest_blob is not None
 
 
-def test_upload_favicons(gcs_storage_client, gcs_storage_bucket, mock_favicon_downloader):
+@pytest.mark.asyncio
+async def test_upload_favicons(gcs_storage_client, gcs_storage_bucket, mock_favicon_downloader):
     """Test upload_favicons method of DomainMetaDataUploader. This test uses the mocked version
     of the favicon downloader. This test also implicitly tests the underlying gcs uploader methods.
     """
@@ -168,7 +169,7 @@ def test_upload_favicons(gcs_storage_client, gcs_storage_bucket, mock_favicon_do
     test_favicons = ["favicon1.jpg", "favicon2.jpg", "favicon3.jpg", "favicon4.jpg"]
 
     # call the upload method with a test top picks json
-    uploaded_favicons = domain_metadata_uploader.upload_favicons(test_favicons)
+    uploaded_favicons = await domain_metadata_uploader.upload_favicons(test_favicons)
 
     bucket_with_uploaded_favicons = gcp_uploader.storage_client.get_bucket(gcs_storage_bucket.name)
 
@@ -313,7 +314,8 @@ def test_upload_image(gcs_storage_client, gcs_storage_bucket, mock_favicon_downl
     assert blob.download_as_bytes() == b"test_image_content"
 
 
-def test_upload_favicon_with_cdn_url(
+@pytest.mark.asyncio
+async def test_upload_favicon_with_cdn_url(
     gcs_storage_client, gcs_storage_bucket, mock_favicon_downloader
 ):
     """Test upload_favicon method with a URL that's already on our CDN."""
@@ -333,13 +335,14 @@ def test_upload_favicon_with_cdn_url(
     cdn_url = f"https://{gcp_uploader.cdn_hostname}/some/path/favicon.png"
 
     # Call upload_favicon
-    result = domain_metadata_uploader.upload_favicon(cdn_url)
+    result = await domain_metadata_uploader.upload_favicon(cdn_url)
 
     # Verify the result is the same URL (no re-upload)
     assert result == cdn_url
 
 
-def test_upload_favicon_with_empty_url(gcs_storage_client, gcs_storage_bucket, mocker):
+@pytest.mark.asyncio
+async def test_upload_favicon_with_empty_url(gcs_storage_client, gcs_storage_bucket, mocker):
     """Test upload_favicon method with an empty URL."""
     # Create uploader
     gcp_uploader = GcsUploader(
@@ -365,13 +368,14 @@ def test_upload_favicon_with_empty_url(gcs_storage_client, gcs_storage_bucket, m
     )
 
     # Call upload_favicon with an empty URL
-    result = domain_metadata_uploader.upload_favicon("")
+    result = await domain_metadata_uploader.upload_favicon("")
 
     # Verify the result is an empty string
     assert result == ""
 
 
-def test_upload_favicon_download_failure(gcs_storage_client, gcs_storage_bucket, mocker):
+@pytest.mark.asyncio
+async def test_upload_favicon_download_failure(gcs_storage_client, gcs_storage_bucket, mocker):
     """Test upload_favicon method when download fails."""
     # Create uploader
     gcp_uploader = GcsUploader(
@@ -394,7 +398,7 @@ def test_upload_favicon_download_failure(gcs_storage_client, gcs_storage_bucket,
     )
 
     # Call upload_favicon with a URL that will fail to download
-    result = domain_metadata_uploader.upload_favicon("https://example.com/favicon.png")
+    result = await domain_metadata_uploader.upload_favicon("https://example.com/favicon.png")
 
     # Verify the result is an empty string
     assert result == ""
@@ -404,7 +408,8 @@ def test_upload_favicon_download_failure(gcs_storage_client, gcs_storage_bucket,
     )
 
 
-def test_upload_favicon_upload_failure(gcs_storage_client, gcs_storage_bucket, mocker):
+@pytest.mark.asyncio
+async def test_upload_favicon_upload_failure(gcs_storage_client, gcs_storage_bucket, mocker):
     """Test upload_favicon method when upload fails."""
     # Create uploader
     gcp_uploader = GcsUploader(
@@ -430,13 +435,14 @@ def test_upload_favicon_upload_failure(gcs_storage_client, gcs_storage_bucket, m
     )
 
     # Call upload_favicon
-    result = domain_metadata_uploader.upload_favicon("https://example.com/favicon.png")
+    result = await domain_metadata_uploader.upload_favicon("https://example.com/favicon.png")
 
     # Verify the result is an empty string (upload failed)
     assert result == ""
 
 
-def test_upload_favicons_with_mixed_results(gcs_storage_client, gcs_storage_bucket, mocker):
+@pytest.mark.asyncio
+async def test_upload_favicons_with_mixed_results(gcs_storage_client, gcs_storage_bucket, mocker):
     """Test upload_favicons method with some successful and some failed uploads."""
     # Create uploader
     gcp_uploader = GcsUploader(
@@ -466,7 +472,7 @@ def test_upload_favicons_with_mixed_results(gcs_storage_client, gcs_storage_buck
     test_favicons = ["success1.png", "fail1.png", "success2.png", "fail2.png"]
 
     # Call upload_favicons
-    results = domain_metadata_uploader.upload_favicons(test_favicons)
+    results = await domain_metadata_uploader.upload_favicons(test_favicons)
 
     # Verify the results
     assert len(results) == 4

--- a/tests/unit/jobs/navigational_suggestions/test_domain_metadata_uploader.py
+++ b/tests/unit/jobs/navigational_suggestions/test_domain_metadata_uploader.py
@@ -276,7 +276,10 @@ def test_upload_top_picks(
     assert result.name == mock_blob.name
 
 
-def test_upload_favicons_upload_if_not_present(mock_favicon_downloader, mock_gcs_uploader) -> None:
+@pytest.mark.asyncio
+async def test_upload_favicons_upload_if_not_present(
+    mock_favicon_downloader, mock_gcs_uploader
+) -> None:
     """Test that favicons are uploaded only if not already present
     in GCS when force upload is not set
     """
@@ -295,7 +298,7 @@ def test_upload_favicons_upload_if_not_present(mock_favicon_downloader, mock_gcs
     expected_image = Image(content=b"\xff", content_type="image/png")
     expected_destination = domain_metadata_uploader.destination_favicon_name(expected_image)
 
-    uploaded_favicons = domain_metadata_uploader.upload_favicons(["favicon1.png"])
+    uploaded_favicons = await domain_metadata_uploader.upload_favicons(["favicon1.png"])
 
     assert uploaded_favicons == [UPLOADED_FAVICON_PUBLIC_URL]
     mock_gcs_uploader.upload_image.assert_called_once_with(
@@ -303,7 +306,8 @@ def test_upload_favicons_upload_if_not_present(mock_favicon_downloader, mock_gcs
     )
 
 
-def test_upload_favicons_upload_if_force_upload_set(
+@pytest.mark.asyncio
+async def test_upload_favicons_upload_if_force_upload_set(
     mock_favicon_downloader, mock_gcs_uploader
 ) -> None:
     """Test that favicons are uploaded always when force upload is set"""
@@ -322,7 +326,7 @@ def test_upload_favicons_upload_if_force_upload_set(
     expected_image = Image(content=b"\xff", content_type="image/png")
     expected_destination = domain_metadata_uploader.destination_favicon_name(expected_image)
 
-    uploaded_favicons = domain_metadata_uploader.upload_favicons(["favicon1.png"])
+    uploaded_favicons = await domain_metadata_uploader.upload_favicons(["favicon1.png"])
 
     assert uploaded_favicons == [UPLOADED_FAVICON_PUBLIC_URL]
     mock_gcs_uploader.upload_image.assert_called_once_with(
@@ -330,7 +334,8 @@ def test_upload_favicons_upload_if_force_upload_set(
     )
 
 
-def test_upload_favicons_return_favicon_with_cdn_hostname_when_provided(
+@pytest.mark.asyncio
+async def test_upload_favicons_return_favicon_with_cdn_hostname_when_provided(
     mock_gcs_client, mock_favicon_downloader, mock_gcs_uploader
 ) -> None:
     """Test if uploaded favicon url has cdn hostname when provided"""
@@ -345,14 +350,15 @@ def test_upload_favicons_return_favicon_with_cdn_hostname_when_provided(
         force_upload=False,
         async_favicon_downloader=mock_favicon_downloader,
     )
-    uploaded_favicons = domain_metadata_uploader.upload_favicons(["favicon1.png"])
+    uploaded_favicons = await domain_metadata_uploader.upload_favicons(["favicon1.png"])
 
     mock_dst_blob.public_url.assert_not_called()
     for uploaded_favicon in uploaded_favicons:
         assert "dummy.cdn.hostname" in uploaded_favicon
 
 
-def test_upload_favicons_return_empty_url_for_failed_favicon_download(
+@pytest.mark.asyncio
+async def test_upload_favicons_return_empty_url_for_failed_favicon_download(
     mock_gcs_client, mock_favicon_downloader, mock_gcs_uploader
 ) -> None:
     """Test if a failure in downloading favicon from the scraped url returns an empty uploaded
@@ -365,13 +371,14 @@ def test_upload_favicons_return_empty_url_for_failed_favicon_download(
         force_upload=False,
         async_favicon_downloader=mock_favicon_downloader,
     )
-    uploaded_favicons = domain_metadata_uploader.upload_favicons(["favicon1.png"])
+    uploaded_favicons = await domain_metadata_uploader.upload_favicons(["favicon1.png"])
 
     for uploaded_favicon in uploaded_favicons:
         assert uploaded_favicon == ""
 
 
-def test_upload_favicons_return_same_url_for_urls_from_our_cdn(
+@pytest.mark.asyncio
+async def test_upload_favicons_return_same_url_for_urls_from_our_cdn(
     mock_gcs_client, mock_favicon_downloader, mock_gcs_uploader, mocker
 ) -> None:
     """Test that upload is skipped when the src favicon URL is from our CDN."""
@@ -386,7 +393,7 @@ def test_upload_favicons_return_same_url_for_urls_from_our_cdn(
     )
 
     src_favicon_url = f"https://{mock_gcs_uploader.cdn_hostname}/favicon1.png"
-    uploaded_favicons = domain_metadata_uploader.upload_favicons([src_favicon_url])
+    uploaded_favicons = await domain_metadata_uploader.upload_favicons([src_favicon_url])
 
     assert uploaded_favicons == [src_favicon_url]
 

--- a/tests/unit/jobs/navigational_suggestions/test_navigational_suggestions.py
+++ b/tests/unit/jobs/navigational_suggestions/test_navigational_suggestions.py
@@ -20,12 +20,13 @@ from merino.jobs.navigational_suggestions import (
 from merino.providers.suggest.base import Category
 
 
-def test_prepare_domain_metadata_top_picks_construction():
+@pytest.mark.asyncio
+async def test_prepare_domain_metadata_top_picks_construction():
     """Test whether top pick is constructed properly"""
     # Mock the functionality that would otherwise be executed
     with patch("merino.jobs.navigational_suggestions._run_normal_mode") as mock_run_normal:
         # Call the function with local_mode=False
-        prepare_domain_metadata(
+        await prepare_domain_metadata(
             "dummy_src_project",
             "dummy_destination_project",
             "dummy_destination_blob",


### PR DESCRIPTION
## References

JIRA: [DISCO-3543](https://mozilla-hub.atlassian.net/browse/DISCO-3543)

## Description
We are running into issues inside the Airflow job when uploading favicons. Since we are calling it inside an async runtime now when we have a custom favicon we want to upload right away.

That's the error message from Airflow:
```
Failed to upload custom favicon for reuters.com: asyncio.run() cannot be called from a running event loop"}
```

Making it `async` has some ramifications. Please take a look. Not really sure what else to do. 


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3543]: https://mozilla-hub.atlassian.net/browse/DISCO-3543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1734)
