### PR TITLE
[DISCO-3716] Add flight aware job to fetch and store flight nums

### DIFF
--- a/merino/cache/none.py
+++ b/merino/cache/none.py
@@ -26,3 +26,12 @@ class NoCacheAdapter:  # pragma: no cover
 
     async def run_script(self, sid: str, keys: list, args: list, readonly: bool = False) -> Any:  # noqa: D102
         pass
+
+    async def sadd(self, key: str, *values: str) -> int:  # noqa: D102
+        return 0
+
+    async def sismember(self, key: str, value: str) -> bool:  # noqa: D102
+        return False
+
+    async def scard(self, key: str) -> int:  # noqa: D102
+        return 0

--- a/merino/cache/protocol.py
+++ b/merino/cache/protocol.py
@@ -62,3 +62,19 @@ class CacheAdapter(Protocol):
             - `CacheAdapterError` if Redis returns an error.
         """
         ...
+
+    async def sadd(self, key: str, *values: str) -> int:
+        """Add one or more values to a Redis set.
+
+        Returns:
+            Number of new elements added to the set.
+        """
+        ...
+
+    async def sismember(self, key: str, value: str) -> bool:
+        """Check if a value is a member of a Redis set."""
+        ...
+
+    async def scard(self, key: str) -> int:
+        """Get the number of members in a Redis set."""
+        ...

--- a/merino/cache/redis.py
+++ b/merino/cache/redis.py
@@ -102,6 +102,31 @@ class RedisAdapter:
         except RedisError as exc:
             raise CacheAdapterError(f"Failed to set `{repr(key)}` with error: `{exc}`") from exc
 
+    async def sadd(self, key: str, *values: str) -> int:
+        """Add one or more values to a Redis set.
+
+        Returns:
+            Number of new elements added to the set.
+        """
+        try:
+            return await self.primary.sadd(key, *values)
+        except RedisError as exc:
+            raise CacheAdapterError(f"Failed to SADD {key} with error: {exc}") from exc
+
+    async def sismember(self, key: str, value: str) -> bool:
+        """Check if a value is a member of a Redis set."""
+        try:
+            return bool(await self.replica.sismember(key, value))
+        except RedisError as exc:
+            raise CacheAdapterError(f"Failed to SISMEMBER {key} with error: {exc}") from exc
+
+    async def scard(self, key: str) -> int:
+        """Get the number of members in a Redis set."""
+        try:
+            return await self.replica.scard(key)
+        except RedisError as exc:
+            raise CacheAdapterError(f"Failed to SCARD {key} with error: {exc}") from exc
+
     async def close(self) -> None:
         """Close the Redis connection."""
         if self.primary is self.replica:

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -814,6 +814,18 @@ circuit_breaker_recover_timeout_sec = 30
 # In production, this should be set via environment variable as a secret.
 api_key = ""
 
+# MERINO_FLIGHTAWARE__STORAGE
+# Storage for flight numbers. Should be either `gcs` or `redis`
+storage = "gcs"
+
+# MERINO_FLIGHTAWARE__BASE_URL
+# The base URL of FlightAware API endpoints.
+base_url = "https://aeroapi.flightaware.com/aeroapi"
+
+# MERINO_FLIGHTAWARE__SCHEDULES_URL
+# The URL path of FlightAware schedules endpoint.
+schedules_url_path = "/schedules/{start}/{end}?max_pages=20"
+
 [default.curated_recommendations.gcs]
 # MERINO__CURATED_RECOMMENDATIONS__GCS__BUCKET_NAME
 # GCS bucket that contains Airflow data for Merino

--- a/merino/jobs/cli.py
+++ b/merino/jobs/cli.py
@@ -11,6 +11,7 @@ from merino.jobs.relevancy_uploader import relevancy_csv_rs_uploader_cmd
 from merino.jobs.wikipedia_indexer import indexer_cmd
 from merino.jobs.wikipedia_offline_uploader import wiki_offline_uploader_cmd
 from merino.jobs.polygon import cli as polygon_ingestion_cmd
+from merino.jobs.flightaware import cli as flightaware_fetch_schedules_cmd
 
 # NOTE: `pretty_exceptions_show_locals` argument is set to False to avoid api_key and secrets exposure.
 cli = typer.Typer(no_args_is_help=True, add_completion=False, pretty_exceptions_show_locals=False)
@@ -35,6 +36,9 @@ cli.add_typer(wiki_offline_uploader_cmd, no_args_is_help=True)
 
 # Add the polygon ingest subcommand
 cli.add_typer(polygon_ingestion_cmd, no_args_is_help=True)
+
+# Add the flightaware fetch schedules subcommand
+cli.add_typer(flightaware_fetch_schedules_cmd, no_args_is_help=True)
 
 
 @cli.callback()

--- a/merino/jobs/flightaware/__init__.py
+++ b/merino/jobs/flightaware/__init__.py
@@ -1,0 +1,37 @@
+"""CLI commands for the flight schedules job"""
+
+import asyncio
+import logging
+
+import httpx
+import typer
+from merino.configs import settings
+
+from merino.jobs.flightaware import fetch_schedules
+
+logger = logging.getLogger(__name__)
+
+cli = typer.Typer(
+    name="fetch_flights",
+    help="Commands to fetch flight schedules and store flight numbers",
+)
+
+
+@cli.command()
+def fetch_and_store():
+    """Fetch and store flight numbers"""
+    logger.info("Starting flight schedules pipeline...")
+
+    base_url = settings.flightaware.base_url
+
+    try:
+        with httpx.Client(base_url=base_url) as client:
+            flight_number_set, api_call_count = fetch_schedules.fetch_schedules(client)
+
+            asyncio.run(fetch_schedules.store_flight_numbers(flight_number_set))
+            logger.info(
+                f"Successfully fetched {len(flight_number_set)} flights with {api_call_count} API calls"
+            )
+
+    except Exception as ex:
+        logger.error(f"Failed to fetch schedules: {ex.__class__.__name__}", exc_info=True)

--- a/merino/jobs/flightaware/fetch_schedules.py
+++ b/merino/jobs/flightaware/fetch_schedules.py
@@ -1,0 +1,170 @@
+"""Fetches and stores flight schedules from flightaware."""
+
+import datetime
+import logging
+from typing import Any
+import httpx
+import json
+
+from merino.cache.none import NoCacheAdapter
+from merino.cache.redis import RedisAdapter, create_redis_clients
+from merino.configs import settings
+from merino.exceptions import CacheAdapterError
+from merino.utils.gcs.gcs_uploader import GcsUploader
+from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_exception_type
+
+
+logger = logging.getLogger(__name__)
+
+setting = settings.providers.flightaware
+cache = (
+    RedisAdapter(
+        *create_redis_clients(
+            settings.redis.server,
+            settings.redis.replica,
+            settings.redis.max_connections,
+            settings.redis.socket_connect_timeout_sec,
+            settings.redis.socket_timeout_sec,
+        )
+    )
+    if setting.cache == "redis"
+    else NoCacheAdapter()
+)
+
+
+FLIGHTAWARE_API_KEY = settings.flightaware.api_key
+STORAGE = settings.flightaware.storage
+SCHEDULES_URL = settings.flightaware.schedules_url_path
+
+CHUNK_SIZE = 100_000
+
+
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=2, min=2, max=30),
+    retry=retry_if_exception_type(httpx.HTTPError),
+    reraise=True,
+)
+def _get_with_retry(client: httpx.Client, url: str, headers: dict[str, str]) -> httpx.Response:
+    """Perform a GET request with retries for HTTP errors"""
+    resp = client.get(url, headers=headers, timeout=60)
+    resp.raise_for_status()
+    return resp
+
+
+def fetch_schedules(client: httpx.Client) -> tuple[set[str], int]:
+    """Fetch schedules for a 6-hour rolling window and accumulate flight numbers in Redis."""
+    now = datetime.datetime.now(datetime.timezone.utc)
+    start = now.isoformat(timespec="seconds").replace("+00:00", "Z")
+    end = (now + datetime.timedelta(hours=6)).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+    url: str | None = SCHEDULES_URL.format(start=start, end=end)
+    headers = {"x-apikey": FLIGHTAWARE_API_KEY}
+    flight_number_set: set[str] = set()
+    page = 1
+    api_calls = 0
+
+    while url is not None:
+        try:
+            assert url is not None  # helps Mypy narrow type
+            resp = _get_with_retry(client, url, headers)
+            api_calls += 1
+            resp.raise_for_status()
+            data = resp.json()
+
+            scheduled_flights = data.get("scheduled", [])
+            logger.info(f"Page {page}: {len(scheduled_flights)} flights")
+
+            process_flight_numbers(flight_number_set, scheduled_flights)
+
+            url = data.get("links", {}).get("next", None)
+            page += 1
+
+        except httpx.HTTPStatusError as ex:
+            logger.error(
+                f"Failed to fetch page {page}: {ex.response.status_code} {ex.response.reason_phrase}"
+            )
+            url = None
+
+    return flight_number_set, api_calls
+
+
+def process_flight_numbers(
+    flight_number_set: set[str],
+    scheduled_flights: list[dict[str, Any]],
+) -> None:
+    """Add unique flight numbers to a set"""
+    for flight in scheduled_flights:
+        flight_num = flight.get("ident_iata", None)
+        if flight_num:
+            flight_number_set.add(flight_num)
+    logger.info(f"Unique flight numbers so far: {len(flight_number_set)}")
+
+
+async def store_flight_numbers(flight_number_set: set[str]) -> None:
+    """Accumulate flight numbers using the configured storage (Redis or GCS)"""
+    if not flight_number_set:
+        logger.info("No flight numbers to persist.")
+        return
+
+    if STORAGE == "redis":
+        await store_flight_numbers_in_redis(flight_number_set)
+
+    elif STORAGE == "gcs":
+        await store_flight_numbers_in_gcs(flight_number_set)
+
+    else:
+        logger.warning(f"Unknown storage backend '{STORAGE}', skipping persist.")
+
+
+async def store_flight_numbers_in_redis(flight_number_set: set[str]) -> None:
+    """Insert flight numbers into Redis in chunks and log new additions."""
+    try:
+        numbers = list(flight_number_set)
+        newly_added_total = 0
+        for i in range(0, len(numbers), CHUNK_SIZE):
+            chunk = numbers[i : i + CHUNK_SIZE]
+            added = await cache.sadd("flights:valid", *chunk)
+            newly_added_total += added
+
+        total = await cache.scard("flights:valid")
+        logger.info(f"Added {newly_added_total} new flight numbers; total now {total} in Redis")
+    except CacheAdapterError as e:
+        logger.error(f"Error storing flight numbers in Redis: {e}")
+
+
+async def store_flight_numbers_in_gcs(flight_number_set: set[str]) -> None:
+    """Add new unique flight numbers in GCS and log additions."""
+    try:
+        uploader = GcsUploader(
+            settings.image_gcs.gcs_project,
+            settings.image_gcs.gcs_bucket,
+            settings.image_gcs.cdn_hostname,
+        )
+
+        existing_blob = uploader.get_most_recent_file(
+            match="flight_numbers",
+            sort_key=lambda b: b.updated,
+        )
+
+        existing_numbers: set[str] = set()
+        if existing_blob:
+            logger.info(f"Downloading existing blob {existing_blob.name} for deduplication")
+
+            existing_numbers.update(json.loads(existing_blob.download_as_text()))
+
+        combined = existing_numbers.union(flight_number_set)
+        newly_added = combined - existing_numbers
+        content = json.dumps(sorted(combined), indent=2)
+
+        uploader.upload_content(
+            content=content,
+            destination_name="flight_numbers_latest.json",
+            content_type="application/json",
+            forced_upload=True,
+        )
+        logger.info(
+            f"Uploaded {len(newly_added)} new flight numbers; total now {len(combined)} in GCS"
+        )
+    except Exception as e:
+        logger.error(f"Error uploading flight numbers to GCS: {e}")

--- a/merino/jobs/polygon/__init__.py
+++ b/merino/jobs/polygon/__init__.py
@@ -2,11 +2,9 @@
 
 import asyncio
 import logging
-from typing import Annotated
 
 import typer
 
-from merino.configs import settings as config
 from merino.jobs.polygon.polygon_ingestion import PolygonIngestion
 
 logger = logging.getLogger(__name__)

--- a/tests/integration/jobs/flightaware/test_fetch_schedules.py
+++ b/tests/integration/jobs/flightaware/test_fetch_schedules.py
@@ -1,0 +1,86 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Integration tests for fetch_schedules.py module."""
+
+import httpx
+import asyncio
+import json
+from unittest.mock import MagicMock, patch
+from merino.jobs.flightaware.fetch_schedules import store_flight_numbers_in_gcs, fetch_schedules
+
+
+def test_fetch_with_mock_transport():
+    """Verify fetch_schedules handles a single-page response with one flight."""
+
+    def handler(request):
+        return httpx.Response(200, json={"scheduled": [{"ident_iata": "AA123"}], "links": {}})
+
+    transport = httpx.MockTransport(handler)
+    client = httpx.Client(transport=transport, base_url="https://aeroapi.flightaware.com/aeroapi")
+
+    flights, calls = fetch_schedules(client)
+
+    assert "AA123" in flights
+    assert calls == 1
+
+
+def test_fetch_schedules_with_pagination():
+    """Verify fetch_schedules follows links.next and collects flights across multiple pages."""
+    responses = [
+        httpx.Response(
+            200,
+            json={"scheduled": [{"ident_iata": "AA123"}], "links": {"next": "/schedules/page2"}},
+        ),
+        httpx.Response(200, json={"scheduled": [{"ident_iata": "UA456"}], "links": {}}),
+    ]
+    call_count = {"i": 0}
+
+    def handler(request):
+        resp = responses[call_count["i"]]
+        call_count["i"] += 1
+        return resp
+
+    transport = httpx.MockTransport(handler)
+    client = httpx.Client(transport=transport, base_url="https://aeroapi.flightaware.com/aeroapi")
+
+    flights, calls = fetch_schedules(client)
+
+    assert "AA123" in flights
+    assert "UA456" in flights
+    assert calls == 2
+
+
+def test_store_flight_numbers_in_gcs_first_upload():
+    """Ensure store_flight_numbers_in_gcs uploads all numbers when no existing blob is present."""
+    mock_uploader = MagicMock()
+    mock_uploader.get_most_recent_file.return_value = None
+
+    with patch("merino.jobs.flightaware.fetch_schedules.GcsUploader", return_value=mock_uploader):
+        flight_numbers = {"AA123", "UA456"}
+        asyncio.run(store_flight_numbers_in_gcs(flight_numbers))
+
+    uploaded_content = mock_uploader.upload_content.call_args[1]["content"]
+    uploaded_list = json.loads(uploaded_content)
+    assert sorted(uploaded_list) == ["AA123", "UA456"]
+
+
+def test_store_flight_numbers_in_gcs_merges_existing():
+    """Ensure store_flight_numbers_in_gcs merges new numbers with existing blob contents and dedupes."""
+    mock_blob = MagicMock()
+    mock_blob.download_as_text.return_value = json.dumps(["AA123", "DL789"])
+    mock_uploader = MagicMock()
+    mock_uploader.get_most_recent_file.return_value = mock_blob
+
+    with patch("merino.jobs.flightaware.fetch_schedules.GcsUploader", return_value=mock_uploader):
+        flight_numbers = {"AA123", "UA456"}  # AA123 is already in the blob
+        asyncio.run(store_flight_numbers_in_gcs(flight_numbers))
+
+    uploaded_content = mock_uploader.upload_content.call_args[1]["content"]
+    uploaded_list = json.loads(uploaded_content)
+
+    assert "AA123" in uploaded_list
+    assert "DL789" in uploaded_list
+    assert "UA456" in uploaded_list
+    assert len(uploaded_list) == 3

--- a/tests/unit/jobs/flightaware/test_fetch_schedules.py
+++ b/tests/unit/jobs/flightaware/test_fetch_schedules.py
@@ -1,0 +1,96 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Unit tests for fetch_schedules.py module."""
+
+import pytest
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import merino.jobs.flightaware.fetch_schedules as fetch_schedules
+
+
+def test_process_flight_numbers_adds_valid_and_skips_none(caplog):
+    """Verify process_flight_numbers adds valid IATA codes and ignores None values."""
+    caplog.set_level("INFO")
+    flights = [{"ident_iata": "AA123"}, {"ident_iata": None}, {}]
+    result = set()
+
+    fetch_schedules.process_flight_numbers(result, flights)
+
+    assert "AA123" in result
+    assert len(result) == 1
+    assert "Unique flight numbers" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_store_flight_numbers_dispatch(caplog):
+    """Ensure store_flight_numbers dispatches correctly to Redis, GCS, or logs unknown backend."""
+    called = {}
+
+    async def fake_redis(numbers):
+        called["redis"] = True
+
+    async def fake_gcs(numbers):
+        called["gcs"] = True
+
+    with (
+        patch.object(fetch_schedules, "store_flight_numbers_in_redis", side_effect=fake_redis),
+        patch.object(fetch_schedules, "store_flight_numbers_in_gcs", side_effect=fake_gcs),
+    ):
+        with patch.object(fetch_schedules, "STORAGE", "redis"):
+            await fetch_schedules.store_flight_numbers({"AA123"})
+            assert "redis" in called
+
+        with patch.object(fetch_schedules, "STORAGE", "gcs"):
+            await fetch_schedules.store_flight_numbers({"AA123"})
+            assert "gcs" in called
+
+        with patch.object(fetch_schedules, "STORAGE", "bogus"):
+            await fetch_schedules.store_flight_numbers({"AA123"})
+            assert "Unknown storage backend" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_store_flight_numbers_in_redis_chunks():
+    """Confirm store_flight_numbers_in_redis splits inserts into chunks and calls sadd multiple times."""
+    fake_cache = AsyncMock()
+    fake_cache.sadd.side_effect = [10, 5]
+    fake_cache.scard.return_value = 15
+
+    with patch.object(fetch_schedules, "cache", fake_cache):
+        numbers = {f"FL{i}" for i in range(fetch_schedules.CHUNK_SIZE + 100)}
+        await fetch_schedules.store_flight_numbers_in_redis(numbers)
+
+        assert fake_cache.sadd.call_count == 2
+        fake_cache.scard.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_store_flight_numbers_in_gcs_first_upload():
+    """Test that store_flight_numbers_in_gcs uploads all numbers when no blob exists."""
+    mock_uploader = MagicMock()
+    mock_uploader.get_most_recent_file.return_value = None
+
+    with patch.object(fetch_schedules, "GcsUploader", return_value=mock_uploader):
+        await fetch_schedules.store_flight_numbers_in_gcs({"AA123"})
+
+    uploaded = json.loads(mock_uploader.upload_content.call_args[1]["content"])
+    assert uploaded == ["AA123"]
+
+
+@pytest.mark.asyncio
+async def test_store_flight_numbers_in_gcs_merges_existing():
+    """Check that store_flight_numbers_in_gcs merges new numbers with existing blob and dedupes."""
+    mock_blob = MagicMock()
+    mock_blob.download_as_text.return_value = json.dumps(["AA123"])
+
+    mock_uploader = MagicMock()
+    mock_uploader.get_most_recent_file.return_value = mock_blob
+
+    with patch.object(fetch_schedules, "GcsUploader", return_value=mock_uploader):
+        await fetch_schedules.store_flight_numbers_in_gcs({"AA123", "UA456"})
+
+    uploaded = json.loads(mock_uploader.upload_content.call_args[1]["content"])
+    assert sorted(uploaded) == ["AA123", "UA456"]


### PR DESCRIPTION
## References

JIRA: [DISCO-3716](https://mozilla-hub.atlassian.net/browse/DISCO-3716)

## Description
We need a robust way to validate user flight number queries without sending arbitrary user queries to AeroAPI. By building a rolling cache of active flight numbers and allowing it to accumulate over time, we establish a stabilized allowlist for validation.
This PR adds a CLI entrypoint for fetching scheduled flights every 6 hours and accumulates unique flight numbers into Redis.

Changes:
- Implemented `fetch_schedules` to query FlightAware’s `/schedules` endpoint for a rolling 6-hour window.
- Extracted unique `ident_iata` values from scheduled flights.
- Added new `RedisAdapter` methods: `sadd`, `sismember`, `scard`.
- Implemented `store_flight_numbers` to accumulate flight numbers in Redis rather than replacing the set.
- Logged number of newly added flight numbers and running total (useful for monitoring stabilization of the cache over time).

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3716]: https://mozilla-hub.atlassian.net/browse/DISCO-3716?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1878)
