### PR TITLE
Fix polygon provider throwing on initialization

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -665,7 +665,8 @@ index_ticker_ttl_sec = 900 # 15 minutes
 # MERINO_POLYGON__API_KEY
 # The API key to Polygon's API endpoint.
 # In production, this should be set via environment variable as a secret.
-api_key = ""
+# TODO replace with actual
+api_key = "test"
 
 ## MERINO_POLYGON__URL_BASE
 url_base = "https://api.polygon.io"

--- a/merino/providers/suggest/finance/backends/polygon/backend.py
+++ b/merino/providers/suggest/finance/backends/polygon/backend.py
@@ -61,7 +61,7 @@ class PolygonBackend:
             ValueError: If API key or URL variables are None or empty.
         """
         required_params = {
-            "Polygon API key": api_key,
+            "api_key": api_key,
             "url_ticker_last_quote": url_ticker_last_quote,
             "url_index_daily_summary": url_index_daily_summary,
         }


### PR DESCRIPTION
## References

JIRA: [DISCO-3555](https://mozilla-hub.atlassian.net/browse/DISCO-3555)

## Description
There was a bug in the Polygon provider throwing on initialization due to the missing `api_key` required param.
```ValueError: Missing required parameters: Polygon API key ```



## PR Review Checklist

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3555]: https://mozilla-hub.atlassian.net/browse/DISCO-3555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1740)
