### PR TITLE
[DISCO-3730] feat: Proxy requests for google suggest

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -850,6 +850,11 @@ url_base = "https://www.google.com"
 # MERINO_GOOGLE_SUGGEST__URL_SUGGEST_PATH
 # The endpoint for google suggest.
 url_suggest_path = "/complete/search"
+# MERINO_GOOGLE_SUGGEST__PROXY_URL
+# The proxy URL that all the Google Suggest requests would go through if specified.
+# No proxying if this URL is left empty. The URL should be fully specified, e.g.
+# "http(s)://{your-proxy-host}:{port}"
+proxy_url = ""
 
 [default.curated_recommendations.gcs.local_model]
 # MERINO__CURATED_RECOMMENDATIONS__GCS__LOCAL_MODEL__MAX_SIZE

--- a/merino/providers/suggest/manager.py
+++ b/merino/providers/suggest/manager.py
@@ -255,6 +255,11 @@ def _create_provider(provider_id: str, setting: Settings) -> BaseProvider:
                 backend=GoogleSuggestBackend(
                     http_client=create_http_client(
                         base_url=settings.google_suggest.url_base,
+                        proxies=(
+                            {"https://": settings.google_suggest.proxy_url}
+                            if settings.google_suggest.proxy_url
+                            else None  # no proxying
+                        ),
                     ),
                     url_suggest_path=settings.google_suggest.url_suggest_path,
                     metrics_client=get_metrics_client(),

--- a/merino/utils/http_client.py
+++ b/merino/utils/http_client.py
@@ -11,6 +11,7 @@ def create_http_client(
     connect_timeout: float = 1.0,
     request_timeout: float = 5.0,
     pool_timeout: float = 1.0,
+    proxies: dict[str, str] | None = None,
 ) -> AsyncClient:
     """Crete a new `httpx.AsyncClient` with common configurations.
 
@@ -20,6 +21,12 @@ def create_http_client(
       - `connect_timeout` {float}: The timeout for establishing a connection to the host.
       - `request_timeout` {float}: The timeuot for handling a request to the host.
       - `pool_timeout` {float}: The timeout for acquiring a connection from the pool.
+      - `proxies` {dict[str, str] | None}: A proxy dictionary for this client or no proxy is not set.
+        the dictionary should look like:
+        {
+            "http://", "http://{your-http-proxy.com}:{port}",
+            "https://", "http://{your-https-proxy.com}:{port}",
+        }
     Returns:
       - {AsyncClient}: An async HTTP client.
     """
@@ -27,4 +34,5 @@ def create_http_client(
         base_url=base_url,
         limits=Limits(max_connections=max_connections),
         timeout=Timeout(request_timeout, connect=connect_timeout, pool=pool_timeout),
+        proxies=proxies,  # type: ignore [arg-type]
     )

--- a/metrics.yaml
+++ b/metrics.yaml
@@ -213,3 +213,19 @@ suggest/google_suggest:
     scope: |
       The "api/v1/suggest" API endpoint.
     alert_policy: []
+  google_suggest_connect_error:
+    description: |
+      A counter to measure the API connect error count for Google Suggest requests
+    type: counter
+    labels: []
+    scope: |
+      The "api/v1/suggest" API endpoint.
+    alert_policy: []
+  google_suggest_proxy_error:
+    description: |
+      A counter to measure the API proxy error count for Google Suggest requests
+    type: counter
+    labels: []
+    scope: |
+      The "api/v1/suggest" API endpoint.
+    alert_policy: []

--- a/tests/unit/providers/suggest/google_suggest/backends/test_google_suggest.py
+++ b/tests/unit/providers/suggest/google_suggest/backends/test_google_suggest.py
@@ -9,7 +9,7 @@ import json
 import pytest
 
 from unittest.mock import AsyncMock
-from httpx import AsyncClient, Request, Response
+from httpx import AsyncClient, ConnectError, ProxyError, Request, Response
 from pytest_mock import MockerFixture
 from typing import Any, cast
 from merino.exceptions import BackendError
@@ -96,3 +96,35 @@ async def test_fetch_google_error(
     assert len(caplog.records) == 1
 
     assert records[0].message.startswith("Google Suggest request error")
+
+
+@pytest.mark.parametrize(
+    "err, metric_id",
+    [
+        (ConnectError("connect error"), "google_suggest.connect.error"),
+        (ProxyError("proxy error"), "google_suggest.proxy.error"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_fetch_google_proxy_error(
+    backend: GoogleSuggestBackend,
+    suggest_request: SuggestRequest,
+    err: Exception,
+    metric_id: str,
+    caplog: LogCaptureFixture,
+    filter_caplog: FilterCaplogFixture,
+) -> None:
+    """Test fetch suggestions from the Google Suggest endpoint - proxy error."""
+    cast(AsyncMock, backend.http_client).get.side_effect = err
+    with pytest.raises(BackendError):
+        _ = await backend.fetch(suggest_request)
+
+    cast(AsyncMock, backend.metrics_client).increment.assert_called_once_with(metric_id)
+
+    records = filter_caplog(
+        caplog.records, "merino.providers.suggest.google_suggest.backends.google_suggest"
+    )
+
+    assert len(caplog.records) == 1
+
+    assert records[0].message.startswith("Google Suggest")


### PR DESCRIPTION
## References

JIRA: [DISCO-3730](https://mozilla-hub.atlassian.net/browse/DISCO-3730)

## Description
This allows Merino to send Google Suggest requests through a proxy to circumvent rate limiting. 

This proxy will be set up separately and we will specify the proxy URL via an envvar.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3730]: https://mozilla-hub.atlassian.net/browse/DISCO-3730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ