### PR TITLE
GENAI-1648 Keep control-b layout unchanged as we experiment with layouts

### DIFF
--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -182,6 +182,7 @@ def is_ml_sections_experiment(request: CuratedRecommendationsRequest) -> bool:
         request, ExperimentName.ML_SECTIONS_EXPERIMENT.value, "treatment"
     )
 
+
 def is_ml_sections_experiment_control_b(request: CuratedRecommendationsRequest) -> bool:
     """Return True if the sections backend experiment is enabled."""
     return is_enrolled_in_experiment(
@@ -190,7 +191,7 @@ def is_ml_sections_experiment_control_b(request: CuratedRecommendationsRequest) 
 
 
 def is_popular_today_double_row_layout(request: CuratedRecommendationsRequest) -> bool:
-    """Return True for the treatment branch of the ML sub-topics experiment, otherwise False."""
+    """Temporarily disable."""
     return is_ml_sections_experiment(request)
 
 
@@ -337,7 +338,9 @@ async def get_sections(
 
     # 6. Split top stories
     top_stories_count = TOP_STORIES_COUNT
-    layout_cycle = LAYOUT_CYCLE_CONTROL if is_ml_sections_experiment_control_b() else LAYOUT_CYCLE
+    layout_cycle = (
+        LAYOUT_CYCLE_CONTROL if is_ml_sections_experiment_control_b(request) else LAYOUT_CYCLE
+    )
     popular_today_layout = layout_4_large
 
     # check if popular today double row experiment is enabled

--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -191,7 +191,7 @@ def is_ml_sections_experiment_control_b(request: CuratedRecommendationsRequest) 
 
 
 def is_popular_today_double_row_layout(request: CuratedRecommendationsRequest) -> bool:
-    """Temporarily disable."""
+    """Return True for the treatment branch of the ML sub-topics experiment, otherwise False."""
     return is_ml_sections_experiment(request)
 
 

--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -46,6 +46,8 @@ from merino.curated_recommendations.utils import is_enrolled_in_experiment
 logger = logging.getLogger(__name__)
 
 LAYOUT_CYCLE = [layout_4_large, layout_4_medium, layout_6_tiles]
+LAYOUT_CYCLE_CONTROL = [layout_4_medium, layout_6_tiles, layout_4_large]
+
 TOP_STORIES_COUNT = 6
 
 
@@ -178,6 +180,12 @@ def is_ml_sections_experiment(request: CuratedRecommendationsRequest) -> bool:
     """Return True if the sections backend experiment is enabled."""
     return is_enrolled_in_experiment(
         request, ExperimentName.ML_SECTIONS_EXPERIMENT.value, "treatment"
+    )
+
+def is_ml_sections_experiment_control_b(request: CuratedRecommendationsRequest) -> bool:
+    """Return True if the sections backend experiment is enabled."""
+    return is_enrolled_in_experiment(
+        request, ExperimentName.ML_SECTIONS_EXPERIMENT.value, "control-b"
     )
 
 
@@ -329,7 +337,7 @@ async def get_sections(
 
     # 6. Split top stories
     top_stories_count = TOP_STORIES_COUNT
-    layout_cycle = LAYOUT_CYCLE
+    layout_cycle = LAYOUT_CYCLE_CONTROL if is_ml_sections_experiment_control_b() else LAYOUT_CYCLE
     popular_today_layout = layout_4_large
 
     # check if popular today double row experiment is enabled

--- a/tests/unit/curated_recommendations/test_sections.py
+++ b/tests/unit/curated_recommendations/test_sections.py
@@ -38,6 +38,7 @@ from merino.curated_recommendations.sections import (
     get_corpus_sections_for_legacy_topic,
     cycle_layouts_for_ranked_sections,
     LAYOUT_CYCLE,
+    is_ml_sections_experiment_control_b,
 )
 from tests.unit.curated_recommendations.fixtures import (
     generate_recommendations,
@@ -206,6 +207,24 @@ class TestMlSectionsExperiment:
         """Test that ML sections experiment flag matches expected logic"""
         req = SimpleNamespace(experimentName=name, experimentBranch=branch)
         assert is_ml_sections_experiment(req) is expected
+
+
+class TestMlSectionsExperimentControl:
+    """Tests covering is_ml_sections_experiment"""
+
+    @pytest.mark.parametrize(
+        "name,branch,expected",
+        [
+            (ExperimentName.ML_SECTIONS_EXPERIMENT.value, "treatment", False),
+            (ExperimentName.ML_SECTIONS_EXPERIMENT.value, "control-b", True),
+            (ExperimentName.ML_SECTIONS_EXPERIMENT.value, "control", False),
+            ("other", "treatment", False),
+        ],
+    )
+    def test_flag_logic(self, name, branch, expected):
+        """Test that ML sections experiment flag matches expected logic"""
+        req = SimpleNamespace(experimentName=name, experimentBranch=branch)
+        assert is_ml_sections_experiment_control_b(req) is expected
 
 
 class TestUpdateReceivedFeedRank:


### PR DESCRIPTION
## References

JIRA: https://mozilla-hub.atlassian.net/browse/GENAI-1648

## Description

Bryan has indicated that he would like control-b layout to remain unchanged as we experiment with different layouts. I've added a flag here to keep the original layout we've been using for the control-b experiment.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1807)
