### PR TITLE
[Disco-3669] Add a suggest provider for google suggest

### DIFF
--- a/merino/configs/app_configs/config_sentry.py
+++ b/merino/configs/app_configs/config_sentry.py
@@ -14,6 +14,7 @@ from merino.utils.version import fetch_app_version_from_file
 logger = logging.getLogger(__name__)
 
 REDACTED_TEXT = "[REDACTED]"
+GOOGLE_SUGGEST_PARAMS = "google_suggest_params"
 
 
 def configure_sentry() -> None:  # pragma: no cover
@@ -50,6 +51,8 @@ def strip_sensitive_data(event: Event, hint: Hint) -> Event | None:
             for entry in event_exception_values[0].get("stacktrace", {}).get("frames", []):
                 vars = entry.get("vars", {})
 
+                # Just delete it if any
+                vars.pop(GOOGLE_SUGGEST_PARAMS, None)
                 match vars:
                     case {"q": _}:
                         vars["q"] = REDACTED_TEXT
@@ -58,12 +61,18 @@ def strip_sensitive_data(event: Event, hint: Hint) -> Event | None:
                         vars["query"] = REDACTED_TEXT
                     case {"query": _}:
                         vars["query"] = REDACTED_TEXT
-
+                    case {"values": {"q": _}, "solved_result": [{"q": _}, *_]}:
+                        vars["values"]["q"] = REDACTED_TEXT  # type: ignore
+                        # Just delete it if any
+                        vars["values"].pop(GOOGLE_SUGGEST_PARAMS, None)
+                        # https://github.com/python/mypy/issues/12770
+                        vars["solved_result"][0]["q"] = REDACTED_TEXT
+                        # Just delete it if any
+                        vars["solved_result"][0].pop(GOOGLE_SUGGEST_PARAMS, None)
                     case {"values": {"q": _}}:
                         vars["values"]["q"] = REDACTED_TEXT
-                    case {"solved_result": [{"q": _}, *_]}:
-                        # https://github.com/python/mypy/issues/12770
-                        vars["solved_result"][0]["q"] = REDACTED_TEXT  # type: ignore
+                        # Just delete it if any
+                        vars["values"].pop(GOOGLE_SUGGEST_PARAMS, None)
                     case _:
                         pass
 

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -775,6 +775,25 @@ bucket_name = ""
 # GCP project name where the GCS bucket lives.
 gcp_project = ""
 
+[default.providers.google_suggest]
+# MERINO_PROVIDERS__GOOGLE_SUGGEST__TYPE
+# The type of this provider, should be `google_suggest`.
+type = "google_suggest"
+
+# MERINO_PROVIDERS__GOOGLE_SUGGEST__ENABLED_BY_DEFAULT
+# Whether this provider is enabled by default.
+enabled_by_default = false
+
+# MERINO_PROVIDERS__GOOGLE_SUGGEST__SCORE
+# The ranking score for this provider as a floating point number.
+score = 0.3
+
+[default.google_suggest]
+# MERINO_GOOGLE_SUGGEST__URL_BASE
+url_base = "https://www.google.com"
+# MERINO_GOOGLE_SUGGEST__URL_SUGGEST_PATH
+# The endpoint for google suggest.
+url_suggest_path = "/complete/search"
 
 [default.curated_recommendations.gcs.local_model]
 # MERINO__CURATED_RECOMMENDATIONS__GCS__LOCAL_MODEL__MAX_SIZE

--- a/merino/providers/suggest/base.py
+++ b/merino/providers/suggest/base.py
@@ -23,6 +23,7 @@ class SuggestionRequest(BaseModel):
     country: str | None = None
     user_agent: UserAgent | None = None
     source: str | None = None
+    google_suggest_params: str | None = None
 
 
 class Category(Enum):

--- a/merino/providers/suggest/custom_details.py
+++ b/merino/providers/suggest/custom_details.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel
 
 from merino.middleware.geolocation import Coordinates
 from merino.providers.suggest.finance.backends.protocol import TickerSummary
+from merino.providers.suggest.google_suggest.backends.protocol import GoogleSuggestResponse
 from merino.providers.suggest.yelp.backends.protocol import YelpBusinessDetails
 
 
@@ -44,6 +45,12 @@ class YelpDetails(BaseModel):
     values: list[YelpBusinessDetails]
 
 
+class GoogleSuggestDetails(BaseModel):
+    """Google Suggest specific fields."""
+
+    suggestions: GoogleSuggestResponse
+
+
 class CustomDetails(BaseModel, arbitrary_types_allowed=False):
     """Contain references to custom fields for each provider.
     This object uses the provider name as the key, and references custom schema models.
@@ -55,3 +62,4 @@ class CustomDetails(BaseModel, arbitrary_types_allowed=False):
     weather: WeatherDetails | None = None
     polygon: PolygonDetails | None = None
     yelp: YelpDetails | None = None
+    google_suggest: GoogleSuggestDetails | None = None

--- a/merino/providers/suggest/google_suggest/__init__.py
+++ b/merino/providers/suggest/google_suggest/__init__.py
@@ -1,0 +1,1 @@
+"""Google Suggest provider"""

--- a/merino/providers/suggest/google_suggest/backends/__init__.py
+++ b/merino/providers/suggest/google_suggest/backends/__init__.py
@@ -1,0 +1,1 @@
+"""Google Suggest backends"""

--- a/merino/providers/suggest/google_suggest/backends/google_suggest.py
+++ b/merino/providers/suggest/google_suggest/backends/google_suggest.py
@@ -1,0 +1,69 @@
+"""Backend for the Google Suggest endpoint."""
+
+import logging
+import urllib.parse
+
+from typing import cast
+
+import aiodogstatsd
+
+from httpx import AsyncClient, Response, HTTPStatusError
+from merino.exceptions import BackendError
+from merino.providers.suggest.google_suggest.backends.protocol import (
+    GoogleSuggestResponse,
+    SuggestRequest,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+class GoogleSuggestBackend:
+    """Backend that interfaces with Google Suggest endpoint."""
+
+    http_client: AsyncClient
+    url_suggest_path: str
+    metrics_client: aiodogstatsd.Client
+
+    def __init__(
+        self,
+        http_client: AsyncClient,
+        url_suggest_path: str,
+        metrics_client: aiodogstatsd.Client,
+    ) -> None:
+        """Initialize the backend."""
+        self.http_client = http_client
+        self.url_suggest_path = url_suggest_path
+        self.metrics_client = metrics_client
+
+    async def fetch(self, request: SuggestRequest) -> GoogleSuggestResponse:  # pragma: no cover
+        """Fetch suggestions from the Google Suggest endpoint.
+
+        `BackendError` will be raised if the request run into any issues.
+        """
+        # The original param string is URL encoded, the HTTP client wants a unencoded string.
+        params = urllib.parse.unquote(request.params)
+
+        try:
+            with self.metrics_client.timeit("google_suggest.request.duration"):
+                response: Response = await self.http_client.get(
+                    self.url_suggest_path, params=params
+                )
+
+            response.raise_for_status()
+        except HTTPStatusError as ex:
+            logger.warning(
+                f"Google Suggest request error: {ex.response.status_code} {ex.response.reason_phrase}"
+            )
+            self.metrics_client.increment(
+                "google_suggest.request.failure", tags={"status_code": ex.response.status_code}
+            )
+            raise BackendError(f"Failed to fetch from Google Suggest: {ex}") from ex
+
+        # Needed to explicitly cast because Merino will not process the response but
+        # relay it as-is to the client.
+        return cast(list, response.json())
+
+    async def shutdown(self) -> None:
+        """Close out the http client during shutdown."""
+        await self.http_client.aclose()

--- a/merino/providers/suggest/google_suggest/backends/protocol.py
+++ b/merino/providers/suggest/google_suggest/backends/protocol.py
@@ -1,0 +1,46 @@
+"""Protocol for Google Suggest provider backends."""
+
+from dataclasses import dataclass
+from typing import Protocol
+
+# An opaque type alias for Google Suggest API response.
+# For a successful request to that endpoint, the response is a JSON array.
+# We do not yet know the detailed response schema and Merino will return the
+# response as-is to Firefox, so we will leave the content untyped for now
+# (i.e. the array entry type is generic).
+type GoogleSuggestResponse[T] = list[T]
+
+
+@dataclass
+class SuggestRequest:
+    """Class that contains parameters needed to make a Google Suggest request."""
+
+    # The query of the request. Note that the client is also provided this
+    # via the `q` parameter in the following `params` parameter, but it could
+    # be dropped from `params` in the future, so we keep it separately.
+    query: str
+
+    # A client provided URL encoded query param string that contains various
+    # parameters needed for making the API request. Merino should relay this
+    # over to the endpoint as-is.
+    params: str
+
+
+class GoogleSuggestBackendProtocol(Protocol):
+    """Protocol for a Google Suggest backend.
+
+    Note: This only defines the methods used by the provider. The actual backend
+    might define additional methods and attributes which this provider doesn't
+    directly depend on.
+    """
+
+    async def fetch(self, request: SuggestRequest) -> GoogleSuggestResponse:  # pragma: no cover
+        """Fetch suggestions from the Google Suggest endpoint.
+
+        `BackendError` will be raised if the request run into any issues.
+        """
+        ...
+
+    async def shutdown(self) -> None:  # pragma: no cover
+        """Close down any open connections."""
+        ...

--- a/merino/providers/suggest/google_suggest/provider.py
+++ b/merino/providers/suggest/google_suggest/provider.py
@@ -1,0 +1,97 @@
+"""Suggest provider for Google Suggest."""
+
+import logging
+
+import aiodogstatsd
+
+from typing import cast
+
+from fastapi import HTTPException
+from pydantic import HttpUrl
+
+from merino.providers.suggest.base import BaseProvider, BaseSuggestion, SuggestionRequest
+from merino.providers.suggest.custom_details import CustomDetails, GoogleSuggestDetails
+from merino.providers.suggest.google_suggest.backends.google_suggest import GoogleSuggestBackend
+from merino.providers.suggest.google_suggest.backends.protocol import (
+    GoogleSuggestResponse,
+    SuggestRequest,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+class Provider(BaseProvider):
+    """Suggestion provider for Google Suggest."""
+
+    backend: GoogleSuggestBackend
+    metrics_client: aiodogstatsd.Client
+    score: float
+    # A dummy URL pointing to Merino itself
+    url: HttpUrl
+
+    def __init__(
+        self,
+        backend: GoogleSuggestBackend,
+        score: float,
+        name: str,
+        enabled_by_default: bool = False,
+    ) -> None:
+        self.backend = backend
+        self.score = score
+        self._name = name
+        self._enabled_by_default = enabled_by_default
+        self.url = HttpUrl("https://merino.services.mozilla.com/")
+
+        super().__init__()
+
+    async def initialize(self) -> None:
+        """Initialize the provider."""
+        pass
+
+    def validate(self, srequest: SuggestionRequest) -> None:
+        """Validate the suggestion request."""
+        if srequest.google_suggest_params is None:
+            logger.warning(
+                "HTTP 400: invalid query parameters, `google_suggest_params` is missing"
+            )
+            raise HTTPException(
+                status_code=400,
+                detail="Invalid query parameters: `google_suggest_params` is missing",
+            )
+
+        if srequest.query == "":
+            logger.warning("HTTP 400: invalid query parameters, `q` should not be empty")
+            raise HTTPException(
+                status_code=400,
+                detail="Invalid query parameters: `q` should not be empty",
+            )
+
+    async def query(self, srequest: SuggestionRequest) -> list[BaseSuggestion]:
+        """Provide Google Suggest suggestions."""
+        try:
+            suggestions: GoogleSuggestResponse = await self.backend.fetch(
+                SuggestRequest(
+                    query=srequest.query,
+                    params=cast(str, srequest.google_suggest_params),
+                )
+            )
+
+            return [
+                BaseSuggestion(
+                    title="Google Suggest",
+                    url=self.url,
+                    provider=self.name,
+                    is_sponsored=False,
+                    score=self.score,
+                    custom_details=CustomDetails(
+                        google_suggest=GoogleSuggestDetails(suggestions=suggestions)
+                    ),
+                )
+            ]
+        except Exception:
+            return []
+
+    async def shutdown(self) -> None:
+        """Shut down the provider."""
+        await self.backend.shutdown()

--- a/merino/providers/suggest/manager.py
+++ b/merino/providers/suggest/manager.py
@@ -31,6 +31,8 @@ from merino.providers.suggest.wikipedia.provider import Provider as WikipediaPro
 from merino.providers.suggest.finance.provider import Provider as PolygonProvider
 from merino.providers.suggest.yelp.provider import Provider as YelpProvider
 from merino.providers.suggest.yelp.backends.yelp import YelpBackend
+from merino.providers.suggest.google_suggest.provider import Provider as GoogleSuggestProvider
+from merino.providers.suggest.google_suggest.backends.google_suggest import GoogleSuggestBackend
 from merino.utils.blocklists import TOP_PICKS_BLOCKLIST, WIKIPEDIA_TITLE_BLOCKLIST
 from merino.utils.http_client import create_http_client
 from merino.utils.icon_processor import IconProcessor
@@ -48,6 +50,7 @@ class ProviderType(str, Enum):
     WIKIPEDIA = "wikipedia"
     POLYGON = "polygon"
     YELP = "yelp"
+    GOOGLE_SUGGEST = "google_suggest"
 
 
 def _create_provider(provider_id: str, setting: Settings) -> BaseProvider:
@@ -244,7 +247,19 @@ def _create_provider(provider_id: str, setting: Settings) -> BaseProvider:
                 query_timeout_sec=setting.query_timeout_sec,
                 enabled_by_default=setting.enabled_by_default,
             )
-
+        case ProviderType.GOOGLE_SUGGEST:
+            return GoogleSuggestProvider(
+                backend=GoogleSuggestBackend(
+                    http_client=create_http_client(
+                        base_url=settings.google_suggest.url_base,
+                    ),
+                    url_suggest_path=settings.google_suggest.url_suggest_path,
+                    metrics_client=get_metrics_client(),
+                ),
+                score=setting.score,
+                name=provider_id,
+                enabled_by_default=setting.enabled_by_default,
+            )
         case _:
             raise InvalidProviderError(f"Unknown provider type: {setting.type}")
 

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -134,7 +134,7 @@ async def suggest(
         "location" or "weather" string. For "location" it will get location completion
         suggestion. For "weather" it will return weather suggestions. If omitted, it defaults
         to weather suggestions.
-    - `google_suggest_params`: [Optional] For the `goole_suggest` provider only, use it to send
+    - `google_suggest_params`: [Optional] For the `google_suggest` provider only, use it to send
         all client specified query params over to the Google Suggest endpont.
 
     **Headers:**

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -92,6 +92,7 @@ async def suggest(
     client_variants: str | None = Query(default=None, max_length=CLIENT_VARIANT_CHARACTER_MAX),
     sources: tuple[dict[str, BaseProvider], list[BaseProvider]] = Depends(get_suggest_providers),
     request_type: Annotated[str | None, Query(pattern="^(location|weather)$")] = None,
+    google_suggest_params: Annotated[str | None, Query(max_length=QUERY_CHARACTER_MAX)] = None,
 ) -> Response:
     """Query Merino for suggestions.
 
@@ -133,6 +134,8 @@ async def suggest(
         "location" or "weather" string. For "location" it will get location completion
         suggestion. For "weather" it will return weather suggestions. If omitted, it defaults
         to weather suggestions.
+    - `google_suggest_params`: [Optional] For the `goole_suggest` provider only, use it to send
+        all client specified query params over to the Google Suggest endpont.
 
     **Headers:**
 
@@ -219,6 +222,7 @@ async def suggest(
             languages=languages,
             user_agent=user_agent,
             source=source,
+            google_suggest_params=google_suggest_params,
         )
         p.validate(srequest)
         task = metrics_client.timeit_task(p.query(srequest), f"providers.{p.name}.query")

--- a/metrics.yaml
+++ b/metrics.yaml
@@ -193,3 +193,23 @@ suggest/yelp:
     scope: |
       Provider initialization
     alert_policy: []
+suggest/google_suggest:
+  google_suggest_request_duration:
+    description: |
+      A histogram to measure the API request duration for Google Suggest requests
+    type: histogram
+    labels: []
+    scope: |
+      The "api/v1/suggest" API endpoint.
+    alert_policy: []
+  google_suggest_request_failure:
+    description: |
+      A counter to measure the API request failure count for Google Suggest requests
+    type: counter
+    labels:
+      - name: status_code
+        description: |
+          The HTTP status code of the failure
+    scope: |
+      The "api/v1/suggest" API endpoint.
+    alert_policy: []

--- a/tests/unit/providers/suggest/google_suggest/__init__.py
+++ b/tests/unit/providers/suggest/google_suggest/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for the Google Suggest provider."""

--- a/tests/unit/providers/suggest/google_suggest/backends/__init__.py
+++ b/tests/unit/providers/suggest/google_suggest/backends/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for Google Suggest backends."""

--- a/tests/unit/providers/suggest/google_suggest/backends/test_google_suggest.py
+++ b/tests/unit/providers/suggest/google_suggest/backends/test_google_suggest.py
@@ -34,7 +34,7 @@ def fixture_backend(
     mocker: MockerFixture,
     statsd_mock: Any,
 ) -> GoogleSuggestBackend:
-    """Create a Polygon backend module object."""
+    """Create a Google Suggest backend module object."""
     return GoogleSuggestBackend(
         metrics_client=statsd_mock,
         url_suggest_path=settings.google_suggest.url_suggest_path,
@@ -71,7 +71,7 @@ async def test_fetch_google_error(
     caplog: LogCaptureFixture,
     filter_caplog: FilterCaplogFixture,
 ) -> None:
-    """Test fetch suggestions from the Google Suggest endpoint - success."""
+    """Test fetch suggestions from the Google Suggest endpoint - error."""
     cast(AsyncMock, backend.http_client).get.return_value = Response(
         status_code=500,
         content=None,

--- a/tests/unit/providers/suggest/google_suggest/backends/test_google_suggest.py
+++ b/tests/unit/providers/suggest/google_suggest/backends/test_google_suggest.py
@@ -1,0 +1,94 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Unit tests for the Google Suggest backend."""
+
+import json
+
+import pytest
+
+from unittest.mock import AsyncMock
+from httpx import AsyncClient, Request, Response
+from pytest_mock import MockerFixture
+from typing import Any, cast
+from merino.exceptions import BackendError
+from merino.providers.suggest.google_suggest.backends.google_suggest import GoogleSuggestBackend
+from merino.providers.suggest.google_suggest.backends.protocol import (
+    GoogleSuggestResponse,
+    SuggestRequest,
+)
+from tests.types import FilterCaplogFixture
+from pytest import LogCaptureFixture
+from merino.configs import settings
+
+
+@pytest.fixture(name="suggest_request")
+def fixture_suggest_request() -> SuggestRequest:
+    """Create a fixture for the test suggest request."""
+    return SuggestRequest(query="test", params="client%30firefox%26q%30test")
+
+
+@pytest.fixture(name="backend")
+def fixture_backend(
+    mocker: MockerFixture,
+    statsd_mock: Any,
+) -> GoogleSuggestBackend:
+    """Create a Polygon backend module object."""
+    return GoogleSuggestBackend(
+        metrics_client=statsd_mock,
+        url_suggest_path=settings.google_suggest.url_suggest_path,
+        http_client=mocker.AsyncMock(spec=AsyncClient),
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_google_success(
+    backend: GoogleSuggestBackend,
+    suggest_request: SuggestRequest,
+    google_suggest_response: GoogleSuggestResponse,
+) -> None:
+    """Test fetch suggestions from the Google Suggest endpoint - success."""
+    cast(AsyncMock, backend.http_client).get.return_value = Response(
+        status_code=200,
+        content=json.dumps(google_suggest_response),
+        request=Request(method="GET", url=""),
+    )
+
+    suggestions = await backend.fetch(suggest_request)
+
+    assert suggestions == google_suggest_response
+
+    cast(AsyncMock, backend.metrics_client).timeit.assert_called_once_with(
+        "google_suggest.request.duration"
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_google_error(
+    backend: GoogleSuggestBackend,
+    suggest_request: SuggestRequest,
+    caplog: LogCaptureFixture,
+    filter_caplog: FilterCaplogFixture,
+) -> None:
+    """Test fetch suggestions from the Google Suggest endpoint - success."""
+    cast(AsyncMock, backend.http_client).get.return_value = Response(
+        status_code=500,
+        content=None,
+        request=Request(method="GET", url=""),
+    )
+
+    with pytest.raises(BackendError):
+        _ = await backend.fetch(suggest_request)
+
+    cast(AsyncMock, backend.metrics_client).increment.assert_called_once_with(
+        "google_suggest.request.failure", tags={"status_code": 500}
+    )
+
+    records = filter_caplog(
+        caplog.records, "merino.providers.suggest.google_suggest.backends.google_suggest"
+    )
+
+    assert len(caplog.records) == 1
+
+    assert records[0].message.startswith("Google Suggest request error")

--- a/tests/unit/providers/suggest/google_suggest/conftest.py
+++ b/tests/unit/providers/suggest/google_suggest/conftest.py
@@ -1,0 +1,44 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Shared fixtures for the Google Suggest unit tests."""
+
+import pytest
+
+from merino.providers.suggest.google_suggest.backends.protocol import GoogleSuggestResponse
+
+
+@pytest.fixture(name="google_suggest_response")
+def fixture_google_suggest_response() -> GoogleSuggestResponse:
+    """Return a test Google Suggest response."""
+    return [
+        "toronto",
+        [
+            "toronto blue jays",
+            "toronto weather",
+            "toronto blue jays standings",
+            "toronto blue jays schedule",
+            "toronto maple leafs",
+            "toronto police",
+            "toronto sun",
+            "toronto",
+            "toronto zoo",
+            "toronto news",
+        ],
+        [],
+        {
+            "google:suggestsubtypes": [
+                [512, 433, 131],
+                [512, 433, 131],
+                [512, 433, 131],
+                [512, 433, 131],
+                [512, 433],
+                [512, 433, 131],
+                [512, 433, 131],
+                [512, 433],
+                [512, 433],
+                [512, 433, 131],
+            ]
+        },
+    ]

--- a/tests/unit/providers/suggest/google_suggest/test_provider.py
+++ b/tests/unit/providers/suggest/google_suggest/test_provider.py
@@ -1,0 +1,143 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Unit tests for the Google Suggest provider."""
+
+import logging
+from typing import Any
+
+from fastapi import HTTPException
+
+import pytest
+from pytest_mock import MockerFixture
+
+from merino.configs import settings
+from merino.exceptions import BackendError
+from merino.middleware.geolocation import Location
+from merino.providers.suggest.base import BaseSuggestion, SuggestionRequest
+from merino.providers.suggest.custom_details import CustomDetails, GoogleSuggestDetails
+from merino.providers.suggest.google_suggest.backends.google_suggest import GoogleSuggestBackend
+from merino.providers.suggest.google_suggest.backends.protocol import GoogleSuggestResponse
+from merino.providers.suggest.google_suggest.provider import Provider
+from tests.types import FilterCaplogFixture
+
+
+@pytest.fixture(name="geolocation")
+def fixture_geolocation() -> Location:
+    """Return a test Location."""
+    return Location()
+
+
+@pytest.fixture(name="backend_mock")
+def fixture_backend_mock(mocker: MockerFixture) -> Any:
+    """Create a GoogleSuggestBackend mock object for test."""
+    return mocker.AsyncMock(spec=GoogleSuggestBackend)
+
+
+@pytest.fixture(name="provider")
+def fixture_provider(backend_mock: Any) -> Provider:
+    """Create a Provider for test."""
+    return Provider(
+        backend=backend_mock,
+        name=settings.providers.google_suggest.type,
+        score=settings.providers.google_suggest.score,
+    )
+
+
+def test_enabled_by_default(provider: Provider) -> None:
+    """Test for the enabled_by_default method."""
+    assert provider.enabled_by_default is False
+
+
+def test_not_hidden_by_default(provider: Provider) -> None:
+    """Test for the hidden method."""
+    assert provider.hidden() is False
+
+
+@pytest.mark.parametrize(
+    "query, params, expected_msg",
+    [
+        ("test", None, "`google_suggest_params` is missing"),
+        ("", "client%30firefox%26q%30", "`q` should not be empty"),
+    ],
+)
+def test_query_with_invalid_params_returns_http_400(
+    query: str,
+    params: str | None,
+    expected_msg: str,
+    provider: Provider,
+    geolocation: Location,
+    caplog: pytest.LogCaptureFixture,
+    filter_caplog: FilterCaplogFixture,
+) -> None:
+    """Test that the query method throws a http 400 error with invalid request parameters."""
+    caplog.set_level(logging.WARNING)
+
+    with pytest.raises(HTTPException) as ex:
+        provider.validate(
+            SuggestionRequest(query=query, geolocation=geolocation, google_suggest_params=params)
+        )
+
+    expected_error_message = f"400: Invalid query parameters: {expected_msg}"
+
+    assert expected_error_message == str(ex.value)
+
+    records = filter_caplog(caplog.records, "merino.providers.suggest.google_suggest.provider")
+
+    assert len(records) == 1
+    assert records[0].message == f"HTTP 400: invalid query parameters, {expected_msg}"
+
+
+@pytest.mark.asyncio
+async def test_query_suggestion_returned(
+    backend_mock: Any,
+    provider: Provider,
+    geolocation: Location,
+    google_suggest_response: GoogleSuggestResponse,
+) -> None:
+    """Test that the query method provides a valid Google Suggest suggestion."""
+    expected_suggestions: list[BaseSuggestion] = [
+        BaseSuggestion(
+            title="Google Suggest",
+            url=provider.url,
+            provider=settings.providers.google_suggest.type,
+            is_sponsored=False,
+            score=settings.providers.google_suggest.score,
+            custom_details=CustomDetails(
+                google_suggest=GoogleSuggestDetails(suggestions=google_suggest_response)
+            ),
+        )
+    ]
+
+    backend_mock.fetch.return_value = google_suggest_response
+
+    suggestions: list[BaseSuggestion] = await provider.query(
+        SuggestionRequest(
+            query="test",
+            geolocation=geolocation,
+            google_suggest_params="client%30firefox%26q%30test",
+        )
+    )
+
+    assert suggestions == expected_suggestions
+
+
+@pytest.mark.asyncio
+async def test_query_suggestion_failed(
+    backend_mock: Any,
+    provider: Provider,
+    geolocation: Location,
+) -> None:
+    """Test that the query method provides an empty list upon a backend error."""
+    backend_mock.fetch.side_effect = BackendError("A backend error")
+
+    suggestions: list[BaseSuggestion] = await provider.query(
+        SuggestionRequest(
+            query="test",
+            geolocation=geolocation,
+            google_suggest_params="client%30firefox%26q%30test",
+        )
+    )
+
+    assert suggestions == []

--- a/tests/unit/test_config_sentry.py
+++ b/tests/unit/test_config_sentry.py
@@ -8,7 +8,11 @@ import typing
 
 from sentry_sdk.types import Event
 
-from merino.configs.app_configs.config_sentry import REDACTED_TEXT, strip_sensitive_data
+from merino.configs.app_configs.config_sentry import (
+    REDACTED_TEXT,
+    GOOGLE_SUGGEST_PARAMS,
+    strip_sensitive_data,
+)
 
 mock_sentry_hint: dict[str, list] = {"exc_info": [RuntimeError, RuntimeError(), None]}
 
@@ -33,6 +37,7 @@ mock_sentry_event_data: Event = {
                                     "path": "'/api/v1/suggest'",
                                 },
                                 "q": "vars_foo",
+                                "google_suggest_params": "vars_foo",
                                 "providers": "'top_picks,adm'",
                                 "client_variants": "None",
                             },
@@ -48,6 +53,7 @@ mock_sentry_event_data: Event = {
                                         "path": "'/api/v1/suggest'",
                                     },
                                     "q": "vars_values_foo",
+                                    "google_suggest_params": "vars_foo",
                                     "providers": "'top_picks,adm'",
                                     "client_variants": "None",
                                 }
@@ -63,6 +69,7 @@ mock_sentry_event_data: Event = {
                                 "qlen": "6",
                                 "query": "foobar",
                                 "ids": "None",
+                                "google_suggest_params": "vars_foo",
                             },
                         },
                         {
@@ -78,6 +85,7 @@ mock_sentry_event_data: Event = {
                                 "solved_result": [
                                     {
                                         "q": "foobar",
+                                        "google_suggest_params": "vars_foo",
                                         "providers": "'top_picks,adm'",
                                         "client_variants": "None",
                                         "request": {
@@ -96,6 +104,7 @@ mock_sentry_event_data: Event = {
                                         },
                                     ],
                                     "q": "'foobar'",
+                                    "google_suggest_params": "vars_foo",
                                     "providers": "'top_picks,adm'",
                                     "client_variants": "None",
                                 },
@@ -125,6 +134,7 @@ mock_sentry_event_data: Event = {
                             "in_app": True,
                             "vars": {
                                 "q": "what?",
+                                "google_suggest_params": "vars_foo",
                                 "self": "<merino.providers.suggest.wikipedia.backends."
                                 "elastic.ElasticBackend object at 0x7faaebfb0380>",
                                 "suggest": {
@@ -209,35 +219,31 @@ def test_strip_sensitive_data() -> None:
         Event, strip_sensitive_data(mock_sentry_event_data, mock_sentry_hint)
     )
     assert sanitized_event["request"].get("query_string") == REDACTED_TEXT
+    assert GOOGLE_SUGGEST_PARAMS not in sanitized_event["request"]
     assert "exc_info" in mock_sentry_hint
     assert isinstance(mock_sentry_hint["exc_info"][1], RuntimeError)
 
-    assert (
-        sanitized_event["exception"]["values"][0]["stacktrace"]["frames"][0]["vars"]["q"]
-        == REDACTED_TEXT
-    )
-    assert (
-        sanitized_event["exception"]["values"][0]["stacktrace"]["frames"][1]["vars"]["values"]["q"]
-        == REDACTED_TEXT
-    )
-    assert (
-        sanitized_event["exception"]["values"][0]["stacktrace"]["frames"][2]["vars"]["srequest"]
-        == REDACTED_TEXT
-    )
+    stack_frames = sanitized_event["exception"]["values"][0]["stacktrace"]["frames"]
 
-    assert (
-        sanitized_event["exception"]["values"][0]["stacktrace"]["frames"][2]["vars"]["query"]
-        == REDACTED_TEXT
-    )
-    assert (
-        sanitized_event["exception"]["values"][0]["stacktrace"]["frames"][4]["vars"]["q"]
-        == REDACTED_TEXT
-    )
-    assert (
-        sanitized_event["exception"]["values"][0]["stacktrace"]["frames"][4]["vars"]["suggest"]
-        == REDACTED_TEXT
-    )
-    assert (
-        sanitized_event["exception"]["values"][0]["stacktrace"]["frames"][5]["vars"]["body"]
-        == REDACTED_TEXT
-    )
+    assert stack_frames[0]["vars"]["q"] == REDACTED_TEXT
+    assert GOOGLE_SUGGEST_PARAMS not in stack_frames[0]["vars"]
+
+    assert stack_frames[1]["vars"]["values"]["q"] == REDACTED_TEXT
+    assert GOOGLE_SUGGEST_PARAMS not in stack_frames[1]["vars"]["values"]
+
+    assert stack_frames[2]["vars"]["srequest"] == REDACTED_TEXT
+    assert stack_frames[2]["vars"]["query"] == REDACTED_TEXT
+    assert GOOGLE_SUGGEST_PARAMS not in stack_frames[2]["vars"]
+
+    solved_result = stack_frames[3]["vars"]["solved_result"][0]
+    assert solved_result["q"] == REDACTED_TEXT
+    assert GOOGLE_SUGGEST_PARAMS not in solved_result
+    values = stack_frames[3]["vars"]["values"]
+    assert values["q"] == REDACTED_TEXT
+    assert GOOGLE_SUGGEST_PARAMS not in values
+
+    assert stack_frames[4]["vars"]["q"] == REDACTED_TEXT
+    assert stack_frames[4]["vars"]["suggest"] == REDACTED_TEXT
+    assert GOOGLE_SUGGEST_PARAMS not in stack_frames[4]["vars"]
+
+    assert stack_frames[5]["vars"]["body"] == REDACTED_TEXT


### PR DESCRIPTION
## References

JIRA: [DISCO-TODO](https://mozilla-hub.atlassian.net/browse/DISCO-3669)

## Description
This integrates Google Suggest/Search Complete API into Merino. Note that:
- We decided to add it as a provider for the suggest endpoint rather than adding a new endpoint to minimize the engineering lift for both Merino and Firefox.
- It's a dead simple suggestion provider connecting directly to Google's API endpoint w/o caching nor location handling.
- The API spec can be found in [DISCO-3669](https://mozilla-hub.atlassian.net/browse/DISCO-3669).
- This integration does not require an API token to Google, therefore it's subject to Google's rate limiting. Will attach a circuit-breaker to it as a follow-up to mitigate that.
- Also updated the sentry filtering to ignore the new query params that might contain user's search data. 



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3669]: https://mozilla-hub.atlassian.net/browse/DISCO-3669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1856)
