### PR TITLE
HNT-666: read report_count from GCS engagement blob

### DIFF
--- a/merino/curated_recommendations/engagement_backends/gcs_engagement.py
+++ b/merino/curated_recommendations/engagement_backends/gcs_engagement.py
@@ -79,10 +79,12 @@ class GcsEngagement(EngagementBackend):
         # Sum clicks and impressions by region.
         clicks: Counter[str] = Counter()
         impressions: Counter[str] = Counter()
+        report_counts: Counter[str] = Counter()
         for (item_id, region), eng in self._cache.items():
             region_name = region.lower() if region is not None else "global"
             clicks[region_name] += eng.click_count
             impressions[region_name] += eng.impression_count
+            report_counts[region_name] += eng.report_count or 0  # report_count can be None
 
         # Emit clicks by region.
         for region, count in clicks.items():
@@ -91,4 +93,9 @@ class GcsEngagement(EngagementBackend):
         for region, count in impressions.items():
             self.metrics_client.gauge(
                 f"{self.metrics_namespace}.{region}.impressions", value=count
+            )
+        # Emit report_counts by region.
+        for region, count in report_counts.items():
+            self.metrics_client.gauge(
+                f"{self.metrics_namespace}.{region}.report_counts", value=count
             )

--- a/merino/curated_recommendations/engagement_backends/protocol.py
+++ b/merino/curated_recommendations/engagement_backends/protocol.py
@@ -25,6 +25,7 @@ class Engagement(BaseModel):
     region: str | None = None  # If region is None, then engagement is across all regions.
     click_count: int
     impression_count: int
+    report_count: int | None = None
 
 
 class EngagementBackend(Protocol):


### PR DESCRIPTION
## References

JIRA: https://mozilla-hub.atlassian.net/browse/HNT-666

## Description
* Read in `report_count` from the engagement blob on GCS.
* Track metric for`report_counts` by `region`



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
