### PR TITLE
HNT-1025 Boost items in Topic Feed experiment that have isTimeSensitive set

### DIFF
--- a/merino/curated_recommendations/prior_backends/experiment_rescaler.py
+++ b/merino/curated_recommendations/prior_backends/experiment_rescaler.py
@@ -64,6 +64,9 @@ class CrawlerExperimentRescaler(SubsectionsExperimentRescaler):
 
     def rescale_prior(self, rec: CuratedRecommendation, alpha, beta):
         """Rescales priors based on content"""
-        # treat subtopics and topics the same
-        # all new data comes in with a lower expected CTR in order to not severely disrupt popular items
+        if rec.isTimeSensitive:
+            # We are using the timeSensitive flag as a means for editors to boost content
+            # The unmodified alpha, beta has an optimistic prior, bringing new content to the top
+            return alpha, beta
+        # Default - data comes in with a lower expected CTR in order to not severely disrupt popular items
         return alpha * PESSIMISTIC_PRIOR_ALPHA_SCALE, beta

--- a/tests/unit/prior_backends/test_experiment_rescaler.py
+++ b/tests/unit/prior_backends/test_experiment_rescaler.py
@@ -62,6 +62,7 @@ class TestCrawlerExperimentRescaler:
         """Test rescaling of priors for relative experiment size"""
         rec = Mock()
         rec.in_experiment.return_value = True
+        rec.isTimeSensitive = False
         opens, no_opens = self.rescaler.rescale(rec, 100, 50)
         expected_opens = 100 / SUBSECTION_EXPERIMENT_PERCENT
         expected_no_opens = 50 / SUBSECTION_EXPERIMENT_PERCENT
@@ -77,6 +78,7 @@ class TestCrawlerExperimentRescaler:
         """Test when no experiment in request"""
         rec = Mock()
         rec.in_experiment.return_value = False
+        rec.isTimeSensitive = False
 
         opens, no_opens = self.rescaler.rescale(rec, 100, 50)
 
@@ -86,4 +88,20 @@ class TestCrawlerExperimentRescaler:
         alpha, beta = self.rescaler.rescale_prior(rec, 40, 20)
 
         assert alpha == 40 * PESSIMISTIC_PRIOR_ALPHA_SCALE
+        assert beta == 20
+
+    def test_rescale_regular_boosted_item(self):
+        """Test when no experiment in request"""
+        rec = Mock()
+        rec.in_experiment.return_value = False
+        rec.isTimeSensitive = True
+        opens, no_opens = self.rescaler.rescale(rec, 100, 50)
+
+        assert opens == 100 / CRAWLED_TOPIC_TOTAL_PERCENT
+        assert no_opens == 50 / CRAWLED_TOPIC_TOTAL_PERCENT
+
+        alpha, beta = self.rescaler.rescale_prior(rec, 40, 20)
+
+        # alpha, beta are unchanged
+        assert alpha == 40
         assert beta == 20


### PR DESCRIPTION


## References

JIRA: [HNT-1025](https://mozilla-hub.atlassian.net/browse/HNT-1025)

## Description
The editors want to be able to force new items to the top of the feed for certain stories.
We are using the isTimeSensitive flag.

[Previously](https://github.com/mozilla-services/merino-py/pull/1073) we changed the default to have new items have somewhat pessimistic priors so that new content doesn't always wash out the top items. This PR basically blocks that feature for 'time sensitive' flagged stories.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[HNT-1025]: https://mozilla-hub.atlassian.net/browse/HNT-1025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1874)
