### PR TITLE
feat: improve geonames uploader job a little

### DIFF
--- a/docs/operations/jobs/geonames-uploader.md
+++ b/docs/operations/jobs/geonames-uploader.md
@@ -26,6 +26,7 @@ simply as "alternates."
 Typically both commands should be run when using this job, first `geonames` and
 then `alternates`.
 
+
 ### Quick start
 
 #### 1. Run the `geonames` command
@@ -33,7 +34,7 @@ then `alternates`.
 ```
 uv run merino-jobs geonames-uploader geonames \
     --country US \
-    --partitions '[[50, "US"], [100, "CA"], 500]' \
+    --partitions '[[50, "US"], [100, ["US", "CA"]], 500]' \
     --rs-server 'https://remote-settings-dev.allizom.org/v1' \
     --rs-bucket main-workspace \
     --rs-collection quicksuggest-other \
@@ -45,7 +46,7 @@ following IDs:
 
 * `geonames-US-50k-100k`
   * US geonames whose populations are in the range [50k, 100k) that will be
-  ingested only by US clients
+    ingested only by US clients
 * `geonames-US-100k-500k`
   * US geonames whose populations are in the range [100k, 500k) that will be
   ingested by US and CA clients
@@ -75,11 +76,12 @@ records in the previous step. They'll have the following IDs:
 * `geonames-US-500k-en`
   * `en` alternates for the geonames in the `geonames-US-500k` record
 
+
 ### The `geonames` command
 
 The `geonames` command downloads geonames for a given country from geonames.org,
-partitions them by given population thresholds, and uploads an RS record for
-each partition.
+partitions them by given population thresholds, uploads an RS record for each
+partition, and deletes existing unused geonames records for the country.
 
 Three types of geonames are downloaded: cities, administrative divisions, and
 the geoname representing the country itself. Administrative divisions correspond
@@ -89,14 +91,17 @@ depends on the country and can even vary within a country.
 
 A list of one or more partitions should always be specified, typically on the
 command line with `--partitions`. One geonames record per partition (per
-country) will be created. Each partition defines a population threshold and
-optionally one or more filter-expression countries. If a partition defines
-filter-expression countries, the partition's record will have a filter
-expression that limits ingest only to clients in those countries. This allows
-clients outside a country to ingest only its large, well known geonames, while
-clients within the country can ingest its smaller geonames.
+country) will be created. Each partition defines a population threshold and any
+number of filter-expression countries. If a partition does define any
+filter-expression countries, its record will have a filter expression that limits
+ingest only to clients in those countries. This allows clients outside a country
+to ingest only its large, well known geonames, while clients within the country
+can ingest its smaller geonames.
 
-Existing geonames records for the given country will be deleted.
+Geonames record IDs have the format `geonames-{lower}-{upper}`, where `lower` is
+the partition's lower population threshold and `upper` is its upper threshold.
+If a partition doesn't have an upper threshold, its record's ID will be
+`geonames-{lower}`.
 
 #### `geonames` command-line options
 
@@ -137,15 +142,6 @@ words a partition's range is `[lower, upper)`.
 The final partition -- that is, the partition with the largest threshold --
 won't have an upper threshold.
 
-Filter-expression countries are cumulative. A country in one partition will
-automatically be included in all partitions with larger thresholds. For example,
-the following two `--partitions` values are equivalent:
-
-```
---partitions '[[50, "US"], [100, "CA"]]'
---partitions '[[50, "US"], [100, ["CA", "US"]]]'
-```
-
 *Examples:*
 
 `--partitions 50`
@@ -165,7 +161,7 @@ the following two `--partitions` values are equivalent:
     US clients will ingest
   * One with geonames whose populations are >= 100k that all clients will ingest
 
-`--partitions '[[50, "US"], [100, ["CA", "GB"]], 500]'`
+`--partitions '[[50, "US"], [100, ["US", "CA", "GB"]], 500]'`
 
 * Creates three records:
   * One with geonames whose populations are in the range [50k, 100k) that only
@@ -174,16 +170,57 @@ the following two `--partitions` values are equivalent:
     CA, and GB clients will ingest
   * One with geonames whose populations are >= 500k that all clients will ingest
 
+#### `geonames` example 1
+
+```
+uv run merino-jobs geonames-uploader geonames \
+    --country US \
+    --partitions '[1000]' \
+    --rs-server 'https://remote-settings-dev.allizom.org/v1' \
+    --rs-bucket main-workspace \
+    --rs-collection quicksuggest-other \
+    --rs-auth 'Bearer ...'
+```
+
+This will create one geonames record whose ID is `geonames-US-1m` containing US
+geonames whose populations are at least 1 million. The record won't have a
+filter expression, so it will be ingested by all clients.
+
+#### `geonames` example 2
+
+```
+uv run merino-jobs geonames-uploader geonames \
+    --country US \
+    --partitions '[[500, "US"], 1000]' \
+    --rs-server 'https://remote-settings-dev.allizom.org/v1' \
+    --rs-bucket main-workspace \
+    --rs-collection quicksuggest-other \
+    --rs-auth 'Bearer ...'
+```
+
+This will create two geonames records containing US geonames with the following
+IDs:
+
+* `geonames-US-500k-1m`
+  * US geonames whose populations are in the range [500k, 1m) that will have a
+    filter expression `env.country in ['US']`
+* `geonames-US-1m`
+  * US geonames whose populations are >= 1 million that won't have a filter
+    expression
+
+
 ### The `alternates` command
 
 The `alternates` command should be run after the `geonames` command. For a given
-country, it gets all the geonames records in remote settings for that country,
-downloads the country's alternates from geonames.org, and creates alternates
-records for the geonames. One alternates record per geonames record per language
-is created. The ID of the alternates record will be the ID of the corresponding
-geonames record with the language code appended.
+country and language, it gets all the geonames records in remote settings for
+that country, downloads those geonames' alternates from geonames.org, creates an
+alternates record for each geonames record that contains alternates for the
+language, and deletes existing unused alternates records for the country and
+language. In summary, one alternates record per geonames record per language is
+created.
 
-Existing alternates records for the given country and languages will be deleted.
+The ID of an alternates record will be the ID of its corresponding geonames
+record with the language code appended.
 
 #### `alternates` command-line options
 
@@ -222,17 +259,30 @@ Can be specified multiple times to upload multiple languages for a country.
 * `--language abbr`
 * `--language iata`
 
-#### Other command-line options
+#### `alternates` example
+
+```
+uv run merino-jobs geonames-uploader alternates \
+    --country US \
+    --alternates-language en \
+    --rs-server 'https://remote-settings-dev.allizom.org/v1' \
+    --rs-bucket main-workspace \
+    --rs-collection quicksuggest-other \
+    --rs-auth 'Bearer ...'
+```
+
+
+### Other command-line options
 
 The following are supported by both the `geonames` and `alternates` commands. As
 with all Merino jobs, they can be defined in Merino's config files in addition
 to being passed on the command line.
 
-##### `--dry-run`
+#### `--dry-run`
 
 Don't perform any mutable remote settings operations.
 
-##### `--rs-auth auth`
+#### `--rs-auth auth`
 
 Your authentication header string from the server. To get a header, log in to
 the server dashboard (don't forget to log in to the Mozilla VPN first) and click
@@ -240,14 +290,47 @@ the small clipboard icon near the top-right of the page, after the text that
 shows your username and server URL. The page will show a "Header copied to
 clipboard" toast notification if successful.
 
-##### `--rs-bucket bucket`
+#### `--rs-bucket bucket`
 
 The remote settings bucket to upload to.
 
-##### `--rs-collection collection`
+#### `--rs-collection collection`
 
 The remote settings collection to upload to.
 
-##### `--rs-server url`
+#### `--rs-server url`
 
 The remote settings server to upload to.
+
+
+### Tips
+
+#### Use attachment sizes to help decide population thresholds
+
+Attachment sizes for geonames and alternates records can be quite large since
+this job makes it easy to select a large number of geonames. As you decide on
+population thresholds, you can check potential attachment sizes without making
+any modifications by using `--rs-dry-run` with a log level of `INFO` like this:
+
+```
+MERINO_LOGGING__LEVEL=INFO \
+    uv run merino-jobs geonames-uploader geonames \
+    --country US \
+    --partitions '[[50, "US"], [100, ["CA", "US"]], 500]' \
+    --rs-dry-run
+```
+
+Look for "Uploading attachment" in the output.
+
+You can make the log easier to read if you have [jq](https://jqlang.org/)
+installed. Use the `mozlog` format and pipe the output to `jq ".Fields.msg"`
+like this:
+
+```
+MERINO_LOGGING__LEVEL=INFO MERINO_LOGGING__FORMAT=mozlog \
+    uv run merino-jobs geonames-uploader geonames \
+    --country US \
+    --partitions '[[50, "US"], [100, ["CA", "US"]], 500]' \
+    --rs-dry-run \
+    | jq ".Fields.msg"
+```

--- a/merino/jobs/geonames_uploader/downloader.py
+++ b/merino/jobs/geonames_uploader/downloader.py
@@ -16,6 +16,8 @@ import requests
 
 from merino.jobs.geonames_uploader.tempzipfile import TempZipFile
 
+from merino.jobs.utils import pretty_file_size
+
 logger = logging.getLogger(__name__)
 
 
@@ -252,13 +254,14 @@ def _download(
     logger.info(f"Sending request: {url}")
     resp = requests.get(url, stream=True)  # nosec
     resp.raise_for_status()
-    content_len = resp.headers.get("content-length", "???")
-    logger.info(f"Downloading {url} ({content_len} bytes)...")
+    content_len = resp.headers.get("content-length")
+    content_len_str = pretty_file_size(int(content_len)) if content_len else "??? bytes"
+    logger.info(f"Downloading {url} ({content_len_str})")
     with TempZipFile(resp.raw) as zip_file:
         txt_filename = f"{country}.txt"
-        logger.info(f"Extracting {txt_filename} from {url}...")
+        logger.info(f"Extracting {txt_filename} from {url}")
         txt_path = zip_file.extract(txt_filename)
-        logger.info(f"Opening {txt_filename} from {url}...")
+        logger.info(f"Opening {txt_filename} from {url}")
         with open(txt_path, newline="", encoding="utf-8-sig") as txt_file:
             reader = csv.reader(txt_file, dialect="excel-tab")
             for line in reader:

--- a/merino/jobs/utils/__init__.py
+++ b/merino/jobs/utils/__init__.py
@@ -1,1 +1,14 @@
 """Util scripts for merino jobs."""
+
+import math
+
+
+def pretty_file_size(bytes_len: int) -> str:
+    """Convert an int to a pretty human-readable size with units abbreviation.
+    Units are metric, not binary, e.g., KB instead of KiB.
+
+    """
+    units = ["bytes", "KB", "MB", "GB"]
+    exp = min(int(math.floor(math.log(bytes_len, 1_000))), len(units) - 1)
+    value = bytes_len / math.pow(1_000, exp)
+    return f"{value:g} {units[exp]}"

--- a/tests/unit/jobs/geonames_uploader/test_upload_geonames.py
+++ b/tests/unit/jobs/geonames_uploader/test_upload_geonames.py
@@ -182,7 +182,7 @@ def test_two_parts_first_part_empty_2(
         country="US",
         # There are no geonames with populations in the range [1k, 10k), so the
         # first partition should not be created.
-        partitions=[[1, "US"], [10, "GB"]],
+        partitions=[[1, "US"], [10, ["US", "GB"]]],
         expected_uploaded_records=[
             Record(
                 data={
@@ -231,14 +231,14 @@ def test_two_parts_neither_empty_1(requests_mock, downloader_fixture: Downloader
 
 
 def test_two_parts_neither_empty_2(requests_mock, downloader_fixture: DownloaderFixture):
-    """Upload two partitions, neither are empty, second has filter-expression
-    countries with one new country
+    """Upload two partitions, neither are empty, second has different
+    filter-expression countries
 
     """
     do_test(
         requests_mock,
         country="US",
-        partitions=[[50, "US"], [1_000, "GB"]],
+        partitions=[[50, "US"], [1_000, ["GB"]]],
         expected_uploaded_records=[
             Record(
                 data={
@@ -255,8 +255,8 @@ def test_two_parts_neither_empty_2(requests_mock, downloader_fixture: Downloader
                     "id": "geonames-US-1m",
                     "type": "geonames-2",
                     "country": "US",
-                    "filter_expression_countries": ["GB", "US"],
-                    "filter_expression": "env.country in ['GB', 'US']",
+                    "filter_expression_countries": ["GB"],
+                    "filter_expression": "env.country in ['GB']",
                 },
                 attachment=[_rs_geoname(g) for g in filter_geonames("US", 1_000_000)],
             ),
@@ -266,9 +266,7 @@ def test_two_parts_neither_empty_2(requests_mock, downloader_fixture: Downloader
 
 def test_two_parts_neither_empty_3(requests_mock, downloader_fixture: DownloaderFixture):
     """Upload two partitions, neither are empty, second has filter-expression
-    countries with one new country plus the country from the first partition.
-    This should be equivalent to the previous test, where the country from the
-    first partition was not included in the second
+    countries with one new country plus the country from the first partition
 
     """
     do_test(

--- a/tests/unit/jobs/utils/test_utils.py
+++ b/tests/unit/jobs/utils/test_utils.py
@@ -1,0 +1,24 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Unit tests for __init__.py."""
+
+from merino.jobs.utils import pretty_file_size
+
+
+def test_pretty_file_size():
+    """Test `pretty_file_size`"""
+    assert pretty_file_size(1) == "1 bytes"
+    assert pretty_file_size(999) == "999 bytes"
+    assert pretty_file_size(1_000) == "1 KB"
+    assert pretty_file_size(1_001) == "1.001 KB"
+    assert pretty_file_size(999 * 1_000) == "999 KB"
+    assert pretty_file_size(1_000 * 1_000) == "1 MB"
+    assert pretty_file_size(1_001 * 1_000) == "1.001 MB"
+    assert pretty_file_size(999 * 1_000 * 1_000) == "999 MB"
+    assert pretty_file_size(1_000 * 1_000 * 1_000) == "1 GB"
+    assert pretty_file_size(1_001 * 1_000 * 1_000) == "1.001 GB"
+    assert pretty_file_size(999 * 1_000 * 1_000 * 1_000) == "999 GB"
+    assert pretty_file_size(1_000 * 1_000 * 1_000 * 1_000) == "1000 GB"
+    assert pretty_file_size(1_001 * 1_000 * 1_000 * 1_000) == "1001 GB"


### PR DESCRIPTION
[Bug 1970276 - Make some small geonames uploader job improvements](https://bugzilla.mozilla.org/show_bug.cgi?id=1970276)

Now that I'm starting to use the newly updated geonames uploader job, I'd like to make a few small improvements:

* Require all desired filter-expression countries to be specified for a partition rather than being cumulative
* Log attachment file sizes when uploading them so it's easy to see if we're inadvertently creating huge geonames attachments
* Improve the doc a little

## References

JIRA: [DISCO-TODO](https://mozilla-hub.atlassian.net/browse/DISCO-TODO)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1741)
