### PR TITLE
HNT-780: fix sections layout

### DIFF
--- a/tests/unit/curated_recommendations/test_sections.py
+++ b/tests/unit/curated_recommendations/test_sections.py
@@ -17,6 +17,7 @@ from merino.curated_recommendations.corpus_backends.protocol import (
 )
 from merino.curated_recommendations.layouts import (
     layout_4_medium,
+    layout_6_tiles,
 )
 from merino.curated_recommendations.protocol import (
     Section,
@@ -269,7 +270,7 @@ class TestMapCorpusSectionToSection:
         sec = map_corpus_section_to_section(cs, 5)
         assert sec.receivedFeedRank == 5
         assert sec.title == cs.title
-        assert sec.layout == layout_4_medium
+        assert sec.layout == layout_6_tiles
         assert sec.iab == cs.iab
         assert len(sec.recommendations) == len(cs.sectionItems)
         for idx, rec in enumerate(sec.recommendations):
@@ -451,14 +452,14 @@ class TestGetCorpusSections:
         section_a = result["secA"]
         assert section_a.receivedFeedRank == 5
         assert len(section_a.recommendations) == 2
-        assert section_a.layout == layout_4_medium
+        assert section_a.layout == layout_6_tiles
 
         section_b = result["secB"]
         assert section_b.receivedFeedRank == 6
         assert len(section_b.recommendations) == 1
-        assert section_b.layout == layout_4_medium
+        assert section_b.layout == layout_6_tiles
 
         section_c = result["secC"]
         assert section_c.receivedFeedRank == 7
         assert len(section_c.recommendations) == 3
-        assert section_c.layout == layout_4_medium
+        assert section_c.layout == layout_6_tiles


### PR DESCRIPTION
## References

JIRA: https://mozilla-hub.atlassian.net/browse/HNT-780

## Description
In some cases, seeing the same layout for 4 consecutive sections

In particular, we want to avoid to avoid the first 2 sections from having the same layout. There have been examples of Popular Today and the 2nd section both using the large card layout. 

* Fix this by sorting ranked sections by `receievedFeedRank` & then apply layout cycling.
* Apply the 6 card layout to all sections before pruning, the ensure we only return sections that can accommodate the biggest layout.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1762)
