### PR TITLE
[DISCO-3633] fix: lazily instantiate gcs storage object

### DIFF
--- a/merino/providers/suggest/finance/backends/polygon/filemanager.py
+++ b/merino/providers/suggest/finance/backends/polygon/filemanager.py
@@ -21,22 +21,34 @@ logger = logging.getLogger(__name__)
 class PolygonFilemanager:
     """Filemanager for fetching logo data from GCS asynchronously and storing only in memory."""
 
-    gcs_client: Storage
+    gcs_bucket_path: str
     blob_name: str
-    bucket: Bucket
+    gcs_client: Storage | None = None
+    bucket: Bucket | None = None
 
     def __init__(self, gcs_bucket_path: str, blob_name: str) -> None:
         """:param gcs_bucket_path: GCS bucket name to fetch from.
         :param blob_name: Name of the blob in the GCS bucket.
         """
-        self.gcs_storage_client = Storage()
+        self.gcs_bucket_path = gcs_bucket_path
         self.blob_name = blob_name
-        self.bucket = Bucket(storage=self.gcs_storage_client, name=gcs_bucket_path)
+
+    async def get_bucket(self) -> Bucket:
+        """Lazily instantiate the GCS client and return the configured bucket"""
+        if self.bucket is not None:
+            return self.bucket
+
+        if self.gcs_client is None:
+            self.gcs_client = Storage()
+
+        self.bucket = Bucket(storage=self.gcs_client, name=self.gcs_bucket_path)
+        return self.bucket
 
     async def get_file(self) -> tuple[GetManifestResultCode, FinanceManifest | None]:
-        """Fetch the manifest file from GCS"""
+        """Fetch the manifest file from GCS and parse it into a FinanceManifest"""
         try:
-            blob: Blob = await self.bucket.get_blob(self.blob_name)
+            bucket = await self.get_bucket()
+            blob: Blob = await bucket.get_blob(self.blob_name)
             blob_data = await blob.download()
 
             manifest_content = FinanceManifest.model_validate(orjson.loads(blob_data))

--- a/tests/unit/providers/suggest/finance/backends/test_filemanager.py
+++ b/tests/unit/providers/suggest/finance/backends/test_filemanager.py
@@ -79,3 +79,77 @@ async def test_get_file_validation_error(mocker):
 
     assert result_code == GetManifestResultCode.FAIL
     assert manifest is None
+
+
+@pytest.mark.asyncio
+async def test_get_bucket_memoization(mocker):
+    """Test that get_bucket returns the same bucket instance on multiple calls (memoized)."""
+    mock_storage = mocker.patch(
+        "merino.providers.suggest.finance.backends.polygon.filemanager.Storage"
+    )
+    mock_bucket_instance = mocker.MagicMock()
+    mock_storage.return_value = mocker.MagicMock()
+    mocker.patch("gcloud.aio.storage.Bucket", return_value=mock_bucket_instance)
+
+    filemanager = PolygonFilemanager("mock-bucket", "mock-blob")
+
+    bucket1 = await filemanager.get_bucket()
+    bucket2 = await filemanager.get_bucket()
+
+    assert bucket1 is bucket2
+    assert mock_storage.call_count == 1  # only one Storage instance should be created
+
+
+@pytest.mark.asyncio
+async def test_get_file_uses_get_bucket(mocker):
+    """Test that get_file calls get_bucket and fetches the blob."""
+    mock_blob = mocker.AsyncMock()
+    mock_blob.download.return_value = orjson.dumps(
+        {"tickers": {"AAPL": "https://example.com/aapl.png"}}
+    )
+
+    mock_bucket = mocker.AsyncMock()
+    mock_bucket.get_blob.return_value = mock_blob
+
+    filemanager = PolygonFilemanager("mock-bucket", "mock-blob")
+    mocker.patch.object(filemanager, "get_bucket", return_value=mock_bucket)
+
+    result_code, manifest = await filemanager.get_file()
+
+    assert result_code == GetManifestResultCode.SUCCESS
+    assert isinstance(manifest, FinanceManifest)
+    filemanager.get_bucket.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_get_bucket_initializes_client_and_bucket(mocker):
+    """Test that get_bucket initializes gcs_client and bucket if unset."""
+    # create mock instances
+    mock_storage_instance = mocker.MagicMock(name="MockStorageInstance")
+    mock_bucket_instance = mocker.MagicMock(name="MockBucketInstance")
+
+    mock_storage_class = mocker.patch(
+        "merino.providers.suggest.finance.backends.polygon.filemanager.Storage",
+        return_value=mock_storage_instance,
+    )
+    mock_bucket_class = mocker.patch(
+        "merino.providers.suggest.finance.backends.polygon.filemanager.Bucket",
+        return_value=mock_bucket_instance,
+    )
+
+    # instantiate filemanager with no initialized clients
+    filemanager = PolygonFilemanager("test-bucket", "manifest.json")
+
+    # confirm client and bucket are None before call
+    assert filemanager.gcs_client is None
+    assert filemanager.bucket is None
+
+    result = await filemanager.get_bucket()
+
+    # check that lazy init worked correctly
+    mock_storage_class.assert_called_once_with()
+    mock_bucket_class.assert_called_once_with(storage=mock_storage_instance, name="test-bucket")
+
+    assert filemanager.gcs_client is mock_storage_instance
+    assert filemanager.bucket is mock_bucket_instance
+    assert result is mock_bucket_instance


### PR DESCRIPTION
## References

JIRA: [DISCO-3633](https://mozilla-hub.atlassian.net/browse/DISCO-3633)

## Description
This PR updates the `PolygonFilemanager` class to defer creation of the `gcloud.aio.storage.Storage` client and `Bucket` until they are actually needed. This fixes the polygon ingestion airflow failure

Why:
Previously, the `Storage()` client was instantiated within the filemanager’s constructor, which caused failures when used in the airflow job because the job was instantiating the filemanager through the polygon provider backend and `Storage()` creates an underlying `aiohttp.TCPConnector` that immediately tries to bind to an async event loop at instantiation time. Specifically, [the job failed](https://workflow.telemetry.mozilla.org/log?dag_id=merino_jobs&task_id=polygon_ingestion_prod&execution_date=2025-08-05T05%3A00%3A00%2B00%3A00) due to an attempt to instantiate an async-bound object outside an event loop. 

What Changed
- Introduced `get_bucket()` as an async method to lazily initialize the GCS client and bucket.
- Removed direct instantiation from the constructor


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3633]: https://mozilla-hub.atlassian.net/browse/DISCO-3633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1820)
