### PR TITLE
[DISCO-3627] fix: update get_most_recent_file matching logic

### DIFF
--- a/merino/jobs/navigational_suggestions/domain_metadata_uploader.py
+++ b/merino/jobs/navigational_suggestions/domain_metadata_uploader.py
@@ -55,6 +55,7 @@ class DomainMetadataUploader:
         can be made between the previous file and the new file to be written.
         """
         most_recent = self.uploader.get_most_recent_file(
+            match="top_picks",
             exclusion=self.DESTINATION_TOP_PICK_FILE_NAME,
             sort_key=lambda blob: blob.name,
         )

--- a/merino/jobs/utils/domain_tester.py
+++ b/merino/jobs/utils/domain_tester.py
@@ -67,7 +67,7 @@ async def async_test_domain(domain: str, min_width: int) -> DomainTestResult:
                 # Just return a dummy URL instead of uploading
                 return f"https://dummy-cdn.example.com/{destination_name}"
 
-            def get_most_recent_file(self, exclusion, sort_key):
+            def get_most_recent_file(self, match, sort_key):
                 return None
 
         # Create a domain metadata uploader with our mock uploader

--- a/merino/providers/suggest/finance/backends/polygon/backend.py
+++ b/merino/providers/suggest/finance/backends/polygon/backend.py
@@ -232,6 +232,7 @@ class PolygonBackend(FinanceBackend):
                 content=manifest_bytes,
                 destination_name=GCS_BLOB_NAME,
                 content_type="application/json",
+                forced_upload=True,
             )
             if blob is None:
                 logger.error("polygon manifest upload failed.")

--- a/merino/utils/gcs/models.py
+++ b/merino/utils/gcs/models.py
@@ -53,6 +53,8 @@ class BaseContentUploader(ABC):
         ...
 
     @abstractmethod
-    def get_most_recent_file(self, exclusion: str, sort_key: Callable) -> Blob | None:
+    def get_most_recent_file(
+        self, match: str, sort_key: Callable, exclusion: str | None
+    ) -> Blob | None:
         """Abstract method for getting the most recent file from the GCS bucket."""
         ...

--- a/tests/integration/jobs/navigational_suggestions/test_domain_metadata_uploader.py
+++ b/tests/integration/jobs/navigational_suggestions/test_domain_metadata_uploader.py
@@ -116,6 +116,27 @@ test_top_picks_2 = {
     ]
 }
 
+test_top_picks_3 = {
+    "domains": [
+        {
+            "rank": 1,
+            "title": "Def",
+            "domain": "def",
+            "url": "https://def.test",
+            "icon": "",
+            "categories": ["web-browser"],
+            "serp_categories": [0],
+            "similars": ["a", "dfe", "def"],
+        },
+    ]
+}
+
+test_polygon = {
+    "tickers": {
+        "AAPL": "http://www.apple.com",
+    }
+}
+
 
 def test_upload_top_picks(gcs_storage_client, gcs_storage_bucket, mock_favicon_downloader):
     """Test upload_top_picks method of DomainMetaDataUploader. This test also implicitly tests
@@ -202,6 +223,12 @@ def test_get_latest_file_for_diff(gcs_storage_client, gcs_storage_bucket, mock_f
     gcp_uploader.upload_content(json.dumps(test_top_picks_1), "20240101120555_top_picks.json")
     # upload test_top_picks_2 for the 2023... file
     gcp_uploader.upload_content(json.dumps(test_top_picks_2), "20230101120555_top_picks.json")
+    # upload test_top_picks_3 for the 2022... file
+    gcp_uploader.upload_content(
+        json.dumps(test_top_picks_3), "20220101120555_top_picks_latest.json"
+    )
+    # upload test_polygon for the 2022... file
+    gcp_uploader.upload_content(json.dumps(test_polygon), "polygon_latest.json")
 
     # get the latest file
     latest_file = domain_metadata_uploader.get_latest_file_for_diff()
@@ -228,7 +255,10 @@ def test_get_latest_file_for_diff_when_no_file_is_found(
         uploader=gcp_uploader, force_upload=False, async_favicon_downloader=mock_favicon_downloader
     )
 
-    # this should return None since we didn't upload anything to our gcs bucket
+    # upload test_polygon
+    gcp_uploader.upload_content(json.dumps(test_polygon), "polygon_latest.json")
+
+    # this should return None since we didn't upload any top picks to our gcs bucket
     latest_file = domain_metadata_uploader.get_latest_file_for_diff()
 
     assert latest_file is None

--- a/tests/unit/content_handler/test_gcp_uploader.py
+++ b/tests/unit/content_handler/test_gcp_uploader.py
@@ -154,7 +154,7 @@ def test_get_most_recent_file_with_two_files(
 
     excluded_file: str = "excluded.json"
     result = gcs_uploader.get_most_recent_file(
-        exclusion=excluded_file, sort_key=lambda blob: blob.name
+        match="top_picks", exclusion=excluded_file, sort_key=lambda blob: blob.name
     )
 
     # result should be the most recent blob / file
@@ -183,7 +183,7 @@ def test_get_most_recent_file_with_excluded_file(
 
     # call the method with the exclusion argument set to the excluded file
     result = gcs_uploader.get_most_recent_file(
-        exclusion=excluded_file, sort_key=lambda blob: blob.name
+        match="top_picks", exclusion=excluded_file, sort_key=lambda blob: blob.name
     )
 
     # result should be none since the bucket only contains the excluded file

--- a/tests/unit/utils/test_gcs_models.py
+++ b/tests/unit/utils/test_gcs_models.py
@@ -70,7 +70,9 @@ class DummyUploader(BaseContentUploader):
         )
         return blob.public_url
 
-    def get_most_recent_file(self, exclusion: str, sort_key) -> DummyBlob | None:
+    def get_most_recent_file(
+        self, match: str, sort_key, exclusion: str | None
+    ) -> DummyBlob | None:
         """Get most recent file."""
         # For the purpose of testing, return a dummy blob if exclusion is non-empty; otherwise, return None.
         if exclusion:
@@ -105,9 +107,9 @@ def test_dummy_uploader_get_most_recent_file():
     """Test dummy uploader get most recent file."""
     uploader = DummyUploader()
     # Test that when exclusion is provided the uploader returns a DummyBlob
-    blob = uploader.get_most_recent_file("exclude.txt", sort_key=lambda x: x)
+    blob = uploader.get_most_recent_file("match", sort_key=lambda x: x, exclusion="exclude.txt")
     assert blob is not None
     assert blob.public_url == "http://dummy/recent_file"
     # Test that when exclusion is empty the uploader returns None
-    blob_none = uploader.get_most_recent_file("", sort_key=lambda x: x)
+    blob_none = uploader.get_most_recent_file("match", exclusion="", sort_key=lambda x: x)
     assert blob_none is None


### PR DESCRIPTION
## References

JIRA: [DISCO-3627](https://mozilla-hub.atlassian.net/browse/DISCO-3627)

## Description
This PR fixes a bug where `get_latest_file_for_diff()` incorrectly returns unrelated JSON files (e.g., `polygon_latest.json`) as the “most recent” top picks file, due to overly broad matching logic.

What Changed:
- Updated `get_most_recent_file` to support an optional match_string parameter that restricts results to files containing a given substring in the filename.
- Updated `get_latest_file_for_diff` to pass "top_picks" as the match string.
- Ensured that `top_picks_latest.json` is still explicitly excluded from diffing logic.
- Added filtering to guarantee only .json files are returned.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3627]: https://mozilla-hub.atlassian.net/browse/DISCO-3627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1806)
