### PR TITLE
Fix pre-commit mypy hook to use the same as make mypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,22 +27,13 @@ repos:
         args:
           - "--skip"
           - "B101,B104,B311"
-  - repo: "https://github.com/pre-commit/mirrors-mypy"
-    rev: v1.14.1
+  - repo: local
     hooks:
       - id: mypy
-        files: "^merino|^tests"
-        args:
-          [
-            --config-file=pyproject.toml
-          ]
-        additional_dependencies:
-          [
-            "pydantic",
-            "types-geoip2",
-            "types-PyYAML",
-            "types-requests",
-            "types-redis",
-            "types-python-dateutil",
-            "types-Pillow",
-          ]
+        name: mypy
+        entry: uv run mypy
+        args: [merino, tests, --config-file=pyproject.toml]
+        language: system
+        types: [python]
+        pass_filenames: false
+        always_run: true


### PR DESCRIPTION
## Description
`git commit` always fails for me with `mypy` errors, which are not shown when using `make mypy`. Let's use one way of using `mypy`. The proposal is to rely on the local `mypy` when using the pre-commit hook.

Since one has to install the dependencies locally anyway, we can assume `mypy` is installed?

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
