### PR TITLE
[DISCO-3667] Add temp fix for failing wiki job

### DIFF
--- a/merino/jobs/wikipedia_indexer/__init__.py
+++ b/merino/jobs/wikipedia_indexer/__init__.py
@@ -96,5 +96,7 @@ def copy_export(
         extra={"gcs_path": gcs_path, "gcp_project": gcp_project},
     )
     latest = file_manager.stream_latest_dump_to_gcs()
-    if not latest.name:
-        raise RuntimeError(f"Unable to ensure latest {language} dump on GCS or missing file name.")
+    if latest is None or not getattr(latest, "name", ""):
+        raise RuntimeError(
+            f"No {language} CirrusSearch dump found in current/ or fallback (20250819)."
+        )

--- a/merino/jobs/wikipedia_indexer/filemanager.py
+++ b/merino/jobs/wikipedia_indexer/filemanager.py
@@ -81,24 +81,40 @@ class FileManager:
 
     def get_latest_dump(self, latest_gcs: Optional[Blob]) -> Optional[str]:
         """Find the latest export that's newer than the latest on GCS (if any)."""
-        resp = requests.get(self.base_url)  # nosec
-        parser = DirectoryParser(self.file_pattern)
-        parser.feed(str(resp.content))
-        links = parser.file_paths
-        if len(links) == 1:
-            name = links[0]
-            url = urljoin(self.base_url, name)
+        last_gcs_date = self._parse_date(str(latest_gcs.name)) if latest_gcs else dt.min
 
-            link_date = self._parse_date(name)
+        # 1. Try current/
+        try:
+            resp = requests.get(self.base_url)  # nosec
+            parser = DirectoryParser(self.file_pattern)
+            parser.feed(str(resp.content))
+            links = parser.file_paths
+            if len(links) == 1:
+                name = links[0]
+                url = urljoin(self.base_url, name)
+                link_date = self._parse_date(name)
+                if link_date > last_gcs_date:
+                    return url
+        except Exception as e:
+            logger.warning(f"Failed to fetch listing from {self.base_url}: {e}")
 
-            if latest_gcs:
-                last_gcs_date = self._parse_date(str(latest_gcs.name))
-            else:
-                logger.info("")
-                last_gcs_date = dt.min  # treat as oldest possible date for first_run
+        # 2. Fallback to dated directory (bandaid)
+        fallback_url = "https://dumps.wikimedia.org/other/cirrussearch/20250819/"
+        try:
+            resp = requests.get(fallback_url)  # nosec
+            parser = DirectoryParser(self.file_pattern)
+            parser.feed(str(resp.content))
+            links = parser.file_paths
+            if len(links) == 1:
+                name = links[0]
+                url = urljoin(fallback_url, name)
+                link_date = self._parse_date(name)
+                if link_date > last_gcs_date:
+                    logger.info(f"Using bandaid fallback dump from {fallback_url}")
+                    return url
+        except Exception as e:
+            logger.warning(f"Fallback fetch failed: {e}")
 
-            if last_gcs_date < link_date:
-                return url
         return None
 
     def _parse_date(self, filename: str) -> dt:

--- a/tests/integration/jobs/wikipedia_indexer/test_filemanager.py
+++ b/tests/integration/jobs/wikipedia_indexer/test_filemanager.py
@@ -204,3 +204,53 @@ def test_stream_dump_to_gcs_blob_deletion(mock_requests, mock_gcs_client, mock_w
 
     mock_blob.exists.assert_called_once()
     mock_blob.delete.assert_called_once()
+
+
+@pytest.mark.usefixtures("mock_gcs_client")
+def test_get_latest_dump_fallback_used_when_current_empty(requests_mock):
+    """Use the bandaid fallback directory when current/ has no matching link."""
+    base_url = "http://test.com"
+    # current/ listing has no match
+    requests_mock.get(base_url, text="<html><body>No matches</body></html>")  # nosec
+
+    # fallback listing has one match
+    fallback_url = "https://dumps.wikimedia.org/other/cirrussearch/20250819/"
+    file_name = "enwiki-20250819-cirrussearch-content.json.gz"
+    requests_mock.get(
+        fallback_url,
+        text=f"<html><body><a href='{file_name}'>{file_name}</a></body></html>",
+    )  # nosec
+
+    # First run (no GCS blob yet)
+    latest_gcs = None
+
+    fm = FileManager("foo/bar", "a-project", base_url, "en")
+    latest_dump_url = fm.get_latest_dump(latest_gcs)
+
+    assert latest_dump_url == f"{fallback_url}{file_name}"
+
+
+@pytest.mark.usefixtures("mock_gcs_client")
+def test_get_latest_dump_fallback_skips_if_not_newer(requests_mock):
+    """Return None if fallback file exists but isn't newer than the GCS blob."""
+    base_url = "http://test.com"
+    # current/ listing has no match
+    requests_mock.get(base_url, text="<html><body>No matches</body></html>")  # nosec
+
+    # fallback listing has one match, but it's older than GCS
+    fallback_url = "https://dumps.wikimedia.org/other/cirrussearch/20250819/"
+    older_file = "enwiki-20240101-cirrussearch-content.json.gz"
+    requests_mock.get(
+        fallback_url,
+        text=f"<html><body><a href='{older_file}'>{older_file}</a></body></html>",
+    )  # nosec
+
+    # GCS already has a newer dump (2024-02-01)
+    from google.cloud.storage import Blob
+
+    latest_gcs = Blob("foo/enwiki-20240201-cirrussearch-content.json.gz", "bucket")
+
+    fm = FileManager("foo/bar", "a-project", base_url, "en")
+    latest_dump_url = fm.get_latest_dump(latest_gcs)
+
+    assert latest_dump_url is None

--- a/tests/unit/jobs/wikipedia_indexer/test_filemanager.py
+++ b/tests/unit/jobs/wikipedia_indexer/test_filemanager.py
@@ -306,3 +306,72 @@ def test_filemanager_rejects_invalid_language():
     """Raises ValueError if FileManager is initialized with an unsupported language."""
     with pytest.raises(ValueError, match="Unsupported language 'es'"):
         FileManager("gcs-bucket", "gcs-project", "http://mock-url", language="es")
+
+
+@patch("merino.jobs.wikipedia_indexer.filemanager.requests.get")
+def test_get_latest_dump_uses_fallback_when_current_has_no_match(mock_get):
+    """Fall back to the dated directory when current/ has no matching link."""
+    # current/ listing: no matching links
+    resp_current = MagicMock()
+    resp_current.content = "<html><body>No matches here</body></html>"
+
+    # fallback listing: one matching link
+    resp_fallback = MagicMock()
+    resp_fallback.content = """
+    <html><body>
+      <a href="frwiki-20250819-cirrussearch-content.json.gz">frwiki-20250819-cirrussearch-content.json.gz</a>
+    </body></html>
+    """
+
+    # First call -> current/, second call -> fallback
+    mock_get.side_effect = [resp_current, resp_fallback]
+
+    mock_client = MagicMock()
+    with patch("merino.jobs.wikipedia_indexer.filemanager.Client", return_value=mock_client):
+        fm = FileManager(
+            gcs_bucket="gcs-bucket",
+            gcs_project="gcs-project",
+            export_base_url="http://mock-url/",
+            language="fr",
+        )
+        # No GCS blob yet (first run)
+        result = fm.get_latest_dump(latest_gcs=None)
+
+    assert (
+        result
+        == "https://dumps.wikimedia.org/other/cirrussearch/20250819/frwiki-20250819-cirrussearch-content.json.gz"
+    )
+
+
+@patch("merino.jobs.wikipedia_indexer.filemanager.requests.get")
+def test_get_latest_dump_fallback_skips_if_not_newer_than_gcs(mock_get):
+    """Return None when fallback file exists but is not newer than the GCS blob."""
+    # current/ listing: no matching links
+    resp_current = MagicMock()
+    resp_current.content = "<html><body>No matches here</body></html>"
+
+    # fallback listing: one matching link, but it's older/equal to GCS date
+    resp_fallback = MagicMock()
+    resp_fallback.content = """
+    <html><body>
+      <a href="frwiki-20240101-cirrussearch-content.json.gz">frwiki-20240101-cirrussearch-content.json.gz</a>
+    </body></html>
+    """
+
+    mock_get.side_effect = [resp_current, resp_fallback]
+
+    # GCS already has a newer file (or same date)
+    mock_blob = MagicMock()
+    mock_blob.name = "frwiki-20240201-cirrussearch-content.json.gz"
+
+    mock_client = MagicMock()
+    with patch("merino.jobs.wikipedia_indexer.filemanager.Client", return_value=mock_client):
+        fm = FileManager(
+            gcs_bucket="gcs-bucket",
+            gcs_project="gcs-project",
+            export_base_url="http://mock-url/",
+            language="fr",
+        )
+        result = fm.get_latest_dump(latest_gcs=mock_blob)
+
+    assert result is None


### PR DESCRIPTION
## References

JIRA: [DISCO-3667](https://mozilla-hub.atlassian.net/browse/DISCO-3667)

## Description

Our Wikipedia indexer jobs rely on fetching [CirrusSearch dumps](https://dumps.wikimedia.org/other/cirrussearch/) from the Wikimedia dumps service. Normally, each language (e.g. `enwiki`, `plwiki`, etc.) has its own `*-cirrussearch-content.json.gz` dump available in the `current/` directory, which our `FileManager` retrieves and copies into GCS for downstream indexing.

## The Problem
Recently, jobs for some languages (e.g. `plwiki`) began failing with:

```
No matching dump files found for pattern: (?:.*/|^)plwiki-(\d+)-cirrussearch-content.json.gz
AttributeError: 'NoneType' object has no attribute 'name'
```

Investigation showed that:
* The `current/` directory at `https://dumps.wikimedia.org/other/cirrussearch/current/` now only contains **two large commonswiki dumps** instead of per-language dumps.
* Other language dumps (like `enwiki`) still succeed because they already had a blob in GCS from prior runs. `plwiki` failed because it had no prior GCS file and nothing in `current/`.

According to Wikimedia’s Phabricator:
* [T401923 – CirrusSearch dumps are not published](https://phabricator.wikimedia.org/T401923)
* [T400158 – CirrusSearch dumps have failed – 2025-07-21](https://phabricator.wikimedia.org/T400158)

Dump generation has been failing for weeks: large wikis (e.g. commonswiki, wikidata) time out after \~7 days, which blocks other language dumps from being published. The absence of language dumps in `current/` is therefore a **bug in Wikimedia’s dump pipeline**, not an intentional change.

## Temp Fix (Bandaid)
This PR introduces a temporary fallback in `FileManager.get_latest_dump`:
* First, attempt to fetch from `current/` as before.
* If no match is found, fall back to the dated directory `https://dumps.wikimedia.org/other/cirrussearch/20250819/`.
* Only return a URL if the dump is newer than what’s already in GCS.
* Guard against `None` to avoid AttributeErrors when no dump exists.

This ensures that languages like `plwiki` can run even though `current/` is incomplete.

## Next Steps

* Monitor the Phabricator tickets above for updates from Wikimedia. Once dumps are reliably back in `current/`, we can remove this hardcoded fallback.
* Longer term, we may want a more robust strategy (crawl recent dated directories) instead of hardcoding to a single date.
* For now, this bandaid keeps our Wikipedia indexer pipelines unblocked.




## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3667]: https://mozilla-hub.atlassian.net/browse/DISCO-3667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ