### PR TITLE
[DISCO-3477] Add request source as tag to weather query metric

### DIFF
--- a/merino/providers/suggest/weather/provider.py
+++ b/merino/providers/suggest/weather/provider.py
@@ -173,8 +173,11 @@ class Provider(BaseProvider):
                         weather_context, search_term=srequest.query
                     )
                 else:
+                    tags = {"source": srequest.source if srequest.source else "newtab"}
                     weather_context.geolocation.key = srequest.query
-                    self.metrics_client.increment(f"providers.{self.name}.query.weather_report")
+                    self.metrics_client.increment(
+                        f"providers.{self.name}.query.weather_report", tags=tags
+                    )
                     weather_report = await self.backend.get_weather_report(weather_context)
         except MissingLocationKeyError:
             return [NO_LOCATION_KEY_SUGGESTION]

--- a/tests/unit/providers/suggest/weather/test_provider.py
+++ b/tests/unit/providers/suggest/weather/test_provider.py
@@ -143,13 +143,15 @@ async def test_query_weather_report_returned(
     backend_mock.get_weather_report.return_value = weather_report
 
     suggestions: list[BaseSuggestion] = await provider.query(
-        SuggestionRequest(query="", geolocation=geolocation)
+        SuggestionRequest(query="", geolocation=geolocation, source="urlbar")
     )
 
     assert suggestions == expected_suggestions
 
     assert len(statsd_mock.increment.call_args_list) == 1
-    assert statsd_mock.increment.call_args_list == [call("providers.weather.query.weather_report")]
+    assert statsd_mock.increment.call_args_list == [
+        call("providers.weather.query.weather_report", tags={"source": "urlbar"})
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## References

JIRA: [DISCO-3477](https://mozilla-hub.atlassian.net/browse/DISCO-3477)

## Description
Unsure if we would like to do more for this. At the moment requests from new tab do not use the `source` param yet, so requests from new tab and from testing etc will be lumped together.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
