### PR TITLE
[DISCO-3624] Optimize upload job to run based on timestamp

### DIFF
--- a/merino/providers/suggest/finance/backends/polygon/backend.py
+++ b/merino/providers/suggest/finance/backends/polygon/backend.py
@@ -208,7 +208,9 @@ class PolygonBackend(FinanceBackend):
             logger.error(f"Failed to build FinanceManifest due to validation error: {e}")
             return FinanceManifest(tickers={})
 
-    async def fetch_manifest_data(self) -> tuple[GetManifestResultCode, FinanceManifest | None]:
+    async def fetch_manifest_data(
+        self,
+    ) -> tuple[GetManifestResultCode, FinanceManifest | None, float | None]:
         """Fetch manifest data from GCS through the filemanager."""
         return await self.filemanager.get_file()
 

--- a/merino/providers/suggest/finance/backends/protocol.py
+++ b/merino/providers/suggest/finance/backends/protocol.py
@@ -96,7 +96,9 @@ class FinanceBackend(Protocol):
         """Build a FinanceManifest from ticker -> GCS image URL mappings."""
         ...
 
-    async def fetch_manifest_data(self) -> tuple[GetManifestResultCode, FinanceManifest | None]:
+    async def fetch_manifest_data(
+        self,
+    ) -> tuple[GetManifestResultCode, FinanceManifest | None, float | None]:
         """Fetch manifest data from GCS through the filemanager."""
         ...
 

--- a/tests/unit/providers/suggest/finance/test_provider.py
+++ b/tests/unit/providers/suggest/finance/test_provider.py
@@ -267,7 +267,7 @@ async def test_fetch_manifest_sets_last_fetch_and_clears_failure(provider, mocke
     mocker.patch.object(
         provider.backend,
         "fetch_manifest_data",
-        return_value=(GetManifestResultCode.SUCCESS, mock_manifest),
+        return_value=(GetManifestResultCode.SUCCESS, mock_manifest, time.time()),
     )
     provider.last_fetch_failure_at = time.time() - 500
 
@@ -277,6 +277,7 @@ async def test_fetch_manifest_sets_last_fetch_and_clears_failure(provider, mocke
 
     assert provider.last_fetch_at >= before and provider.last_fetch_at <= after
     assert provider.last_fetch_failure_at is None
+    assert provider.last_upload_at is not None
 
 
 @pytest.mark.asyncio
@@ -285,11 +286,10 @@ async def test_fetch_manifest_sets_last_failure_on_error(provider, mocker):
     mocker.patch.object(
         provider.backend,
         "fetch_manifest_data",
-        return_value=(GetManifestResultCode.FAIL, None),
+        return_value=(GetManifestResultCode.FAIL, None, None),
     )
 
     await provider._fetch_manifest()
-
     assert provider.last_fetch_failure_at is not None
 
 


### PR DESCRIPTION
## References

JIRA: [DISCO-3624](https://mozilla-hub.atlassian.net/browse/DISCO-3624)

## Description
This PR improves the polygon provider's resync logic by introducing accurate tracking of the last successful manifest upload time using the GCS timestamp. This prevents unnecessary manifest uploads during provider restarts or redeployments by using the actual last modified time of the manifest in GCS, ensuring we only re-upload after the resync_interval has passed.

Changes:
- Updated the `PolygonFilemanager.get_file()` method to return the Blob.updated timestamp.
- Used the GCS blob's `updated` metadata field as the source of truth for `last_upload_at`.
- `last_upload_at` is now initialized during ` _fetch_manifest()` using the fetched manifest’s blob timestamp.
- Upload jobs still update `last_upload_at` based on `time.time()` after a successful upload.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3624]: https://mozilla-hub.atlassian.net/browse/DISCO-3624?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1803)
