### PR TITLE
[GENAI-1370] added a new FakeLocalModel which is over sections instead of topics

### DIFF
--- a/merino/curated_recommendations/__init__.py
+++ b/merino/curated_recommendations/__init__.py
@@ -18,7 +18,9 @@ from merino.curated_recommendations.corpus_backends.sections_backend import (
 from merino.curated_recommendations.engagement_backends.fake_engagement import FakeEngagement
 from merino.curated_recommendations.engagement_backends.gcs_engagement import GcsEngagement
 from merino.curated_recommendations.engagement_backends.protocol import EngagementBackend
-from merino.curated_recommendations.ml_backends.fake_local_model import FakeLocalModelSections as FakeLocalModel
+from merino.curated_recommendations.ml_backends.fake_local_model import (
+    FakeLocalModelSections as FakeLocalModel,
+)
 from merino.curated_recommendations.ml_backends.gcs_local_model import GCSLocalModel
 from merino.curated_recommendations.ml_backends.protocol import LocalModelBackend
 from merino.curated_recommendations.prior_backends.gcs_prior import GcsPrior

--- a/merino/curated_recommendations/__init__.py
+++ b/merino/curated_recommendations/__init__.py
@@ -18,7 +18,7 @@ from merino.curated_recommendations.corpus_backends.sections_backend import (
 from merino.curated_recommendations.engagement_backends.fake_engagement import FakeEngagement
 from merino.curated_recommendations.engagement_backends.gcs_engagement import GcsEngagement
 from merino.curated_recommendations.engagement_backends.protocol import EngagementBackend
-from merino.curated_recommendations.ml_backends.fake_local_model import FakeLocalModel
+from merino.curated_recommendations.ml_backends.fake_local_model import FakeLocalModelSections as FakeLocalModel
 from merino.curated_recommendations.ml_backends.gcs_local_model import GCSLocalModel
 from merino.curated_recommendations.ml_backends.protocol import LocalModelBackend
 from merino.curated_recommendations.prior_backends.gcs_prior import GcsPrior

--- a/merino/curated_recommendations/ml_backends/fake_local_model.py
+++ b/merino/curated_recommendations/ml_backends/fake_local_model.py
@@ -33,7 +33,7 @@ BASE_TOPICS = [
 
 # Creates a simple model based on topics. Topic features are stored with a t_
 # in telemetry
-class FakeLocalModel(LocalModelBackend):
+class FakeLocalModelTopics(LocalModelBackend):
     """Class that defines sample parameters on the local Firefox client for defining an interest
     vector from interaction events
 
@@ -73,8 +73,34 @@ class FakeLocalModel(LocalModelBackend):
 
 
 BASE_SECTIONS = [
-      'dummy'
+    "nfl",
+    "nba",
+    "mlb",
+    "nhl",
+    "soccer",
+    "tv",
+    "movies",
+    "music",
+    "celebrity news",
+    "books",
+    "business",
+    "career",
+    "arts",
+    "food",
+    "health",
+    "home",
+    "finance",
+    "government",
+    "sports",
+    "tech",
+    "travel",
+    "education",
+    "hobbies",
+    "society-parenting",
+    "education-science",
+    "society",
 ]
+
 
 # Creates a simple model based on sections. Section features are stored with a s_
 # in telemetry

--- a/merino/curated_recommendations/ml_backends/fake_local_model.py
+++ b/merino/curated_recommendations/ml_backends/fake_local_model.py
@@ -57,6 +57,7 @@ class FakeLocalModelTopics(LocalModelBackend):
         model_data: ModelData = ModelData(
             model_type=ModelType.CTR,
             rescale=False,
+            noise_scale=0.01,
             day_time_weighting=DayTimeWeightingConfig(
                 days=[3, 14, 45],
                 relative_weight=[1, 1, 1],
@@ -128,6 +129,7 @@ class FakeLocalModelSections(LocalModelBackend):
         model_data: ModelData = ModelData(
             model_type=ModelType.CTR,
             rescale=False,
+            noise_scale=0.01,
             day_time_weighting=DayTimeWeightingConfig(
                 days=[3, 14, 45],
                 relative_weight=[1, 1, 1],

--- a/merino/curated_recommendations/ml_backends/fake_local_model.py
+++ b/merino/curated_recommendations/ml_backends/fake_local_model.py
@@ -36,6 +36,10 @@ BASE_TOPICS = [
 class FakeLocalModel(LocalModelBackend):
     """Class that defines sample parameters on the local Firefox client for defining an interest
     vector from interaction events
+
+    Topics are the features of the model. The model is a represetion of users interests.
+
+    Set which model is used at __init__ import
     """
 
     def get(self, surface_id: str | None = None) -> InferredLocalModel | None:
@@ -50,6 +54,51 @@ class FakeLocalModel(LocalModelBackend):
             )
 
         category_fields: dict[str, InterestVectorConfig] = {a: get_topic(a) for a in BASE_TOPICS}
+        model_data: ModelData = ModelData(
+            model_type=ModelType.CTR,
+            rescale=False,
+            day_time_weighting=DayTimeWeightingConfig(
+                days=[3, 14, 45],
+                relative_weight=[1, 1, 1],
+            ),
+            interest_vector=category_fields,
+        )
+
+        return InferredLocalModel(
+            model_id=CTR_TOPIC_MODEL_ID,
+            surface_id=surface_id,
+            model_data=model_data,
+            model_version=0,
+        )
+
+
+BASE_SECTIONS = [
+      'dummy'
+]
+
+# Creates a simple model based on sections. Section features are stored with a s_
+# in telemetry
+class FakeLocalModelSections(LocalModelBackend):
+    """Class that defines sample parameters on the local Firefox client for defining an interest
+    vector from interaction events
+
+    Sections are the features of the model. The model is a represetion of users interests.
+
+    Set which model is used at __init__ import
+    """
+
+    def get(self, surface_id: str | None = None) -> InferredLocalModel | None:
+        """Fetch local model for the region"""
+
+        def get_topic(topic: str) -> InterestVectorConfig:
+            return InterestVectorConfig(
+                features={f"s_{topic}": 1},
+                thresholds=[0.3, 0.4],
+                diff_p=0.75,
+                diff_q=0.25,
+            )
+
+        category_fields: dict[str, InterestVectorConfig] = {a: get_topic(a) for a in BASE_SECTIONS}
         model_data: ModelData = ModelData(
             model_type=ModelType.CTR,
             rescale=False,

--- a/merino/curated_recommendations/ml_backends/fake_local_model.py
+++ b/merino/curated_recommendations/ml_backends/fake_local_model.py
@@ -10,6 +10,7 @@ from merino.curated_recommendations.ml_backends.protocol import (
 )
 
 CTR_TOPIC_MODEL_ID = "ctr_model_topic_1"
+CTR_SECTION_MODEL_ID = "ctr_model_section_1"
 SPECIAL_FEATURE_CLICK = "clicks"
 
 BASE_TOPICS = [
@@ -57,7 +58,7 @@ class FakeLocalModelTopics(LocalModelBackend):
         model_data: ModelData = ModelData(
             model_type=ModelType.CTR,
             rescale=False,
-            noise_scale=0.01,
+            noise_scale=0.002,
             day_time_weighting=DayTimeWeightingConfig(
                 days=[3, 14, 45],
                 relative_weight=[1, 1, 1],
@@ -129,7 +130,7 @@ class FakeLocalModelSections(LocalModelBackend):
         model_data: ModelData = ModelData(
             model_type=ModelType.CTR,
             rescale=False,
-            noise_scale=0.01,
+            noise_scale=0.002,
             day_time_weighting=DayTimeWeightingConfig(
                 days=[3, 14, 45],
                 relative_weight=[1, 1, 1],
@@ -138,7 +139,7 @@ class FakeLocalModelSections(LocalModelBackend):
         )
 
         return InferredLocalModel(
-            model_id=CTR_TOPIC_MODEL_ID,
+            model_id=CTR_SECTION_MODEL_ID,
             surface_id=surface_id,
             model_data=model_data,
             model_version=0,

--- a/merino/curated_recommendations/ml_backends/protocol.py
+++ b/merino/curated_recommendations/ml_backends/protocol.py
@@ -46,6 +46,7 @@ class ModelData(BaseModel):
     day_time_weighting: DayTimeWeightingConfig
     # Output key, and inputs for how fields affect it
     interest_vector: dict[str, InterestVectorConfig]
+    noise_scale: float
 
 
 class InferredLocalModel(BaseModel):

--- a/tests/integration/api/v1/curated_recommendations/ml_backends/test_gcs_local_model.py
+++ b/tests/integration/api/v1/curated_recommendations/ml_backends/test_gcs_local_model.py
@@ -125,7 +125,7 @@ async def test_gcs_local_model_fetches_data(gcs_storage_client, gcs_bucket, metr
     model_data = ModelData(
         model_type=ModelType.CTR,
         rescale=True,
-        noise_scale=0.01,
+        noise_scale=0.002,
         day_time_weighting=DayTimeWeightingConfig(
             days=[3, 14, 45],
             relative_weight=[1, 1, 1],

--- a/tests/integration/api/v1/curated_recommendations/ml_backends/test_gcs_local_model.py
+++ b/tests/integration/api/v1/curated_recommendations/ml_backends/test_gcs_local_model.py
@@ -42,7 +42,7 @@ def create_gcs_local_model(
         metrics_client=metrics_client,
         metrics_namespace="recommendation.local_model",
         max_size=settings.curated_recommendations.gcs.local_model.max_size,
-        cron_interval_seconds=0.01,
+        cron_interval_seconds=0.002,
         cron_job_name="fetch_local_model",
     )
     # Call initialize to start the cron job in the same event loop

--- a/tests/integration/api/v1/curated_recommendations/ml_backends/test_gcs_local_model.py
+++ b/tests/integration/api/v1/curated_recommendations/ml_backends/test_gcs_local_model.py
@@ -86,6 +86,7 @@ def blob(gcs_bucket):
                 "model_data": {
                     "model_type": ModelType.CTR,
                     "rescale": True,
+                    "noise_scale": 0.01,
                     "day_time_weighting": {"days": [], "relative_weight": []},
                     "interest_vector": {},
                 },
@@ -124,6 +125,7 @@ async def test_gcs_local_model_fetches_data(gcs_storage_client, gcs_bucket, metr
     model_data = ModelData(
         model_type=ModelType.CTR,
         rescale=True,
+        noise_scale=0.01,
         day_time_weighting=DayTimeWeightingConfig(
             days=[3, 14, 45],
             relative_weight=[1, 1, 1],

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -109,6 +109,7 @@ class MockLocalModelBackend(LocalModelBackend):
         model_data = ModelData(
             model_type=ModelType.CLICKS,
             rescale=True,
+            noise_scale=0.01,
             day_time_weighting=DayTimeWeightingConfig(
                 days=[3, 14, 45],
                 relative_weight=[1, 1, 1],

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -109,7 +109,7 @@ class MockLocalModelBackend(LocalModelBackend):
         model_data = ModelData(
             model_type=ModelType.CLICKS,
             rescale=True,
-            noise_scale=0.01,
+            noise_scale=0.002,
             day_time_weighting=DayTimeWeightingConfig(
                 days=[3, 14, 45],
                 relative_weight=[1, 1, 1],

--- a/tests/unit/curated_recommendations/ml_backends/test_fake_local_model.py
+++ b/tests/unit/curated_recommendations/ml_backends/test_fake_local_model.py
@@ -5,6 +5,7 @@ from merino.curated_recommendations.ml_backends.fake_local_model import (
     FakeLocalModelTopics,
     FakeLocalModelSections,
     CTR_TOPIC_MODEL_ID,
+    CTR_SECTION_MODEL_ID,
 )
 from merino.curated_recommendations.ml_backends.protocol import InferredLocalModel
 
@@ -43,7 +44,7 @@ def test_model_returns_inferred_local_model_sections(model_sections):
     result = model_sections.get(surface_id)
 
     assert isinstance(result, InferredLocalModel)
-    assert result.model_id == CTR_TOPIC_MODEL_ID
+    assert result.model_id == CTR_SECTION_MODEL_ID
     assert result.surface_id == surface_id
     assert result.model_version == 0
     assert result.model_data is not None

--- a/tests/unit/curated_recommendations/ml_backends/test_fake_local_model.py
+++ b/tests/unit/curated_recommendations/ml_backends/test_fake_local_model.py
@@ -2,22 +2,44 @@
 
 import pytest
 from merino.curated_recommendations.ml_backends.fake_local_model import (
-    FakeLocalModel,
+    FakeLocalModelTopics,
+    FakeLocalModelSections,
     CTR_TOPIC_MODEL_ID,
 )
 from merino.curated_recommendations.ml_backends.protocol import InferredLocalModel
 
 
 @pytest.fixture
-def model():
+def model_topics():
     """Create fake model"""
-    return FakeLocalModel()
+    return FakeLocalModelTopics()
 
 
-def test_model_returns_inferred_local_model(model):
-    """Tests fake local model"""
+def test_model_returns_inferred_local_model_topics(model_topics):
+    """Tests fake local model, topics"""
     surface_id = "test_surface"
-    result = model.get(surface_id)
+    result = model_topics.get(surface_id)
+
+    assert isinstance(result, InferredLocalModel)
+    assert result.model_id == CTR_TOPIC_MODEL_ID
+    assert result.surface_id == surface_id
+    assert result.model_version == 0
+    assert result.model_data is not None
+    assert len(result.model_data.interest_vector) > 0
+    assert len(result.model_data.day_time_weighting.days) > 0
+    assert len(result.model_data.day_time_weighting.relative_weight) > 0
+
+
+@pytest.fixture
+def model_sections():
+    """Create fake model"""
+    return FakeLocalModelSections()
+
+
+def test_model_returns_inferred_local_model_sections(model_sections):
+    """Tests fake local model, sections"""
+    surface_id = "test_surface"
+    result = model_sections.get(surface_id)
 
     assert isinstance(result, InferredLocalModel)
     assert result.model_id == CTR_TOPIC_MODEL_ID

--- a/tests/unit/curated_recommendations/ml_backends/test_fake_local_model.py
+++ b/tests/unit/curated_recommendations/ml_backends/test_fake_local_model.py
@@ -25,6 +25,7 @@ def test_model_returns_inferred_local_model_topics(model_topics):
     assert result.surface_id == surface_id
     assert result.model_version == 0
     assert result.model_data is not None
+    assert result.model_data.noise_scale > 0
     assert len(result.model_data.interest_vector) > 0
     assert len(result.model_data.day_time_weighting.days) > 0
     assert len(result.model_data.day_time_weighting.relative_weight) > 0
@@ -46,6 +47,7 @@ def test_model_returns_inferred_local_model_sections(model_sections):
     assert result.surface_id == surface_id
     assert result.model_version == 0
     assert result.model_data is not None
+    assert result.model_data.noise_scale > 0
     assert len(result.model_data.interest_vector) > 0
     assert len(result.model_data.day_time_weighting.days) > 0
     assert len(result.model_data.day_time_weighting.relative_weight) > 0


### PR DESCRIPTION
## References

JIRA: [GENAI-1370](https://mozilla-hub.atlassian.net/browse/GENAI-1370)

## Description
This switches the merino response to send down a personal interest model where the features are sections instead of topics.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: skip]` keywords are applied to the last commit message (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[GENAI-1370]: https://mozilla-hub.atlassian.net/browse/GENAI-1370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1764)
