### PR TITLE
HNT-894: Increase engagement size threshold

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -715,7 +715,7 @@ cron_interval_seconds = 600
 [default.curated_recommendations.gcs.engagement]
 # MERINO__CURATED_RECOMMENDATIONS__GCS__ENGAGEMENT__MAX_SIZE
 # The maximum size in bytes of the GCS engagement blob. If exceeded, an error will be logged.
-max_size = 2_000_000
+max_size = 4_000_000
 
 # MERINO__CURATED_RECOMMENDATIONS__GCS__ENGAGEMENT__BLOB_PREFIX
 # GCS path of the priors JSON file.


### PR DESCRIPTION
## References

JIRA: [DISCO-TODO](https://mozilla-hub.atlassian.net/browse/DISCO-TODO)

## Description
When the engagement blob size exceeded 2 MB for several hours, this logged [an error](https://mozilla.sentry.io/issues/6770002689/?environment=prod&project=6622434&query=is%3Aunresolved&referrer=issue-stream) to Sentry and prevented the engagement from being loaded.

With our expansion into subtopics, we have been scheduling more diverse content, which is the likely cause of our engagement size growing.

<img width="624" height="277" alt="image" src="https://github.com/user-attachments/assets/743500d4-68e3-49b9-961e-a38f489fd4da" />

The `max_size` config is meant to safeguard the Merino app from claiming too much memory. It looks like we have some room to load more engagement:

<img width="523" height="451" alt="image" src="https://github.com/user-attachments/assets/437ef0cf-17e5-4789-bd66-d6581b43903e" />

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1791)
