### PR TITLE
GENAI-1903 Improve crawler (legacy feeds) experiment by changing behavior of new content

### DIFF
--- a/merino/curated_recommendations/prior_backends/experiment_rescaler.py
+++ b/merino/curated_recommendations/prior_backends/experiment_rescaler.py
@@ -9,6 +9,11 @@ SUBTOPIC_TOTAL_PERCENT = 0.06  # This may eventually be computed by an airflow j
 CRAWLED_TOPIC_TOTAL_PERCENT = 0.06
 SUBTOPIC_EXPERIMENT_CURATED_ITEM_FLAG = "SUBTOPICS"
 
+# This is derived using data analysis on scores and existing priors
+# See more at:
+# https://mozilla-hub.atlassian.net/wiki/spaces/FAAMT/pages/1727725665/Thompson+Sampling+of+Subtopic+Sections
+PESSIMISTIC_PRIOR_ALPHA_SCALE = 0.25
+
 
 class SubsectionsExperimentRescaler(ExperimentRescaler):
     """Scales experiment based content on relative size of experiment, as a fractional percentage"""
@@ -36,7 +41,7 @@ class SubsectionsExperimentRescaler(ExperimentRescaler):
         Scale of 4 puts an item with no activity just below the pack of common items that have good activity
         """
         if self.is_subtopic_story(rec):
-            return alpha / 4.0, beta
+            return alpha * PESSIMISTIC_PRIOR_ALPHA_SCALE, beta
         else:
             return alpha, beta
 
@@ -61,4 +66,4 @@ class CrawlerExperimentRescaler(SubsectionsExperimentRescaler):
         """Rescales priors based on content"""
         # treat subtopics and topics the same
         # all new data comes in with a lower expected CTR in order to not severely disrupt popular items
-        return alpha / 4.0, beta
+        return alpha * PESSIMISTIC_PRIOR_ALPHA_SCALE, beta

--- a/tests/unit/prior_backends/test_experiment_rescaler.py
+++ b/tests/unit/prior_backends/test_experiment_rescaler.py
@@ -8,6 +8,7 @@ from merino.curated_recommendations.prior_backends.experiment_rescaler import (
     SubsectionsExperimentRescaler,
     CRAWLED_TOPIC_TOTAL_PERCENT,
     CrawlerExperimentRescaler,
+    PESSIMISTIC_PRIOR_ALPHA_SCALE,
 )
 
 SUBSECTION_EXPERIMENT_PERCENT = 0.25
@@ -69,7 +70,7 @@ class TestCrawlerExperimentRescaler:
 
         alpha, beta = self.rescaler.rescale_prior(rec, 40, 20)
 
-        assert alpha == 40 / 4  # should scale down
+        assert alpha == 40 * PESSIMISTIC_PRIOR_ALPHA_SCALE
         assert beta == 20
 
     def test_rescale_regular_item(self):
@@ -84,5 +85,5 @@ class TestCrawlerExperimentRescaler:
 
         alpha, beta = self.rescaler.rescale_prior(rec, 40, 20)
 
-        assert alpha == 40 / 4  # should scale down
+        assert alpha == 40 * PESSIMISTIC_PRIOR_ALPHA_SCALE
         assert beta == 20


### PR DESCRIPTION
## References

JIRA: https://mozilla-hub.atlassian.net/browse/GENAI-1903

## Description
[An analysis was done](https://mozilla-hub.atlassian.net/wiki/spaces/FAAMT/pages/1813416826/Data+Analysis+of+Legacy+Feeds+Crawler+Experiment) and we determined that the hourly update of new content in the experiment is disrupting thompson sampling.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1868)
