### PR TITLE
HNT-821: Fix favicons for domains with multiple TLD

### DIFF
--- a/merino/jobs/navigational_suggestions/__init__.py
+++ b/merino/jobs/navigational_suggestions/__init__.py
@@ -10,6 +10,7 @@ from typing import Optional, Any
 
 import typer
 from httpx import URL
+import tldextract
 
 from merino.configs import settings as config
 from merino.jobs.navigational_suggestions.partner_favicons import PARTNER_FAVICONS
@@ -298,7 +299,8 @@ def _run_local_mode(
         try:
             # Check if this domain has a custom favicon
             domain = domain_data.get("domain", "")
-            has_custom_favicon = bool(get_custom_favicon_url(domain))
+            second_level = tldextract.extract(domain).domain if domain else ""
+            has_custom_favicon = bool(get_custom_favicon_url(second_level))
 
             result = await original_process_method(domain_data, min_width, uploader)
 

--- a/merino/jobs/navigational_suggestions/custom_favicons.py
+++ b/merino/jobs/navigational_suggestions/custom_favicons.py
@@ -1,24 +1,24 @@
 """Custom favicon URLs for domains that block scrapers or have unreliable favicon detection"""
 
-# Mapping of domain names to their direct favicon URLs
+# Mapping domain names without any suffix to their direct favicon URLs
 CUSTOM_FAVICONS: dict[str, str] = {
-    "axios.com": "https://static.axios.com/icons/favicon.svg",
-    "ign.com": "https://kraken.ignimgs.com/favicon.ico",
-    "infobae.com": "https://www.infobae.com/pf/resources/favicon/favicon-32x32.png?d=3209",
-    "reuters.com": "https://www.reuters.com/pf/resources/images/reuters/favicon/tr_kinesis_v2.svg?d=287",
-    "si.com": "https://images2.minutemediacdn.com/image/upload/v1713365891/shape/cover/sport/SI-f87ae31620c381274a85426b5c4f1341.ico",
-    "yahoo.com": "https://s.yimg.com/rz/l/favicon.ico",
-    "espn.com": "https://a.espncdn.com/favicon.ico",
-    "telegraph.co.uk": "https://www.telegraph.co.uk/etc.clientlibs/settings/wcm/designs/telegraph/core/clientlibs/core/resources/icons/favicon-196x196.png",
-    "ndtv.com": "https://www.ndtv.com/images/icons/ndtv.ico",
+    "axios": "https://static.axios.com/icons/favicon.svg",
+    "ign": "https://kraken.ignimgs.com/favicon.ico",
+    "infobae": "https://www.infobae.com/pf/resources/favicon/favicon-32x32.png?d=3209",
+    "reuters": "https://www.reuters.com/pf/resources/images/reuters/favicon/tr_kinesis_v2.svg?d=287",
+    "si": "https://images2.minutemediacdn.com/image/upload/v1713365891/shape/cover/sport/SI-f87ae31620c381274a85426b5c4f1341.ico",
+    "yahoo": "https://s.yimg.com/rz/l/favicon.ico",
+    "espn": "https://a.espncdn.com/favicon.ico",
+    "telegraph": "https://www.telegraph.co.uk/etc.clientlibs/settings/wcm/designs/telegraph/core/clientlibs/core/resources/icons/favicon-196x196.png",
+    "ndtv": "https://www.ndtv.com/images/icons/ndtv.ico",
 }
 
 
 def get_custom_favicon_url(domain: str) -> str:
-    """Get the custom favicon URL for a given domain.
+    """Get the custom favicon URL for a given domain without a suffix.
 
     Args:
-        domain: The domain name to look up
+        domain: The second-level domain name to look up (no suffix)
 
     Returns:
         The custom favicon URL if found, empty string otherwise

--- a/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
+++ b/merino/jobs/navigational_suggestions/domain_metadata_extractor.py
@@ -628,12 +628,10 @@ class DomainMetadataExtractor:
         domain: str = domain_data["domain"]
         suffix: str = domain_data["suffix"]
 
-        # Normalize domain for custom favicon lookup
         e = tldextract.extract(domain)
-        normalized_domain = f"{e.domain}.{e.suffix}"
 
         # STEP 1: Check custom favicons FIRST (primary source)
-        custom_favicon_url = get_custom_favicon_url(normalized_domain)
+        custom_favicon_url = get_custom_favicon_url(e.domain)
         if custom_favicon_url:
             try:
                 # If URL is already from our CDN, use it directly

--- a/tests/integration/jobs/navigational_suggestions/conftest.py
+++ b/tests/integration/jobs/navigational_suggestions/conftest.py
@@ -12,12 +12,14 @@ import pytest
 # pytest tests/integration/jobs/navigational_suggestions/test_domain_metadata_extractor.py
 # E   ImportError: cannot import name 'DOMAIN_MAPPING' from partially initialized module
 # 'merino.jobs.utils.domain_category_mapping' (most likely due to a circular import)
-import sys, types
+import sys
+import types
+
 _stub = types.ModuleType("merino.jobs.utils.domain_category_mapping")
-_stub.DOMAIN_MAPPING = {}
+setattr(_stub, "DOMAIN_MAPPING", {})
 sys.modules["merino.jobs.utils.domain_category_mapping"] = _stub
 
-from merino.jobs.navigational_suggestions.domain_metadata_extractor import Scraper
+from merino.jobs.navigational_suggestions.domain_metadata_extractor import Scraper  # noqa
 
 
 @pytest.fixture

--- a/tests/integration/jobs/navigational_suggestions/conftest.py
+++ b/tests/integration/jobs/navigational_suggestions/conftest.py
@@ -8,6 +8,15 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+# Avoid a circular import error that happens when a single test is run:
+# pytest tests/integration/jobs/navigational_suggestions/test_domain_metadata_extractor.py
+# E   ImportError: cannot import name 'DOMAIN_MAPPING' from partially initialized module
+# 'merino.jobs.utils.domain_category_mapping' (most likely due to a circular import)
+import sys, types
+_stub = types.ModuleType("merino.jobs.utils.domain_category_mapping")
+_stub.DOMAIN_MAPPING = {}
+sys.modules["merino.jobs.utils.domain_category_mapping"] = _stub
+
 from merino.jobs.navigational_suggestions.domain_metadata_extractor import Scraper
 
 

--- a/tests/integration/jobs/navigational_suggestions/test_domain_metadata_extractor.py
+++ b/tests/integration/jobs/navigational_suggestions/test_domain_metadata_extractor.py
@@ -1126,7 +1126,9 @@ class TestCustomFavicons:
 
         # Mock uploader methods
         mock_uploader.destination_favicon_name = mocker.MagicMock(return_value="favicons/espn.ico")
-        mock_uploader.upload_image = mocker.MagicMock(return_value="https://cdn.example.com/espn.ico")
+        mock_uploader.upload_image = mocker.MagicMock(
+            return_value="https://cdn.example.com/espn.ico"
+        )
         mock_uploader.force_upload = True
         mock_uploader.uploader = mocker.MagicMock()
         mock_uploader.uploader.cdn_hostname = "cdn.example.com"

--- a/tests/integration/jobs/navigational_suggestions/test_domain_metadata_extractor.py
+++ b/tests/integration/jobs/navigational_suggestions/test_domain_metadata_extractor.py
@@ -839,7 +839,7 @@ class TestCustomFavicons:
     @pytest.mark.asyncio
     async def test_process_single_domain_with_custom_favicon_success(self, mock_uploader, mocker):
         """Test that custom favicon is used when available and upload succeeds."""
-        # Mock the custom favicon function to return a URL for axios.com
+        # Mock the custom favicon function to return a URL for axios
         mock_get_custom_favicon = mocker.patch(
             "merino.jobs.navigational_suggestions.domain_metadata_extractor.get_custom_favicon_url"
         )
@@ -874,7 +874,7 @@ class TestCustomFavicons:
         result = await extractor._process_single_domain(domain_data, 32, mock_uploader)
 
         # Verify custom favicon was used
-        mock_get_custom_favicon.assert_called_once_with("axios.com")
+        mock_get_custom_favicon.assert_called_once_with("axios")
 
         # Verify the inline processing was used instead of upload_favicon
         extractor.favicon_downloader.download_favicon.assert_called_once_with(
@@ -932,7 +932,7 @@ class TestCustomFavicons:
         result = await extractor._process_single_domain(domain_data, 32, mock_uploader)
 
         # Verify custom favicon was attempted first
-        mock_get_custom_favicon.assert_called_once_with("axios.com")
+        mock_get_custom_favicon.assert_called_once_with("axios")
         extractor.favicon_downloader.download_favicon.assert_called_once_with(
             "https://static.axios.com/icons/favicon.svg"
         )
@@ -985,7 +985,7 @@ class TestCustomFavicons:
         result = await extractor._process_single_domain(domain_data, 32, mock_uploader)
 
         # Verify custom favicon was attempted
-        mock_get_custom_favicon.assert_called_once_with("axios.com")
+        mock_get_custom_favicon.assert_called_once_with("axios")
         extractor.favicon_downloader.download_favicon.assert_called_once_with(
             "https://static.axios.com/icons/favicon.svg"
         )
@@ -1003,8 +1003,8 @@ class TestCustomFavicons:
         # Mock the custom favicon function to return URLs only for specific domains
         def mock_custom_favicon_lookup(domain):
             custom_favicons = {
-                "axios.com": "https://static.axios.com/icons/favicon.svg",
-                "reuters.com": "https://www.reuters.com/pf/resources/images/reuters/favicon/tr_kinesis_v2.svg?d=287",
+                "axios": "https://static.axios.com/icons/favicon.svg",
+                "reuters": "https://www.reuters.com/pf/resources/images/reuters/favicon/tr_kinesis_v2.svg?d=287",
             }
             return custom_favicons.get(domain, "")
 
@@ -1111,3 +1111,46 @@ class TestCustomFavicons:
         assert get_custom_favicon_url("localhost") == ""
 
         assert get_custom_favicon_url(".com") == ""
+
+    def test_process_domain_metadata_multiple_tlds(self, mock_uploader, mocker):
+        """Ensure domains sharing the same base use the custom favicon."""
+        extractor = DomainMetadataExtractor(blocked_domains=set())
+
+        # Mock favicon downloader to always return an image
+        from merino.utils.gcs.models import Image
+
+        mock_image = Image(content=b"espn_icon", content_type="image/x-icon")
+        extractor.favicon_downloader = mocker.AsyncMock()
+        extractor.favicon_downloader.download_favicon.return_value = mock_image
+        extractor.favicon_downloader.reset = mocker.AsyncMock()
+
+        # Mock uploader methods
+        mock_uploader.destination_favicon_name = mocker.MagicMock(return_value="favicons/espn.ico")
+        mock_uploader.upload_image = mocker.MagicMock(return_value="https://cdn.example.com/espn.ico")
+        mock_uploader.force_upload = True
+        mock_uploader.uploader = mocker.MagicMock()
+        mock_uploader.uploader.cdn_hostname = "cdn.example.com"
+
+        # Patch Scraper since it should not be used when custom favicon is found
+        mock_scraper = mocker.MagicMock()
+        mock_scraper.__enter__.return_value = mock_scraper
+        mock_scraper.__exit__.return_value = None
+        mocker.patch(
+            "merino.jobs.navigational_suggestions.domain_metadata_extractor.Scraper",
+            return_value=mock_scraper,
+        )
+
+        domains = [
+            {"domain": "espn.com", "suffix": "com"},
+            {"domain": "espn.in", "suffix": "in"},
+            {"domain": "espn.co.uk", "suffix": "co.uk"},
+        ]
+
+        results = extractor.process_domain_metadata(domains, 32, mock_uploader)
+
+        assert len(results) == 3
+        for res in results:
+            assert res["domain"] == "espn"
+            assert res["icon"] == "https://cdn.example.com/espn.ico"
+            assert res["title"] == "Espn"
+            assert res["url"].startswith("https://espn")


### PR DESCRIPTION
## References

JIRA: [HNT-821](https://mozilla-hub.atlassian.net/browse/HNT-821)

## Description
Fix an issue where custom favicons were not applied for domains such as espn.com.

I believe the issue occurred because `ManifestBackend` keys icons on the domain without a suffix ('espn'), while `CUSTOM_FAVICONS` included the suffix ('espn.com'). This caused the custom favicon to be overwritten if the same publisher was added on a different TLD ('espn.in').

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[HNT-821]: https://mozilla-hub.atlassian.net/browse/HNT-821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1775)
