### PR TITLE
[DISCO-3569] Publish locust image to GAR

### DIFF
--- a/.github/workflows/build-docker-image.yaml
+++ b/.github/workflows/build-docker-image.yaml
@@ -1,0 +1,40 @@
+name: build-docker-image
+
+on:
+  workflow_call:
+    inputs:
+      image_tag:
+        required: true
+        type: string
+    secrets:
+      DOCKER_IMAGE_PATH:
+        required: true
+
+jobs:
+  build:
+    environment: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get info
+        run: |
+          uname -v
+          docker info
+      - name: Create version.json
+        run: |
+          printf '{"commit":"%s","version":"%s","source":"%s","build":"%s"}\n' \
+          "$GITHUB_SHA" \
+          "$GITHUB_REF_NAME" \
+          "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" \
+          "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" > version.json
+      - name: Output version.json
+        run: cat version.json
+      - name: Build docker image
+        run: make docker-build
+      - name: Save app:build image
+        run: docker save app:build | gzip > image.tar.gz
+      - name: Upload image artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: merino
+          path: image.tar.gz

--- a/.github/workflows/build-locust-image.yaml
+++ b/.github/workflows/build-locust-image.yaml
@@ -1,0 +1,29 @@
+name: build-locust-image
+
+on:
+  workflow_call:
+    inputs:
+      image_tag:
+        required: true
+        type: string
+    secrets:
+      DOCKER_IMAGE_PATH:
+        required: true
+
+jobs:
+  build-locust:
+    environment: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build Locust Docker image
+        run: docker build -t merino-locust -f ./tests/load/Dockerfile .
+      - name: Tag with GAR path
+        run: docker tag merino-locust ${{ secrets.DOCKER_IMAGE_PATH }}/merino-locust:${{ inputs.image_tag }}
+      - name: Save image
+        run: docker save ${{ secrets.DOCKER_IMAGE_PATH }}/merino-locust:${{ inputs.image_tag }} | gzip > locust-image.tar.gz
+      - name: Upload image artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: locust-image
+          path: locust-image.tar.gz

--- a/.github/workflows/main-workflow.yaml
+++ b/.github/workflows/main-workflow.yaml
@@ -29,35 +29,33 @@ jobs:
   run-docs-publish-github-pages:
     needs: run-docs-build
     uses: ./.github/workflows/docs-publish-github-pages.yaml
-  run-docker-image-build-and-push:
-    environment: build
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      deployments: write
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - name: Get info
-        run: |
-          uname -v
-          docker info
-      - name: Create version.json
-        run: |
-          printf '{"commit":"%s","version":"%s","source":"%s","build":"%s"}\n' \
-          "$GITHUB_SHA" \
-          "$GITHUB_REF_NAME" \
-          "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" \
-          "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" > version.json
-      - name: Output version.json
-        run: cat version.json
-      - name: Build docker image
-        run: make docker-build
-      - name: Push the docker image to GAR
-        uses: mozilla-it/deploy-actions/docker-push@v3.11.1
-        with:
-          local_image: app:build
-          image_repo_path: ${{ secrets.DOCKER_IMAGE_PATH }}
-          image_tag: latest
-          workload_identity_pool_project_number: ${{ vars.GCPV2_WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER }}
-          project_id: ${{ vars.GCP_PROJECT_ID }}
+  run-build-docker-image:
+    uses: ./.github/workflows/build-docker-image.yaml
+    with:
+      image_tag: latest
+    secrets:
+      DOCKER_IMAGE_PATH: ${{ secrets.DOCKER_IMAGE_PATH }}
+  run-publish-docker-image:
+    needs: run-build-docker-image
+    uses: ./.github/workflows/publish-docker-image.yaml
+    with:
+      image_tag: latest
+      project_id: ${{ vars.GCP_PROJECT_ID }}
+      workload_identity_pool_project_number: ${{ vars.GCPV2_WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER }}
+    secrets:
+      DOCKER_IMAGE_PATH: ${{ secrets.DOCKER_IMAGE_PATH }}
+  run-build-locust-image:
+    uses: ./.github/workflows/build-locust-image.yaml
+    with:
+      image_tag: latest
+    secrets:
+      DOCKER_IMAGE_PATH: ${{ secrets.DOCKER_IMAGE_PATH }}
+  run-publish-locust-image:
+    needs: run-build-locust-image
+    uses: ./.github/workflows/publish-locust-image.yaml
+    with:
+      image_tag: latest
+      project_id: ${{ vars.GCP_PROJECT_ID }}
+      workload_identity_pool_project_number: ${{ vars.GCPV2_WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER }}
+    secrets:
+      DOCKER_IMAGE_PATH: ${{ secrets.DOCKER_IMAGE_PATH }}

--- a/.github/workflows/pr-workflow.yaml
+++ b/.github/workflows/pr-workflow.yaml
@@ -9,24 +9,15 @@ jobs:
     uses: ./.github/workflows/tests.yaml
   run-docs-build:
     uses: ./.github/workflows/docs-build.yaml
-  run-docker-image-build:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-      - name: Get info
-        run: |
-          uname -v
-          docker info
-      - name: Create version.json
-        run: |
-          printf '{"commit":"%s","version":"%s","source":"%s","build":"%s"}\n' \
-          "$GITHUB_SHA" \
-          "$GITHUB_REF_NAME" \
-          "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" \
-          "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" > version.json
-      - name: Output version.json
-        run: cat version.json
-      - name: Build docker image
-        run: make docker-build
+  run-build-docker-image:
+    uses: ./.github/workflows/build-docker-image.yaml
+    with:
+      image_tag: latest
+    secrets:
+      DOCKER_IMAGE_PATH: ${{ secrets.DOCKER_IMAGE_PATH }}
+  run-build-locust-image:
+    uses: ./.github/workflows/build-locust-image.yaml
+    with:
+      image_tag: latest
+    secrets:
+      DOCKER_IMAGE_PATH: ${{ secrets.DOCKER_IMAGE_PATH }}

--- a/.github/workflows/publish-docker-image.yaml
+++ b/.github/workflows/publish-docker-image.yaml
@@ -1,0 +1,43 @@
+name: publish-docker-image
+
+on:
+  workflow_call:
+    inputs:
+      image_tag:
+        required: true
+        type: string
+      project_id:
+        required: true
+        type: string
+      workload_identity_pool_project_number:
+        required: true
+        type: string
+    secrets:
+      DOCKER_IMAGE_PATH:
+        required: true
+
+jobs:
+  publish:
+    environment: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Download image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: merino
+          path: .
+      - name: Load Docker image
+        run: gunzip -c image.tar.gz | docker load
+      - name: Tag image with GAR path
+        run: docker tag app:build ${{ secrets.DOCKER_IMAGE_PATH }}/merino:${{ inputs.image_tag }}
+      - name: Push image to GAR
+        uses: mozilla-it/deploy-actions/docker-push@v3.11.1
+        with:
+          local_image: app:build
+          image_repo_path: ${{ secrets.DOCKER_IMAGE_PATH }}/merino
+          image_tag: ${{ inputs.image_tag }}
+          workload_identity_pool_project_number: ${{ inputs.workload_identity_pool_project_number }}
+          project_id: ${{ inputs.project_id }}

--- a/.github/workflows/publish-locust-image.yaml
+++ b/.github/workflows/publish-locust-image.yaml
@@ -1,0 +1,50 @@
+name: publish-locust-image
+
+on:
+  workflow_call:
+    inputs:
+      image_tag:
+        required: true
+        type: string
+      project_id:
+        required: true
+        type: string
+      workload_identity_pool_project_number:
+        required: true
+        type: string
+    secrets:
+      DOCKER_IMAGE_PATH:
+        required: true
+
+jobs:
+  publish-locust:
+    environment: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check for [load test skip] directive
+        run: |
+          if git log -1 --pretty=%B | grep -qi '\[load test: skip\]'; then
+            echo "Skipping Locust image publish due to [load test: skip] directive."
+            exit 0
+          fi
+      - name: Download Locust image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: locust-image
+          path: .
+      - name: Load Locust Docker image
+        run: gunzip -c locust-image.tar.gz | docker load
+      - name: Tag image as latest
+        run: docker tag ${{ secrets.DOCKER_IMAGE_PATH }}/merino-locust:${{ inputs.image_tag }} ${{ secrets.DOCKER_IMAGE_PATH }}/merino-locust:latest
+      - name: Push Locust image to GAR
+        uses: mozilla-it/deploy-actions/docker-push@v3.11.1
+        with:
+          local_image: ${{ secrets.DOCKER_IMAGE_PATH }}/merino-locust:latest
+          image_repo_path: ${{ secrets.DOCKER_IMAGE_PATH }}/merino-locust
+          image_tag: latest
+          workload_identity_pool_project_number: ${{ inputs.workload_identity_pool_project_number }}
+          project_id: ${{ inputs.project_id }}


### PR DESCRIPTION
## References

JIRA: [DISCO-3569](https://mozilla-hub.atlassian.net/browse/DISCO-3569)

## Description
This PR refactors the CI workflows and migrates the Locust Docker image build and publish steps from CircleCI to GitHub Actions.
- Extracted the Locust Docker image build and publish logic into two reusable workflows:
       - build-locust-image.yaml
       - publish-locust-image.yaml
- Integrated these workflows into the main-workflow.yaml for execution on pushes to main.
- Images are now published to Google Artifact Registry (GAR) under merino-locust.
- Added support for [load test: skip] commit directive to conditionally skip publishing.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3569]: https://mozilla-hub.atlassian.net/browse/DISCO-3569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1760)
