### PR TITLE
[DISCO-3632] Disable polygon upstream requests in stage environment

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -675,6 +675,10 @@ circuit_breaker_failure_threshold = 10
 # The circuit breaker will stay open for this period of time until the next recovery attempt.
 circuit_breaker_recover_timeout_sec = 30
 
+# MERINO_PROVIDERS__POLYGON__DISABLE_UPSTREAM_REQUESTS
+# This provider config value is only used to disable the requests in the stage environment.
+disable_upstream_requests = false
+
 [default.providers.polygon.cache_ttls]
 # Cache TTLs for finance data.
 

--- a/merino/configs/stage.toml
+++ b/merino/configs/stage.toml
@@ -39,3 +39,8 @@ bucket_name = "merino-airflow-data-stagepy"
 # MERINO__CURATED_RECOMMENDATIONS__GCS__GCP_PROJECT
 # GCP project name where the GCS bucket lives.
 gcp_project = "moz-fx-merino-nonprod-ee93"
+
+[stage.providers.polygon]
+# MERINO_PROVIDERS__POLYGON__DISABLE_UPSTREAM_REQUESTS
+# This provider config value is only used to disable the requests in the stage environment.
+disable_upstream_requests = true

--- a/merino/providers/suggest/finance/backends/polygon/ticker_company_mapping.py
+++ b/merino/providers/suggest/finance/backends/polygon/ticker_company_mapping.py
@@ -1,4 +1,6 @@
-"""Module containing JSON object with ticker symbol to company name mapping for RUSSELL1000 tickers."""
+"""Module containing JSON object with ticker symbol to company name mapping for RUSSELL1000 tickers.
+This list was sourced from www.barchart.com/stocks/indices/russell/russell1000
+"""
 
 # Source of truth for ticker symbol and company name mapping.
 # NOTE: Should be treated as read-only and runtime.

--- a/merino/providers/suggest/finance/provider.py
+++ b/merino/providers/suggest/finance/provider.py
@@ -41,6 +41,7 @@ class Provider(BaseProvider):
     cron_interval_sec: int
     last_fetch_at: float
     last_upload_at: float | None
+    disable_upstream_requests: bool
     last_fetch_failure_at: float | None = None
     last_upload_failure_at: float | None = None
 
@@ -53,6 +54,7 @@ class Provider(BaseProvider):
         query_timeout_sec: float,
         resync_interval_sec: int,
         cron_interval_sec: int,
+        disable_upstream_requests: bool,
         enabled_by_default: bool = False,
     ) -> None:
         self.backend = backend
@@ -67,6 +69,7 @@ class Provider(BaseProvider):
         self.resync_interval_sec = resync_interval_sec
         self.cron_interval_sec = cron_interval_sec
         self.last_fetch_at = 0.0
+        self.disable_upstream_requests = disable_upstream_requests
 
         super().__init__()
 
@@ -175,6 +178,10 @@ class Provider(BaseProvider):
 
     async def query(self, srequest: SuggestionRequest) -> list[BaseSuggestion]:
         """Provide finance suggestions."""
+        # Should only disable upstream requests in stage environment.
+        if self.disable_upstream_requests:
+            return []
+
         # Extract ticker from the query string. Validte for a supported keyword or a stock ticker.
         ticker: str | None = get_ticker_if_valid(srequest.query) or get_ticker_for_keyword(
             srequest.query

--- a/merino/providers/suggest/manager.py
+++ b/merino/providers/suggest/manager.py
@@ -207,6 +207,8 @@ def _create_provider(provider_id: str, setting: Settings) -> BaseProvider:
                 enabled_by_default=setting.enabled_by_default,
                 resync_interval_sec=setting.resync_interval_sec,
                 cron_interval_sec=setting.cron_interval_sec,
+                # only true for stage environment (see stage.toml)
+                disable_upstream_requests=setting.disable_upstream_requests,
             )
         case _:
             raise InvalidProviderError(f"Unknown provider type: {setting.type}")

--- a/tests/unit/providers/suggest/finance/test_provider.py
+++ b/tests/unit/providers/suggest/finance/test_provider.py
@@ -70,6 +70,7 @@ def fixture_provider(backend_mock: Any, statsd_mock: Any) -> Provider:
         query_timeout_sec=0.2,
         cron_interval_sec=60,
         resync_interval_sec=3600,
+        disable_upstream_requests=False,
     )
 
 


### PR DESCRIPTION
## References

JIRA: [DISCO-3632](https://mozilla-hub.atlassian.net/browse/DISCO-3632)

## Description
Disabling upstream Polygon requests in stage environment to address the `401` errors.



## PR Review Checklist
- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3632]: https://mozilla-hub.atlassian.net/browse/DISCO-3632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1812)
