### PR TITLE
GENAI-1645 Restore layout for sections temporarily to troubleshoot data anomaly 

### DIFF
--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -45,7 +45,7 @@ from merino.curated_recommendations.utils import is_enrolled_in_experiment
 
 logger = logging.getLogger(__name__)
 
-LAYOUT_CYCLE = [layout_4_medium, layout_6_tiles, layout_4_large]
+LAYOUT_CYCLE = [layout_4_large, layout_4_medium, layout_6_tiles]
 TOP_STORIES_COUNT = 6
 
 

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -234,10 +234,11 @@ def get_max_total_retry_duration() -> float:
 def assert_section_layouts_are_cycled(sections: dict):
     """Assert that layouts of all sections (excluding 'top_stories_section') are cycled through expected pattern."""
     layout_cycle = [
+        "4-large-small-medium-1-ad",
         "4-medium-small-1-ad",
         "6-small-medium-1-ad",
-        "4-large-small-medium-1-ad",
     ]
+
     cycled_sections = [
         section for sid, section in sections.items() if sid != "top_stories_section"
     ]  # Exclude top stories


### PR DESCRIPTION
## References

JIRA: https://mozilla-hub.atlassian.net/browse/GENAI-1645

## Description
Prior to https://mozilla-hub.atlassian.net/browse/HNT-540 patch, layout_4_largewas observed to be the 2nd section. (It wasn’t listed as 2nd section, but due to sorting quirks it was) 

Restore this to the 2nd section (one after Top Stories) and observer any behavior changes.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1805)
