### PR TITLE
HNT-629: updating interest picker

### DIFF
--- a/merino/curated_recommendations/interest_picker.py
+++ b/merino/curated_recommendations/interest_picker.py
@@ -51,10 +51,10 @@ def _get_interest_picker_rank(
 ) -> int:
     """Return a random rank for the interest picker."""
     if any(s.isFollowed for s in sections.values()):
-        # If followed, picker shows between 2nd-3rd position
-        return random.randint(2, 3)
+        # If followed, picker always at rank 2 (3rd position)
+        return 2
     # If no sections followed, picker shows between 1st-3rd position
-    return random.randint(1, 3)
+    return random.randint(1, 2)
 
 
 def _renumber_sections(

--- a/merino/curated_recommendations/interest_picker.py
+++ b/merino/curated_recommendations/interest_picker.py
@@ -7,7 +7,7 @@ from merino.curated_recommendations.protocol import (
     Section,
 )
 
-MIN_INITIALLY_VISIBLE_SECTION_COUNT = 3  # Minimum number of sections shown by default.
+MIN_INITIALLY_VISIBLE_SECTION_COUNT = 5  # Minimum number of sections shown by default.
 MIN_INTEREST_PICKER_COUNT = 8  # Minimum number of items in the interest picker.
 
 
@@ -51,7 +51,9 @@ def _get_interest_picker_rank(
 ) -> int:
     """Return a random rank for the interest picker."""
     if any(s.isFollowed for s in sections.values()):
-        return random.randint(2, 4)
+        # If followed, picker shows between 2nd-3rd position
+        return random.randint(2, 3)
+    # If no sections followed, picker shows between 1st-3rd position
     return random.randint(1, 3)
 
 
@@ -85,6 +87,6 @@ def _build_picker(
     picker_rank = _get_interest_picker_rank(sections)
     return InterestPicker(
         receivedFeedRank=picker_rank,
-        title="Follow topics to fine-tune your feed",
+        title="Follow topics to fine-tune your experience",
         sections=[InterestPickerSection(sectionId=section_id) for section_id in section_ids],
     )

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -1740,7 +1740,10 @@ class TestSections:
             interest_picker_response = data["interestPicker"]
             if enable_interest_picker:
                 assert interest_picker_response is not None
-                assert interest_picker_response["title"] == "Follow topics to fine-tune your experience"
+                assert (
+                    interest_picker_response["title"]
+                    == "Follow topics to fine-tune your experience"
+                )
             else:
                 assert interest_picker_response is None
             # Ensure top_stories_section always has receivedFeedRank == 0
@@ -1778,7 +1781,10 @@ class TestSections:
             interest_picker_response = data["interestPicker"]
             if enable_interest_picker:
                 assert interest_picker_response is not None
-                assert interest_picker_response["title"] == "Follow topics to fine-tune your experience"
+                assert (
+                    interest_picker_response["title"]
+                    == "Follow topics to fine-tune your experience"
+                )
             else:
                 assert interest_picker_response is None
             # Ensure top_stories_section always has receivedFeedRank == 0

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -1740,6 +1740,7 @@ class TestSections:
             interest_picker_response = data["interestPicker"]
             if enable_interest_picker:
                 assert interest_picker_response is not None
+                assert interest_picker_response["title"] == "Follow topics to fine-tune your experience"
             else:
                 assert interest_picker_response is None
             # Ensure top_stories_section always has receivedFeedRank == 0
@@ -1777,6 +1778,7 @@ class TestSections:
             interest_picker_response = data["interestPicker"]
             if enable_interest_picker:
                 assert interest_picker_response is not None
+                assert interest_picker_response["title"] == "Follow topics to fine-tune your experience"
             else:
                 assert interest_picker_response is None
             # Ensure top_stories_section always has receivedFeedRank == 0

--- a/tests/unit/curated_recommendations/test_interest_picker.py
+++ b/tests/unit/curated_recommendations/test_interest_picker.py
@@ -46,7 +46,7 @@ def test_interest_picker_is_created(followed_count: int):
     assert picker is not None
 
     # Picker has expected title string and no subtitle.
-    assert picker.title == "Follow topics to fine-tune your feed"
+    assert picker.title == "Follow topics to fine-tune your experience"
     assert picker.subtitle is None
 
     # Picker rank range depends on followed sections.
@@ -108,7 +108,7 @@ def test_renumber_sections_preserves_order_skips_picker_rank():
     "followed, expected_ranks",
     [
         (False, {1, 2, 3}),
-        (True, {2, 3, 4}),
+        (True, {2, 3}),
     ],
 )
 def test_get_interest_picker_rank_param(followed: bool, expected_ranks: set[int]):

--- a/tests/unit/curated_recommendations/test_interest_picker.py
+++ b/tests/unit/curated_recommendations/test_interest_picker.py
@@ -107,8 +107,8 @@ def test_renumber_sections_preserves_order_skips_picker_rank():
 @pytest.mark.parametrize(
     "followed, expected_ranks",
     [
-        (False, {1, 2, 3}),
-        (True, {2, 3}),
+        (False, {1, 2}),  # no followed sections - picker can be right after 1st - 2nd section
+        (True, {2}),  # has followed sections - picker at the 3rd section (2nd rank)
     ],
 )
 def test_get_interest_picker_rank_param(followed: bool, expected_ranks: set[int]):


### PR DESCRIPTION
## References

JIRA: https://mozilla-hub.atlassian.net/browse/HNT-629

## Description
- Change max position of inline picker to the 3rd section
- Change title to “Follow topics to fine-tune your experience”
- Show more sections once interest picker is enabled



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1833)
