### PR TITLE
[DISCO-3147] migrate locust image build and publish jobs to gh actions

### DIFF
--- a/.github/workflows/build-dockerhub-locust-image.yaml
+++ b/.github/workflows/build-dockerhub-locust-image.yaml
@@ -1,0 +1,28 @@
+name: build-dockerhub-locust-image
+
+on:
+  workflow_call:
+    inputs:
+      image_tag:
+        required: true
+        type: string
+    secrets:
+      DOCKERHUB_MERINO_LOCUST_REPO:
+        required: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build locust image
+        run: docker build -t merino-locust -f ./tests/load/Dockerfile .
+      - name: Tag image
+        run: docker tag merino-locust ${{ secrets.DOCKERHUB_MERINO_LOCUST_REPO }}:${{ inputs.image_tag }}
+      - name: Save image
+        run: docker save ${{ secrets.DOCKERHUB_MERINO_LOCUST_REPO }}:${{ inputs.image_tag }} | gzip > merino-locust.tar.gz
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: merino-locust-image
+          path: merino-locust.tar.gz

--- a/.github/workflows/main-workflow.yaml
+++ b/.github/workflows/main-workflow.yaml
@@ -74,3 +74,18 @@ jobs:
       DOCKERHUB_REPO: ${{ secrets.DOCKERHUB_REPO }}
       DOCKER_USER: ${{ secrets.DOCKER_USER }}
       DOCKERHUB_ACCESS_TOKEN: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+  run-build-dockerhub-locust:
+    uses: ./.github/workflows/build-dockerhub-locust-image.yaml
+    with:
+      image_tag: ${{ github.sha }}
+    secrets:
+      DOCKERHUB_MERINO_LOCUST_REPO: ${{ secrets.DOCKERHUB_MERINO_LOCUST_REPO }}
+  run-publish-dockerhub-locust:
+    needs: run-build-dockerhub-locust
+    uses: ./.github/workflows/publish-dockerhub-locust-image.yaml
+    with:
+      image_tag: ${{ github.sha }}
+    secrets:
+      DOCKERHUB_MERINO_LOCUST_REPO: ${{ secrets.DOCKERHUB_MERINO_LOCUST_REPO }}
+      DOCKER_USER: ${{ secrets.DOCKER_USER }}
+      DOCKERHUB_ACCESS_TOKEN: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}

--- a/.github/workflows/pr-workflow.yaml
+++ b/.github/workflows/pr-workflow.yaml
@@ -27,3 +27,9 @@ jobs:
       image_tag: ${{ github.sha }}
     secrets:
       DOCKERHUB_REPO: ${{ secrets.DOCKERHUB_REPO }}
+  run-build-dockerhub-locust:
+    uses: ./.github/workflows/build-dockerhub-locust-image.yaml
+    with:
+      image_tag: ${{ github.sha }}
+    secrets:
+      DOCKERHUB_MERINO_LOCUST_REPO: ${{ secrets.DOCKERHUB_MERINO_LOCUST_REPO }}

--- a/.github/workflows/publish-dockerhub-locust-image.yaml
+++ b/.github/workflows/publish-dockerhub-locust-image.yaml
@@ -1,0 +1,50 @@
+name: publish-dockerhub-locust-image
+
+on:
+  workflow_call:
+    inputs:
+      image_tag:
+        required: true
+        type: string
+    secrets:
+      DOCKERHUB_MERINO_LOCUST_REPO:
+        required: true
+      DOCKER_USER:
+        required: true
+      DOCKERHUB_ACCESS_TOKEN:
+        required: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check for [load test skip]
+        run: |
+          msg=$(git log -1 --pretty=%B)
+          echo "Commit message: $msg"
+          if echo "$msg" | grep -qi '\[load test: skip\]'; then
+            echo "Skipping locust image publish"
+            exit 0
+          fi
+      - name: Download image
+        uses: actions/download-artifact@v4
+        with:
+          name: merino-locust-image
+          path: .
+      - name: Load image
+        run: gunzip -c merino-locust.tar.gz | docker load
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+      - name: Tag and push
+        run: |
+          # Tag loaded image as 'latest'
+          docker tag ${{ secrets.DOCKERHUB_MERINO_LOCUST_REPO }}:${{ inputs.image_tag }} ${{ secrets.DOCKERHUB_MERINO_LOCUST_REPO }}:latest
+
+          # Push both tags
+          docker push ${{ secrets.DOCKERHUB_MERINO_LOCUST_REPO }}:${{ inputs.image_tag }}
+          docker push ${{ secrets.DOCKERHUB_MERINO_LOCUST_REPO }}:latest


### PR DESCRIPTION
## References

JIRA: [DISCO-3147](https://mozilla-hub.atlassian.net/browse/DISCO-3147)

## Description
This PR migrates the dockerhub build and publish workflow for the `merino-locust` image from CircleCI to GitHub Actions.

## Changes
- Introduced two reusable workflows:
  - `build-dockerhub-locust-image.yaml`:  builds the Locust image (`merino-locust`) from `./tests/load/Dockerfile` and uploads it as an artifact
  - `publish-dockerhub-locust-image.yaml`:  downloads, loads, tags, and pushes the image to Docker Hub
- Preserved `[load test: skip]` directive to optionally skip the publish step
- Published tags include:
  - `latest`
  - `sha-<commit>`


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3147]: https://mozilla-hub.atlassian.net/browse/DISCO-3147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1767)
