### PR TITLE
GENAI-1895 final pivacy constants, bug fix for thresholds for sports

### DIFF
--- a/merino/curated_recommendations/ml_backends/fake_local_model.py
+++ b/merino/curated_recommendations/ml_backends/fake_local_model.py
@@ -156,7 +156,7 @@ class FakeLocalModelSections(LocalModelBackend):
 
 
 V0_MODEL_P_VALUE = 0.806
-VO_MODEL_Q_VALUE = 0.030
+V0_MODEL_Q_VALUE = 0.030
 
 
 # Creates a simple model based on sections. Section features are stored with a s_
@@ -195,7 +195,7 @@ class LimitedTopicV0Model(LocalModelBackend):
                 if topic is not Topic.SPORTS
                 else [0.005, 0.008, 0.02],
                 diff_p=V0_MODEL_P_VALUE,
-                diff_q=VO_MODEL_Q_VALUE,
+                diff_q=V0_MODEL_Q_VALUE,
             )
 
         category_fields: dict[str, InterestVectorConfig] = {

--- a/merino/curated_recommendations/ml_backends/fake_local_model.py
+++ b/merino/curated_recommendations/ml_backends/fake_local_model.py
@@ -155,10 +155,15 @@ class FakeLocalModelSections(LocalModelBackend):
         )
 
 
+V0_MODEL_P_VALUE = 0.806
+VO_MODEL_Q_VALUE = 0.030
+
+
 # Creates a simple model based on sections. Section features are stored with a s_
-# in telemetry
+# in telemetry.
 class LimitedTopicV0Model(LocalModelBackend):
     """Class that defines a limited topic model that supports coarse interest vector
+    This is the first version for the privacy launch, with vetted p/q privacy values
     Set which model is used at __init__ import
     """
 
@@ -188,9 +193,9 @@ class LimitedTopicV0Model(LocalModelBackend):
                 features={f"t_{topic}": 1},
                 thresholds=[0.01, 0.02, 0.03]
                 if topic is not Topic.SPORTS
-                else [0.005, 0.08, 0.02],
-                diff_p=0.84,
-                diff_q=0.05,
+                else [0.005, 0.008, 0.02],
+                diff_p=V0_MODEL_P_VALUE,
+                diff_q=VO_MODEL_Q_VALUE,
             )
 
         category_fields: dict[str, InterestVectorConfig] = {


### PR DESCRIPTION
## References

JIRA: https://mozilla-hub.atlassian.net/browse/GENAI-1895

## Description
Insert final p/q privacy values for differential privacy that were approved by our privacy lead. Values add randomness to prevent user identification for inferred with requests sent over the OHTTP protocol. Details in the ticket.

Also fixed a threshold bug for the Sports section


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1864)
