### PR TITLE
[DISCO-3729] feat: Include sesion_id as a header for google suggest r…

### DIFF
--- a/merino/providers/suggest/base.py
+++ b/merino/providers/suggest/base.py
@@ -24,6 +24,7 @@ class SuggestionRequest(BaseModel):
     user_agent: UserAgent | None = None
     source: str | None = None
     google_suggest_params: str | None = None
+    session_id: str | None = None
 
 
 class Category(Enum):

--- a/merino/providers/suggest/google_suggest/backends/google_suggest.py
+++ b/merino/providers/suggest/google_suggest/backends/google_suggest.py
@@ -46,8 +46,10 @@ class GoogleSuggestBackend:
 
         try:
             with self.metrics_client.timeit("google_suggest.request.duration"):
+                # this header is set to circumvent rate limiting, see DISCO-3729.
+                headers = {"x-session-id": request.session_id}
                 response: Response = await self.http_client.get(
-                    self.url_suggest_path, params=params
+                    self.url_suggest_path, params=params, headers=headers
                 )
 
             response.raise_for_status()

--- a/merino/providers/suggest/google_suggest/backends/protocol.py
+++ b/merino/providers/suggest/google_suggest/backends/protocol.py
@@ -25,6 +25,9 @@ class SuggestRequest:
     # over to the endpoint as-is.
     params: str
 
+    # A unique identifier for a search/suggest session.
+    session_id: str
+
 
 class GoogleSuggestBackendProtocol(Protocol):
     """Protocol for a Google Suggest backend.

--- a/merino/providers/suggest/google_suggest/provider.py
+++ b/merino/providers/suggest/google_suggest/provider.py
@@ -1,6 +1,7 @@
 """Suggest provider for Google Suggest."""
 
 import logging
+import uuid
 
 import aiodogstatsd
 
@@ -74,6 +75,7 @@ class Provider(BaseProvider):
             SuggestRequest(
                 query=srequest.query,
                 params=cast(str, srequest.google_suggest_params),
+                session_id=srequest.session_id or str(uuid.uuid4()),
             )
         )
 

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -93,6 +93,7 @@ async def suggest(
     sources: tuple[dict[str, BaseProvider], list[BaseProvider]] = Depends(get_suggest_providers),
     request_type: Annotated[str | None, Query(pattern="^(location|weather)$")] = None,
     google_suggest_params: Annotated[str | None, Query(max_length=QUERY_CHARACTER_MAX)] = None,
+    sid: Annotated[str | None, Query(max_length=QUERY_CHARACTER_MAX)] = None,
 ) -> Response:
     """Query Merino for suggestions.
 
@@ -136,6 +137,7 @@ async def suggest(
         to weather suggestions.
     - `google_suggest_params`: [Optional] For the `google_suggest` provider only, use it to send
         all client specified query params over to the Google Suggest endpont.
+    - `sid`: [Optional] A unique identifier for each search/suggest session. Note that this not a UUID for a user.
 
     **Headers:**
 
@@ -223,6 +225,7 @@ async def suggest(
             user_agent=user_agent,
             source=source,
             google_suggest_params=google_suggest_params,
+            session_id=sid,
         )
         p.validate(srequest)
         task = metrics_client.timeit_task(p.query(srequest), f"providers.{p.name}.query")

--- a/tests/unit/providers/suggest/google_suggest/backends/test_google_suggest.py
+++ b/tests/unit/providers/suggest/google_suggest/backends/test_google_suggest.py
@@ -26,7 +26,11 @@ from merino.configs import settings
 @pytest.fixture(name="suggest_request")
 def fixture_suggest_request() -> SuggestRequest:
     """Create a fixture for the test suggest request."""
-    return SuggestRequest(query="test", params="client%30firefox%26q%30test")
+    return SuggestRequest(
+        query="test",
+        params="client%30firefox%26q%30test",
+        session_id="85f6f38b31804147b54f9cfd02eee9e2",
+    )
 
 
 @pytest.fixture(name="backend")


### PR DESCRIPTION
…equests

## References

JIRA: [DISCO-3729](https://mozilla-hub.atlassian.net/browse/DISCO-3729)

## Description
Include `sid` (search session ID) as a custom HTTP header (`x-session-id`) in the requests to Google Suggest.
Note that `sid` is already provided by Firefox via MerinoClient. A one-off session ID will be generated by Merino if it's missing to make development/test easier.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
