### PR TITLE
Bug 1971234 - Rewrite the geonames uploader to make it simpler to use

### DIFF
--- a/docs/operations/jobs/geonames-uploader.md
+++ b/docs/operations/jobs/geonames-uploader.md
@@ -7,278 +7,332 @@ The geonames uploader is a job that uploads geographical place data from
 by the Suggest client to recognize place names and relationships for certain
 suggestion types like weather suggestions.
 
-The job consists of two commands:
+The job consists of a single command called `upload`. It uploads two types of
+records:
 
-* **`geonames-uploader geonames`** - Uploads core geonames data to remote settings
-* **`geonames-uploader alternates`** - Uploads alternate names to remote settings
+* Core geonames data ([geonames](#geonames-records))
+* Alternate names ([alternates](#alternates-records))
 
-The core geonames data includes places' primary names, IDs, their countries and
-administrative regions, geographic coordinates, populations, etc. This data is
-derived from the main `geoname` table described in the
-[geonames documentation](https://download.geonames.org/export/dump/readme.txt).
+Core geonames data includes places' primary names, numeric IDs, their countries
+and administrative divisions, geographic coordinates, population sizes, etc.
+This data is derived from the main `geoname` table described in the [geonames
+documentation](https://download.geonames.org/export/dump/readme.txt).
 
-Alternate names are the different names associated with a place. A single
+A single place and its data is referred to as a **geoname**.
+
+Alternate names are the different names associated with a geoname. A single
 geoname can have many alternate names since a place can have many different
-variations of its name. Alternate names can also include translations of the
-geoname's name into different languages. Alternate names are usually referred to
-simply as "alternates."
+variations of its name. For example, New York City can be referred to as "New
+York City," "New York," "NYC," "NY", etc. Alternate names also include
+translations of the geoname's name into different languages. In Spanish, New
+York City is "Nueva York."
 
-Typically both commands should be run when using this job, first `geonames` and
-then `alternates`.
+Alternate names are referred to simply as **alternates**.
 
 
-### Quick start
-
-#### 1. Run the `geonames` command
+### Usage
 
 ```
-uv run merino-jobs geonames-uploader geonames \
-    --country US \
-    --partitions '[[50, "US"], [100, ["US", "CA"]], 500]' \
+uv run merino-jobs geonames-uploader upload \
     --rs-server 'https://remote-settings-dev.allizom.org/v1' \
     --rs-bucket main-workspace \
     --rs-collection quicksuggest-other \
     --rs-auth 'Bearer ...'
 ```
 
-This will create three geonames records containing US geonames with the
-following IDs:
-
-* `geonames-US-50k-100k`
-  * US geonames whose populations are in the range [50k, 100k) that will be
-    ingested only by US clients
-* `geonames-US-100k-500k`
-  * US geonames whose populations are in the range [100k, 500k) that will be
-  ingested by US and CA clients
-* `geonames-US-500k`
-  * US geonames whose populations are >= 500k that will be ingested by all
-    clients
-
-#### 2. Run the `alternates` command
-
-```
-uv run merino-jobs geonames-uploader alternates \
-    --country US \
-    --alternates-language en \
-    --rs-server 'https://remote-settings-dev.allizom.org/v1' \
-    --rs-bucket main-workspace \
-    --rs-collection quicksuggest-other \
-    --rs-auth 'Bearer ...'
-```
-
-This will create three English alternates records corresponding to the geonames
-records in the previous step. They'll have the following IDs:
-
-* `geonames-US-50k-100k-en`
-  * `en` alternates for the geonames in the `geonames-US-50k-100k` record
-* `geonames-US-100k-500k-en`
-  * `en` alternates for the geonames in the `geonames-US-100k-500k` record
-* `geonames-US-500k-en`
-  * `en` alternates for the geonames in the `geonames-US-500k` record
+This will upload data for the countries and client locales that are hardcoded by
+the job.
 
 
-### The `geonames` command
+### Geonames records
 
-The `geonames` command downloads geonames for a given country from geonames.org,
-partitions them by given population thresholds, uploads an RS record for each
-partition, and deletes existing unused geonames records for the country.
+Each geonames record corresponds to a **partition** of geonames within a given
+country. A partition has a lower population threshold and an optional upper
+population threshold, and the geonames in the partition are the geonames in the
+partition's country with population sizes that fall within that range. The lower
+threshold is inclusive and the upper threshold is exclusive.
 
-Three types of geonames are downloaded: cities, administrative divisions, and
-the geoname representing the country itself. Administrative divisions correspond
-to things like states, provinces, territories, and boroughs. A geoname can have
-up to four administrative divisions, and the meaning and number of divisions
+If a partition has an upper threshold, its record's attachment contains its
+country's geonames with populations in the range [lower, upper), and the
+record's ID is `geonames-{country}-{lower}-{upper}`.
+
+If a partition does not have an upper threshold, its attachment contains
+geonames with populations in the range [lower, infinity), and the record's ID is
+`geonames-{country}-{lower}`.
+
+`country` is an [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)
+code like `US`, `GB`, and `CA`. `lower` and `upper` are in thousands and
+zero-padded to four places.
+
+A partition can have a list of **client countries**, which are are added to its
+record's filter expression so that only clients in those countries will ingest
+the partition's record.
+
+Partitions serve a couple of purposes. First, they help keep geonames attachment
+sizes small. Second, they give us control over the clients that ingest a set of
+geonames. For example, we might want clients outside a country to ingest only
+its large, well known geonames, while clients within the country should ingest
+its smaller geonames.
+
+If there are no geonames with population sizes in a partition's range, no record
+will be created for the partition.
+
+#### Types of geonames
+
+Three types of geonames can be included in each attachment: cities,
+administrative divisions, and countries. Administrative divisions correspond to
+things like states, provinces, territories, and boroughs. A geoname can have up
+to four administrative divisions, and the meaning and number of divisions
 depends on the country and can even vary within a country.
 
-A list of one or more partitions should always be specified, typically on the
-command line with `--partitions`. One geonames record per partition (per
-country) will be created. Each partition defines a population threshold and any
-number of filter-expression countries. If a partition does define any
-filter-expression countries, its record will have a filter expression that limits
-ingest only to clients in those countries. This allows clients outside a country
-to ingest only its large, well known geonames, while clients within the country
-can ingest its smaller geonames.
+#### Example geonames record IDs
 
-Geonames record IDs have the format `geonames-{lower}-{upper}`, where `lower` is
-the partition's lower population threshold and `upper` is its upper threshold.
-If a partition doesn't have an upper threshold, its record's ID will be
-`geonames-{lower}`.
-
-#### `geonames` command-line options
-
-##### `--country code`
-
-*Required.* The country whose geonames should be uploaded as an
-[ISO-3166](https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes)
-two-letter uppercase country code.
-
-*Examples:*
-
-* `--country US`
-* `--country GB`
-* `--country CA`
-
-##### `--partitions json`
-
-*Required.* A JSON string describing how the geonames should be partitioned. One
-geonames record will be created per partition. Each partition defines a
-population threshold and optionally one or more filter-expression countries. The
-`json` value should be any one of the following:
-
-* An integer population threshold
-* A tuple `[threshold, country]`, where `threshold` is an integer population
-  threshold and `country` is country code string
-* A tuple `[threshold, countries]`, where `threshold` is an integer population
-  threshold and `countries` is an array of country code strings
-* An array whose items are any combination of the above
-
-**Important: All integer population thresholds are in thousands**. For example,
-a specified value of `50` means 50 thousand.
-
-Each partition defines only its lower threshold. The upper threshold is
-automatically calculated from the partition with the next-largest threshold. The
-lower threshold is inclusive and the upper threshold is exclusive, or in other
-words a partition's range is `[lower, upper)`.
-
-The final partition -- that is, the partition with the largest threshold --
-won't have an upper threshold.
-
-*Examples:*
-
-`--partitions 50`
-
-* Creates one record with geonames whose populations are >= 50k that all clients
-  will ingest
-
-`--partitions '[50, "US"]'`
-
-* Creates one record with geonames whose populations are >= 50k that only US
-  clients will ingest
-
-`--partitions '[[50, "US"], 100]'`
-
-* Creates two records:
-  * One with geonames whose populations are in the range [50k, 100k) that only
-    US clients will ingest
-  * One with geonames whose populations are >= 100k that all clients will ingest
-
-`--partitions '[[50, "US"], [100, ["US", "CA", "GB"]], 500]'`
-
-* Creates three records:
-  * One with geonames whose populations are in the range [50k, 100k) that only
-    US clients will ingest
-  * One with geonames whose populations are in the range [100k, 500k) that US,
-    CA, and GB clients will ingest
-  * One with geonames whose populations are >= 500k that all clients will ingest
-
-#### `geonames` example 1
-
-```
-uv run merino-jobs geonames-uploader geonames \
-    --country US \
-    --partitions '[1000]' \
-    --rs-server 'https://remote-settings-dev.allizom.org/v1' \
-    --rs-bucket main-workspace \
-    --rs-collection quicksuggest-other \
-    --rs-auth 'Bearer ...'
-```
-
-This will create one geonames record whose ID is `geonames-US-1m` containing US
-geonames whose populations are at least 1 million. The record won't have a
-filter expression, so it will be ingested by all clients.
-
-#### `geonames` example 2
-
-```
-uv run merino-jobs geonames-uploader geonames \
-    --country US \
-    --partitions '[[500, "US"], 1000]' \
-    --rs-server 'https://remote-settings-dev.allizom.org/v1' \
-    --rs-bucket main-workspace \
-    --rs-collection quicksuggest-other \
-    --rs-auth 'Bearer ...'
-```
-
-This will create two geonames records containing US geonames with the following
-IDs:
-
-* `geonames-US-500k-1m`
-  * US geonames whose populations are in the range [500k, 1m) that will have a
-    filter expression `env.country in ['US']`
-* `geonames-US-1m`
-  * US geonames whose populations are >= 1 million that won't have a filter
-    expression
+* `geonames-US-0050-0100`
+  * US geonames with populations in the range [50k, 100k)
+* `geonames-US-1000`
+  * US geonames with populations in the range [1m, infinity)
 
 
-### The `alternates` command
+### Alternates records
 
-The `alternates` command should be run after the `geonames` command. For a given
-country and language, it gets all the geonames records in remote settings for
-that country, downloads those geonames' alternates from geonames.org, creates an
-alternates record for each geonames record that contains alternates for the
-language, and deletes existing unused alternates records for the country and
-language. In summary, one alternates record per geonames record per language is
-created.
+Each alternates record corresponds to a single geonames record and language.
+Since a geonames record corresponds to a country and partition, that means each
+alternates record corresponds to a country, partition, and language. The
+alternates record contains alternates in the language for the geonames in the
+geonames record.
 
-The ID of an alternates record will be the ID of its corresponding geonames
-record with the language code appended.
+The ID of an alternates record is the ID of its corresponding geonames record
+with the language code appended:
 
-#### `alternates` command-line options
+* `geonames-{country}-{lower}-{upper}-{language}`
+* `geonames-{country}-{lower}-{language}` (for geonames records without an upper
+  threshold)
 
-##### `--country code`
+`language` is a language code as defined in the geonames alternates data. There
+are generally three types of language codes in the data:
 
-*Required.* The country whose alternates should be uploaded as an
-[ISO-3166](https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes)
-two-letter uppercase country code.
+* A two-letter [ISO 639](https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes)
+  language code, like `en`, `es`, `pt`, `de`, and `fr`
+* A locale code combining an ISO 639 language code with an
+  [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country
+  code, like `en-GB`, `es-MX`, and `pt-BR`
+* A geonames-specific pseudo-code:
+  * `abbr` - Abbreviations, like "NYC" for New York City
+  * `iata` - Airport codes, like "PDX" for Portland Oregon USA
+  * Others that we generally don't use
 
-*Examples:*
+The input to the geonames uploader job takes Firefox locale codes, and the job
+automatically converts each locale code to a set of appropriate geonames
+language codes. Alternates record IDs always include the geonames language code,
+not the Firefox locale code (although sometimes they're the same).
 
-* `--country US`
-* `--country GB`
-* `--country CA`
+If a geonames record includes client countries (or in other words has a filter
+expression limiting ingest to clients in certain countries), the corresponding
+alternates record for a given language will have a filter expression limiting
+ingest to clients using a locale that is both valid for the language and
+supported within the country.
 
-##### `--language code`
+If a geonames record does not include any client countries, then the
+corresponding alternates record will have a filter expression limiting ingest to
+clients using a locale that is valid for the language.
 
-*Required.* The language of the alternates that should be uploaded. This can be
-an [ISO 639](https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes)
-two-letter language code or one of the pseudo-codes specific to geonames.org
-like "abbr" for abbreviations. See the
-[geonames documentation](https://download.geonames.org/export/dump/readme.txt)
-for details. This value should always be lowercase.
+The supported locales of each country are defined in
+[`CONFIGS_BY_COUNTRY`](#country-and-locale-selection).
 
-We typically create alternates records for the following pseudo-codes:
+Alternates records for the `abbr` (abbreviations) and `iata` (airport codes)
+pseudo-language codes are automatically created for each geonames partition,
+when `abbr` and `iata` alternates exist for geonames in the parition.
 
-* `abbr` - Abbreviations
-* `iata` - Airport codes
+#### Excluded alternates
 
-Can be specified multiple times to upload multiple languages for a country.
+The job may exclude selected alternates in certain cases, or in other words it
+may not include some alternates you expect it to. To save space in remote
+settings, alternates that are the same as a geoname's primary name or ASCII name
+are usually excluded.
 
-*Examples:*
+Also, it's often the case that a partition does not have any alternates at all,
+or any alternates in a given language.
 
-* `--language en`
-* `--language de`
-* `--language abbr`
-* `--language iata`
+#### Example alternates record IDs
 
-#### `alternates` example
+* `geonames-US-0050-0100-en`
+  * English-language alternates for US geonames with populations in the range
+    [50k, 100k)
+* `geonames-US-0050-0100-en-GB`
+  * British-English-language alternates for US geonames with populations in the
+    range [1m, infinity)
+* `geonames-US-1000-de`
+  * German-language alternates for US geonames with populations in the range
+    [1m, infinity)
+* `geonames-US-1000-abbr`
+  * Abbreviations for US geonames with populations in the range [1m, infinity)
+* `geonames-US-1000-iata`
+  * Airport codes for US geonames with populations in the range [1m, infinity)
 
-```
-uv run merino-jobs geonames-uploader alternates \
-    --country US \
-    --alternates-language en \
-    --rs-server 'https://remote-settings-dev.allizom.org/v1' \
-    --rs-bucket main-workspace \
-    --rs-collection quicksuggest-other \
-    --rs-auth 'Bearer ...'
+
+### Country and locale selection
+
+Because the geonames uploader is a complex job and typically uploads a lot of
+data at once, it hardcodes the selection of countries and Firefox locales. This
+means that, if you want to make any changes to the records that are uploaded,
+you'll need to modify the code, but the tradeoff is that all supported countries
+and locales are listed in one place, you don't need to run the job more than
+once per upload, and there's no chance of making mistakes on the command line.
+
+The job does not re-upload unchanged records by default.
+
+The selection of countries and locales is defined in the `CONFIGS_BY_COUNTRY`
+dict in the job's `__init__.py`. Here are example entries for Canada and the US:
+
+```python
+CONFIGS_BY_COUNTRY = {
+    "CA": CountryConfig(
+        geonames_partitions=[
+            Partition(threshold=50_000, client_countries=["CA"]),
+            Partition(threshold=250_000, client_countries=["CA", "US"]),
+            Partition(threshold=500_000),
+        ],
+        supported_client_locales=EN_CLIENT_LOCALES + ["fr"],
+    ),
+    "US": CountryConfig(
+        geonames_partitions=[
+            Partition(threshold=50_000, client_countries=["US"]),
+            Partition(threshold=250_000, client_countries=["CA", "US"]),
+            Partition(threshold=500_000),
+        ],
+        supported_client_locales=EN_CLIENT_LOCALES,
+    ),
+}
 ```
 
+Each entry maps an [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)
+country code to data for the country. The data includes two properties:
 
-### Other command-line options
+* `geonames_partitions` determines the geonames records that will be created for the country
+* `supported_client_locales` contributes to the set of languages for which
+  alternates records will be created, not only for the country but for all
+  countries in `CONFIGS_BY_COUNTRY`
 
-The following are supported by both the `geonames` and `alternates` commands. As
-with all Merino jobs, they can be defined in Merino's config files in addition
-to being passed on the command line.
+#### `geonames_partitions`
 
-#### `--dry-run`
+`geonames_partitions` is a list of one or more [partitions](#geonames-records).
+Each partition defines its lower population threshold and client countries. The
+upper threshold is automatically calculated from the partition with the
+next-largest threshold.
+
+Client countries should be defined for all partitions except possibly the last.
+If the last partition doesn't include `client_countries`, its record won't have
+a filter expression, so it will be ingested by all clients regardless of
+country.
+
+In the example `CONFIGS_BY_COUNTRY` above, US geonames will be partitioned into
+three records:
+
+* `geonames-US-0050-0100`
+  * US geonames with populations in the range [50k, 100k) that will be ingested
+    only by US clients. Its filter expression will be `env.country in ['US']`
+* `geonames-US-0100-0500`
+  * US geonames with populations in the range [100k, 500k) that will be ingested
+    by US and Canadian clients. Its filter expression will be
+    `env.country in ['CA', 'US']`
+* `geonames-US-0500`
+  * US geonames with populations in the range [500k, infinity) that will be
+    ingested by all clients. It won't have a filter expression.
+
+#### `supported_client_locales`
+
+`supported_client_locales` is a list of Firefox locales. The job will convert
+the locales to geonames alternates languages and create one alternates record
+per geoname record per country per language (generally -- see the caveat about
+[excluded alternates](#excluded-alternates)).
+
+Note that `supported_client_locales` is not necessarily a list of all
+conceivable locales for a country. It's only a list of locales that need to be
+supported in the country. In the example `CONFIGS_BY_COUNTRY` above, the entry
+for Canada includes both English and French locales. If you didn't need to
+support Canadian clients using the `fr` locale, you could leave out `fr`. If you
+did leave out `fr` but then added a `CONFIGS_BY_COUNTRY` entry for France, which
+presumably would include support for the `fr` locale, then French-language
+alternates for all countries in `CONFIGS_BY_COUNTRY` would be uploaded anyway,
+and Canadian clients using the `fr` locale would ingest them even though `fr`
+wasn't listed as a supported Canadian locale.
+
+The example `CONFIGS_BY_COUNTRY` uses `EN_CLIENT_LOCALES`, which is all English
+locales supported by Firefox: `en-CA`, `en-GB`, `en-US`, and `en-ZA`. Up to 15
+alternates records will be created for the three US geonames records due to the
+following math:
+
+```
+3 US geonames records * (
+    `en` language
+    + `en-CA` language
+    + `en-GB` language
+    + `en-US` language
+    + `en-ZA` language
+)
+```
+
+In reality, most of the US geonames records won't have geonames with alternates
+in the `en-*` languages, only the `en` language, so it's more likely that only
+the following alternates records will be created:
+
+* `geonames-US-0050-0100-en`
+  * `en` language alternates for the geonames in the `geonames-US-0050-0100`
+    record. Its filter expression will be
+    `env.locale in ['en-CA', 'en-GB', 'en-US', 'en-ZA']`
+* `geonames-US-0100-0500-en`
+  * `en` language alternates for the geonames in the `geonames-US-0100-0500`
+    record. Its filter expression will be
+    `env.locale in ['en-CA', 'en-GB', 'en-US', 'en-ZA']`
+* `geonames-US-0500-en`
+  * `en` language alternates for the geonames in the `geonames-US-0500` record.
+    Its filter expression will be
+    `env.locale in ['en-CA', 'en-GB', 'en-US', 'en-ZA']`
+* Plus maybe one or two `en-GB` and/or `en-CA` records
+
+### Operation
+
+For each country in `CONFIGS_BY_COUNTRY`, the job performs two steps
+corresponding to the two types of records:
+
+Step 1:
+
+1. Download the country's geonames from geonames.org
+2. Upload the country's geonames records
+3. Delete unused geonames records for the country
+
+Step 2:
+
+1. Download the country's alternates from geonames.org
+2. For each alternates language, upload the country's alternates records
+3. Delete unused alternates records for the country
+
+The job does not re-create or re-upload records and attachments that haven't
+changed.
+
+
+### Command-line options
+
+As with all Merino jobs, options can be defined in Merino's config files in
+addition to being passed on the command line.
+
+#### `--alternates-url-format`
+
+Format string for alternates zip files on the geonames server. Should contain a
+reference to a `country` variable. Default value:
+`https://download.geonames.org/export/dump/alternatenames/{country}.zip`
+
+#### `--force-reupload`
+
+Recreate records and attachments even when they haven't changed.
+
+#### `--geonames-url-format`
+
+Format string for geonames zip files on the geonames server. Should contain a
+reference to a `country` variable. Default value:
+`https://download.geonames.org/export/dump/{country}.zip`
+
+#### `--rs-dry-run`
 
 Don't perform any mutable remote settings operations.
 
@@ -314,9 +368,11 @@ any modifications by using `--rs-dry-run` with a log level of `INFO` like this:
 
 ```
 MERINO_LOGGING__LEVEL=INFO \
-    uv run merino-jobs geonames-uploader geonames \
-    --country US \
-    --partitions '[[50, "US"], [100, ["CA", "US"]], 500]' \
+    uv run merino-jobs geonames-uploader upload \
+    --rs-server 'https://remote-settings-dev.allizom.org/v1' \
+    --rs-bucket main-workspace \
+    --rs-collection quicksuggest-other \
+    --rs-auth 'Bearer ...' \
     --rs-dry-run
 ```
 
@@ -328,9 +384,11 @@ like this:
 
 ```
 MERINO_LOGGING__LEVEL=INFO MERINO_LOGGING__FORMAT=mozlog \
-    uv run merino-jobs geonames-uploader geonames \
-    --country US \
-    --partitions '[[50, "US"], [100, ["CA", "US"]], 500]' \
+    uv run merino-jobs geonames-uploader upload \
+    --rs-server 'https://remote-settings-dev.allizom.org/v1' \
+    --rs-bucket main-workspace \
+    --rs-collection quicksuggest-other \
+    --rs-auth 'Bearer ...' \
     --rs-dry-run \
     | jq ".Fields.msg"
 ```

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -858,18 +858,3 @@ geonames_record_type = "geonames-2"
 # MERINO_JOBS__GEONAMES_UPLOADER__ALTERNATES_RECORD_TYPE
 # The `type` field of geonames alternates records.
 alternates_record_type = "geonames-alternates"
-
-# MERINO_JOBS__GEONAMES_UPLOADER__COUNTRY
-# The country whose geonames or alternates to upload. Typically specified on the
-# command line. See `geonames-uploader.md` doc.
-country = ""
-
-# MERINO_JOBS__GEONAMES_UPLOADER__PARTITIONS
-# JSON string of population thresholds and filter-expression countries.
-# Typically specified on the command line. See `geonames-uploader.md` doc.
-partitions = ""
-
-# MERINO_JOBS__GEONAMES_UPLOADER__LANGUAGES
-# List of language codes of alternates to upload. Typically specified on the
-# command line. See `geonames-uploader.md` doc.
-languages = []

--- a/merino/jobs/geonames_uploader/alternates.py
+++ b/merino/jobs/geonames_uploader/alternates.py
@@ -1,89 +1,120 @@
-"""The `upload alternates` command for the `geonames_uploader` job."""
+"""Geonames alternates helpers for the geonames-uploader command."""
 
 import logging
-from typing import Any, Tuple
+from typing import Any, Iterable, Mapping, Tuple
+import itertools
 
 from merino.jobs.utils.rs_client import RemoteSettingsClient, filter_expression_dict
 from merino.jobs.geonames_uploader.downloader import download_alternates, GeonameAlternate
 
+from merino.jobs.geonames_uploader.geonames import GeonamesRecord
 
-# This maps language codes to all locales that include them, for language codes
-# that are not by themselves also locale codes. This is necessary because remote
-# settings filter expressions can filter on locale but not language. Languages
-# not listed here are assumed to also be valid locales.
-LOCALES_BY_LANGUAGE = {
-    "en": ["en-CA", "en-GB", "en-US", "en-ZA"],
+
+# Maps from Firefox locales to alternates languages in the geonames data.
+ALTERNATES_LANGUAGES_BY_CLIENT_LOCALE = {
+    "en-CA": ["en", "en-CA"],
+    "en-GB": ["en", "en-GB"],
+    "en-US": ["en"],
+    "en-ZA": ["en"],
+    "de": ["de"],
+    "fr": ["fr"],
+    "it": ["it"],
+    "pl": ["pl"],
 }
+
+# Geonames pseudo-language codes for which we should create alternates records.
+# There are others than the ones here but typically we shouldn't be using them.
+PSEUDO_LANGUAGES = [
+    "abbr",  # abbreviations
+    "iata",  # airport codes
+]
 
 
 logger = logging.getLogger(__name__)
 
 
-def alternates_cmd(
-    languages: set[str],
+def upload_alternates(
     alternates_record_type: str,
     alternates_url_format: str,
     country: str,
+    existing_alternates_records_by_id: Mapping[str, dict[str, Any]],
+    force_reupload: bool,
     geonames_record_type: str,
-    rs_auth: str,
-    rs_bucket: str,
-    rs_collection: str,
-    rs_dry_run: bool,
-    rs_server: str,
+    geonames_records: list[GeonamesRecord],
+    locales_by_country: Mapping[str, Iterable[str]],
+    rs_client: RemoteSettingsClient,
+    alternates_languages_by_client_locale: Mapping[
+        str, Iterable[str]
+    ] = ALTERNATES_LANGUAGES_BY_CLIENT_LOCALE,
 ):
-    """Perform the `alternates` command, which uploads geonames alternates to
-    remote settings.
+    """Download alternates from the geonames server for a given country and
+    upload alternates records to remote settings.
 
     """
-    rs_client = RemoteSettingsClient(
-        auth=rs_auth,
-        bucket=rs_bucket,
-        collection=rs_collection,
-        server=rs_server,
-        dry_run=rs_dry_run,
-    )
+    logger.info(f"Uploading alternates records for country '{country}'")
 
-    # Get geonames records and existing alternates records for the country.
-    geonames_records = []
-    existing_alternates_records = []
-    for record in rs_client.get_records():
-        if record.get("type") == geonames_record_type and record.get("country") == country:
-            geonames_records.append(record)
-        elif (
-            record.get("type") == alternates_record_type
-            and record.get("country") == country
-            and record.get("language") in languages
-        ):
-            existing_alternates_records.append(record)
-
+    # If there are no geonames records for the country, consider all its
+    # alternates records as unused and delete them. Then we're done.
     if not geonames_records:
-        logger.info(f"No records for country '{country}' in remote settings, stopping")
+        logger.info(f"No geonames records for country '{country}'")
+        for record_id in existing_alternates_records_by_id.keys():
+            rs_client.delete_record(record_id)
         return
 
-    # Download the attachments of the geonames records. Each attachment is a
-    # list of geonames.
-    record_and_geonames_tuples: list[Tuple[dict[str, Any], list[dict[int, Any]]]] = []
-    all_geoname_ids: set[int] = set()
-    for record in geonames_records:
-        geonames = rs_client.download_attachment(record)
-        record_and_geonames_tuples.append((record, geonames))
-        all_geoname_ids |= set(g["id"] for g in geonames)
+    # Build a set of all geoname IDs.
+    all_geoname_ids = set(
+        itertools.chain.from_iterable((g["id"] for g in r.geonames) for r in geonames_records)
+    )
+
+    # Build a set of all alternates languages and an augmented version of
+    # `locales_by_country` that maps from locales to alternates languages.
+    all_langs: set[str] = set(PSEUDO_LANGUAGES)
+    langs_by_locale_by_country: dict[str, dict[str, set[str]]] = {}
+    for client_country, locales in locales_by_country.items():
+        for locale in locales:
+            langs = alternates_languages_by_client_locale.get(locale)
+            if not langs:
+                raise ValueError(
+                    f"Client locale '{locale}' not mapped to any alternates languages. "
+                    "Please add an entry for it!"
+                )
+            for lang in langs:
+                all_langs.add(lang)
+                langs_by_locale_by_country.setdefault(client_country, {}).setdefault(
+                    locale, set()
+                ).add(lang)
 
     # Download alternates from the geonames server.
     download = download_alternates(
         country=country,
         geoname_ids=all_geoname_ids,
-        languages=languages,
+        languages=all_langs,
         url_format=alternates_url_format,
     )
 
-    # Create an alternates record for each language and geonames record.
-    uploaded_record_ids = set()
-    for lang in sorted(languages):
-        for geonames_record, geonames in record_and_geonames_tuples:
-            geonames_record_id = geonames_record["id"]
-            geonames_by_id = {g["id"]: g for g in geonames}
+    # For each geonames record and language, create (potentially) an alternates
+    # record.
+    final_record_ids = set()
+    for geonames_record in geonames_records:
+        geonames_record_id = geonames_record.data["id"]
+        geonames_by_id = {g["id"]: g for g in geonames_record.geonames}
+        client_countries = geonames_record.data.get("client_countries", [])
 
+        # Build a map from alternates languages to client locales for the
+        # locales that are relevant to the client countries in the geonames
+        # record. If the record doesn't have any client countries, then the map
+        # will contain all supported languages and locales. Always include the
+        # pseudo-languages since they're locale agnostic.
+        locales_by_lang: dict[str, set[str]] = {lang: set() for lang in PSEUDO_LANGUAGES}
+        for lang_country, langs_by_locale in langs_by_locale_by_country.items():
+            if not client_countries or lang_country in client_countries:
+                for locale, langs in langs_by_locale.items():
+                    for lang in langs:
+                        locales_by_lang.setdefault(lang, set()).add(locale)
+
+        # For each language, create (potentially) an alternates record.
+        for lang, locales in sorted(list(locales_by_lang.items()), key=lambda t: t[0]):
+            # Collect the alternates for the geonames in the geonames record.
             alts_by_geoname_id = {
                 geoname_id: alt
                 for geoname_id, alt in download.alternates_by_geoname_id_by_language.get(
@@ -92,14 +123,14 @@ def alternates_cmd(
                 if geoname_id in geonames_by_id
             }
             if not alts_by_geoname_id:
-                logger.warning(
-                    f"No alternates for record '{geonames_record_id}' in language '{lang}'"
+                # No alternates for this country and language.
+                logger.info(
+                    f"{geonames_record_id}: No alternates for country '{country}' and language '{lang}'"
                 )
                 continue
 
-            # Build the list of tuples of geoname IDs and alternates that will
-            # be in the attachment. Keep in mind that `_rs_alternate` may return
-            # None.
+            # Build the list of tuples of geoname IDs and alternates for the
+            # attachment. Keep in mind that `_rs_alternate` may return None.
             rs_geoname_and_alts_lists = _rs_alternates_list(
                 [
                     (geonames_by_id[geoname_id], alts)
@@ -111,42 +142,42 @@ def alternates_cmd(
                 # they're all the same as their geonames' names or ASCII names,
                 # so no alternates record is necessary.
                 logger.info(
-                    f"Alternates record not necessary for geonames record '{geonames_record_id}' in language '{lang}'"
+                    f"{geonames_record_id}: Alternates unnecessary for country '{country}' and language '{lang}'"
                 )
                 continue
 
             alts_record_id = f"{geonames_record_id}-{lang}"
-            uploaded_record_ids.add(alts_record_id)
+            final_record_ids.add(alts_record_id)
 
-            # Build the filter expression. Include the same countries as the
-            # geonames record.
-            filter_countries = geonames_record.get("filter_expression_countries", [])
+            record = {
+                "id": alts_record_id,
+                "type": alternates_record_type,
+                "country": country,
+                "language": lang,
+                **filter_expression_dict(locales=locales),
+            }
 
-            # If the language code is a natural language and not "abbr"
-            # (abbreviation) or "iata" (airport code), include a locales filter.
-            filter_locales = []
-            if lang not in ["abbr", "iata"]:
-                filter_locales = [lang] + LOCALES_BY_LANGUAGE.get(lang, [])
+            existing_alts_record = existing_alternates_records_by_id.get(alts_record_id)
+            force_record = force_reupload or bool(
+                existing_alts_record
+                and record != {k: existing_alts_record.get(k) for k, v in record.items()}
+            )
 
             rs_client.upload(
-                record={
-                    "id": alts_record_id,
-                    "type": alternates_record_type,
-                    "country": country,
-                    "language": lang,
-                    **filter_expression_dict(countries=filter_countries, locales=filter_locales),
-                },
+                record=record,
                 attachment={
                     "language": lang,
                     "alternates_by_geoname_id": rs_geoname_and_alts_lists,
                 },
+                existing_record=existing_alts_record,
+                force_reupload=force_record,
             )
 
     # Delete existing records for the country and languages that weren't
     # uploaded above.
-    for r in existing_alternates_records:
-        if r["id"] not in uploaded_record_ids:
-            rs_client.delete_record(r["id"])
+    for record_id in existing_alternates_records_by_id.keys():
+        if record_id not in final_record_ids:
+            rs_client.delete_record(record_id)
 
 
 def _rs_alternates_list(

--- a/tests/unit/jobs/geonames_uploader/geonames_utils.py
+++ b/tests/unit/jobs/geonames_uploader/geonames_utils.py
@@ -6,7 +6,7 @@
 
 import csv
 import pytest
-from typing import Generator, Tuple
+from typing import Any, Generator, Tuple
 
 from io import BufferedReader
 
@@ -37,6 +37,9 @@ from merino.jobs.geonames_uploader.downloader import (
     Geoname,
     GeonameAlternate,
 )
+
+from merino.jobs.geonames_uploader.alternates import _rs_alternates_list
+from merino.jobs.geonames_uploader.geonames import _rs_geoname
 
 
 SERVER_DATA = {
@@ -140,6 +143,70 @@ GEONAME_NY_STATE = Geoname(
     longitude="-75.4999",
 )
 
+GEONAME_SACRAMENTO = Geoname(
+    id=5389489,
+    name="Sacramento",
+    ascii_name="Sacramento",
+    feature_class="P",
+    feature_code="PPLA",
+    country_code="US",
+    admin1_code="CA",
+    admin2_code="067",
+    admin3_code=None,
+    admin4_code=None,
+    population=490712,
+    latitude="38.58157",
+    longitude="-121.4944",
+)
+
+GEONAME_WATERLOO_ON = Geoname(
+    id=6176823,
+    name="Waterloo",
+    ascii_name="Waterloo",
+    feature_class="P",
+    feature_code="PPL",
+    country_code="CA",
+    admin1_code="08",
+    admin2_code="3530",
+    admin3_code=None,
+    admin4_code=None,
+    population=104986,
+    latitude="43.4668",
+    longitude="-80.51639",
+)
+
+GEONAME_HALIFAX = Geoname(
+    id=6324729,
+    name="Halifax",
+    ascii_name="Halifax",
+    feature_class="P",
+    feature_code="PPLA",
+    country_code="CA",
+    admin1_code="07",
+    admin2_code="1209",
+    admin3_code=None,
+    admin4_code=None,
+    population=439819,
+    latitude="44.64269",
+    longitude="-63.57688",
+)
+
+GEONAME_VANCOUVER = Geoname(
+    id=6173331,
+    name="Vancouver",
+    ascii_name="Vancouver",
+    feature_class="P",
+    feature_code="PPL",
+    country_code="CA",
+    admin1_code="02",
+    admin2_code="5915",
+    admin3_code=None,
+    admin4_code=None,
+    population=600000,
+    latitude="49.24966",
+    longitude="-123.11934",
+)
+
 GEONAME_GOESSNITZ = Geoname(
     id=2918770,
     name="Gößnitz",
@@ -157,52 +224,147 @@ GEONAME_GOESSNITZ = Geoname(
     longitude="12.43292",
 )
 
-GEONAMES = [
-    GEONAME_WATERLOO_AL,
-    GEONAME_AL,
-    GEONAME_WATERLOO_IA,
-    GEONAME_IA,
-    GEONAME_NYC,
-    GEONAME_NY_STATE,
-]
+GEONAME_KIEL = Geoname(
+    id=2918770,
+    name="Kiel",
+    ascii_name="Kiel",
+    feature_class="P",
+    feature_code="PPLA",
+    country_code="DE",
+    admin1_code="10",
+    admin2_code="00",
+    admin3_code="01002",
+    admin4_code="01002000",
+    population=246601,
+    latitude="54.32133",
+    longitude="10.13489",
+)
 
-ALTERNATES = {
-    "abbr": [
-        (GEONAME_AL, [GeonameAlternate("AL")]),
-        (GEONAME_IA, [GeonameAlternate("IA")]),
-        (GEONAME_NYC, [GeonameAlternate("NY"), GeonameAlternate("NYC")]),
-        (GEONAME_NY_STATE, [GeonameAlternate("NY")]),
+GEONAME_BERLIN = Geoname(
+    id=2950159,
+    name="Berlin",
+    ascii_name="Berlin",
+    feature_class="P",
+    feature_code="PPLC",
+    country_code="DE",
+    admin1_code="16",
+    admin2_code="00",
+    admin3_code="11000",
+    admin4_code="11000000",
+    population=3426354,
+    latitude="52.52437",
+    longitude="13.41053",
+)
+
+GEONAME_GUADALUPE = Geoname(
+    id=4005509,
+    name="Guadalupe",
+    ascii_name="Guadalupe",
+    feature_class="P",
+    feature_code="PPLA2",
+    country_code="MX",
+    admin1_code="32",
+    admin2_code="17",
+    admin3_code=None,
+    admin4_code=None,
+    population=215000,
+    latitude="22.74753",
+    longitude="-102.51874",
+)
+
+GEONAME_MEXICO_CITY = Geoname(
+    id=3530597,
+    name="Mexico City",
+    ascii_name="Mexico City",
+    feature_class="P",
+    feature_code="PPLC",
+    country_code="MX",
+    admin1_code="09",
+    admin2_code=None,
+    admin3_code=None,
+    admin4_code=None,
+    population=12294193,
+    latitude="19.42847",
+    longitude="-99.12766",
+)
+
+GEONAMES_BY_COUNTRY = {
+    "DE": [
+        GEONAME_GOESSNITZ,
+        GEONAME_KIEL,
+        GEONAME_BERLIN,
     ],
-    "en": [
-        (GEONAME_WATERLOO_AL, [GeonameAlternate("Waterloo")]),
-        (GEONAME_AL, [GeonameAlternate("State of Alabama")]),
-        (GEONAME_WATERLOO_IA, [GeonameAlternate("Waterloo")]),
-        (GEONAME_IA, [GeonameAlternate("State of Iowa")]),
-        (
-            GEONAME_NYC,
-            [
-                GeonameAlternate("New York", is_preferred=True, is_short=True),
-                GeonameAlternate("New York City"),
-            ],
-        ),
-        (GEONAME_NY_STATE, [GeonameAlternate("State of New York")]),
-        (
-            GEONAME_GOESSNITZ,
-            [
-                GeonameAlternate("Gößnitz"),
-                GeonameAlternate("Goessnitz"),
-                GeonameAlternate("Gössnitz"),
-            ],
-        ),
+    "CA": [
+        GEONAME_WATERLOO_ON,
+        GEONAME_HALIFAX,
+        GEONAME_VANCOUVER,
     ],
-    "es": [
-        (GEONAME_WATERLOO_IA, [GeonameAlternate("Waterloo")]),
-        (GEONAME_NYC, [GeonameAlternate("Nueva York")]),
-        (GEONAME_NY_STATE, [GeonameAlternate("Nueva York")]),
+    "MX": [
+        GEONAME_GUADALUPE,
+        GEONAME_MEXICO_CITY,
     ],
-    "iata": [
-        (GEONAME_NYC, [GeonameAlternate("LGA")]),
+    "US": [
+        GEONAME_WATERLOO_AL,
+        GEONAME_AL,
+        GEONAME_WATERLOO_IA,
+        GEONAME_IA,
+        GEONAME_NYC,
+        GEONAME_NY_STATE,
+        GEONAME_SACRAMENTO,
     ],
+}
+
+ALTERNATES_BY_COUNTRY = {
+    "DE": {
+        "en": [
+            (
+                GEONAME_GOESSNITZ,
+                [
+                    GeonameAlternate("Gößnitz"),
+                    GeonameAlternate("Goessnitz"),
+                    GeonameAlternate("Gössnitz"),
+                ],
+            ),
+        ],
+    },
+    "US": {
+        "abbr": [
+            (GEONAME_AL, [GeonameAlternate("AL")]),
+            (GEONAME_IA, [GeonameAlternate("IA")]),
+            (GEONAME_NYC, [GeonameAlternate("NY"), GeonameAlternate("NYC")]),
+            (GEONAME_NY_STATE, [GeonameAlternate("NY")]),
+        ],
+        "en": [
+            (GEONAME_WATERLOO_AL, [GeonameAlternate("Waterloo")]),
+            (GEONAME_AL, [GeonameAlternate("State of Alabama")]),
+            (GEONAME_WATERLOO_IA, [GeonameAlternate("Waterloo")]),
+            (GEONAME_IA, [GeonameAlternate("State of Iowa")]),
+            (
+                GEONAME_NYC,
+                [
+                    GeonameAlternate("New York", is_preferred=True, is_short=True),
+                    GeonameAlternate("New York City"),
+                ],
+            ),
+            (GEONAME_NY_STATE, [GeonameAlternate("State of New York")]),
+            (GEONAME_SACRAMENTO, [GeonameAlternate("Sac")]),
+        ],
+        "es": [
+            (GEONAME_WATERLOO_IA, [GeonameAlternate("Waterloo")]),
+            (GEONAME_NYC, [GeonameAlternate("Nueva York")]),
+            (GEONAME_NY_STATE, [GeonameAlternate("Nueva York")]),
+        ],
+        "fr": [
+            (GEONAME_NY_STATE, [GeonameAlternate("État de New York")]),
+        ],
+        "iata": [
+            (GEONAME_NYC, [GeonameAlternate("LGA")]),
+        ],
+        # an unused/unrecognized language
+        "xx": [
+            (GEONAME_NYC, [GeonameAlternate("New York Xx")]),
+        ],
+    },
 }
 
 
@@ -211,18 +373,26 @@ class DownloaderFixture:
     mocks requests for them.
     """
 
-    geonames: BufferedReader
-    alternates: BufferedReader
+    # country => (geonames_zip, alternates_zip)
+    zips_by_country: dict[str, Tuple[BufferedReader, BufferedReader]]
 
-    def __init__(self, requests_mock, country: str = "US") -> None:
-        """Initialize test"""
-        self.geonames = self.make_geonames_zip(GEONAMES, country)
-        self.alternates = self.make_alternates_zip(ALTERNATES, country)
+    def __init__(
+        self,
+        requests_mock,
+        countries: list[str] = [c for c in GEONAMES_BY_COUNTRY.keys()],
+    ):
+        """Initialize fixture"""
+        self.zips_by_country = {}
+        for country in countries:
+            geonames = self.make_geonames_zip(GEONAMES_BY_COUNTRY[country], country)
+            alternates = self.make_alternates_zip(ALTERNATES_BY_COUNTRY.get(country, {}), country)
 
-        geonames_url = SERVER_DATA["geonames_url_format"].format(country=country)
-        alternates_url = SERVER_DATA["alternates_url_format"].format(country=country)
-        requests_mock.get(geonames_url, body=self.geonames)
-        requests_mock.get(alternates_url, body=self.alternates)
+            self.zips_by_country[country] = (geonames, alternates)
+
+            geonames_url = SERVER_DATA["geonames_url_format"].format(country=country)
+            alternates_url = SERVER_DATA["alternates_url_format"].format(country=country)
+            requests_mock.get(geonames_url, body=geonames)
+            requests_mock.get(alternates_url, body=alternates)
 
     def make_geonames_zip(self, geonames: list[Geoname], country: str) -> BufferedReader:
         """Create a geonames zip file"""
@@ -282,8 +452,9 @@ class DownloaderFixture:
 
     def clean_up(self) -> None:
         """Tear down the test"""
-        self.geonames.close()
-        self.alternates.close()
+        for geonames_zip, alternates_zip in self.zips_by_country.values():
+            geonames_zip.close()
+            alternates_zip.close()
 
 
 @pytest.fixture()
@@ -302,8 +473,25 @@ def filter_geonames(
     """Return geonames for the given country and population partition."""
     return [
         g
-        for g in GEONAMES
-        if g.country_code == country
-        and lower_threshold <= (g.population or 0)
+        for g in GEONAMES_BY_COUNTRY[country]
+        if lower_threshold <= (g.population or 0)
         and (upper_threshold is None or (g.population or 0) < upper_threshold)
     ]
+
+
+def filter_alternates(
+    country: str,
+    language: str,
+    geonames: list[Geoname],
+) -> list[list[int | list[str | None | dict[str, Any]]]]:
+    """Filter `ALTERNATES` on a language and geonames and return a list of
+    tuples appropriate for including in a remote settings attachment.
+
+    """
+    return _rs_alternates_list(
+        [
+            (_rs_geoname(geoname), alts)
+            for geoname, alts in ALTERNATES_BY_COUNTRY[country][language]
+            if geoname in geonames
+        ]
+    )

--- a/tests/unit/jobs/geonames_uploader/test_downloader.py
+++ b/tests/unit/jobs/geonames_uploader/test_downloader.py
@@ -19,13 +19,13 @@ from merino.jobs.geonames_uploader.downloader import (
 from tests.unit.jobs.geonames_uploader.geonames_utils import (
     DownloaderFixture,
     SERVER_DATA,
-    GEONAMES,
+    GEONAMES_BY_COUNTRY,
     GEONAME_AL,
     GEONAME_WATERLOO_IA,
     GEONAME_IA,
     GEONAME_NYC,
     GEONAME_NY_STATE,
-    ALTERNATES,
+    ALTERNATES_BY_COUNTRY,
 )
 
 
@@ -92,7 +92,7 @@ def filter_alternates(
 ) -> dict[str, dict[int, list[GeonameAlternate]]]:
     """Filter `ALTERNATES` on a given predicate."""
     alts_by_geoname_id_by_lang: dict[str, dict[int, list[GeonameAlternate]]] = {}
-    for lang, geoname_and_alts_tuples in ALTERNATES.items():
+    for lang, geoname_and_alts_tuples in ALTERNATES_BY_COUNTRY["US"].items():
         for geoname, alts in geoname_and_alts_tuples:
             # The `AlternatesDownloaderTest` fixture only provides US geonames
             # and alternates, so ignore ones in other countries (Goessnitz).
@@ -131,6 +131,11 @@ def test_filter_alternates_on_geoname_id():
                 GeonameAlternate("LGA"),
             ],
         },
+        "xx": {
+            GEONAME_NYC.id: [
+                GeonameAlternate("New York Xx"),
+            ],
+        },
     }
 
 
@@ -160,7 +165,7 @@ def test_geonames_all(
         population_threshold=1,
         expected_download=GeonamesDownload(
             population_threshold=1,
-            geonames=GEONAMES,
+            geonames=GEONAMES_BY_COUNTRY["US"],
         ),
     )
 
@@ -182,8 +187,8 @@ def test_alternates_all(
     alternates_downloader_test: AlternatesDownloaderTest,
 ):
     """Request all alternates"""
-    languages = set(["abbr", "en", "es", "iata"])
-    geoname_ids = set(g.id for g in GEONAMES)
+    languages = set(["abbr", "en", "es", "fr", "iata"])
+    geoname_ids = set(g.id for g in GEONAMES_BY_COUNTRY["US"])
     alternates_downloader_test.run(
         languages=languages,
         geoname_ids=geoname_ids,
@@ -191,7 +196,7 @@ def test_alternates_all(
             languages=languages,
             geoname_ids=geoname_ids,
             alternates_by_geoname_id_by_language=filter_alternates(
-                lambda geoname_id, lang, alt: True
+                lambda geoname_id, lang, alt: lang in languages
             ),
         ),
     )
@@ -202,7 +207,7 @@ def test_alternates_en(
 ):
     """Request en alternates"""
     languages = set(["en"])
-    geoname_ids = set(g.id for g in GEONAMES)
+    geoname_ids = set(g.id for g in GEONAMES_BY_COUNTRY["US"])
     alternates_downloader_test.run(
         languages=languages,
         geoname_ids=geoname_ids,
@@ -210,7 +215,7 @@ def test_alternates_en(
             languages=languages,
             geoname_ids=geoname_ids,
             alternates_by_geoname_id_by_language=filter_alternates(
-                lambda geoname_id, lang, alt: lang == "en"
+                lambda geoname_id, lang, alt: lang in languages
             ),
         ),
     )
@@ -229,8 +234,7 @@ def test_alternates_specific_geoname(
             languages=languages,
             geoname_ids=geoname_ids,
             alternates_by_geoname_id_by_language=filter_alternates(
-                lambda geoname_id, lang, alt: geoname_id == GEONAME_NYC.id
-                and lang in ["en", "abbr"]
+                lambda geoname_id, lang, alt: geoname_id == GEONAME_NYC.id and lang in languages
             ),
         ),
     )

--- a/tests/unit/jobs/geonames_uploader/test_upload.py
+++ b/tests/unit/jobs/geonames_uploader/test_upload.py
@@ -1,0 +1,486 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Ignore "F811 Redefinition of unused `downloader_fixture`" in this file
+# ruff: noqa: F811
+
+"""Unit tests for __init__.py module and `upload` command."""
+
+from merino.jobs.geonames_uploader import _upload, CountryConfig, EN_CLIENT_LOCALES
+
+from merino.jobs.geonames_uploader.alternates import ALTERNATES_LANGUAGES_BY_CLIENT_LOCALE
+
+from merino.jobs.geonames_uploader.geonames import Partition, _rs_geoname
+
+from tests.unit.jobs.utils.rs_utils import (
+    Record,
+    check_delete_requests,
+    check_upload_requests,
+    mock_responses,
+    SERVER_DATA as RS_SERVER_DATA,
+)
+from tests.unit.jobs.geonames_uploader.geonames_utils import (
+    DownloaderFixture,
+    downloader_fixture,  # noqa: F401
+    filter_alternates,
+    filter_geonames,
+    GEONAME_NYC,
+    GEONAME_NY_STATE,
+    GEONAME_GOESSNITZ,
+    SERVER_DATA as GEONAMES_SERVER_DATA,
+)
+
+
+def do_test(
+    requests_mock,
+    force_reupload: bool,
+    configs_by_country: dict[str, CountryConfig],
+    expected_uploaded_records: list[Record],
+    existing_records: list[Record] = [],
+    alternates_languages_by_client_locale: dict[
+        str, list[str]
+    ] = ALTERNATES_LANGUAGES_BY_CLIENT_LOCALE,
+    alternates_record_type: str = "geonames-alternates",
+    alternates_url_format: str = GEONAMES_SERVER_DATA["alternates_url_format"],
+    geonames_record_type: str = "geonames-2",
+    geonames_url_format: str = GEONAMES_SERVER_DATA["geonames_url_format"],
+    rs_auth: str = RS_SERVER_DATA["auth"],
+    rs_bucket: str = RS_SERVER_DATA["bucket"],
+    rs_collection: str = RS_SERVER_DATA["collection"],
+    rs_dry_run: bool = False,
+    rs_server: str = RS_SERVER_DATA["server"],
+) -> None:
+    """Perform an upload test."""
+    # A `requests_mock.exceptions.NoMockAddress: No mock address` error means
+    # there was a request for a record that's not mocked here.
+    mock_responses(
+        requests_mock,
+        get=existing_records + expected_uploaded_records,
+        update=expected_uploaded_records,
+    )
+
+    # Call the upload function.
+    _upload(
+        force_reupload=force_reupload,
+        configs_by_country=configs_by_country,
+        alternates_languages_by_client_locale=alternates_languages_by_client_locale,
+        alternates_record_type=alternates_record_type,
+        alternates_url_format=alternates_url_format,
+        geonames_record_type=geonames_record_type,
+        geonames_url_format=geonames_url_format,
+        rs_auth=rs_auth,
+        rs_bucket=rs_bucket,
+        rs_collection=rs_collection,
+        rs_dry_run=rs_dry_run,
+        rs_server=rs_server,
+    )
+
+    # Only check remote settings requests, ignore geonames requests.
+    rs_requests = [r for r in requests_mock.request_history if r.url.startswith(rs_server)]
+
+    check_upload_requests(rs_requests, expected_uploaded_records)
+    check_delete_requests(rs_requests, [])
+
+
+def test_simple(requests_mock, downloader_fixture: DownloaderFixture):
+    """Simple upload test with one country, one partition, one client locale"""
+    do_test(
+        requests_mock,
+        force_reupload=True,
+        configs_by_country={
+            "US": CountryConfig(
+                geonames_partitions=[
+                    Partition(threshold=500_000),
+                ],
+                supported_client_locales=["en-US"],
+            ),
+        },
+        expected_uploaded_records=[
+            Record(
+                data={
+                    "id": "geonames-US-0500",
+                    "type": "geonames-2",
+                    "country": "US",
+                },
+                attachment=[_rs_geoname(g) for g in filter_geonames("US", 500_000)],
+            ),
+            Record(
+                data={
+                    "id": "geonames-US-0500-abbr",
+                    "type": "geonames-alternates",
+                    "country": "US",
+                    "language": "abbr",
+                },
+                attachment={
+                    "language": "abbr",
+                    "alternates_by_geoname_id": filter_alternates(
+                        "US",
+                        "abbr",
+                        filter_geonames("US", 500_000),
+                    ),
+                },
+            ),
+            Record(
+                data={
+                    "id": "geonames-US-0500-en",
+                    "type": "geonames-alternates",
+                    "country": "US",
+                    "language": "en",
+                    "filter_expression": "env.locale in ['en-US']",
+                },
+                attachment={
+                    "language": "en",
+                    "alternates_by_geoname_id": filter_alternates(
+                        "US",
+                        "en",
+                        filter_geonames("US", 500_000),
+                    ),
+                },
+            ),
+            Record(
+                data={
+                    "id": "geonames-US-0500-iata",
+                    "type": "geonames-alternates",
+                    "country": "US",
+                    "language": "iata",
+                },
+                attachment={
+                    "language": "iata",
+                    "alternates_by_geoname_id": filter_alternates(
+                        "US",
+                        "iata",
+                        filter_geonames("US", 500_000),
+                    ),
+                },
+            ),
+        ],
+    )
+
+
+def test_realistic(requests_mock, downloader_fixture: DownloaderFixture):
+    """Realistic upload test with multiple many, many partitions, many client
+    locales
+
+    """
+    # This test heavily depends on the geonames and alternates that are defined
+    # in the `geonames_utils.py` test file -- all tests do, but this one does in
+    # particular since it selects geonames and alternates in so many countries.
+    do_test(
+        requests_mock,
+        force_reupload=True,
+        configs_by_country={
+            "CA": CountryConfig(
+                geonames_partitions=[
+                    Partition(threshold=50_000, client_countries=["CA"]),
+                    Partition(threshold=250_000, client_countries=["CA", "US"]),
+                    Partition(threshold=500_000),
+                ],
+                supported_client_locales=EN_CLIENT_LOCALES,
+            ),
+            "DE": CountryConfig(
+                geonames_partitions=[
+                    Partition(threshold=50_000, client_countries=["DE"]),
+                    Partition(threshold=500_000),
+                ],
+                supported_client_locales=["de"],
+            ),
+            "MX": CountryConfig(
+                geonames_partitions=[
+                    Partition(threshold=50_000, client_countries=["MX"]),
+                    Partition(threshold=500_000),
+                ],
+                supported_client_locales=["es-MX"],
+            ),
+            "US": CountryConfig(
+                geonames_partitions=[
+                    Partition(threshold=50_000, client_countries=["US"]),
+                    Partition(threshold=250_000, client_countries=["CA", "US"]),
+                    Partition(threshold=500_000),
+                ],
+                supported_client_locales=EN_CLIENT_LOCALES,
+            ),
+        },
+        alternates_languages_by_client_locale={
+            "en-CA": ["en", "en-CA"],
+            "en-GB": ["en", "en-GB"],
+            "en-US": ["en"],
+            "en-ZA": ["en"],
+            "de": ["de"],
+            "es-MX": ["es"],
+        },
+        expected_uploaded_records=[
+            # geonames
+            Record(
+                data={
+                    "id": "geonames-CA-0050-0250",
+                    "type": "geonames-2",
+                    "country": "CA",
+                    "client_countries": ["CA"],
+                    "filter_expression": "env.country in ['CA']",
+                },
+                attachment=[_rs_geoname(g) for g in filter_geonames("CA", 50_000, 250_000)],
+            ),
+            Record(
+                data={
+                    "id": "geonames-CA-0250-0500",
+                    "type": "geonames-2",
+                    "country": "CA",
+                    "client_countries": ["CA", "US"],
+                    "filter_expression": "env.country in ['CA', 'US']",
+                },
+                attachment=[_rs_geoname(g) for g in filter_geonames("CA", 250_000, 500_000)],
+            ),
+            Record(
+                data={
+                    "id": "geonames-CA-0500",
+                    "type": "geonames-2",
+                    "country": "CA",
+                },
+                attachment=[_rs_geoname(g) for g in filter_geonames("CA", 500_000)],
+            ),
+            Record(
+                data={
+                    "id": "geonames-DE-0050-0500",
+                    "type": "geonames-2",
+                    "country": "DE",
+                    "client_countries": ["DE"],
+                    "filter_expression": "env.country in ['DE']",
+                },
+                attachment=[_rs_geoname(g) for g in filter_geonames("DE", 50_000, 500_000)],
+            ),
+            Record(
+                data={
+                    "id": "geonames-DE-0500",
+                    "type": "geonames-2",
+                    "country": "DE",
+                },
+                attachment=[_rs_geoname(g) for g in filter_geonames("DE", 500_000)],
+            ),
+            Record(
+                data={
+                    "id": "geonames-MX-0050-0500",
+                    "type": "geonames-2",
+                    "country": "MX",
+                    "client_countries": ["MX"],
+                    "filter_expression": "env.country in ['MX']",
+                },
+                attachment=[_rs_geoname(g) for g in filter_geonames("MX", 50_000, 500_000)],
+            ),
+            Record(
+                data={
+                    "id": "geonames-MX-0500",
+                    "type": "geonames-2",
+                    "country": "MX",
+                },
+                attachment=[_rs_geoname(g) for g in filter_geonames("MX", 500_000)],
+            ),
+            Record(
+                data={
+                    "id": "geonames-US-0050-0250",
+                    "type": "geonames-2",
+                    "country": "US",
+                    "client_countries": ["US"],
+                    "filter_expression": "env.country in ['US']",
+                },
+                attachment=[_rs_geoname(g) for g in filter_geonames("US", 50_000, 250_000)],
+            ),
+            Record(
+                data={
+                    "id": "geonames-US-0250-0500",
+                    "type": "geonames-2",
+                    "country": "US",
+                    "client_countries": ["CA", "US"],
+                    "filter_expression": "env.country in ['CA', 'US']",
+                },
+                attachment=[_rs_geoname(g) for g in filter_geonames("US", 250_000, 500_000)],
+            ),
+            Record(
+                data={
+                    "id": "geonames-US-0500",
+                    "type": "geonames-2",
+                    "country": "US",
+                },
+                attachment=[_rs_geoname(g) for g in filter_geonames("US", 500_000)],
+            ),
+            # alternates
+            Record(
+                data={
+                    "id": "geonames-US-0250-0500-en",
+                    "type": "geonames-alternates",
+                    "country": "US",
+                    "language": "en",
+                    "filter_expression": "env.locale in ['en-CA', 'en-GB', 'en-US', 'en-ZA']",
+                },
+                attachment={
+                    "language": "en",
+                    "alternates_by_geoname_id": filter_alternates(
+                        "US",
+                        "en",
+                        filter_geonames("US", 250_000, 500_000),
+                    ),
+                },
+            ),
+            Record(
+                data={
+                    "id": "geonames-US-0500-abbr",
+                    "type": "geonames-alternates",
+                    "country": "US",
+                    "language": "abbr",
+                },
+                attachment={
+                    "language": "abbr",
+                    "alternates_by_geoname_id": filter_alternates(
+                        "US",
+                        "abbr",
+                        filter_geonames("US", 500_000),
+                    ),
+                },
+            ),
+            Record(
+                data={
+                    "id": "geonames-US-0500-en",
+                    "type": "geonames-alternates",
+                    "country": "US",
+                    "language": "en",
+                    "filter_expression": "env.locale in ['en-CA', 'en-GB', 'en-US', 'en-ZA']",
+                },
+                attachment={
+                    "language": "en",
+                    "alternates_by_geoname_id": filter_alternates(
+                        "US",
+                        "en",
+                        filter_geonames("US", 500_000),
+                    ),
+                },
+            ),
+            Record(
+                data={
+                    "id": "geonames-US-0500-es",
+                    "type": "geonames-alternates",
+                    "country": "US",
+                    "language": "es",
+                    "filter_expression": "env.locale in ['es-MX']",
+                },
+                attachment={
+                    "language": "es",
+                    "alternates_by_geoname_id": filter_alternates(
+                        "US",
+                        "es",
+                        filter_geonames("US", 500_000),
+                    ),
+                },
+            ),
+            Record(
+                data={
+                    "id": "geonames-US-0500-iata",
+                    "type": "geonames-alternates",
+                    "country": "US",
+                    "language": "iata",
+                },
+                attachment={
+                    "language": "iata",
+                    "alternates_by_geoname_id": filter_alternates(
+                        "US",
+                        "iata",
+                        filter_geonames("US", 500_000),
+                    ),
+                },
+            ),
+        ],
+    )
+
+
+def test_force_reupload_false(requests_mock, downloader_fixture: DownloaderFixture):
+    """Existing records shouldn't be re-uploaded when force_reupload=False"""
+    do_test(
+        requests_mock,
+        force_reupload=False,
+        configs_by_country={
+            "US": CountryConfig(
+                geonames_partitions=[
+                    Partition(threshold=500_000),
+                ],
+                supported_client_locales=["en-US"],
+            ),
+        },
+        existing_records=[
+            Record(
+                data={
+                    "id": "geonames-US-0500",
+                    "type": "geonames-2",
+                    "country": "US",
+                },
+                attachment=[_rs_geoname(g) for g in filter_geonames("US", 500_000)],
+            ),
+            Record(
+                data={
+                    "id": "geonames-US-0500-abbr",
+                    "type": "geonames-alternates",
+                    "country": "US",
+                    "language": "abbr",
+                },
+                attachment={
+                    "language": "abbr",
+                    "alternates_by_geoname_id": filter_alternates(
+                        "US",
+                        "abbr",
+                        filter_geonames("US", 500_000),
+                    ),
+                },
+            ),
+            Record(
+                data={
+                    "id": "geonames-US-0500-en",
+                    "type": "geonames-alternates",
+                    "country": "US",
+                    "language": "en",
+                    "filter_expression": "env.locale in ['en-US']",
+                },
+                attachment={
+                    "language": "en",
+                    "alternates_by_geoname_id": filter_alternates(
+                        "US",
+                        "en",
+                        filter_geonames("US", 500_000),
+                    ),
+                },
+            ),
+            Record(
+                data={
+                    "id": "geonames-US-0500-iata",
+                    "type": "geonames-alternates",
+                    "country": "US",
+                    "language": "iata",
+                },
+                attachment={
+                    "language": "iata",
+                    "alternates_by_geoname_id": filter_alternates(
+                        "US",
+                        "iata",
+                        filter_geonames("US", 500_000),
+                    ),
+                },
+            ),
+        ],
+        expected_uploaded_records=[],
+    )
+
+
+def test_filter_alternates():
+    """Test the `filter_alternates` test helper function"""
+    # NYC has one alt that's not its name or ASCII name, and `None` values
+    # should not be included.
+    assert filter_alternates("US", "en", [GEONAME_NYC]) == [
+        [GEONAME_NYC.id, [{"name": "New York", "is_preferred": True, "is_short": True}]],
+    ]
+
+    # Goessnitz has one alt that's not its name or ASCII name, and `None` values
+    # should not be included.
+    assert filter_alternates("DE", "en", [GEONAME_GOESSNITZ]) == [
+        [GEONAME_GOESSNITZ.id, ["Gössnitz"]],
+    ]
+
+    assert filter_alternates("US", "fr", [GEONAME_NY_STATE]) == [
+        [GEONAME_NY_STATE.id, ["État de New York"]],
+    ]

--- a/tests/unit/jobs/geonames_uploader/test_upload_geonames.py
+++ b/tests/unit/jobs/geonames_uploader/test_upload_geonames.py
@@ -7,12 +7,15 @@
 
 """Unit tests for geonames.py module and `geonames` command."""
 
-import json
+from merino.jobs.geonames_uploader.geonames import (
+    _rs_geoname,
+    _record_id,
+    Partition,
+    upload_geonames,
+    GeonamesRecord,
+)
 
-from typing import Any
-
-from merino.jobs.geonames_uploader import geonames as upload_geonames, _parse_partitions
-from merino.jobs.geonames_uploader.geonames import _rs_geoname, _record_id, Partition
+from merino.jobs.utils.rs_client import RemoteSettingsClient
 
 from tests.unit.jobs.utils.rs_utils import (
     Record,
@@ -33,8 +36,9 @@ from tests.unit.jobs.geonames_uploader.geonames_utils import (
 
 def do_test(
     requests_mock,
+    force_reupload: bool,
     country: str,
-    partitions: list[Any],
+    partitions: list[Partition],
     expected_uploaded_records: list[Record],
     expected_deleted_records: list[Record] = [],
     existing_records: list[Record] = [],
@@ -50,21 +54,48 @@ def do_test(
     # A `requests_mock.exceptions.NoMockAddress: No mock address` error means
     # there was a request for a record that's not mocked here.
     mock_responses(
-        requests_mock, existing_records + expected_uploaded_records + expected_deleted_records
+        requests_mock,
+        get=existing_records,
+        update=expected_uploaded_records,
+        delete=expected_deleted_records,
     )
 
-    # Call the command.
-    upload_geonames(
+    rs_client = RemoteSettingsClient(
+        auth=rs_auth,
+        bucket=rs_bucket,
+        collection=rs_collection,
+        server=rs_server,
+        dry_run=rs_dry_run,
+    )
+
+    geonames_records_by_id = {}
+    for record in rs_client.get_records():
+        if record.get("country") == country and (record_id := record.get("id")):
+            if record.get("type") == geonames_record_type:
+                geonames_records_by_id[record_id] = record
+
+    # Call the upload function.
+    final_geonames_records = upload_geonames(
         country=country,
-        partitions=json.dumps(partitions),
+        existing_geonames_records_by_id=geonames_records_by_id,
+        force_reupload=force_reupload,
+        partitions=partitions,
         geonames_record_type=geonames_record_type,
         geonames_url_format=geonames_url_format,
-        rs_auth=rs_auth,
-        rs_bucket=rs_bucket,
-        rs_collection=rs_collection,
-        rs_dry_run=rs_dry_run,
-        rs_server=rs_server,
+        rs_client=rs_client,
     )
+
+    expected_final_geonames_records = sorted(
+        list(
+            {
+                r.data["id"]: GeonamesRecord(data=r.data, geonames=r.attachment)
+                for r in existing_records + expected_uploaded_records
+                if r.data["type"] == geonames_record_type and r.attachment
+            }.values()
+        ),
+        key=lambda r: r.data["id"],
+    )
+    assert final_geonames_records == expected_final_geonames_records
 
     # Only check remote settings requests, ignore geonames requests.
     rs_requests = [r for r in requests_mock.request_history if r.url.startswith(rs_server)]
@@ -77,15 +108,16 @@ def test_one_part_no_filter_countries(
     requests_mock,
     downloader_fixture,
 ):
-    """Upload one partition, no filter-expression countries"""
+    """Upload one partition, no client countries"""
     do_test(
         requests_mock,
+        force_reupload=False,
         country="US",
-        partitions=[1],
+        partitions=[Partition(1_000)],
         expected_uploaded_records=[
             Record(
                 data={
-                    "id": "geonames-US-1k",
+                    "id": "geonames-US-0001",
                     "type": "geonames-2",
                     "country": "US",
                 },
@@ -96,18 +128,19 @@ def test_one_part_no_filter_countries(
 
 
 def test_one_part_filter_countries(requests_mock, downloader_fixture: DownloaderFixture):
-    """Upload one partition with some filter-expression countries"""
+    """Upload one partition with some client countries"""
     do_test(
         requests_mock,
+        force_reupload=False,
         country="US",
-        partitions=[[1, ["GB", "US"]]],
+        partitions=[Partition(1_000, ["GB", "US"])],
         expected_uploaded_records=[
             Record(
                 data={
-                    "id": "geonames-US-1k",
+                    "id": "geonames-US-0001",
                     "type": "geonames-2",
                     "country": "US",
-                    "filter_expression_countries": ["GB", "US"],
+                    "client_countries": ["GB", "US"],
                     "filter_expression": "env.country in ['GB', 'US']",
                 },
                 attachment=[_rs_geoname(g) for g in filter_geonames("US", 1_000)],
@@ -117,24 +150,23 @@ def test_one_part_filter_countries(requests_mock, downloader_fixture: Downloader
 
 
 def test_one_part_empty_1(requests_mock, downloader_fixture: DownloaderFixture):
-    """Upload one partition that's empty and has no filter-expression countries"""
+    """Upload one partition that's empty and has no client countries"""
     do_test(
         requests_mock,
+        force_reupload=False,
         country="US",
-        partitions=[999_999_999_999],
+        partitions=[Partition(999_999_999_999)],
         expected_uploaded_records=[],
     )
 
 
 def test_one_part_empty_2(requests_mock, downloader_fixture: DownloaderFixture):
-    """Upload one partition that's empty and has some filter-expression
-    countries
-
-    """
+    """Upload one partition that's empty and has some client countries"""
     do_test(
         requests_mock,
+        force_reupload=False,
         country="US",
-        partitions=[[999_999_999_999, ["US", "GB"]]],
+        partitions=[Partition(999_999_999_999, ["US", "GB"])],
         expected_uploaded_records=[],
     )
 
@@ -143,23 +175,24 @@ def test_two_parts_first_part_empty_1(
     requests_mock,
     downloader_fixture: DownloaderFixture,
 ):
-    """Upload two partitions, first is empty, second does not have
-    filter-expression countries
+    """Upload two partitions, first is empty, second does not have client
+    countries
 
     """
     do_test(
         requests_mock,
+        force_reupload=False,
         country="US",
-        # There are no geonames with populations in the range [1k, 10k), so the
-        # first partition should not be created.
-        partitions=[[1, "US"], 10],
+        # There are no US geonames with populations in the range [1k, 10k), so
+        # the first partition should not be created.
+        partitions=[Partition(1_000, ["US"]), Partition(10_000)],
         expected_uploaded_records=[
             Record(
                 data={
                     # There shouldn't be a filter expression since the second
                     # partition doesn't specify any countries -- it should be
                     # available to all clients.
-                    "id": "geonames-US-10k",
+                    "id": "geonames-US-0010",
                     "type": "geonames-2",
                     "country": "US",
                 },
@@ -173,23 +206,21 @@ def test_two_parts_first_part_empty_2(
     requests_mock,
     downloader_fixture: DownloaderFixture,
 ):
-    """Upload two partitions, first is empty, second has filter-expression
-    countries
-
-    """
+    """Upload two partitions, first is empty, second has client countries"""
     do_test(
         requests_mock,
+        force_reupload=False,
         country="US",
         # There are no geonames with populations in the range [1k, 10k), so the
         # first partition should not be created.
-        partitions=[[1, "US"], [10, ["US", "GB"]]],
+        partitions=[Partition(1_000, ["US"]), Partition(10_000, ["US", "GB"])],
         expected_uploaded_records=[
             Record(
                 data={
-                    "id": "geonames-US-10k",
+                    "id": "geonames-US-0010",
                     "type": "geonames-2",
                     "country": "US",
-                    "filter_expression_countries": ["GB", "US"],
+                    "client_countries": ["GB", "US"],
                     "filter_expression": "env.country in ['GB', 'US']",
                 },
                 attachment=[_rs_geoname(g) for g in filter_geonames("US", 10_000)],
@@ -199,30 +230,33 @@ def test_two_parts_first_part_empty_2(
 
 
 def test_two_parts_neither_empty_1(requests_mock, downloader_fixture: DownloaderFixture):
-    """Upload two partitions, neither are empty, second does not have
-    filter-expression countries
+    """Upload two partitions, neither are empty, second does not have client
+    countries
 
     """
     do_test(
         requests_mock,
+        force_reupload=False,
         country="US",
-        partitions=[[50, "US"], 1_000],
+        partitions=[Partition(50_000, ["US"]), Partition(1_000_000)],
         expected_uploaded_records=[
             Record(
                 data={
-                    "id": "geonames-US-50k-1m",
+                    "id": "geonames-US-0050-1000",
                     "type": "geonames-2",
                     "country": "US",
-                    "filter_expression_countries": ["US"],
+                    "client_countries": ["US"],
                     "filter_expression": "env.country in ['US']",
                 },
                 attachment=[_rs_geoname(g) for g in filter_geonames("US", 50_000, 1_000_000)],
             ),
             Record(
                 data={
-                    "id": "geonames-US-1m",
+                    "id": "geonames-US-1000",
                     "type": "geonames-2",
                     "country": "US",
+                    # No `client_countries` or `filter_expression` since the
+                    # final partition didn't include them
                 },
                 attachment=[_rs_geoname(g) for g in filter_geonames("US", 1_000_000)],
             ),
@@ -231,31 +265,32 @@ def test_two_parts_neither_empty_1(requests_mock, downloader_fixture: Downloader
 
 
 def test_two_parts_neither_empty_2(requests_mock, downloader_fixture: DownloaderFixture):
-    """Upload two partitions, neither are empty, second has different
-    filter-expression countries
+    """Upload two partitions, neither are empty, second has different client
+    countries
 
     """
     do_test(
         requests_mock,
+        force_reupload=False,
         country="US",
-        partitions=[[50, "US"], [1_000, ["GB"]]],
+        partitions=[Partition(50_000, ["US"]), Partition(1_000_000, ["GB"])],
         expected_uploaded_records=[
             Record(
                 data={
-                    "id": "geonames-US-50k-1m",
+                    "id": "geonames-US-0050-1000",
                     "type": "geonames-2",
                     "country": "US",
-                    "filter_expression_countries": ["US"],
+                    "client_countries": ["US"],
                     "filter_expression": "env.country in ['US']",
                 },
                 attachment=[_rs_geoname(g) for g in filter_geonames("US", 50_000, 1_000_000)],
             ),
             Record(
                 data={
-                    "id": "geonames-US-1m",
+                    "id": "geonames-US-1000",
                     "type": "geonames-2",
                     "country": "US",
-                    "filter_expression_countries": ["GB"],
+                    "client_countries": ["GB"],
                     "filter_expression": "env.country in ['GB']",
                 },
                 attachment=[_rs_geoname(g) for g in filter_geonames("US", 1_000_000)],
@@ -265,31 +300,32 @@ def test_two_parts_neither_empty_2(requests_mock, downloader_fixture: Downloader
 
 
 def test_two_parts_neither_empty_3(requests_mock, downloader_fixture: DownloaderFixture):
-    """Upload two partitions, neither are empty, second has filter-expression
-    countries with one new country plus the country from the first partition
+    """Upload two partitions, neither are empty, second has client countries
+    with one new country plus the country from the first partition
 
     """
     do_test(
         requests_mock,
+        force_reupload=False,
         country="US",
-        partitions=[[50, "US"], [1_000, ["GB", "US"]]],
+        partitions=[Partition(50_000, ["US"]), Partition(1_000_000, ["GB", "US"])],
         expected_uploaded_records=[
             Record(
                 data={
-                    "id": "geonames-US-50k-1m",
+                    "id": "geonames-US-0050-1000",
                     "type": "geonames-2",
                     "country": "US",
-                    "filter_expression_countries": ["US"],
+                    "client_countries": ["US"],
                     "filter_expression": "env.country in ['US']",
                 },
                 attachment=[_rs_geoname(g) for g in filter_geonames("US", 50_000, 1_000_000)],
             ),
             Record(
                 data={
-                    "id": "geonames-US-1m",
+                    "id": "geonames-US-1000",
                     "type": "geonames-2",
                     "country": "US",
-                    "filter_expression_countries": ["GB", "US"],
+                    "client_countries": ["GB", "US"],
                     "filter_expression": "env.country in ['GB', 'US']",
                 },
                 attachment=[_rs_geoname(g) for g in filter_geonames("US", 1_000_000)],
@@ -298,26 +334,51 @@ def test_two_parts_neither_empty_3(requests_mock, downloader_fixture: Downloader
     )
 
 
-def test_update_old_records(requests_mock, downloader_fixture: DownloaderFixture):
-    """Upload a record that already exists"""
+def test_existing_record_dont_force(requests_mock, downloader_fixture: DownloaderFixture):
+    """Try to update an existing record but with no changes. Don't force
+    re-upload. No mutable requests should be made.
+
+    """
     do_test(
         requests_mock,
+        force_reupload=False,
         country="US",
-        partitions=[1],
+        partitions=[Partition(1_000)],
         existing_records=[
             Record(
                 data={
-                    "id": "geonames-US-1k",
+                    "id": "geonames-US-0001",
                     "type": "geonames-2",
                     "country": "US",
                 },
-                attachment=[],
+                attachment=[_rs_geoname(g) for g in filter_geonames("US", 1_000)],
+            ),
+        ],
+        expected_uploaded_records=[],
+    )
+
+
+def test_existing_record_force(requests_mock, downloader_fixture: DownloaderFixture):
+    """Try to update an existing record but with no changes. Force re-upload."""
+    do_test(
+        requests_mock,
+        force_reupload=True,
+        country="US",
+        partitions=[Partition(1_000)],
+        existing_records=[
+            Record(
+                data={
+                    "id": "geonames-US-0001",
+                    "type": "geonames-2",
+                    "country": "US",
+                },
+                attachment=[_rs_geoname(g) for g in filter_geonames("US", 1_000)],
             ),
         ],
         expected_uploaded_records=[
             Record(
                 data={
-                    "id": "geonames-US-1k",
+                    "id": "geonames-US-0001",
                     "type": "geonames-2",
                     "country": "US",
                 },
@@ -332,7 +393,7 @@ def test_delete_old_records(requests_mock, downloader_fixture: DownloaderFixture
     existing_us_records = [
         Record(
             data={
-                "id": "geonames-US-50k-100k",
+                "id": "geonames-US-0050-0100",
                 "type": "geonames-2",
                 "country": "US",
             },
@@ -340,7 +401,7 @@ def test_delete_old_records(requests_mock, downloader_fixture: DownloaderFixture
         ),
         Record(
             data={
-                "id": "geonames-US-100k",
+                "id": "geonames-US-0100",
                 "type": "geonames-2",
                 "country": "US",
             },
@@ -349,14 +410,15 @@ def test_delete_old_records(requests_mock, downloader_fixture: DownloaderFixture
     ]
     do_test(
         requests_mock,
+        force_reupload=False,
         country="US",
-        partitions=[1],
+        partitions=[Partition(1_000)],
         existing_records=[
             *existing_us_records,
             # A record with a different country should not be deleted.
             Record(
                 data={
-                    "id": "geonames-GB-1m",
+                    "id": "geonames-GB-1000",
                     "type": "geonames-2",
                     "country": "GB",
                 },
@@ -366,7 +428,7 @@ def test_delete_old_records(requests_mock, downloader_fixture: DownloaderFixture
         expected_uploaded_records=[
             Record(
                 data={
-                    "id": "geonames-US-1k",
+                    "id": "geonames-US-0001",
                     "type": "geonames-2",
                     "country": "US",
                 },
@@ -413,72 +475,49 @@ def test_rs_geoname_goessnitz():
 
 def test_record_id_1():
     """Test the `_record_id` helper function"""
-    assert _record_id("US", 1) == "geonames-US-1"
+    assert _record_id("US", 1) == "geonames-US-0000"
 
 
 def test_record_id_2():
     """Test the `_record_id` helper function"""
-    assert _record_id("US", 1, 50) == "geonames-US-1-50"
+    assert _record_id("US", 1, 50) == "geonames-US-0000-0000"
 
 
 def test_record_id_1k_1():
     """Test the `_record_id` helper function"""
-    assert _record_id("US", 1_000, 5_000) == "geonames-US-1k-5k"
+    assert _record_id("US", 1_000, 5_000) == "geonames-US-0001-0005"
 
 
 def test_record_id_1k_2():
     """Test the `_record_id` helper function"""
-    assert _record_id("US", 1_001, 5_001) == "geonames-US-1001-5001"
+    assert _record_id("US", 1_001, 5_001) == "geonames-US-0001-0005"
 
 
 def test_record_id_10k_1():
     """Test the `_record_id` helper function"""
-    assert _record_id("US", 10_000, 50_000) == "geonames-US-10k-50k"
+    assert _record_id("US", 10_000, 50_000) == "geonames-US-0010-0050"
 
 
 def test_record_id_10k_2():
     """Test the `_record_id` helper function"""
-    assert _record_id("US", 10_001, 50_001) == "geonames-US-10001-50001"
+    assert _record_id("US", 10_001, 50_001) == "geonames-US-0010-0050"
 
 
 def test_record_id_100k_1():
     """Test the `_record_id` helper function"""
-    assert _record_id("US", 100_000, 500_000) == "geonames-US-100k-500k"
+    assert _record_id("US", 100_000, 500_000) == "geonames-US-0100-0500"
 
 
 def test_record_id_100k_2():
     """Test the `_record_id` helper function"""
-    assert _record_id("US", 100_001, 500_001) == "geonames-US-100001-500001"
+    assert _record_id("US", 100_001, 500_001) == "geonames-US-0100-0500"
 
 
 def test_record_id_1m_1():
     """Test the `_record_id` helper function"""
-    assert _record_id("US", 1_000_000, 5_000_000) == "geonames-US-1m-5m"
+    assert _record_id("US", 1_000_000, 5_000_000) == "geonames-US-1000-5000"
 
 
 def test_record_id_1m_2():
     """Test the `_record_id` helper function"""
-    assert _record_id("US", 1_000_001, 5_000_001) == "geonames-US-1000001-5000001"
-
-
-def test_parse_partitions_one_threshold():
-    """Test the `_parse_partitions` helper function"""
-    assert _parse_partitions("[1]") == [Partition(1)]
-
-
-def test_parse_partitions_one_tuple_one_country():
-    """Test the `_parse_partitions` helper function"""
-    assert _parse_partitions('[[1, "US"]]') == [Partition(1, ["US"])]
-
-
-def test_parse_partitions_one_tuple_many_countries():
-    """Test the `_parse_partitions` helper function"""
-    assert _parse_partitions('[[1, ["US", "GB"]]]') == [Partition(1, ["US", "GB"])]
-
-
-def test_parse_partitions_one_tuple_one_threshold():
-    """Test the `_parse_partitions` helper function"""
-    assert _parse_partitions('[[1, ["US", "GB"]], 50]') == [
-        Partition(1, ["US", "GB"]),
-        Partition(50),
-    ]
+    assert _record_id("US", 1_000_001, 5_000_001) == "geonames-US-1000-5000"

--- a/tests/unit/jobs/utils/rs_utils.py
+++ b/tests/unit/jobs/utils/rs_utils.py
@@ -167,7 +167,9 @@ def check_delete_requests(actual_requests: list, records: list[Record]) -> None:
 
 def mock_responses(
     requests_mock,
-    records: list[Record],
+    get: list[Record] = [],
+    update: list[Record] = [],
+    delete: list[Record] = [],
     bucket: str = SERVER_DATA["bucket"],
     collection: str = SERVER_DATA["collection"],
     server: str = SERVER_DATA["server"],
@@ -201,21 +203,23 @@ def mock_responses(
     requests_mock.get(
         records_url,
         json={
-            "data": [r.all_data() for r in records],
+            "data": [r.all_data() for r in get],
         },
     )
 
-    for r in records:
-        # update record
-        requests_mock.put(r.url, json={})
-
-        # delete record
-        requests_mock.delete(r.url, json={"data": [{"deleted": True, "id": r.id}]})
-
-        # post attachment
-        requests_mock.post(r.post_attachment_url, json={})
-
+    for r in get:
         # get attachment
         attachment_metadata = r.all_data().get("attachment")
         if attachment_metadata:
             requests_mock.get(urljoin(server, attachment_metadata["location"]), json=r.attachment)
+
+    for r in update:
+        # update record
+        requests_mock.put(r.url, json={})
+
+        # post attachment
+        requests_mock.post(r.post_attachment_url, json={})
+
+    for r in delete:
+        # delete record
+        requests_mock.delete(r.url, json={"data": [{"deleted": True, "id": r.id}]})

--- a/tests/unit/jobs/utils/test_chunked_rs_uploader.py
+++ b/tests/unit/jobs/utils/test_chunked_rs_uploader.py
@@ -59,7 +59,7 @@ def do_upload_test(
     suggestion_score: float | None = None,
 ) -> None:
     """Perform an upload test."""
-    mock_responses(requests_mock, expected_records)
+    mock_responses(requests_mock, update=expected_records)
 
     with ChunkedRemoteSettingsSuggestionUploader(
         chunk_size=chunk_size,

--- a/tests/unit/jobs/utils/test_rs_client.py
+++ b/tests/unit/jobs/utils/test_rs_client.py
@@ -49,7 +49,7 @@ def do_get_records_test(
     client_kwargs: dict[str, Any] = {},
 ) -> None:
     """Perform a get_records and download_attachment test."""
-    mock_responses(requests_mock, TEST_RECORDS)
+    mock_responses(requests_mock, get=TEST_RECORDS)
 
     client = RemoteSettingsClient(**(TEST_CLIENT_KWARGS | client_kwargs))
     actual_records = client.get_records()
@@ -72,7 +72,7 @@ def do_upload_test(
     client_kwargs: dict[str, Any] = {},
 ) -> None:
     """Perform an upload test."""
-    mock_responses(requests_mock, records)
+    mock_responses(requests_mock, update=records)
 
     client = RemoteSettingsClient(**(TEST_CLIENT_KWARGS | client_kwargs))
     for record in records:
@@ -89,7 +89,7 @@ def do_delete_test(
     client_kwargs: dict[str, Any] = {},
 ) -> None:
     """Perform a delete test."""
-    mock_responses(requests_mock, TEST_RECORDS)
+    mock_responses(requests_mock, delete=TEST_RECORDS)
 
     client = RemoteSettingsClient(**(TEST_CLIENT_KWARGS | client_kwargs))
     for record_id in record_ids:


### PR DESCRIPTION
This replaces the two `geonames` and `alternates` command with a single `upload` command. The core job config is defined in the `CONFIGS_BY_COUNTRY` dict.

Another improvement this makes is to download existing RS records only once, at the start of the job, instead of having both the geonames part and the alternates part do it. The alternates part also doesn't need to download each geonames RS attachment anymore. So overall the job is faster to complete.

## References

JIRA: [DISCO-TODO](https://mozilla-hub.atlassian.net/browse/DISCO-TODO)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
