### PR TITLE
[DISCO-3550] fix: weather gb cities to try all regions

### DIFF
--- a/merino/providers/suggest/weather/backends/accuweather/pathfinder.py
+++ b/merino/providers/suggest/weather/backends/accuweather/pathfinder.py
@@ -518,7 +518,7 @@ FIPS_ISO_MAPPING_COUNTRIES: frozenset = frozenset(FIPS_ISO_MAPPING.keys())
 
 # Countries that use the most specific region to retrieve weather
 KNOWN_SPECIFIC_REGION_COUNTRIES: frozenset = frozenset(
-    ["AR", "AU", "BR", "CA", "CN", "DE", "GB", "MX", "NZ", "PL", "PT", "RU", "US"]
+    ["AR", "AU", "BR", "CA", "CN", "DE", "MX", "NZ", "PL", "PT", "RU", "US"]
 )
 # Countries that use the least specific region to retrieve weather
 KNOWN_REGION_COUNTRIES: frozenset = frozenset(["IT", "ES", "GR"])

--- a/tests/unit/providers/suggest/weather/backends/test_pathfinder.py
+++ b/tests/unit/providers/suggest/weather/backends/test_pathfinder.py
@@ -87,6 +87,20 @@ def test_compass(location: Location, expected_region_and_city: str) -> None:
             ),
             1,
         ),
+        (
+            WeatherContext(
+                Location(
+                    country="GB",
+                    regions=[
+                        "ENG",
+                        "WNH",
+                    ],
+                    city="Northampton",
+                ),
+                languages=["en-US"],
+            ),
+            3,
+        ),
     ],
 )
 @pytest.mark.asyncio


### PR DESCRIPTION
## References

JIRA: [DISCO-3550](https://mozilla-hub.atlassian.net/browse/DISCO-3550)

## Description
There are some GB cities that don't even provide FIPs region codes to map, as a result to handle this. We're going to try find an iso code, if it fails, we will try the region codes and then lastly try to retrieve weather without a region value.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
