### PR TITLE
fix: make RS client jobs util download to temp dir

### DIFF
--- a/merino/jobs/utils/rs_client.py
+++ b/merino/jobs/utils/rs_client.py
@@ -83,9 +83,10 @@ class RemoteSettingsClient:
 
     def download_attachment(self, record: dict[str, Any]) -> Any:
         """Download and return a record's attachment."""
-        path = self.kinto.download_attachment(record)
-        with open(path, "r") as file:
-            return json.load(file)
+        with TemporaryDirectory() as tmp_dir_name:
+            path = self.kinto.download_attachment(record, filepath=tmp_dir_name)
+            with open(path, "r") as file:
+                return json.load(file)
 
 
 def filter_expression(countries: list[str] = [], locales: list[str] = []) -> str:


### PR DESCRIPTION
## References

[Bug 1970473 - Geonames uploader Merino job downloads remote settings attachments to the current directory](https://bugzilla.mozilla.org/show_bug.cgi?id=1970473)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
