### PR TITLE
GENAI-1922 Fix incorrect threshold for sports in inferred personalization

### DIFF
--- a/merino/curated_recommendations/ml_backends/fake_local_model.py
+++ b/merino/curated_recommendations/ml_backends/fake_local_model.py
@@ -192,7 +192,7 @@ class LimitedTopicV0Model(LocalModelBackend):
             return InterestVectorConfig(
                 features={f"t_{topic}": 1},
                 thresholds=[0.01, 0.02, 0.03]
-                if topic is not Topic.SPORTS
+                if topic is not Topic.SPORTS.value
                 else [0.005, 0.008, 0.02],
                 diff_p=V0_MODEL_P_VALUE,
                 diff_q=V0_MODEL_Q_VALUE,

--- a/tests/unit/curated_recommendations/ml_backends/test_fake_local_model.py
+++ b/tests/unit/curated_recommendations/ml_backends/test_fake_local_model.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 from types import SimpleNamespace
 
+from merino.curated_recommendations.corpus_backends.protocol import Topic
 from merino.curated_recommendations.ml_backends.fake_local_model import (
     FakeLocalModelTopics,
     FakeLocalModelSections,
@@ -92,6 +93,9 @@ def test_model_returns_limited_model(model_limited):
     assert len(result.model_data.interest_vector) > 0
     assert len(result.model_data.day_time_weighting.days) > 0
     assert len(result.model_data.day_time_weighting.relative_weight) > 0
+
+    # test a specific threshold value
+    assert result.model_data.interest_vector[Topic.SPORTS.value].thresholds[0] == 0.005
 
 
 def test_unary_decoding(model_limited):


### PR DESCRIPTION
## References

JIRA: [GENAI-1922](https://mozilla-hub.atlassian.net/browse/GENAI-1922)

## Description
Minor code error in the model definition


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ x ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ x ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[GENAI-1922]: https://mozilla-hub.atlassian.net/browse/GENAI-1922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1876)
