### PR TITLE
chore: remove weather skip/success logging

### DIFF
--- a/merino/providers/suggest/weather/provider.py
+++ b/merino/providers/suggest/weather/provider.py
@@ -16,10 +16,8 @@ from merino.providers.suggest.base import BaseProvider, BaseSuggestion, Suggesti
 from merino.providers.suggest.custom_details import CustomDetails, WeatherDetails
 from merino.providers.suggest.weather.backends.accuweather.pathfinder import (
     get_region_mapping_size,
-    get_region_mapping,
     get_skip_cities_mapping_total,
     get_skip_cities_mapping_size,
-    get_skip_cities_mapping,
 )
 from merino.providers.suggest.weather.backends.protocol import (
     CurrentConditions,
@@ -128,8 +126,6 @@ class Provider(BaseProvider):
             name=f"providers.{self.name}.pathfinder.mapping.size",
             value=get_region_mapping_size(),
         )
-        logger.info(f"Weather Successful Mapping Values: {get_region_mapping()}")
-
         self.metrics_client.gauge(
             name=f"providers.{self.name}.skip_cities_mapping.total.size",
             value=get_skip_cities_mapping_total(),
@@ -138,8 +134,6 @@ class Provider(BaseProvider):
             name=f"providers.{self.name}.skip_cities_mapping.unique.size",
             value=get_skip_cities_mapping_size(),
         )
-
-        logger.info(f"Weather Skip Cities: {get_skip_cities_mapping()}")
 
     def validate(self, srequest: SuggestionRequest) -> None:
         """Validate the suggestion request."""

--- a/tests/unit/providers/suggest/weather/test_provider.py
+++ b/tests/unit/providers/suggest/weather/test_provider.py
@@ -238,10 +238,3 @@ async def test_fetch_mapping(
         call(name="providers.weather.skip_cities_mapping.total.size", value=2),
         call(name="providers.weather.skip_cities_mapping.unique.size", value=1),
     ]
-
-    records = filter_caplog(caplog.records, "merino.providers.suggest.weather.provider")
-    assert len(records) == 2
-    assert [record.message for record in records] == [
-        "Weather Successful Mapping Values: {('NL', 'Andel'): 'NB'}",
-        "Weather Skip Cities: {('CA', 'BC', 'Vancouver'): 2}",
-    ]


### PR DESCRIPTION
## References


## Description
Going forward, we're just going to try to proactively normalize cities based on population rather than retroactively correcting them, so these logs aren't really needed



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1877)
