### PR TITLE
HNT-976: support opt-in crawl experiment enrollment

### DIFF
--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -258,10 +258,17 @@ def get_crawl_experiment_branch(request: CuratedRecommendationsRequest) -> str |
     - control: Non-crawl legacy topics only
     - treatment-crawl: Crawl legacy topics only
     - treatment-crawl-plus-subtopics: Crawl legacy topics + non-crawl subtopics
+
+    Handles both the regular experiment name and the optin- prefixed version for forced enrollment.
     """
-    if request.experimentName != ExperimentName.RSS_VS_ZYTE_EXPERIMENT.value:
-        return None
-    return request.experimentBranch
+    experiment_name = ExperimentName.RSS_VS_ZYTE_EXPERIMENT.value
+    # Check for both the experiment name and the optin- prefixed version (forced enrollment)
+    if (
+        request.experimentName == experiment_name
+        or request.experimentName == f"optin-{experiment_name}"
+    ):
+        return request.experimentBranch
+    return None
 
 
 def is_crawl_experiment_treatment(request: CuratedRecommendationsRequest) -> bool:

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -1551,10 +1551,11 @@ class TestSections:
                 assert not data["feeds"]["health"]["isBlocked"]
 
             # For RSS vs. Zyte experiment, verify that section IDs don't have _crawl suffix
-            if (
-                experiment_payload.get("experimentName")
-                == ExperimentName.RSS_VS_ZYTE_EXPERIMENT.value
-            ):
+            experiment_name = experiment_payload.get("experimentName")
+            if experiment_name in [
+                ExperimentName.RSS_VS_ZYTE_EXPERIMENT.value,
+                f"optin-{ExperimentName.RSS_VS_ZYTE_EXPERIMENT.value}",
+            ]:
                 for section_id in sections:
                     if section_id != "top_stories_section":
                         assert not section_id.endswith("_crawl"), (
@@ -1573,6 +1574,14 @@ class TestSections:
             },
             {
                 "experimentName": ExperimentName.RSS_VS_ZYTE_EXPERIMENT.value,
+                "experimentBranch": CrawlExperimentBranchName.TREATMENT_CRAWL.value,
+            },
+            {
+                "experimentName": f"optin-{ExperimentName.RSS_VS_ZYTE_EXPERIMENT.value}",
+                "experimentBranch": CrawlExperimentBranchName.CONTROL.value,
+            },
+            {
+                "experimentName": f"optin-{ExperimentName.RSS_VS_ZYTE_EXPERIMENT.value}",
                 "experimentBranch": CrawlExperimentBranchName.TREATMENT_CRAWL.value,
             },
         ],
@@ -1620,11 +1629,11 @@ class TestSections:
                 if "corpusItemId" in rec
             }
 
-            is_crawl_treatment = experiment_payload.get(
-                "experimentName"
-            ) == ExperimentName.RSS_VS_ZYTE_EXPERIMENT.value and experiment_payload.get(
-                "experimentBranch"
-            ) in [
+            experiment_name = experiment_payload.get("experimentName")
+            is_crawl_treatment = experiment_name in [
+                ExperimentName.RSS_VS_ZYTE_EXPERIMENT.value,
+                f"optin-{ExperimentName.RSS_VS_ZYTE_EXPERIMENT.value}",
+            ] and experiment_payload.get("experimentBranch") in [
                 CrawlExperimentBranchName.TREATMENT_CRAWL.value,
                 CrawlExperimentBranchName.TREATMENT_CRAWL_PLUS_SUBTOPICS.value,
             ]

--- a/tests/unit/curated_recommendations/test_sections.py
+++ b/tests/unit/curated_recommendations/test_sections.py
@@ -286,6 +286,22 @@ class TestCrawlExperiment:
                 CrawlExperimentBranchName.CONTROL.value,
                 False,
             ),
+            # Test with optin- prefix
+            (
+                f"optin-{ExperimentName.RSS_VS_ZYTE_EXPERIMENT.value}",
+                CrawlExperimentBranchName.TREATMENT_CRAWL.value,
+                True,
+            ),
+            (
+                f"optin-{ExperimentName.RSS_VS_ZYTE_EXPERIMENT.value}",
+                CrawlExperimentBranchName.TREATMENT_CRAWL_PLUS_SUBTOPICS.value,
+                True,
+            ),
+            (
+                f"optin-{ExperimentName.RSS_VS_ZYTE_EXPERIMENT.value}",
+                CrawlExperimentBranchName.CONTROL.value,
+                False,
+            ),
             ("other", CrawlExperimentBranchName.TREATMENT_CRAWL.value, False),
         ],
     )
@@ -311,6 +327,22 @@ class TestCrawlExperiment:
             ),
             (
                 ExperimentName.RSS_VS_ZYTE_EXPERIMENT.value,
+                CrawlExperimentBranchName.TREATMENT_CRAWL_PLUS_SUBTOPICS.value,
+                CrawlExperimentBranchName.TREATMENT_CRAWL_PLUS_SUBTOPICS.value,
+            ),
+            # Test with optin- prefix
+            (
+                f"optin-{ExperimentName.RSS_VS_ZYTE_EXPERIMENT.value}",
+                CrawlExperimentBranchName.CONTROL.value,
+                CrawlExperimentBranchName.CONTROL.value,
+            ),
+            (
+                f"optin-{ExperimentName.RSS_VS_ZYTE_EXPERIMENT.value}",
+                CrawlExperimentBranchName.TREATMENT_CRAWL.value,
+                CrawlExperimentBranchName.TREATMENT_CRAWL.value,
+            ),
+            (
+                f"optin-{ExperimentName.RSS_VS_ZYTE_EXPERIMENT.value}",
                 CrawlExperimentBranchName.TREATMENT_CRAWL_PLUS_SUBTOPICS.value,
                 CrawlExperimentBranchName.TREATMENT_CRAWL_PLUS_SUBTOPICS.value,
             ),


### PR DESCRIPTION
## References

JIRA: [HNT-976](https://mozilla-hub.atlassian.net/browse/HNT-976)

## Description
Handle the case where the crawl experiment has an `optin-` prefix, which happens when we opt-in to the experiment.

## QA
```shell
curl --location 'http://localhost:8000/api/v1/curated-recommendations' \
--header 'Content-Type: application/json' \
--data '{
    "locale": "en-US",
    "feeds": ["sections"],
    "experimentName":"optin-new-ranking-for-legacy-topics-in-new-tab-v1",
    "experimentBranch":"treatment-crawl"
}'
```

- [x] Returns crawled legacy topics.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[HNT-976]: https://mozilla-hub.atlassian.net/browse/HNT-976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1847)
