### PR TITLE
[DISCO-3637] Validate json response before extracting snapshot values

### DIFF
--- a/merino/providers/suggest/finance/backends/polygon/backend.py
+++ b/merino/providers/suggest/finance/backends/polygon/backend.py
@@ -19,7 +19,7 @@ from merino.providers.suggest.finance.backends.protocol import (
 )
 from merino.providers.suggest.finance.backends.polygon.utils import (
     TICKERS,
-    extract_ticker_snapshot,
+    extract_snapshot_if_valid,
     build_ticker_summary,
 )
 from merino.utils.gcs.gcs_uploader import GcsUploader
@@ -80,7 +80,7 @@ class PolygonBackend(FinanceBackend):
         This method first calls the fetch for snapshot method, extracts the ticker snapshot
         and builds the ticker summary.
         """
-        snapshot: TickerSnapshot | None = extract_ticker_snapshot(
+        snapshot: TickerSnapshot | None = extract_snapshot_if_valid(
             await self.fetch_ticker_snapshot(ticker)
         )
 

--- a/tests/unit/providers/suggest/finance/backends/test_utils.py
+++ b/tests/unit/providers/suggest/finance/backends/test_utils.py
@@ -10,7 +10,7 @@ from typing import Any
 from merino.providers.suggest.finance.backends.polygon.utils import (
     build_ticker_summary,
     lookup_ticker_company,
-    extract_ticker_snapshot,
+    extract_snapshot_if_valid,
     get_ticker_for_keyword,
     _is_valid_ticker as is_valid_ticker,
     _is_valid_keyword_for_stock_ticker as is_valid_keyword_for_stock_ticker,
@@ -134,18 +134,20 @@ def test_get_ticker_for_keyword_for_etf_fail() -> None:
     assert get_ticker_for_keyword("bobs burgers stock index fund") is None
 
 
-def test_extract_ticker_snapshot_success(single_ticker_snapshot_response: dict[str, Any]) -> None:
+def test_extract_snapshot_if_valid_success(
+    single_ticker_snapshot_response: dict[str, Any],
+) -> None:
     """Test extract_ticker_snapshot_returns_none method. Should return TickerSnapshot object."""
     expected = TickerSnapshot(last_price="120.47", todays_change_perc="0.82")
-    actual = extract_ticker_snapshot(single_ticker_snapshot_response)
+    actual = extract_snapshot_if_valid(single_ticker_snapshot_response)
 
     assert actual is not None
     assert actual == expected
 
 
-def test_extract_ticker_snapshot_returns_none() -> None:
+def test_extract_snapshot_if_valid_returns_none() -> None:
     """Test extract_ticker_snapshot_returns_none method. Should return None when snapshot param is None."""
-    assert extract_ticker_snapshot(None) is None
+    assert extract_snapshot_if_valid(None) is None
 
 
 def test_build_ticker_summary_success() -> None:


### PR DESCRIPTION
## References

JIRA: [DISCO-3637](https://mozilla-hub.atlassian.net/browse/DISCO-3637)

## Description
This will potentially help with intermittent issues where the numeric snapshot values are returned as `0.00`, as reported in this [bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1981734#c1).



## PR Review Checklist

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
