### PR TITLE
GENAI-1657 Adjust priors Thompson sampling for subtopic items 

### DIFF
--- a/merino/curated_recommendations/prior_backends/experiment_rescaler.py
+++ b/merino/curated_recommendations/prior_backends/experiment_rescaler.py
@@ -33,6 +33,6 @@ class SubsectionsExperimentRescaler(ExperimentRescaler):
         Scale of 4 puts an item with no activity just below the pack of common items that have good activity
         """
         if self.is_experiment_story(rec):
-            return alpha / 4., beta
+            return alpha / 4.0, beta
         else:
             return alpha, beta

--- a/merino/curated_recommendations/prior_backends/experiment_rescaler.py
+++ b/merino/curated_recommendations/prior_backends/experiment_rescaler.py
@@ -27,3 +27,12 @@ class SubsectionsExperimentRescaler(ExperimentRescaler):
             return opens / self.experiment_relative_size, no_opens / self.experiment_relative_size
         else:
             return opens, no_opens
+
+    def rescale_prior(self, rec: CuratedRecommendation, alpha, beta):
+        """Update priors values based on whether item is unique to the experiment.
+        Scale of 4 puts an item with no activity just below the pack of common items that have good activity
+        """
+        if self.is_experiment_story(rec):
+            return alpha / 4., beta
+        else:
+            return alpha, beta

--- a/merino/curated_recommendations/prior_backends/protocol.py
+++ b/merino/curated_recommendations/prior_backends/protocol.py
@@ -47,3 +47,7 @@ class ExperimentRescaler(BaseModel):
         impressions and clicks can be used in place of opens and no_opens
         """
         return opens, no_opens
+
+    def rescale_prior(self, rec: CuratedRecommendation, alpha, beta):
+        """Update priors values based on whether item is unique to the experiment."""
+        return alpha, beta

--- a/merino/curated_recommendations/rankers.py
+++ b/merino/curated_recommendations/rankers.py
@@ -166,7 +166,9 @@ def section_thompson_sampling(
                 total_imps += impressions
 
                 if rescaler is not None:
-                    a_prior_mod, b_prior_mod = rescaler.rescale_prior(rec, a_prior_per_item, b_prior_per_item)
+                    a_prior_mod, b_prior_mod = rescaler.rescale_prior(
+                        rec, a_prior_per_item, b_prior_per_item
+                    )
                     a_prior_total += a_prior_mod
                     b_prior_total += b_prior_mod
                 else:

--- a/merino/curated_recommendations/rankers.py
+++ b/merino/curated_recommendations/rankers.py
@@ -147,13 +147,13 @@ def section_thompson_sampling(
         recs = sec.recommendations[:top_n]
         total_clicks = 0
         total_imps = 0
-        a_prior_total = 0
-        b_prior_total = 0
+        a_prior_total = 0.0
+        b_prior_total = 0.0
 
         # constant prior α, β
         prior = ConstantPrior().get()
-        a_prior_per_item = prior.alpha
-        b_prior_per_item = prior.beta
+        a_prior_per_item = float(prior.alpha)
+        b_prior_per_item = float(prior.beta)
         for rec in recs:
             if engagement := engagement_backend.get(rec.corpusItemId):
                 clicks = engagement.click_count
@@ -176,8 +176,8 @@ def section_thompson_sampling(
                     b_prior_total += b_prior_per_item
 
         # Sum engagement and priors.
-        opens = max(total_clicks + a_prior_total, 1)
-        no_opens = max(total_imps - total_clicks + b_prior_total, 1)
+        opens = max(total_clicks + a_prior_total, 1.0)
+        no_opens = max(total_imps - total_clicks + b_prior_total, 1.0)
         # Sample distribution
         return float(beta.rvs(opens, no_opens))
 

--- a/merino/curated_recommendations/rankers.py
+++ b/merino/curated_recommendations/rankers.py
@@ -110,7 +110,7 @@ def thompson_sampling(
         if rescaler is not None:
             # rescale for content associated exclusively with an experiment in a specific region
             opens, no_opens = rescaler.rescale(rec, opens, no_opens)
-
+            a_prior, b_prior = rescaler.rescale_prior(rec, a_prior, b_prior)
         # Add priors and ensure opens and no_opens are > 0, which is required by beta.rvs.
         opens += max(a_prior, 1e-18)
         no_opens += max(b_prior, 1e-18)
@@ -147,26 +147,35 @@ def section_thompson_sampling(
         recs = sec.recommendations[:top_n]
         total_clicks = 0
         total_imps = 0
+        a_prior_total = 0
+        b_prior_total = 0
+
+        # constant prior α, β
+        prior = ConstantPrior().get()
+        a_prior_per_item = prior.alpha
+        b_prior_per_item = prior.beta
         for rec in recs:
             if engagement := engagement_backend.get(rec.corpusItemId):
                 clicks = engagement.click_count
                 impressions = engagement.impression_count
                 if rescaler is not None:
-                    # rescale for content associated exclusively with an experiment in a specific region
+                    # rescale for content associated exclusively with an experiment in a specific experiment
                     clicks, impressions = rescaler.rescale(rec, clicks, impressions)
 
                 total_clicks += clicks
                 total_imps += impressions
 
-        # constant prior α, β
-        prior = ConstantPrior().get()
-        a_prior = top_n * prior.alpha
-        b_prior = top_n * prior.beta
+                if rescaler is not None:
+                    a_prior_mod, b_prior_mod = rescaler.rescale_prior(rec, a_prior_per_item, b_prior_per_item)
+                    a_prior_total += a_prior_mod
+                    b_prior_total += b_prior_mod
+                else:
+                    a_prior_total += a_prior_per_item
+                    b_prior_total += b_prior_per_item
 
         # Sum engagement and priors.
-        opens = total_clicks + a_prior
-        no_opens = total_imps - total_clicks + b_prior
-
+        opens = max(total_clicks + a_prior_total, 1)
+        no_opens = max(total_imps - total_clicks + b_prior_total, 1)
         # Sample distribution
         return float(beta.rvs(opens, no_opens))
 


### PR DESCRIPTION
## References

JIRA: https://mozilla-hub.atlassian.net/browse/GENAI-1657

## Description
Writeup here

Currently we’ve added approximately 10 new subtopic sections as an experiment branch for the subtopics experiment. Unlike the legacy topics, these topics are refreshed twice during the day. In contrast, the primary sections are refreshed daily at approximately 1AM EDT. 

https://mozilla-hub.atlassian.net/wiki/spaces/FAAMT/pages/1727725665/Thompson+Sampling+of+Subtopic+Sections

We divide the prior alpha by 4 for unseen subtopic items, and leave the priors for scheduled items the same. This keeps most of the unseen items just below the popular items.

I should add that there is a bug fix here. We added priors * n for the priors without checking that there are that many items. This could have resulted in 4 and 5 sections moved lower unnecessarily. As part of the fix we only add priors for an item that exists.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1811)
