### PR TITLE
[DISCO-3698]: Add a circuit breaker for google suggest

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -788,6 +788,14 @@ enabled_by_default = false
 # The ranking score for this provider as a floating point number.
 score = 0.3
 
+# MERINO_PROVIDERS__GOOGLE_SUGGEST__CIRCUIT_BREAKER_FAILURE_THRESHOLD
+# The circuit breaker will open when the failure is over this threshold.
+circuit_breaker_failure_threshold = 10
+
+# MERINO_PROVIDERS__GOOGLE_SUGGEST__CIRCUIT_BREAKER_RECOVER_TIMEOUT_SEC
+# The circuit breaker will stay open for this period of time until the next recovery attempt.
+circuit_breaker_recover_timeout_sec = 30
+
 [default.google_suggest]
 # MERINO_GOOGLE_SUGGEST__URL_BASE
 url_base = "https://www.google.com"

--- a/merino/configs/testing.toml
+++ b/merino/configs/testing.toml
@@ -98,6 +98,10 @@ resync_interval_sec = 86400
 bucket_name = "test-bucket"
 gcp_project = "test-project"
 
+[testing.providers.google_suggest]
+circuit_breaker_failure_threshold = 1
+circuit_breaker_recover_timeout_sec = 3
+
 [testing.curated_recommendations.rankers.thompson_sampling]
 # MERINO__CURATED_RECOMMENDATIONS__RANKERS__THOMPSON_SAMPLING__TEST_REPEAT_COUNT
 # The number of times that Thompson sampling tests are repeated. When you change how recommendations

--- a/merino/governance/circuitbreakers.py
+++ b/merino/governance/circuitbreakers.py
@@ -56,8 +56,8 @@ class GoogleSuggestCircuitBreaker(CircuitBreaker):
 
     FAILURE_THRESHOLD = settings.providers.google_suggest.circuit_breaker_failure_threshold
     RECOVERY_TIMEOUT = settings.providers.google_suggest.circuit_breaker_recover_timeout_sec
-    # This breaker only cares about these two errors, which would cover both Redis errors
-    # and AccuWeather API errors.
+    # This breaker only cares about `BackendError` that could get raised for any
+    # HTTP request failures to the Google Suggest endpoint
     EXPECTED_EXCEPTION = (BackendError,)
     # When the breaker is open, use this to simply return an empty suggestion list to the caller.
     FALLBACK_FUNCTION = _suggest_provider_fallback_fn

--- a/merino/governance/circuitbreakers.py
+++ b/merino/governance/circuitbreakers.py
@@ -49,3 +49,15 @@ class WeatherCircuitBreaker(CircuitBreaker):
     EXPECTED_EXCEPTION = (AccuweatherError, BackendError)
     # When the breaker is open, use this to simply return an empty suggestion list to the caller.
     FALLBACK_FUNCTION = _suggest_provider_fallback_fn
+
+
+class GoogleSuggestCircuitBreaker(CircuitBreaker):
+    """Circuit Breader for the Google Suggest provider."""
+
+    FAILURE_THRESHOLD = settings.providers.google_suggest.circuit_breaker_failure_threshold
+    RECOVERY_TIMEOUT = settings.providers.google_suggest.circuit_breaker_recover_timeout_sec
+    # This breaker only cares about these two errors, which would cover both Redis errors
+    # and AccuWeather API errors.
+    EXPECTED_EXCEPTION = (BackendError,)
+    # When the breaker is open, use this to simply return an empty suggestion list to the caller.
+    FALLBACK_FUNCTION = _suggest_provider_fallback_fn

--- a/merino/providers/suggest/google_suggest/provider.py
+++ b/merino/providers/suggest/google_suggest/provider.py
@@ -72,7 +72,7 @@ class Provider(BaseProvider):
     async def query(self, srequest: SuggestionRequest) -> list[BaseSuggestion]:
         """Provide Google Suggest suggestions.
 
-        All the `BackendError` errors, raised from the frontend, are intentionally
+        All the `BackendError` errors, raised from the backend, are intentionally
         unhandled here to drive the circuit breaker. Those exceptions will eventually
         be propagated to the provider consumer (i.e. the API handler) and be handled
         there.


### PR DESCRIPTION
## References

JIRA: [DISCO-3698](https://mozilla-hub.atlassian.net/browse/DISCO-3698)

## Description
This CB is made specifically due to Google's rate limiter on their search suggest endpoint. We might need to tweak the CB parameters once the experiment is live.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3698]: https://mozilla-hub.atlassian.net/browse/DISCO-3698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1859)
