### PR TITLE
[DISCO-3633] Migrate polygon image ingestion to airflow

### DIFF
--- a/merino/jobs/polygon/__init__.py
+++ b/merino/jobs/polygon/__init__.py
@@ -1,0 +1,27 @@
+"""CLI commands for the polygon image ingestion job"""
+
+import asyncio
+import logging
+from typing import Annotated
+
+import typer
+
+from merino.configs import settings as config
+from merino.jobs.polygon.polygon_ingestion import PolygonIngestion
+
+logger = logging.getLogger(__name__)
+
+cli = typer.Typer(
+    name="polygon-ingestion",
+    help="Commands to download ticker logos, upload to GCS, and generate manifest",
+)
+
+
+@cli.command()
+def ingest():
+    """Download logos, upload to GCS, and generate manifest."""
+    logger.info("Starting Polygon ingestion pipeline...")
+
+    ingestion = PolygonIngestion()
+
+    asyncio.run(ingestion.ingest())

--- a/merino/jobs/polygon/polygon_ingestion.py
+++ b/merino/jobs/polygon/polygon_ingestion.py
@@ -1,0 +1,57 @@
+"""Downloads and uploads ticker images for polygon"""
+
+from merino.providers.suggest.finance.backends.polygon.backend import PolygonBackend
+from merino.providers.suggest.finance.backends.protocol import FinanceBackend
+from merino.providers.suggest.finance.provider import Provider
+from merino.configs import settings
+from merino.utils.metrics import get_metrics_client
+from merino.utils.http_client import create_http_client
+from merino.utils.gcs.gcs_uploader import GcsUploader
+
+setting = settings.providers.polygon
+
+
+class PolygonIngestion:
+    """Class for managing the Polygon image ingestion pipeline"""
+
+    provider: Provider
+
+    def __init__(self):
+        self.provider = self.get_provider()
+
+    def get_provider(self) -> Provider:
+        """Return a polygon provider instance"""
+        provider = Provider(
+            backend=PolygonBackend(
+                api_key=settings.polygon.api_key,
+                metrics_client=get_metrics_client(),
+                metrics_sample_rate=settings.polygon.metrics_sampling_rate,
+                http_client=create_http_client(
+                    base_url=settings.polygon.url_base,
+                    connect_timeout=settings.providers.polygon.connect_timeout_sec,
+                ),
+                url_param_api_key=settings.polygon.url_param_api_key,
+                url_single_ticker_snapshot=settings.polygon.url_single_ticker_snapshot,
+                url_single_ticker_overview=settings.polygon.url_single_ticker_overview,
+                gcs_uploader=GcsUploader(
+                    settings.image_gcs.gcs_project,
+                    settings.image_gcs.gcs_bucket,
+                    settings.image_gcs.cdn_hostname,
+                ),
+            ),
+            metrics_client=get_metrics_client(),
+            score=setting.score,
+            name="polygon",
+            query_timeout_sec=setting.query_timeout_sec,
+            enabled_by_default=setting.enabled_by_default,
+            resync_interval_sec=setting.resync_interval_sec,
+            cron_interval_sec=setting.cron_interval_sec,
+        )
+
+        return provider
+
+    async def ingest(self) -> None:
+        """Trigger the ingestion pipeline: download logos, upload them, and write manifest."""
+        backend: FinanceBackend = self.provider.backend
+        await backend.build_and_upload_manifest_file()
+        await backend.shutdown()

--- a/merino/providers/suggest/finance/backends/polygon/backend.py
+++ b/merino/providers/suggest/finance/backends/polygon/backend.py
@@ -210,7 +210,7 @@ class PolygonBackend(FinanceBackend):
 
     async def fetch_manifest_data(
         self,
-    ) -> tuple[GetManifestResultCode, FinanceManifest | None, float | None]:
+    ) -> tuple[GetManifestResultCode, FinanceManifest | None]:
         """Fetch manifest data from GCS through the filemanager."""
         return await self.filemanager.get_file()
 
@@ -242,4 +242,6 @@ class PolygonBackend(FinanceBackend):
 
     async def shutdown(self) -> None:
         """Close http client and cache connections."""
+        logger.info("Shutting down polygon backend")
         await self.http_client.aclose()
+        logger.info("polygon backend successfully shut down")

--- a/merino/providers/suggest/finance/backends/polygon/filemanager.py
+++ b/merino/providers/suggest/finance/backends/polygon/filemanager.py
@@ -3,7 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 """A Filemanager to retrieve data for the Polygon Provider."""
 
-from datetime import datetime
 import orjson
 import logging
 
@@ -34,29 +33,17 @@ class PolygonFilemanager:
         self.blob_name = blob_name
         self.bucket = Bucket(storage=self.gcs_storage_client, name=gcs_bucket_path)
 
-    async def get_file(self) -> tuple[GetManifestResultCode, FinanceManifest | None, float | None]:
-        """Fetch the manifest file and the updated timestamp from GCS"""
+    async def get_file(self) -> tuple[GetManifestResultCode, FinanceManifest | None]:
+        """Fetch the manifest file from GCS"""
         try:
             blob: Blob = await self.bucket.get_blob(self.blob_name)
             blob_data = await blob.download()
 
             manifest_content = FinanceManifest.model_validate(orjson.loads(blob_data))
 
-            # retrieve time stamp
-            updated_ts = None
-            updated_str = getattr(blob, "updated", None)
-            if isinstance(updated_str, str):
-                try:
-                    updated_ts = datetime.strptime(
-                        updated_str, "%Y-%m-%dT%H:%M:%S.%fZ"
-                    ).timestamp()
-                except ValueError as parse_err:
-                    logger.warning(f"Could not parse blob.updated: {updated_str} ({parse_err})")
-            logger.info(
-                f"Successfully loaded finance manifest file: {self.blob_name}, timestamp:{updated_ts}"
-            )
+            logger.info(f"Successfully loaded finance manifest file: {self.blob_name}")
 
-            return GetManifestResultCode.SUCCESS, manifest_content, updated_ts
+            return GetManifestResultCode.SUCCESS, manifest_content
 
         except JSONDecodeError as json_error:
             logger.error("Failed to decode finance manifest JSON: %s", json_error)
@@ -66,4 +53,4 @@ class PolygonFilemanager:
 
         except Exception as e:
             logger.error(f"Error fetching finance manifest file {self.blob_name}: {e}")
-        return GetManifestResultCode.FAIL, None, None
+        return GetManifestResultCode.FAIL, None

--- a/merino/providers/suggest/finance/backends/protocol.py
+++ b/merino/providers/suggest/finance/backends/protocol.py
@@ -98,7 +98,7 @@ class FinanceBackend(Protocol):
 
     async def fetch_manifest_data(
         self,
-    ) -> tuple[GetManifestResultCode, FinanceManifest | None, float | None]:
+    ) -> tuple[GetManifestResultCode, FinanceManifest | None]:
         """Fetch manifest data from GCS through the filemanager."""
         ...
 

--- a/tests/integration/jobs/polygon/test_polygon_ingestion.py
+++ b/tests/integration/jobs/polygon/test_polygon_ingestion.py
@@ -1,0 +1,47 @@
+"""Unit tests for the polygon ingestion class"""
+
+import pytest
+from unittest.mock import AsyncMock
+
+from merino.jobs.polygon.polygon_ingestion import PolygonIngestion
+
+
+@pytest.fixture
+def patched_provider(mocker):
+    """Return a mock Provider with a mock PolygonBackend."""
+    mock_provider = mocker.MagicMock()
+    mock_backend = mocker.MagicMock()
+    mock_provider.backend = mock_backend
+    return mock_provider, mock_backend
+
+
+@pytest.mark.asyncio
+async def test_ingest_triggers_upload_and_shutdown(mocker, patched_provider):
+    """Test that ingest() calls the expected backend methods."""
+    mock_provider, mock_backend = patched_provider
+
+    mocker.patch(
+        "merino.jobs.polygon.polygon_ingestion.PolygonIngestion.get_provider",
+        return_value=mock_provider,
+    )
+
+    mock_backend.build_and_upload_manifest_file = AsyncMock()
+    mock_backend.shutdown = AsyncMock()
+
+    ingestion = PolygonIngestion()
+
+    await ingestion.ingest()
+
+    mock_backend.build_and_upload_manifest_file.assert_awaited_once()
+    mock_backend.shutdown.assert_awaited_once()
+
+
+def test_provider_instantiation(mocker):
+    """Ensure get_provider builds a Provider with a backend."""
+    mocker.patch("merino.providers.suggest.finance.backends.polygon.backend.PolygonFilemanager")
+
+    ingestion = PolygonIngestion()
+    provider = ingestion.get_provider()
+
+    assert provider is not None
+    assert hasattr(provider, "backend")

--- a/tests/unit/providers/suggest/finance/backends/test_filemanager.py
+++ b/tests/unit/providers/suggest/finance/backends/test_filemanager.py
@@ -7,7 +7,6 @@
 import pytest
 import orjson
 from gcloud.aio.storage import Blob
-from datetime import datetime
 
 from merino.providers.suggest.finance.backends.polygon.filemanager import PolygonFilemanager
 from merino.providers.suggest.finance.backends.protocol import (
@@ -28,7 +27,6 @@ async def test_get_file_success(mocker):
 
     mock_blob = mocker.AsyncMock(spec=Blob)
     mock_blob.download.return_value = blob_data
-    mock_blob.updated = "2024-08-01T12:30:45.123456Z"
 
     mock_bucket = mocker.MagicMock()
     mock_bucket.get_blob = mocker.AsyncMock(return_value=mock_blob)
@@ -36,15 +34,11 @@ async def test_get_file_success(mocker):
     filemanager = PolygonFilemanager("mock-bucket", "mock-blob")
     filemanager.bucket = mock_bucket
 
-    result_code, manifest, updated_ts = await filemanager.get_file()
+    result_code, manifest = await filemanager.get_file()
 
     assert result_code == GetManifestResultCode.SUCCESS
     assert isinstance(manifest, FinanceManifest)
     assert "AAPL" in manifest.tickers
-
-    expected_ts = datetime.strptime(mock_blob.updated, "%Y-%m-%dT%H:%M:%S.%fZ").timestamp()
-    assert isinstance(updated_ts, float)
-    assert updated_ts == expected_ts
 
 
 @pytest.mark.asyncio
@@ -54,7 +48,6 @@ async def test_get_file_invalid_json(mocker):
     """
     mock_blob = mocker.AsyncMock(spec=Blob)
     mock_blob.download.return_value = b"invalid json"
-    mock_blob.updated = "2024-08-01T12:30:45.123456Z"
 
     mock_bucket = mocker.MagicMock()
     mock_bucket.get_blob = mocker.AsyncMock(return_value=mock_blob)
@@ -62,11 +55,10 @@ async def test_get_file_invalid_json(mocker):
     filemanager = PolygonFilemanager("mock-bucket", "mock-blob")
     filemanager.bucket = mock_bucket
 
-    result_code, manifest, updated_ts = await filemanager.get_file()
+    result_code, manifest = await filemanager.get_file()
 
     assert result_code == GetManifestResultCode.FAIL
     assert manifest is None
-    assert updated_ts is None
 
 
 @pytest.mark.asyncio
@@ -76,7 +68,6 @@ async def test_get_file_validation_error(mocker):
 
     mock_blob = mocker.AsyncMock()
     mock_blob.download.return_value = orjson.dumps(invalid_data)
-    mock_blob.updated = "2024-08-01T12:30:45.123456Z"
 
     mock_bucket = mocker.MagicMock()
     mock_bucket.get_blob = mocker.AsyncMock(return_value=mock_blob)
@@ -84,8 +75,7 @@ async def test_get_file_validation_error(mocker):
     filemanager = PolygonFilemanager("mock-bucket", "mock-blob")
     filemanager.bucket = mock_bucket
 
-    result_code, manifest, updated_ts = await filemanager.get_file()
+    result_code, manifest = await filemanager.get_file()
 
     assert result_code == GetManifestResultCode.FAIL
     assert manifest is None
-    assert updated_ts is None

--- a/tests/unit/providers/suggest/finance/backends/test_polygon.py
+++ b/tests/unit/providers/suggest/finance/backends/test_polygon.py
@@ -553,23 +553,19 @@ async def test_fetch_manifest_data_success(polygon: PolygonBackend, mocker):
     when the filemanager returns a valid result.
     """
     mock_manifest = FinanceManifest(tickers={"AAPL": "https://cdn.example.com/aapl.png"})
-    fixed_time = 1234567890.0
-
-    mocker.patch("time.time", return_value=fixed_time)
 
     mocker.patch.object(
         polygon.filemanager,
         "get_file",
         new_callable=AsyncMock,
-        return_value=(GetManifestResultCode.SUCCESS, mock_manifest, fixed_time),
+        return_value=(GetManifestResultCode.SUCCESS, mock_manifest),
     )
 
-    result_code, manifest, timestamp = await polygon.fetch_manifest_data()
+    result_code, manifest = await polygon.fetch_manifest_data()
 
     assert result_code == GetManifestResultCode.SUCCESS
     assert isinstance(manifest, FinanceManifest)
     assert "AAPL" in manifest.tickers
-    assert timestamp is not None
 
 
 @pytest.mark.asyncio
@@ -579,14 +575,13 @@ async def test_fetch_manifest_data_fail(polygon: PolygonBackend, mocker):
         polygon.filemanager,
         "get_file",
         new_callable=AsyncMock,
-        return_value=(GetManifestResultCode.FAIL, None, None),
+        return_value=(GetManifestResultCode.FAIL, None),
     )
 
-    result_code, manifest, timestamp = await polygon.fetch_manifest_data()
+    result_code, manifest = await polygon.fetch_manifest_data()
 
     assert result_code == GetManifestResultCode.FAIL
     assert manifest is None
-    assert timestamp is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## References

JIRA: [DISCO-3633](https://mozilla-hub.atlassian.net/browse/DISCO-3633)

## Description
This PR migrates the finance ticker logo ingestion and manifest generation workflow for the Polygon provider from a Merino cron job to airflow. This changed was prompted by upcoming scale changes: the number of tickers is growing and the cron job model risks possible race conditions, longer runtimes, and less observability.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
