### PR TITLE
[GENAI-1504] Updated threshold for local interest model

### DIFF
--- a/merino/curated_recommendations/ml_backends/fake_local_model.py
+++ b/merino/curated_recommendations/ml_backends/fake_local_model.py
@@ -113,6 +113,12 @@ class FakeLocalModelSections(LocalModelBackend):
     Sections are the features of the model. The model is a represetion of users interests.
 
     Set which model is used at __init__ import
+
+    0.002 is about the CTR of users who have clicked at least once
+    .0092 is ~99% not to be noise given laplace noise and 0.002 scale
+    .0184 is double the first edge
+    with these thresholds, the buckets are:
+    [probably never clicked, almost certainly clicked, clicked quite a bit]
     """
 
     def get(self, surface_id: str | None = None) -> InferredLocalModel | None:
@@ -121,7 +127,7 @@ class FakeLocalModelSections(LocalModelBackend):
         def get_topic(topic: str) -> InterestVectorConfig:
             return InterestVectorConfig(
                 features={f"s_{topic}": 1},
-                thresholds=[0.3, 0.4],
+                thresholds=[0.0092, 0.0184],
                 diff_p=0.75,
                 diff_q=0.25,
             )


### PR DESCRIPTION
## References

JIRA: [DISCO-TODO](https://mozilla-hub.atlassian.net/browse/DISCO-TODO)

## Description
After the CTR model change, we didn’t update the thresholds for the coarse interest vector. They are too large and causing a confusing amount of zeros.

This PR updates the thresholds in the sections-CTR model. The logic of the values chosen:
    0.002 is about the CTR of users who have clicked at least once
    .0092 is ~99% not to be noise given laplace noise and 0.002 scale
    .0184 is double the first edge
    with these thresholds, the buckets are:
    [probably never clicked, almost certainly clicked, clicked quite a bit]



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [skip ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [N/A ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [N/A] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1776)
