### PR TITLE
[DISCO-3635] update resync interval for polygon fetch job

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -664,8 +664,8 @@ cron_interval_sec = 60
 
 # MERINO_PROVIDERS__POLYGON__RESYNC_INTERVAL_SEC
 # Time between re-syncs of the polygon manifest file, in seconds.
-# Set to 7 days.
-resync_interval_sec = 604800
+# Set to daily.
+resync_interval_sec = 86400
 
 # MERINO_PROVIDERS__POLYGON__CIRCUIT_BREAKER_FAILURE_THRESHOLD
 # The circuit breaker will open when the failure is over this threshold.

--- a/tests/unit/providers/suggest/finance/test_provider.py
+++ b/tests/unit/providers/suggest/finance/test_provider.py
@@ -114,7 +114,7 @@ def fixture_provider(backend_mock: Any, statsd_mock: Any) -> Provider:
         score=0.3,
         query_timeout_sec=0.2,
         cron_interval_sec=60,
-        resync_interval_sec=3600,
+        resync_interval_sec=86400,
     )
 
 
@@ -334,7 +334,7 @@ def test_should_fetch_respects_interval(provider: Provider):
 
 def test_should_fetch_after_interval(provider: Provider):
     """Test that _should_fetch returns True after interval has passed."""
-    provider.last_fetch_at = time.time() - 4000  # > resync_interval_sec
+    provider.last_fetch_at = time.time() - 87000  # > resync_interval_sec
     provider.last_fetch_failure_at = None
 
     assert provider._should_fetch() is True
@@ -342,7 +342,7 @@ def test_should_fetch_after_interval(provider: Provider):
 
 def test_should_fetch_skips_after_failure(provider: Provider):
     """Test that _should_fetch returns False if a recent failure occurred."""
-    provider.last_fetch_at = time.time() - 4000
+    provider.last_fetch_at = time.time() - 87000
     provider.last_fetch_failure_at = time.time() - 100  # failure < 1hr ago
 
     assert provider._should_fetch() is False


### PR DESCRIPTION
## References

JIRA: [DISCO-3635](https://mozilla-hub.atlassian.net/browse/DISCO-3635)

## Description
Update the resync interval for the manifest fetch job from weekly to daily



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3635]: https://mozilla-hub.atlassian.net/browse/DISCO-3635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1831)
