### PR TITLE
DISCO-3681 Add Yelp icon to business response

### DIFF
--- a/merino/providers/suggest/custom_details.py
+++ b/merino/providers/suggest/custom_details.py
@@ -46,6 +46,7 @@ class YelpDetails(BaseModel):
     rating: float | None = None
     review_count: int | None = None
     business_hours: list[dict] | None = None
+    image_url: str | None = None
 
 
 class CustomDetails(BaseModel, arbitrary_types_allowed=False):

--- a/merino/providers/suggest/yelp/backends/yelp.py
+++ b/merino/providers/suggest/yelp/backends/yelp.py
@@ -14,6 +14,8 @@ from merino.providers.suggest.yelp.backends.protocol import YelpBackendProtocol
 LIMIT_DEFAULT = 1
 logger = logging.getLogger(__name__)
 
+YELP_ICON_URL = "https://firefox-settings-attachments.cdn.mozilla.net/main-workspace/quicksuggest-other/6f44101f-8385-471e-b2dd-2b2ed6624637.svg"
+
 
 class YelpBackend(YelpBackendProtocol):
     """Backend that connects to the Yelp API."""
@@ -140,6 +142,7 @@ class YelpBackend(YelpBackendProtocol):
                 "price": price,
                 "review_count": review_count,
                 "business_hours": business_hours,
+                "image_url": YELP_ICON_URL,
             }
 
         except (KeyError, IndexError):

--- a/tests/unit/providers/yelp/backends/test_yelp.py
+++ b/tests/unit/providers/yelp/backends/test_yelp.py
@@ -109,6 +109,7 @@ def fixture_yelp_processed_response() -> dict:
                 "is_open_now": False,
             }
         ],
+        "image_url": "https://firefox-settings-attachments.cdn.mozilla.net/main-workspace/quicksuggest-other/6f44101f-8385-471e-b2dd-2b2ed6624637.svg",
     }
 
 
@@ -132,7 +133,6 @@ async def test_get_business_success(
 
     expected = yelp_processed_response
     actual = await yelp.get_business(term, location)
-    assert actual == expected
     assert actual == expected
 
 


### PR DESCRIPTION
## References

JIRA: [DISCO-3681](https://mozilla-hub.atlassian.net/browse/DISCO-3681)

## Description
Adding the Yelp icon for each business suggestion (for now, later, we want to send the restaurant preview image). We currently host the image on Remote Settings. So a constant should be fine?


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
