### PR TITLE
GENAI-1839 Handle priors and rescaling for crawler topic experiments

### DIFF
--- a/merino/curated_recommendations/prior_backends/experiment_rescaler.py
+++ b/merino/curated_recommendations/prior_backends/experiment_rescaler.py
@@ -6,7 +6,7 @@ from merino.curated_recommendations.prior_backends.protocol import ExperimentRes
 from merino.curated_recommendations.protocol import CuratedRecommendation
 
 SUBTOPIC_TOTAL_PERCENT = 0.06  # This may eventually be computed by an airflow job
-CRAWLED_TOPIC_TOTAL_PERCENT = 0.03
+CRAWLED_TOPIC_TOTAL_PERCENT = 0.06
 SUBTOPIC_EXPERIMENT_CURATED_ITEM_FLAG = "SUBTOPICS"
 
 

--- a/merino/curated_recommendations/prior_backends/protocol.py
+++ b/merino/curated_recommendations/prior_backends/protocol.py
@@ -40,8 +40,6 @@ class ExperimentRescaler(BaseModel):
     include content that is not in other test branches.
     """
 
-    experiment_relative_size: float
-
     def rescale(self, rec: CuratedRecommendation, opens, no_opens):
         """Update open and non-open values based on whether item is unique to the experiment. Note that
         impressions and clicks can be used in place of opens and no_opens

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -41,7 +41,7 @@ from merino.curated_recommendations.ml_backends.protocol import (
     DayTimeWeightingConfig,
 )
 from merino.curated_recommendations.prior_backends.experiment_rescaler import (
-    SUBSECTION_EXPERIMENT_PERCENT,
+    SUBTOPIC_TOTAL_PERCENT,
 )
 from merino.curated_recommendations.prior_backends.protocol import PriorBackend
 from merino.curated_recommendations.protocol import (
@@ -56,7 +56,7 @@ from merino.main import app
 from merino.providers.manifest import get_provider as get_manifest_provider
 from merino.providers.manifest.backends.protocol import Domain
 
-ML_EXPERIMENT_SCALE = SUBSECTION_EXPERIMENT_PERCENT
+ML_EXPERIMENT_SCALE = SUBTOPIC_TOTAL_PERCENT
 
 
 class MockEngagementBackend(EngagementBackend):

--- a/tests/unit/prior_backends/test_experiment_rescaler.py
+++ b/tests/unit/prior_backends/test_experiment_rescaler.py
@@ -6,6 +6,8 @@ from unittest.mock import Mock
 
 from merino.curated_recommendations.prior_backends.experiment_rescaler import (
     SubsectionsExperimentRescaler,
+    CRAWLED_TOPIC_TOTAL_PERCENT,
+    CrawlerExperimentRescaler,
 )
 
 SUBSECTION_EXPERIMENT_PERCENT = 0.25
@@ -18,7 +20,7 @@ class TestSubsectionsExperimentRescaler:
     def setup_method(self):
         """Set up test"""
         self.rescaler = SubsectionsExperimentRescaler(
-            experiment_relative_size=SUBSECTION_EXPERIMENT_PERCENT
+            subtopic_relative_size=SUBSECTION_EXPERIMENT_PERCENT
         )
 
     def test_rescale_when_in_experiment(self):
@@ -31,6 +33,10 @@ class TestSubsectionsExperimentRescaler:
         assert opens == expected_opens
         assert no_opens == expected_no_opens
 
+        alpha, beta = self.rescaler.rescale_prior(rec, 10, 20)
+        assert alpha == 10 / 4.0
+        assert beta == 20
+
     def test_rescale_when_not_in_experiment(self):
         """Test when no experiment in request"""
         rec = Mock()
@@ -40,3 +46,43 @@ class TestSubsectionsExperimentRescaler:
 
         assert opens == 100
         assert no_opens == 50
+
+
+class TestCrawlerExperimentRescaler:
+    """Test Rig for the rescaler"""
+
+    def setup_method(self):
+        """Set up test"""
+        self.rescaler = CrawlerExperimentRescaler(
+            subtopic_relative_size=SUBSECTION_EXPERIMENT_PERCENT
+        )
+
+    def test_rescale_subtopic_item(self):
+        """Test rescaling of priors for relative experiment size"""
+        rec = Mock()
+        rec.in_experiment.return_value = True
+        opens, no_opens = self.rescaler.rescale(rec, 100, 50)
+        expected_opens = 100 / SUBSECTION_EXPERIMENT_PERCENT
+        expected_no_opens = 50 / SUBSECTION_EXPERIMENT_PERCENT
+        assert opens == expected_opens
+        assert no_opens == expected_no_opens
+
+        alpha, beta = self.rescaler.rescale_prior(rec, 10, 20)
+        # no change
+        assert alpha == 10
+        assert beta == 20
+
+    def test_rescale_regular_item(self):
+        """Test when no experiment in request"""
+        rec = Mock()
+        rec.in_experiment.return_value = False
+
+        opens, no_opens = self.rescaler.rescale(rec, 100, 50)
+
+        assert opens == 100 / CRAWLED_TOPIC_TOTAL_PERCENT
+        assert no_opens == 50 / CRAWLED_TOPIC_TOTAL_PERCENT
+
+        alpha, beta = self.rescaler.rescale_prior(rec, 10, 20)
+        # no change
+        assert alpha == 10
+        assert beta == 20


### PR DESCRIPTION
## References

JIRA: https://mozilla-hub.atlassian.net/browse/GENAI-1839

As we expand the content experiments we occasionally have experiments that have content that is shared among different experiments. If the impression distribution have dramatically different scales, the content will be ranked in an uneven way. Specifically, content that is only in a small (i.e. 3% experiment) will always show at the top when mixed with other content.

We are tracking these issues here and using them to create the appropriate experiment rescaler.
https://mozilla-hub.atlassian.net/wiki/spaces/FAAMT/pages/1795457076/HNT+Content+Experiment+Tracking


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1858)
