### PR TITLE
DISCO-3608 Decrease the sync interval for the Manifest provider

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -324,8 +324,8 @@ forecast_ttl_sec = 3600 # 1 hr
 cron_interval_sec = 60
 
 # MERINO_PROVIDERS__MANIFEST__RESYNC_INTERVAL_SEC
-# Time between re-syncs of the manifest file, in seconds. Defaults to 24 hours.
-resync_interval_sec = 86400
+# Time between re-syncs of the manifest file, in seconds. Defaults to every hour.
+resync_interval_sec = 3600
 
 [default.accuweather]
 # MERINO_ACCUWEATHER__API_KEY
@@ -680,7 +680,7 @@ api_key = "test"
 url_base = "https://api.polygon.io"
 
 # MERINO_POLYGON__URL_TICKER_LAST_QUOTE
-url_ticker_last_quote ="/v2/last/nbbo/{stock_ticker}"
+url_ticker_last_quote = "/v2/last/nbbo/{stock_ticker}"
 
 # MERINO_POLYGON__URL_INDEX_DAILY_SUMMARY
 url_index_daily_summary = "/v1/open-close/{indices_ticker}/{date}"

--- a/tests/unit/providers/manifest/test_provider.py
+++ b/tests/unit/providers/manifest/test_provider.py
@@ -83,9 +83,8 @@ async def test_should_fetch_false(
         "merino.providers.manifest.backends.manifest.ManifestBackend.fetch",
         return_value=(GetManifestResultCode.SUCCESS, manifest_data),
     ):
-        # difference between last fetch and current time is 40000 (less than 86400)
         with patch(
-            "merino.providers.manifest.provider.time.time", side_effect=[100000, 140000, 200000]
+            "merino.providers.manifest.provider.time.time", side_effect=[100000, 101000, 101500]
         ):
             await manifest_provider.initialize()
             await cleanup(manifest_provider)


### PR DESCRIPTION
## References

JIRA: [DISCO-3608](https://mozilla-hub.atlassian.net/browse/DISCO-3608)

## Description
A short term solution. If we encouter a bug or want to ship an improvement for favicons, we shouldn't wait too long to bring it into production. We can manually trigger the Airflow job, but the Manifest provider should check at least once an hour if there is an updated top_picks.json available.

For the long term, I talked with @mmiermans and we thought an ADR might be helpful. Different endpoints and providers sync (or check for updates) differently, and it should be more standardized. 

For example, we have the [sync_gcs_blob.py](https://github.com/mozilla-services/merino-py/blob/main/merino/utils/synced_gcs_blob.py), which is able to check the timestamp every few minutes, and if there is an update, it can download th file.

We could use that for the Manifest provider, and check every hour if there is an update, and then download the file.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3608]: https://mozilla-hub.atlassian.net/browse/DISCO-3608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1777)
