### PR TITLE
[DISCO-3567] Weather: return admin code or country name based on request

### DIFF
--- a/merino/providers/suggest/weather/backends/accuweather/backend.py
+++ b/merino/providers/suggest/weather/backends/accuweather/backend.py
@@ -7,7 +7,7 @@ import hashlib
 import orjson
 import logging
 from enum import Enum
-from typing import Any, Callable, NamedTuple, cast
+from typing import Any, Callable, NamedTuple, cast, Optional
 
 import aiodogstatsd
 from dateutil import parser
@@ -155,6 +155,9 @@ class AccuweatherLocation(BaseModel):
     # Unique Administrative Area ID for the Location.
     administrative_area_id: str
 
+    # Country name for the location
+    country_name: Optional[str] = None
+
 
 class WeatherData(NamedTuple):
     """The quartet for weather data used internally."""
@@ -283,9 +286,9 @@ class AccuweatherBackend:
                     hasher.update(key.encode("utf-8") + value.encode("utf-8"))
             extra_identifiers = hasher.hexdigest()
 
-            return f"{self.__class__.__name__}:v6:{url}:{extra_identifiers}"
+            return f"{self.__class__.__name__}:v7:{url}:{extra_identifiers}"
 
-        return f"{self.__class__.__name__}:v6:{url}"
+        return f"{self.__class__.__name__}:v7:{url}"
 
     @functools.cache
     def cache_key_template(self, dt: WeatherDataType, language: str) -> str:
@@ -501,7 +504,26 @@ class AccuweatherBackend:
         if location.localized_name == geolocation.city_names.get("en"):
             return geolocation.city_names.get(normalized_lang)
 
-        return None
+        return location.localized_name
+
+    @staticmethod
+    def get_region_for_weather_report(
+        location: AccuweatherLocation, weather_context: WeatherContext
+    ) -> str | None:
+        """Get region based on request country origin and the country of the requested city."""
+        geolocation = weather_context.geolocation
+        # we don't override country_name so it should tell us where the request came from
+        request_origin_country = geolocation.country_name
+        requested_country = geolocation.country
+
+        # None in the list because if we don't know the origin country of the request, use NA convention.
+        if request_origin_country in ["Canada", "United States", None] and requested_country in [
+            "CA",
+            "US",
+        ]:
+            return location.administrative_area_id
+        else:
+            return location.country_name
 
     async def get_weather_report_with_location_key(
         self, weather_context: WeatherContext
@@ -669,20 +691,24 @@ class AccuweatherBackend:
             # request was made with location key rather than geolocation
             # so location info is not in the cache
             location = AccuweatherLocation(
-                localized_name="N/A", key=location_key, administrative_area_id="N/A"
+                localized_name="N/A",
+                key=location_key,
+                administrative_area_id="N/A",
+                country_name="N/A",
             )
         # if all the other three values are present, ttl here would be a valid ttl value
         if location and current_conditions and forecast and ttl:
             # Return the weather report with the values returned from the cache.
             city_name = self.get_localized_city_name(location, weather_context)
+            admin_area = self.get_region_for_weather_report(location, weather_context)
+
             return WeatherReport(
                 city_name=city_name if city_name else location.localized_name,
-                region_code=location.administrative_area_id,
+                region_code=admin_area,
                 current_conditions=current_conditions,
                 forecast=forecast,
                 ttl=ttl,
             )
-
         # The cached report is incomplete, now fetching from AccuWeather.
         if location is None:
             try:
@@ -727,10 +753,11 @@ class AccuweatherBackend:
             forecast, forecast_ttl = forecast_response
             weather_report_ttl = min(current_conditions_ttl, forecast_ttl)
             city_name = self.get_localized_city_name(location, weather_context)
+            admin_area = self.get_region_for_weather_report(location, weather_context)
             return (
                 WeatherReport(
                     city_name=city_name if city_name else location.localized_name,
-                    region_code=location.administrative_area_id,
+                    region_code=admin_area,
                     current_conditions=current_conditions,
                     forecast=forecast,
                     ttl=weather_report_ttl,

--- a/merino/providers/suggest/weather/backends/accuweather/backend.py
+++ b/merino/providers/suggest/weather/backends/accuweather/backend.py
@@ -7,7 +7,7 @@ import hashlib
 import orjson
 import logging
 from enum import Enum
-from typing import Any, Callable, NamedTuple, cast, Optional
+from typing import Any, Callable, NamedTuple, cast
 
 import aiodogstatsd
 from dateutil import parser
@@ -156,7 +156,7 @@ class AccuweatherLocation(BaseModel):
     administrative_area_id: str
 
     # Country name for the location
-    country_name: Optional[str] = None
+    country_name: str
 
 
 class WeatherData(NamedTuple):
@@ -515,9 +515,7 @@ class AccuweatherBackend:
         # we don't override country_name so it should tell us where the request came from
         request_origin_country = geolocation.country_name
         requested_country = geolocation.country
-
-        # None in the list because if we don't know the origin country of the request, use NA convention.
-        if request_origin_country in ["Canada", "United States", None] and requested_country in [
+        if request_origin_country in ["Canada", "United States"] and requested_country in [
             "CA",
             "US",
         ]:

--- a/merino/providers/suggest/weather/backends/accuweather/utils.py
+++ b/merino/providers/suggest/weather/backends/accuweather/utils.py
@@ -32,6 +32,7 @@ class ProcessedLocationResponse(TypedDict):
     key: str
     localized_name: str
     administrative_area_id: str
+    country_name: str
 
 
 def add_partner_code(
@@ -89,6 +90,9 @@ def process_location_response(
                 "Key": key,
                 "LocalizedName": localized_name,
                 "AdministrativeArea": {"ID": administrative_area_id},
+                "Country": {
+                    "LocalizedName": country_name,
+                },
             },
             *_,
         ]:
@@ -100,6 +104,7 @@ def process_location_response(
                 "key": key,
                 "localized_name": localized_name,
                 "administrative_area_id": administrative_area_id,
+                "country_name": country_name,
             }
         case _:
             return None

--- a/tests/integration/providers/suggest/weather/backends/test_accuweather.py
+++ b/tests/integration/providers/suggest/weather/backends/test_accuweather.py
@@ -160,6 +160,7 @@ def fixture_weather_context_without_location_key() -> WeatherContext:
             city="San Francisco",
             dma=807,
             postal_code="94105",
+            country_name="United States",
         ),
         ["en-US", "fr"],
     )
@@ -176,6 +177,7 @@ def fixture_weather_context_with_location_key() -> WeatherContext:
             dma=807,
             postal_code="94105",
             key=ACCUWEATHER_LOCATION_KEY,
+            country_name="United States",
         ),
         ["en-US", "fr"],
     )
@@ -188,6 +190,7 @@ def fixture_accuweather_cached_location_key() -> bytes:
         "key": "39376",
         "localized_name": "San Francisco",
         "administrative_area_id": "CA",
+        "country_name": "United States",
     }
     return json.dumps(location).encode("utf-8")
 

--- a/tests/unit/providers/suggest/weather/backends/test_accuweather.py
+++ b/tests/unit/providers/suggest/weather/backends/test_accuweather.py
@@ -337,7 +337,7 @@ def fixture_expected_weather_report() -> WeatherReport:
     """Create an `AccuWeatherReport` for assertions"""
     return WeatherReport(
         city_name="San Francisco",
-        region_code="CA",
+        region_code="United States",
         current_conditions=CurrentConditions(
             url=HttpUrl(
                 "https://www.accuweather.com/en/us/san-francisco-ca/94103/"
@@ -602,6 +602,7 @@ def fixture_accuweather_cached_location_key() -> bytes:
         "key": "39376",
         "localized_name": "San Francisco",
         "administrative_area_id": "CA",
+        "country_name": "United States",
     }
     return orjson.dumps(location)
 
@@ -2632,7 +2633,10 @@ async def test_get_localized_city_name(
 ) -> None:
     """Test return city name returns correct localized city name."""
     location = AccuweatherLocation(
-        key="123", localized_name="San Francisco", administrative_area_id="CA"
+        key="123",
+        localized_name="San Francisco",
+        administrative_area_id="CA",
+        country_name="United States",
     )
     modified_weather_context = replace(weather_context_without_location_key, languages=languages)
     city_name = accuweather.get_localized_city_name(location, modified_weather_context)
@@ -2644,7 +2648,7 @@ async def test_get_localized_city_name(
     [
         ("United States", "CA"),
         ("France", "United States"),
-        (None, "CA"),
+        (None, "United States"),
     ],
 )
 @pytest.mark.asyncio

--- a/tests/unit/providers/suggest/weather/backends/test_accuweather.py
+++ b/tests/unit/providers/suggest/weather/backends/test_accuweather.py
@@ -163,31 +163,6 @@ def fixture_location_response_for_fallback() -> bytes:
     )
 
 
-@pytest.fixture(name="localized_name_response")
-def fixture_localized_name_response() -> bytes:
-    """Fixture for localized name response."""
-    return orjson.dumps(
-        {
-            "Version": 1,
-            "Key": "39376",
-            "Type": "City",
-            "Rank": 35,
-            "LocalizedName": "Santo Francisco",
-            "EnglishName": "San Francisco",
-            "PrimaryPostalCode": "94105",
-            "AdministrativeArea": {
-                "ID": "CA",
-                "LocalizedName": "California",
-                "EnglishName": "California",
-                "Level": 1,
-                "LocalizedType": "State",
-                "EnglishType": "State",
-                "CountryID": "US",
-            },
-        }
-    )
-
-
 @pytest.fixture(name="location_completion_sample_cities")
 def fixture_location_completion_sample_cities() -> list[dict[str, Any]]:
     """Create a list of sample location completions for the search term 'new'"""
@@ -1668,7 +1643,10 @@ async def test_get_location_by_geolocation(
 ) -> None:
     """Test that the get_location method returns an AccuweatherLocation."""
     expected_location: AccuweatherLocation = AccuweatherLocation(
-        key="39376", localized_name="San Francisco", administrative_area_id="CA"
+        key="39376",
+        localized_name="San Francisco",
+        administrative_area_id="CA",
+        country_name="United States",
     )
     weather_context_without_location_key.selected_region = "CA"
     weather_context_without_location_key.selected_city = "San Francisco"
@@ -2051,16 +2029,16 @@ async def test_get_forecast_error(accuweather: AccuweatherBackend, language: str
     [
         (
             {"q": "asdfg", "apikey": "filter_me_out"},
-            f"AccuweatherBackend:v6:localhost:"
+            f"AccuweatherBackend:v7:localhost:"
             f"{hashlib.blake2s('q'.encode('utf-8') + 'asdfg'.encode('utf-8')).hexdigest()}",
         ),
         (
             {},
-            "AccuweatherBackend:v6:localhost",
+            "AccuweatherBackend:v7:localhost",
         ),
         (
             {"q": "asdfg"},
-            f"AccuweatherBackend:v6:localhost:"
+            f"AccuweatherBackend:v7:localhost:"
             f"{hashlib.blake2s('q'.encode('utf-8') + 'asdfg'.encode('utf-8')).hexdigest()}",
         ),
     ],
@@ -2651,7 +2629,6 @@ async def test_get_localized_city_name(
     expected_city_name: str,
     accuweather: AccuweatherBackend,
     response_header: dict[str, str],
-    localized_name_response: bytes,
 ) -> None:
     """Test return city name returns correct localized city name."""
     location = AccuweatherLocation(
@@ -2660,3 +2637,70 @@ async def test_get_localized_city_name(
     modified_weather_context = replace(weather_context_without_location_key, languages=languages)
     city_name = accuweather.get_localized_city_name(location, modified_weather_context)
     assert city_name == expected_city_name
+
+
+@pytest.mark.parametrize(
+    ("country_request_origin", "expected_region"),
+    [
+        ("United States", "CA"),
+        ("France", "United States"),
+        (None, "CA"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_get_region_for_weather_report_north_america(
+    weather_context_without_location_key: WeatherContext,
+    country_request_origin: str,
+    expected_region: str,
+    accuweather: AccuweatherBackend,
+    response_header: dict[str, str],
+) -> None:
+    """Test return city name returns correct localized city name."""
+    location = AccuweatherLocation(
+        key="123",
+        localized_name="San Francisco",
+        administrative_area_id="CA",
+        country_name="United States",
+    )
+    geolocation = weather_context_without_location_key.geolocation
+    modified_geolocation = geolocation.model_copy(update={"country_name": country_request_origin})
+    modified_weather_context = replace(
+        weather_context_without_location_key, geolocation=modified_geolocation
+    )
+    region = accuweather.get_region_for_weather_report(location, modified_weather_context)
+    assert region == expected_region
+
+
+@pytest.mark.parametrize(
+    ("country_request_origin", "request_country", "expected_region"),
+    [
+        ("United States", "GB", "United Kingdom"),
+        ("United Kingdom", "GB", "United Kingdom"),
+        (None, "GB", "United Kingdom"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_get_region_for_weather_report_outside_north_america(
+    weather_context_without_location_key: WeatherContext,
+    country_request_origin: str,
+    request_country: str,
+    expected_region: str,
+    accuweather: AccuweatherBackend,
+    response_header: dict[str, str],
+) -> None:
+    """Test return city name returns correct localized city name."""
+    location = AccuweatherLocation(
+        key="123",
+        localized_name="London",
+        administrative_area_id="LND",
+        country_name="United Kingdom",
+    )
+    geolocation = weather_context_without_location_key.geolocation
+    modified_geolocation = geolocation.model_copy(
+        update={"country_name": country_request_origin, "country": request_country}
+    )
+    modified_weather_context = replace(
+        weather_context_without_location_key, geolocation=modified_geolocation
+    )
+    region = accuweather.get_region_for_weather_report(location, modified_weather_context)
+    assert region == expected_region


### PR DESCRIPTION
## References

JIRA: [DISCO-3567](https://mozilla-hub.atlassian.net/browse/DISCO-3567)

## Description
Since countries outside of the US and CA find it odd that locations are displayed as <City>, <Admin Code> rather than <City>, <Country>
Modifications are made such that depending on the city request for weather and the country of where the request is coming from. We change region_code to use either admin code or country name.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3567]: https://mozilla-hub.atlassian.net/browse/DISCO-3567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1747)
