### PR TITLE
[DISCO-3672] Prepend plus symbol for positive percent changes

### DIFF
--- a/merino/providers/suggest/finance/backends/polygon/utils.py
+++ b/merino/providers/suggest/finance/backends/polygon/utils.py
@@ -62,9 +62,15 @@ def extract_snapshot_if_valid(data: dict[str, Any] | None) -> TickerSnapshot | N
                 "lastTrade": {"p": float(last_price)},
             }
         }:
+            # Prepending a "+" if the `todays_change` is an above 0 value. We don't need to prepend a "-"
+            # since that is already done by the upstream api response.
+            todays_change_percent = (
+                f"+{todays_change:.2f}" if todays_change > 0 else f"{todays_change:.2f}"
+            )
+
             return TickerSnapshot(
                 ticker=ticker,
-                todays_change_perc=f"{todays_change:.2f}",
+                todays_change_perc=todays_change_percent,
                 last_price=f"{last_price:.2f}",
             )
         case _:

--- a/tests/unit/providers/suggest/finance/backends/test_utils.py
+++ b/tests/unit/providers/suggest/finance/backends/test_utils.py
@@ -131,7 +131,7 @@ def test_extract_snapshot_if_valid_success(
     single_ticker_snapshot_response: dict[str, Any],
 ) -> None:
     """Test extract_ticker_snapshot_returns_none method. Should return TickerSnapshot object."""
-    expected = TickerSnapshot(ticker="AAPL", last_price="120.47", todays_change_perc="0.82")
+    expected = TickerSnapshot(ticker="AAPL", last_price="120.47", todays_change_perc="+0.82")
     actual = extract_snapshot_if_valid(single_ticker_snapshot_response)
 
     assert actual is not None
@@ -175,14 +175,14 @@ def test_extract_snapshot_if_valid_returns_none_for_missing_property(
 def test_build_ticker_summary_success() -> None:
     """Test build_ticker_summary method."""
     actual = build_ticker_summary(
-        snapshot=TickerSnapshot(ticker="AAPL", last_price="120.47", todays_change_perc="0.82"),
+        snapshot=TickerSnapshot(ticker="AAPL", last_price="120.47", todays_change_perc="+0.82"),
         image_url=None,
     )
     expected = TickerSummary(
         ticker="AAPL",
         name="Apple Inc",
         last_price="$120.47 USD",
-        todays_change_perc="0.82",
+        todays_change_perc="+0.82",
         query="AAPL stock",
         image_url=None,
         exchange="NASDAQ",


### PR DESCRIPTION
## References

JIRA: [DISCO-TODO](https://mozilla-hub.atlassian.net/browse/DISCO-TODO)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
