### PR TITLE
[DISCO-3633] fix: register the polygon ingestion cli command

### DIFF
--- a/merino/jobs/cli.py
+++ b/merino/jobs/cli.py
@@ -10,6 +10,8 @@ from merino.jobs.navigational_suggestions import navigational_suggestions_cmd
 from merino.jobs.relevancy_uploader import relevancy_csv_rs_uploader_cmd
 from merino.jobs.wikipedia_indexer import indexer_cmd
 from merino.jobs.wikipedia_offline_uploader import wiki_offline_uploader_cmd
+from merino.jobs.polygon import cli as polygon_ingestion_cmd
+
 
 cli = typer.Typer(no_args_is_help=True, add_completion=False)
 # Add the wikipedia-indexer subcommands
@@ -29,6 +31,9 @@ cli.add_typer(relevancy_csv_rs_uploader_cmd, no_args_is_help=True)
 cli.add_typer(geonames_uploader_cmd, no_args_is_help=True)
 
 cli.add_typer(wiki_offline_uploader_cmd, no_args_is_help=True)
+
+# Add the polygon ingest subcommand
+cli.add_typer(polygon_ingestion_cmd, no_args_is_help=True)
 
 
 @cli.callback()


### PR DESCRIPTION
## References

JIRA: [DISCO-3633](https://mozilla-hub.atlassian.net/browse/DISCO-3633)

## Description
We previously added a new airflow job for polygon image ingestion but forgot to register the command in `cli.py`



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3633]: https://mozilla-hub.atlassian.net/browse/DISCO-3633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1819)
