### PR TITLE
[DISCO 3622] - add a toggle for suggest request logging

### DIFF
--- a/merino/configs/__init__.py
+++ b/merino/configs/__init__.py
@@ -19,6 +19,7 @@ _validators = [
     Validator("logging.format", is_in=["mozlog", "pretty"]),
     Validator("logging.level", is_in=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]),
     Validator("logging.can_propagate", is_type_of=bool),
+    Validator("logging.log_suggest_request", is_type_of=bool),
     Validator("metrics.dev_logger", is_type_of=bool),
     Validator("metrics.host", is_type_of=str),
     Validator("metrics.port", gte=0, is_type_of=int),

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -77,6 +77,10 @@ format = "mozlog"
 # Boolean to allow log propagation.
 can_propagate = false
 
+# MERINO_LOGGING__LOG_SUGGEST_REQUEST
+# Boolean to toggle the `web.suggest.request` logging.
+log_suggest_request = true
+
 [default.governance]
 # MERINO_GOVERNANCE__CRON_INTERVAL_SEC
 # The interval of the background cron job for Merino governance.

--- a/merino/middleware/logging.py
+++ b/merino/middleware/logging.py
@@ -13,12 +13,17 @@ from merino.utils.log_data_creators import (
     SuggestLogDataModel,
     create_suggest_log_data,
 )
+from merino.configs import settings
+
 
 # web.suggest.request is used for logs coming from the /suggest endpoint
 suggest_request_logger = logging.getLogger("web.suggest.request")
 
 # The path pattern for the suggest API
 PATTERN: Pattern = re.compile(r"/api/v[1-9]\d*/suggest$")
+
+# Whether to log `web.suggest.request`
+LOG_SUGGEST_REQUEST: bool = settings.logging.log_suggest_request
 
 
 class LoggingMiddleware:
@@ -40,7 +45,8 @@ class LoggingMiddleware:
                 dt: datetime = datetime.fromtimestamp(time.time())
                 # https://mozilla-hub.atlassian.net/browse/DISCO-2489
                 if (
-                    PATTERN.match(request.url.path)
+                    LOG_SUGGEST_REQUEST
+                    and PATTERN.match(request.url.path)
                     and request.query_params.get("providers", "").strip().lower() != "accuweather"
                 ):
                     suggest_log_data: SuggestLogDataModel = create_suggest_log_data(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "merino-py"
 version = "0.1.0"
 description = "Service for Firefox Suggest at Mozilla"
 authors = [{ name = "Mozilla" }]
-requires-python = "~=3.13"
+requires-python = "~=3.13.0"
 license = { text = "MPL-2.0" }
 dependencies = [
     "fastapi[standard]>=0.115.2,<0.116",

--- a/tests/unit/middleware/test_logging.py
+++ b/tests/unit/middleware/test_logging.py
@@ -29,3 +29,21 @@ async def test_logging_invalid_scope_type(
     await logging_middleware(scope, receive_mock, send_mock)
 
     assert len(caplog.messages) == 0
+
+
+@pytest.mark.asyncio
+async def test_logging_toggle_suggest_request_logging(
+    mocker: MockerFixture,
+    caplog: LogCaptureFixture,
+    receive_mock: Receive,
+    send_mock: Send,
+) -> None:
+    """Test that no logging action takes place if suggest_request logging is disabled."""
+    mocker.patch("merino.middleware.logging.LOG_SUGGEST_REQUEST", False)
+    caplog.set_level(logging.INFO)
+    scope: Scope = {"type": "http"}
+    logging_middleware: LoggingMiddleware = LoggingMiddleware(mocker.AsyncMock(spec=ASGIApp))
+
+    await logging_middleware(scope, receive_mock, send_mock)
+
+    assert len(caplog.messages) == 0

--- a/uv.lock
+++ b/uv.lock
@@ -1,10 +1,6 @@
 version = 1
 revision = 2
-requires-python = ">=3.13, <4"
-resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version < '3.14'",
-]
+requires-python = "==3.13.*"
 
 [[package]]
 name = "aiodogstatsd"
@@ -1035,7 +1031,6 @@ dependencies = [
     { name = "flask" },
     { name = "flask-cors" },
     { name = "flask-login" },
-    { name = "gevent", marker = "python_full_version >= '3.14'" },
     { name = "geventhttpclient" },
     { name = "msgpack" },
     { name = "psutil" },


### PR DESCRIPTION
## References

JIRA: [DISCO-3622](https://mozilla-hub.atlassian.net/browse/DISCO-3622)

## Description
With this, we can leave the suggest request logging on for GCP V1 and toggle it off for V2.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3622]: https://mozilla-hub.atlassian.net/browse/DISCO-3622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1796)
