### PR TITLE
HNT-892: Fix DomainDataDownloader subdomain handling

### DIFF
--- a/docs/operations/jobs/navigational_suggestions.md
+++ b/docs/operations/jobs/navigational_suggestions.md
@@ -104,6 +104,10 @@ $ ./scripts/import_domains.sh DOWNLOADED_FILE.csv
 
 This will add the domains to the `custom_domains.py` file, check if the domain exists, and if not, it adds it. Afterwards, all domains are getting alphabetically sorted.
 
+> Note
+> - Subdomains are supported and treated as distinct domains. For example, `sub.example.com` is different from `example.com` and can be added separately.
+> - Duplicate checks are done by exact domain string, not by apex/normalized form. If a custom domain exactly matches an existing domain, it will be skipped and logged as: `Skipped duplicate domains: <domain>`.
+
 ## Running the Navigational Suggestions job locally
 
 The Navigational Suggestions job can be run locally for development and testing purposes without requiring access to Google Cloud. This is useful for testing changes to the favicon extraction and domain processing logic.

--- a/merino/jobs/navigational_suggestions/domain_data_downloader.py
+++ b/merino/jobs/navigational_suggestions/domain_data_downloader.py
@@ -13,36 +13,6 @@ from merino.utils.metrics import logger
 class DomainDataDownloader:
     """Download domain data from BigQuery tables"""
 
-    def _normalize_domain(self, domain: str) -> str:
-        """Normalize domain names for comparison by extracting the registered domain.
-        Handles special cases like subdomains, paths, and multi-part TLDs correctly.
-
-        Example:
-            www.example.com -> example.com
-            search.bbc.co.uk -> bbc.co.uk
-            startsiden.no/sok -> startsiden.no
-        """
-        if not domain:
-            return ""
-
-        # Add http:// if no scheme present to make urlparse work properly
-        if "://" not in domain:
-            domain = f"http://{domain}"
-
-        # Handle URL paths (like startsiden.no/sok)
-        parsed = urlparse(domain)
-        hostname = parsed.netloc or parsed.path.split("/")[0]
-
-        # Use tldextract to correctly handle all domain patterns
-        extracted = tldextract.extract(hostname)
-
-        # Build the normalized domain (registered domain without www)
-        if extracted.suffix:
-            # Return the registered domain (domain + suffix)
-            return f"{extracted.domain}.{extracted.suffix}"
-        else:
-            # For cases where suffix might be empty
-            return str(extracted.domain)
 
     DOMAIN_DATA_QUERY = """
 with apex_names as (

--- a/merino/jobs/navigational_suggestions/domain_data_downloader.py
+++ b/merino/jobs/navigational_suggestions/domain_data_downloader.py
@@ -13,7 +13,6 @@ from merino.utils.metrics import logger
 class DomainDataDownloader:
     """Download domain data from BigQuery tables"""
 
-
     DOMAIN_DATA_QUERY = """
 with apex_names as (
   select

--- a/tests/integration/jobs/navigational_suggestions/test_init.py
+++ b/tests/integration/jobs/navigational_suggestions/test_init.py
@@ -690,30 +690,6 @@ class TestDomainDataDownloader:
 
     @patch("google.auth.default", return_value=(MagicMock(), "test-project"))
     @patch("google.cloud.bigquery.Client")
-    def test_normalize_domain(self, mock_bigquery_client, mock_auth_default):
-        """Test the _normalize_domain method with various inputs."""
-        downloader = DomainDataDownloader("test-project")
-
-        # Test with subdomain
-        assert downloader._normalize_domain("www.example.com") == "example.com"
-
-        # Test with multi-part TLD
-        assert downloader._normalize_domain("bbc.co.uk") == "bbc.co.uk"
-
-        # Test with path
-        assert downloader._normalize_domain("startsiden.no/sok") == "startsiden.no"
-
-        # Test with protocol
-        assert downloader._normalize_domain("https://example.com") == "example.com"
-
-        # Test with empty input
-        assert downloader._normalize_domain("") == ""
-
-        # Test with just a domain name (no TLD)
-        assert downloader._normalize_domain("localhost") == "localhost"
-
-    @patch("google.auth.default", return_value=(MagicMock(), "test-project"))
-    @patch("google.cloud.bigquery.Client")
     def test_parse_custom_domain(self, mock_bigquery_client, mock_auth_default):
         """Test the _parse_custom_domain method with various inputs."""
         downloader = DomainDataDownloader("test-project")
@@ -790,7 +766,6 @@ class TestDomainDataDownloader:
 
         # Create a simplified version of the methods we're testing
         # by mocking them to return known values
-        mocker.patch.object(downloader, "_normalize_domain", side_effect=lambda domain: domain)
 
         mocker.patch.object(
             downloader,
@@ -854,12 +829,6 @@ class TestDomainDataDownloader:
         downloader = DomainDataDownloader("test-project")
         downloader.client = mock_client
 
-        # Use actual implementation for _normalize_domain and _parse_custom_domain
-        mocker.patch.object(
-            downloader,
-            "_normalize_domain",
-            side_effect=lambda domain: domain,  # Simplified for test
-        )
 
         mocker.patch.object(
             downloader,

--- a/tests/integration/jobs/navigational_suggestions/test_init.py
+++ b/tests/integration/jobs/navigational_suggestions/test_init.py
@@ -865,7 +865,7 @@ class TestDomainDataDownloader:
 
         # Verify logging of duplicates
         mock_logger.info.assert_any_call("Added 1 custom domains (1 were duplicates)")
-        mock_logger.info.assert_any_call("Skipped domains: example.com -> example.com")
+        mock_logger.info.assert_any_call("Skipped duplicate domains: example.com")
 
     def test_download_data_with_custom_domain_error(self, mocker):
         """Test that errors during custom domain processing are handled properly."""

--- a/tests/integration/jobs/navigational_suggestions/test_init.py
+++ b/tests/integration/jobs/navigational_suggestions/test_init.py
@@ -829,7 +829,6 @@ class TestDomainDataDownloader:
         downloader = DomainDataDownloader("test-project")
         downloader.client = mock_client
 
-
         mocker.patch.object(
             downloader,
             "_parse_custom_domain",

--- a/tests/unit/jobs/navigational_suggestions/test_domain_data_downloader.py
+++ b/tests/unit/jobs/navigational_suggestions/test_domain_data_downloader.py
@@ -84,41 +84,6 @@ def test_custom_domains(mock_bigquery_client):
         ), f"All categories should be strings in {domain}"
 
 
-def test_normalize_domain_empty(domain_data_downloader):
-    """Test normalizing an empty domain"""
-    assert domain_data_downloader._normalize_domain("") == ""
-
-
-def test_normalize_domain_without_scheme(domain_data_downloader):
-    """Test normalizing a domain without scheme"""
-    assert domain_data_downloader._normalize_domain("example.com") == "example.com"
-
-
-def test_normalize_domain_with_scheme(domain_data_downloader):
-    """Test normalizing a domain with scheme"""
-    assert domain_data_downloader._normalize_domain("http://example.com") == "example.com"
-
-
-def test_normalize_domain_with_subdomain(domain_data_downloader):
-    """Test normalizing a domain with subdomain"""
-    assert domain_data_downloader._normalize_domain("www.example.com") == "example.com"
-    assert domain_data_downloader._normalize_domain("sub.example.com") == "example.com"
-
-
-def test_normalize_domain_with_path(domain_data_downloader):
-    """Test normalizing a domain with path"""
-    assert domain_data_downloader._normalize_domain("example.com/path") == "example.com"
-
-
-def test_normalize_domain_complex_tld(domain_data_downloader):
-    """Test normalizing a domain with complex TLD"""
-    assert domain_data_downloader._normalize_domain("example.co.uk") == "example.co.uk"
-    assert domain_data_downloader._normalize_domain("www.bbc.co.uk") == "bbc.co.uk"
-
-
-def test_normalize_domain_with_port(domain_data_downloader):
-    """Test normalizing a domain with port"""
-    assert domain_data_downloader._normalize_domain("example.com:8080") == "example.com"
 
 
 def test_parse_custom_domain_basic(domain_data_downloader):

--- a/tests/unit/jobs/navigational_suggestions/test_domain_data_downloader.py
+++ b/tests/unit/jobs/navigational_suggestions/test_domain_data_downloader.py
@@ -216,12 +216,6 @@ def test_download_data_exception_handling(mock_bigquery_client, mocker):
         DomainDataDownloader, "_parse_custom_domain", side_effect=Exception("Test exception")
     )
 
-    # Mock CUSTOM_DOMAINS to have a test domain
-    mocker.patch(
-        "merino.jobs.navigational_suggestions.domain_data_downloader.CUSTOM_DOMAINS",
-        ["test.com"],
-    )
-
     # Patch the logger
     mock_logger = mocker.patch(
         "merino.jobs.navigational_suggestions.domain_data_downloader.logger"

--- a/tests/unit/jobs/navigational_suggestions/test_domain_data_downloader.py
+++ b/tests/unit/jobs/navigational_suggestions/test_domain_data_downloader.py
@@ -84,8 +84,6 @@ def test_custom_domains(mock_bigquery_client):
         ), f"All categories should be strings in {domain}"
 
 
-
-
 def test_parse_custom_domain_basic(domain_data_downloader):
     """Test parsing a basic custom domain"""
     result = domain_data_downloader._parse_custom_domain("example.com", 10)


### PR DESCRIPTION
## References

JIRA: [HNT-871](https://mozilla-hub.atlassian.net/browse/HNT-871)

## Description
Download data for subdomains, instead of removing the subdomains during normalization.

For example, this will allow us to download the correct favicon for abcnews.go.com.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[HNT-871]: https://mozilla-hub.atlassian.net/browse/HNT-871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1816)
