### PR TITLE
[DISCO-3731] fix: Allow empty queries for google suggest

### DIFF
--- a/merino/providers/suggest/google_suggest/provider.py
+++ b/merino/providers/suggest/google_suggest/provider.py
@@ -61,13 +61,6 @@ class Provider(BaseProvider):
                 detail="Invalid query parameters: `google_suggest_params` is missing",
             )
 
-        if srequest.query == "":
-            logger.warning("HTTP 400: invalid query parameters, `q` should not be empty")
-            raise HTTPException(
-                status_code=400,
-                detail="Invalid query parameters: `q` should not be empty",
-            )
-
     @GoogleSuggestCircuitBreaker(name="google_suggest")  # Expect `BackendError`
     async def query(self, srequest: SuggestionRequest) -> list[BaseSuggestion]:
         """Provide Google Suggest suggestions.

--- a/tests/unit/providers/suggest/google_suggest/test_provider.py
+++ b/tests/unit/providers/suggest/google_suggest/test_provider.py
@@ -78,7 +78,6 @@ def test_not_hidden_by_default(provider: Provider) -> None:
     "query, params, expected_msg",
     [
         ("test", None, "`google_suggest_params` is missing"),
-        ("", "client%30firefox%26q%30", "`q` should not be empty"),
     ],
 )
 def test_query_with_invalid_params_returns_http_400(


### PR DESCRIPTION
## References

JIRA: [DISCO-3731](https://mozilla-hub.atlassian.net/browse/DISCO-3731)

## Description
Google Trending requests do not specify the `q` query param.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3731]: https://mozilla-hub.atlassian.net/browse/DISCO-3731?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1870)
