### PR TITLE
[DISCO-3659] Fix Polygon airflow job logging locals

### DIFF
--- a/merino/jobs/polygon/__init__.py
+++ b/merino/jobs/polygon/__init__.py
@@ -15,7 +15,7 @@ cli = typer.Typer(
     name="polygon-ingestion",
     help="Commands to download ticker logos, upload to GCS, and generate manifest",
     pretty_exceptions_enable=True,
-    pretty_exceptions_show_locals=False, # NOTE: Set to False to avoid api_key exposure.
+    pretty_exceptions_show_locals=False,  # NOTE: Set to False to avoid api_key exposure.
 )
 
 

--- a/merino/jobs/polygon/__init__.py
+++ b/merino/jobs/polygon/__init__.py
@@ -14,6 +14,8 @@ logger = logging.getLogger(__name__)
 cli = typer.Typer(
     name="polygon-ingestion",
     help="Commands to download ticker logos, upload to GCS, and generate manifest",
+    pretty_exceptions_enable=True,
+    pretty_exceptions_show_locals=False, # NOTE: Set to False to avoid api_key exposure.
 )
 
 
@@ -22,6 +24,12 @@ def ingest():
     """Download logos, upload to GCS, and generate manifest."""
     logger.info("Starting Polygon ingestion pipeline...")
 
-    ingestion = PolygonIngestion()
+    try:
+        ingestion = PolygonIngestion()
 
-    asyncio.run(ingestion.ingest())
+        asyncio.run(ingestion.ingest())
+    except Exception as ex:
+        # Minimal, sanitized message; traceback but *no locals* (since Rich locals are disabled see line 18)
+        logger.error(f"Ingestion failed: {ex.__class__.__name__}", exc_info=True)
+        # Re-raise so Airflow marks the task as failed
+        raise


### PR DESCRIPTION
## References

JIRA: [DISCO-TODO](https://mozilla-hub.atlassian.net/browse/DISCO-TODO)

## Description
This change is supposed to disable rich locals logging for airflow DAG failures.



## PR Review Checklist
- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
