### PR TITLE
[DISCO-3638] Set log level to warning for polygon request errors

### DIFF
--- a/merino/providers/suggest/finance/backends/polygon/backend.py
+++ b/merino/providers/suggest/finance/backends/polygon/backend.py
@@ -100,7 +100,7 @@ class PolygonBackend(FinanceBackend):
 
             response.raise_for_status()
         except HTTPStatusError as ex:
-            logger.error(
+            logger.warning(
                 f"Polygon request error for ticker snapshot: {ex.response.status_code} {ex.response.reason_phrase}"
             )
             return None

--- a/merino/providers/suggest/finance/backends/polygon/utils.py
+++ b/merino/providers/suggest/finance/backends/polygon/utils.py
@@ -74,7 +74,7 @@ def extract_snapshot_if_valid(data: dict[str, Any] | None) -> TickerSnapshot | N
                 todays_change_perc=f"{todays_change:.2f}", last_price=f"{last_price:.2f}"
             )
         case _:
-            logger.warning(f"Invalid ticker snapshot json response: {data}")
+            logger.warning(f"Polygon invalid ticker snapshot json response: {data}")
             return None
 
 


### PR DESCRIPTION
## References

JIRA: [DISCO-3638](https://mozilla-hub.atlassian.net/browse/DISCO-3638)

## Description
Setting the level to `warning` so that it doesn't trigger Sentry.



## PR Review Checklist

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
