### PR TITLE
[DISCO-3594] Add metrics for Polygon

### DIFF
--- a/merino/providers/suggest/finance/provider.py
+++ b/merino/providers/suggest/finance/provider.py
@@ -135,6 +135,7 @@ class Provider(BaseProvider):
         # Get the list of tickers (0 to 3) for the query string.
         tickers = get_tickers_for_query(srequest.query)
 
+        # here for overall query method duration timeit
         try:
             if not tickers:
                 return []
@@ -148,10 +149,12 @@ class Provider(BaseProvider):
                     image_url = self.get_image_url_for_ticker(snapshot.ticker)
                     ticker_summaries.append(self.backend.get_ticker_summary(snapshot, image_url))
 
+                # here for provider query success count
                 return [self.build_suggestion(ticker_summaries)]
 
         except Exception as e:
             logger.warning(f"Exception occurred for Polygon provider: {e}")
+            # here for provider query fail count
             return []
 
     def build_suggestion(self, data: list[TickerSummary]) -> BaseSuggestion:

--- a/merino/providers/suggest/finance/provider.py
+++ b/merino/providers/suggest/finance/provider.py
@@ -135,7 +135,6 @@ class Provider(BaseProvider):
         # Get the list of tickers (0 to 3) for the query string.
         tickers = get_tickers_for_query(srequest.query)
 
-        # here for overall query method duration timeit
         try:
             if not tickers:
                 return []
@@ -149,12 +148,10 @@ class Provider(BaseProvider):
                     image_url = self.get_image_url_for_ticker(snapshot.ticker)
                     ticker_summaries.append(self.backend.get_ticker_summary(snapshot, image_url))
 
-                # here for provider query success count
                 return [self.build_suggestion(ticker_summaries)]
 
         except Exception as e:
             logger.warning(f"Exception occurred for Polygon provider: {e}")
-            # here for provider query fail count
             return []
 
     def build_suggestion(self, data: list[TickerSummary]) -> BaseSuggestion:

--- a/metrics.yaml
+++ b/metrics.yaml
@@ -13,3 +13,66 @@ suggest/accuweather:
     scope: |
       The "api/v1/suggest" API endpoint.
     alert_policy: []
+suggest/polygon:
+  polygon_request_snapshot_get:
+    description: |
+      A gauge to track the latency for snapshot v3 get request
+    type: gauge
+    labels: [] # no labels
+    scope: |
+      The "api/v1/suggest" API endpoint.
+    alert_policy:
+
+  polygon_request_snapshot_get_failed:
+      description: |
+        A counter for failed snapshot v3 get requests
+      type: counter
+      labels: []
+      scope: |
+        The "api/v1/suggest" API endpoint.
+      alert_policy: []
+
+  polygon_request_ticker_overview_get:
+    description: |
+      A gauge to track the latency for ticker overview get request
+    type: gauge
+    labels: []
+    scope: |
+      The "api/v1/suggest" API endpoint.
+    alert_policy: []
+
+  polygon_request_ticker_overview_get_failed:
+    description: |
+      A counter for failed ticker overview get requests
+    type: counter
+    labels: []
+    scope: |
+      The "api/v1/suggest" API endpoint.
+    alert_policy: []
+
+  polygon_request_company_logo_get:
+    description: |
+      A gauge to track the latency for company logo get request
+    type: gauge
+    labels: []
+    scope: |
+      The "api/v1/suggest" API endpoint.
+    alert_policy: []
+
+  polygon_request_company_logo_get_failed:
+    description: |
+      A counter for failed company logo get requests
+    type: counter
+    labels: []
+    scope: |
+      The "api/v1/suggest" API endpoint.
+    alert_policy: []
+
+  polygon_company_logo_not_found:
+    description: |
+      A counter for when a requested company logo is not found
+    type: counter
+    labels: []
+    scope: |
+      The "api/v1/suggest" API endpoint.
+    alert_policy: []

--- a/tests/unit/providers/suggest/finance/backends/test_polygon.py
+++ b/tests/unit/providers/suggest/finance/backends/test_polygon.py
@@ -9,7 +9,7 @@ import orjson
 import logging
 from pydantic import HttpUrl
 import pytest
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, call
 from httpx import AsyncClient, HTTPStatusError, Request, Response
 from pytest_mock import MockerFixture
 from typing import Any, cast
@@ -26,6 +26,7 @@ from merino.providers.suggest.finance.backends.protocol import (
     TickerSnapshot,
     TickerSummary,
 )
+
 
 URL_SINGLE_TICKER_SNAPSHOT = settings.polygon.url_single_ticker_snapshot
 URL_SINGLE_TICKER_OVERVIEW = settings.polygon.url_single_ticker_overview
@@ -249,6 +250,101 @@ async def test_get_ticker_summary_success(
 
     assert actual is not None
     assert actual == expected
+
+@pytest.mark.asyncio
+async def test_get_snapshots_success(
+    mocker,
+    polygon: PolygonBackend,
+    single_ticker_snapshot_response: dict[str, Any],
+    ticker_snapshot: TickerSnapshot,
+) -> None:
+    """Test get_snapshots method. Mocks the fetch_ticker_snapshot and extract_snapshot_if_valid methods.
+    Asserts on all three valid snapshots. Also asserts on metric not emitted for invalid snapshot.
+    """
+    tickers = ["AAPL", "MSFT", "TSLA"]
+
+    # Mocking the fetch_ticker_snapshot method to return single_ticker_snapshot_response fixture for two of the calls.
+    # Returns None for one of the calls.
+    fetch_mock = mocker.patch.object(
+        polygon,
+        "fetch_ticker_snapshot",
+        side_effect=[
+            single_ticker_snapshot_response,  # -> valid
+            single_ticker_snapshot_response,  # -> valid
+            single_ticker_snapshot_response,  # -> valid
+        ],
+    )
+
+    # Patch extract_snapshot_if_valid to map payloads -> snapshots/None.
+    extract_mock = mocker.patch(
+        "merino.providers.suggest.finance.backends.polygon.backend.extract_snapshot_if_valid",
+        side_effect=[ticker_snapshot, ticker_snapshot, ticker_snapshot],
+    )
+
+    # Mock metrics client.
+    polygon.metrics_client = MagicMock()
+    increment_metric_mock = polygon.metrics_client.increment
+
+    # Call the method being tested.
+    result = await polygon.get_snapshots(tickers)
+
+    # Asserts
+    assert result == [ticker_snapshot, ticker_snapshot, ticker_snapshot]
+
+    assert fetch_mock.await_count == 3
+    assert fetch_mock.await_args_list == [call("AAPL"), call("MSFT"), call("TSLA")]
+
+    assert extract_mock.call_count == 3
+
+    increment_metric_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_snapshots_success_and_fail(
+    mocker,
+    polygon: PolygonBackend,
+    single_ticker_snapshot_response: dict[str, Any],
+    ticker_snapshot: TickerSnapshot,
+) -> None:
+    """Test get_snapshots method. Mocks the fetch_ticker_snapshot and extract_snapshot_if_valid methods.
+    Asserts on two valid snapshots and one invalid. Also asserts on metric emitted for invalid.
+    """
+    tickers = ["AAPL", "MSFT", "TSLA"]
+
+    # Mocking the fetch_ticker_snapshot method to return single_ticker_snapshot_response fixture for two of the calls.
+    # Returns None for one of the calls.
+    fetch_mock = mocker.patch.object(
+        polygon,
+        "fetch_ticker_snapshot",
+        side_effect=[
+            single_ticker_snapshot_response,  # -> valid
+            None,  # -> invalid
+            single_ticker_snapshot_response,  # -> valid
+        ],
+    )
+
+    # Patch extract_snapshot_if_valid to map payloads -> snapshots/None.
+    extract_mock = mocker.patch(
+        "merino.providers.suggest.finance.backends.polygon.backend.extract_snapshot_if_valid",
+        side_effect=[ticker_snapshot, None, ticker_snapshot],
+    )
+
+    # Mock metrics client.
+    polygon.metrics_client = MagicMock()
+    increment_metric_mock = polygon.metrics_client.increment
+
+    # Call the method being tested.
+    result = await polygon.get_snapshots(tickers)
+
+    # Asserts
+    assert result == [ticker_snapshot, ticker_snapshot]
+
+    assert fetch_mock.await_count == 3
+    assert fetch_mock.await_args_list == [call("AAPL"), call("MSFT"), call("TSLA")]
+
+    assert extract_mock.call_count == 3
+
+    increment_metric_mock.assert_called_once_with("polygon.snapshot.invalid")
 
 
 @pytest.mark.asyncio

--- a/tests/unit/providers/suggest/finance/backends/test_polygon.py
+++ b/tests/unit/providers/suggest/finance/backends/test_polygon.py
@@ -251,6 +251,7 @@ async def test_get_ticker_summary_success(
     assert actual is not None
     assert actual == expected
 
+
 @pytest.mark.asyncio
 async def test_get_snapshots_success(
     mocker,


### PR DESCRIPTION
## References

JIRA: [DISCO-3594](https://mozilla-hub.atlassian.net/browse/DISCO-3594])

## Description
Adding request latency (`timeit`) and count (`increment`) metrics for Polygon requests.



## PR Review Checklist
- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3594]: https://mozilla-hub.atlassian.net/browse/DISCO-3594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1841)
