### PR TITLE
MC-1793 Fix item GCS Content Engagment data getting clobbered with lower values 

### DIFF
--- a/merino/curated_recommendations/engagement_backends/gcs_engagement.py
+++ b/merino/curated_recommendations/engagement_backends/gcs_engagement.py
@@ -62,7 +62,13 @@ class GcsEngagement(EngagementBackend):
             data: The engagement blob string data, with an array of Engagement objects.
         """
         parsed_data = [Engagement(**item) for item in json.loads(data)]
-        self._cache = {(d.corpus_item_id, d.region): d for d in parsed_data}
+        next_cache = {}
+        for engagement in parsed_data:
+            cache_key = (engagement.corpus_item_id, engagement.region)
+            prev_engagement = next_cache.get(cache_key, None)
+            next_cache[cache_key] = engagement if prev_engagement is None else prev_engagement + engagement
+        if len(next_cache) > 0:
+            self._cache = next_cache
         self._track_metrics()
 
     def _track_metrics(self) -> None:

--- a/merino/curated_recommendations/engagement_backends/gcs_engagement.py
+++ b/merino/curated_recommendations/engagement_backends/gcs_engagement.py
@@ -62,11 +62,13 @@ class GcsEngagement(EngagementBackend):
             data: The engagement blob string data, with an array of Engagement objects.
         """
         parsed_data = [Engagement(**item) for item in json.loads(data)]
-        next_cache = {}
+        next_cache: EngagementCacheType = {}
         for engagement in parsed_data:
             cache_key = (engagement.corpus_item_id, engagement.region)
             prev_engagement = next_cache.get(cache_key, None)
-            next_cache[cache_key] = engagement if prev_engagement is None else prev_engagement + engagement
+            next_cache[cache_key] = (
+                engagement if prev_engagement is None else prev_engagement + engagement
+            )
         if len(next_cache) > 0:
             self._cache = next_cache
         self._track_metrics()

--- a/merino/curated_recommendations/engagement_backends/protocol.py
+++ b/merino/curated_recommendations/engagement_backends/protocol.py
@@ -1,9 +1,9 @@
 """Protocol and Pydantic models for the Engagement provider backend."""
-
+import logging
 from typing import Protocol
 from pydantic import BaseModel
 
-
+logger = logging.getLogger(__name__)
 class Engagement(BaseModel):
     """Represents the engagement data from the last 24 hours for a scheduled corpus item.
 
@@ -27,6 +27,21 @@ class Engagement(BaseModel):
     impression_count: int
     report_count: int | None = None
 
+    def __add__(self, other):
+        if not isinstance(other, Engagement):
+            return NotImplemented
+        if self.region != other.region:
+            logger.error("Regions don't match adding engagements")
+        if self.corpus_item_id != other.corpus_item_id:
+            logger.error("corpus_item_id don't adding engagements")
+        return Engagement(
+            scheduled_corpus_item_id=self.scheduled_corpus_item_id or other.scheduled_corpus_item_id,
+            corpus_item_id=self.corpus_item_id,
+            region=self.region,
+            click_count=self.click_count + other.click_count,
+            impression_count=self.impression_count + other.impression_count,
+            report_count=(self.report_count or 0) + (other.report_count or 0)
+        )
 
 class EngagementBackend(Protocol):
     """Protocol for Engagement backend that the provider depends on."""

--- a/merino/curated_recommendations/engagement_backends/protocol.py
+++ b/merino/curated_recommendations/engagement_backends/protocol.py
@@ -1,9 +1,12 @@
 """Protocol and Pydantic models for the Engagement provider backend."""
+
 import logging
 from typing import Protocol
 from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
+
+
 class Engagement(BaseModel):
     """Represents the engagement data from the last 24 hours for a scheduled corpus item.
 
@@ -35,13 +38,15 @@ class Engagement(BaseModel):
         if self.corpus_item_id != other.corpus_item_id:
             logger.error("corpus_item_id don't adding engagements")
         return Engagement(
-            scheduled_corpus_item_id=self.scheduled_corpus_item_id or other.scheduled_corpus_item_id,
+            scheduled_corpus_item_id=self.scheduled_corpus_item_id
+            or other.scheduled_corpus_item_id,
             corpus_item_id=self.corpus_item_id,
             region=self.region,
             click_count=self.click_count + other.click_count,
             impression_count=self.impression_count + other.impression_count,
-            report_count=(self.report_count or 0) + (other.report_count or 0)
+            report_count=(self.report_count or 0) + (other.report_count or 0),
         )
+
 
 class EngagementBackend(Protocol):
     """Protocol for Engagement backend that the provider depends on."""

--- a/tests/integration/api/v1/curated_recommendations/engagement_backends/test_gcs_engagement.py
+++ b/tests/integration/api/v1/curated_recommendations/engagement_backends/test_gcs_engagement.py
@@ -110,6 +110,22 @@ def blob(gcs_bucket):
                 "click_count": 1,
                 "impression_count": 5,
             },
+            # Multiple records for same corpus_item_id, one with missing scheduled_corpus_item_id
+            {
+                "corpus_item_id": "AA",
+                "region": "US",
+                "click_count": 10,
+                "impression_count": 1000,
+            },
+            {
+                "corpus_item_id": "AA",
+                "scheduled_corpus_item_id": "A3",
+                "region": "US",
+                "click_count": 2,
+                "impression_count": 20,
+                "report_count": 1
+            },
+
         ],
     )
 
@@ -158,7 +174,6 @@ async def test_gcs_engagement_fetches_data(gcs_storage_client, gcs_bucket, metri
         corpus_item_id="6A", click_count=40, impression_count=400
     )
 
-
 @pytest.mark.asyncio
 async def test_gcs_engagement_fetches_region_data(
     gcs_storage_client, gcs_bucket, metrics_client, blob
@@ -173,6 +188,12 @@ async def test_gcs_engagement_fetches_region_data(
     assert gcs_engagement.get("6A", "US") == Engagement(
         corpus_item_id="6A", region="US", click_count=4, impression_count=9
     )
+
+    assert gcs_engagement.get("AA", "US") == Engagement(
+        corpus_item_id="AA", scheduled_corpus_item_id="A3", region="US", click_count=12, impression_count=1020, report_count=1
+    )
+    assert gcs_engagement.get("AA", "AU") is None
+    assert gcs_engagement.get("AA") is None
 
     # Fixture does not contain data for AU, so None should be returned.
     assert gcs_engagement.get("6A", "AU") is None
@@ -231,9 +252,9 @@ async def test_gcs_engagement_metrics(gcs_storage_client, gcs_bucket, metrics_cl
     )
     metrics_client.gauge.assert_any_call("recommendation.engagement.global.clicks", value=120)
     metrics_client.gauge.assert_any_call("recommendation.engagement.global.impressions", value=800)
-    metrics_client.gauge.assert_any_call("recommendation.engagement.us.count", value=3)
-    metrics_client.gauge.assert_any_call("recommendation.engagement.us.clicks", value=8)
-    metrics_client.gauge.assert_any_call("recommendation.engagement.us.impressions", value=23)
+    metrics_client.gauge.assert_any_call("recommendation.engagement.us.count", value=4)
+    metrics_client.gauge.assert_any_call("recommendation.engagement.us.clicks", value=8+12)
+    metrics_client.gauge.assert_any_call("recommendation.engagement.us.impressions", value=23+1020)
     metrics_client.timeit.assert_any_call("recommendation.engagement.update.timing")
 
     # Check the last_updated gauge value shows that the engagement was updated just now.

--- a/tests/integration/api/v1/curated_recommendations/engagement_backends/test_gcs_engagement.py
+++ b/tests/integration/api/v1/curated_recommendations/engagement_backends/test_gcs_engagement.py
@@ -123,9 +123,8 @@ def blob(gcs_bucket):
                 "region": "US",
                 "click_count": 2,
                 "impression_count": 20,
-                "report_count": 1
+                "report_count": 1,
             },
-
         ],
     )
 
@@ -174,6 +173,7 @@ async def test_gcs_engagement_fetches_data(gcs_storage_client, gcs_bucket, metri
         corpus_item_id="6A", click_count=40, impression_count=400
     )
 
+
 @pytest.mark.asyncio
 async def test_gcs_engagement_fetches_region_data(
     gcs_storage_client, gcs_bucket, metrics_client, blob
@@ -190,7 +190,12 @@ async def test_gcs_engagement_fetches_region_data(
     )
 
     assert gcs_engagement.get("AA", "US") == Engagement(
-        corpus_item_id="AA", scheduled_corpus_item_id="A3", region="US", click_count=12, impression_count=1020, report_count=1
+        corpus_item_id="AA",
+        scheduled_corpus_item_id="A3",
+        region="US",
+        click_count=12,
+        impression_count=1020,
+        report_count=1,
     )
     assert gcs_engagement.get("AA", "AU") is None
     assert gcs_engagement.get("AA") is None
@@ -253,8 +258,10 @@ async def test_gcs_engagement_metrics(gcs_storage_client, gcs_bucket, metrics_cl
     metrics_client.gauge.assert_any_call("recommendation.engagement.global.clicks", value=120)
     metrics_client.gauge.assert_any_call("recommendation.engagement.global.impressions", value=800)
     metrics_client.gauge.assert_any_call("recommendation.engagement.us.count", value=4)
-    metrics_client.gauge.assert_any_call("recommendation.engagement.us.clicks", value=8+12)
-    metrics_client.gauge.assert_any_call("recommendation.engagement.us.impressions", value=23+1020)
+    metrics_client.gauge.assert_any_call("recommendation.engagement.us.clicks", value=8 + 12)
+    metrics_client.gauge.assert_any_call(
+        "recommendation.engagement.us.impressions", value=23 + 1020
+    )
     metrics_client.timeit.assert_any_call("recommendation.engagement.update.timing")
 
     # Check the last_updated gauge value shows that the engagement was updated just now.


### PR DESCRIPTION
## References

JIRA: https://mozilla-hub.atlassian.net/browse/MC-1793

## Description
With the release of the sections experiment, the ETL jobs are returning multiple items from a single content_id, because some have scheduled_surface_id and some do not.

We implement a temporary fix by adding them together, though the best long term fix is an ETL fix perhaps

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1797)
