### PR TITLE
chore: readd London into region mapping

### DIFF
--- a/merino/providers/suggest/weather/backends/accuweather/pathfinder.py
+++ b/merino/providers/suggest/weather/backends/accuweather/pathfinder.py
@@ -14,6 +14,7 @@ LOCALITY_SUFFIX_PATTERN: re.Pattern = re.compile(r"\s+(city|municipality|town)$"
 SUCCESSFUL_REGIONS_MAPPING: dict[tuple[str, str], str | None] = {
     ("AR", "El Sombrero"): None,
     ("BR", "Barcellos"): None,
+    ("GB", "London"): "LND",
     ("IE", "Dublin"): None,
     ("IN", "Angul"): None,
     ("IN", "Bhadrāchalam"): None,


### PR DESCRIPTION
## References


## Description
We still need this entry for London. Using the weather widget, the mapping doesn't work so we need this hardcoded.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1736)
