### PR TITLE
[DISCO-3659] Fix typer cli object exposing local variables on exceptions

### DIFF
--- a/merino/jobs/cli.py
+++ b/merino/jobs/cli.py
@@ -12,8 +12,9 @@ from merino.jobs.wikipedia_indexer import indexer_cmd
 from merino.jobs.wikipedia_offline_uploader import wiki_offline_uploader_cmd
 from merino.jobs.polygon import cli as polygon_ingestion_cmd
 
+# NOTE: `pretty_exceptions_show_locals` argument is set to False to avoid api_key and secrets exposure.
+cli = typer.Typer(no_args_is_help=True, add_completion=False, pretty_exceptions_show_locals=False)
 
-cli = typer.Typer(no_args_is_help=True, add_completion=False)
 # Add the wikipedia-indexer subcommands
 cli.add_typer(indexer_cmd, no_args_is_help=True)
 

--- a/merino/jobs/polygon/__init__.py
+++ b/merino/jobs/polygon/__init__.py
@@ -14,8 +14,6 @@ logger = logging.getLogger(__name__)
 cli = typer.Typer(
     name="polygon-ingestion",
     help="Commands to download ticker logos, upload to GCS, and generate manifest",
-    pretty_exceptions_enable=True,
-    pretty_exceptions_show_locals=False,  # NOTE: Set to False to avoid api_key exposure.
 )
 
 

--- a/merino/jobs/polygon/polygon_ingestion.py
+++ b/merino/jobs/polygon/polygon_ingestion.py
@@ -23,7 +23,7 @@ class PolygonIngestion:
         """Return a polygon provider instance"""
         provider = Provider(
             backend=PolygonBackend(
-                # api_key=settings.polygon.api_key,
+                api_key=settings.polygon.api_key,
                 metrics_client=get_metrics_client(),
                 metrics_sample_rate=settings.polygon.metrics_sampling_rate,
                 http_client=create_http_client(

--- a/merino/providers/suggest/finance/backends/polygon/backend.py
+++ b/merino/providers/suggest/finance/backends/polygon/backend.py
@@ -52,7 +52,7 @@ class PolygonBackend(FinanceBackend):
 
     def __init__(
         self,
-        # api_key: str,
+        api_key: str,
         url_param_api_key: str,
         url_single_ticker_snapshot: str,
         url_single_ticker_overview: str,
@@ -62,7 +62,7 @@ class PolygonBackend(FinanceBackend):
         metrics_sample_rate: float,
     ) -> None:
         """Initialize the Polygon backend."""
-        # self.api_key = api_key
+        self.api_key = api_key
         self.metrics_client = metrics_client
         self.http_client = http_client
         self.metrics_sample_rate = metrics_sample_rate
@@ -97,7 +97,7 @@ class PolygonBackend(FinanceBackend):
 
     async def fetch_ticker_snapshot(self, ticker: str) -> Any | None:
         """Make a request and fetch the snapshot for this single ticker."""
-        params = {self.url_param_api_key: settings.polygon.api_key}
+        params = {self.url_param_api_key: self.api_key}
 
         try:
             response: Response = await self.http_client.get(
@@ -115,7 +115,7 @@ class PolygonBackend(FinanceBackend):
 
     async def get_ticker_image_url(self, ticker: str) -> str | None:
         """Get the logo URL for the ticker (requires API key when fetching)"""
-        params = {self.url_param_api_key: settings.polygon.api_key}
+        params = {self.url_param_api_key: self.api_key}
 
         try:
             response: Response = await self.http_client.get(
@@ -147,7 +147,7 @@ class PolygonBackend(FinanceBackend):
         if not image_url:
             return None
 
-        params = {self.url_param_api_key: settings.polygon.api_key}
+        params = {self.url_param_api_key: self.api_key}
         try:
             response: Response = await self.http_client.get(image_url, params=params)
             response.raise_for_status()

--- a/merino/providers/suggest/manager.py
+++ b/merino/providers/suggest/manager.py
@@ -184,7 +184,7 @@ def _create_provider(provider_id: str, setting: Settings) -> BaseProvider:
         case ProviderType.POLYGON:
             return PolygonProvider(
                 backend=PolygonBackend(
-                    # api_key=settings.polygon.api_key,
+                    api_key=settings.polygon.api_key,
                     metrics_client=get_metrics_client(),
                     metrics_sample_rate=settings.polygon.metrics_sampling_rate,
                     http_client=create_http_client(

--- a/tests/unit/providers/suggest/finance/backends/test_polygon.py
+++ b/tests/unit/providers/suggest/finance/backends/test_polygon.py
@@ -58,7 +58,7 @@ def fixture_polygon_parameters(
 ) -> dict[str, Any]:
     """Create constructor parameters for Polygon backend module."""
     return {
-        # "api_key": "api_key",
+        "api_key": "api_key",
         "metrics_client": statsd_mock,
         "http_client": mocker.AsyncMock(spec=AsyncClient),
         "metrics_sample_rate": 1,


### PR DESCRIPTION
## References

JIRA: [DISCO-3659](https://mozilla-hub.atlassian.net/browse/DISCO-3659)

## Description
- Undoes changes from this [PR](https://github.com/mozilla-services/merino-py/pull/1028).
- Fixes this issue properly which we hoped to do in this [PR](https://github.com/mozilla-services/merino-py/pull/1027).

## PR Review Checklist
- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1823)
