### PR TITLE
HNT-1063: Support new-tab-crawling-v2 experiment

### DIFF
--- a/merino/curated_recommendations/prior_backends/experiment_rescaler.py
+++ b/merino/curated_recommendations/prior_backends/experiment_rescaler.py
@@ -5,14 +5,14 @@ from typing import Any
 from merino.curated_recommendations.prior_backends.protocol import ExperimentRescaler
 from merino.curated_recommendations.protocol import CuratedRecommendation
 
-SUBTOPIC_TOTAL_PERCENT = 0.06  # This may eventually be computed by an airflow job
-CRAWLED_TOPIC_TOTAL_PERCENT = 0.06
+SUBTOPIC_TOTAL_PERCENT = 0.13  # This may eventually be computed by an airflow job
+CRAWLED_TOPIC_TOTAL_PERCENT = 0.13
 SUBTOPIC_EXPERIMENT_CURATED_ITEM_FLAG = "SUBTOPICS"
 
 # This is derived using data analysis on scores and existing priors
 # See more at:
 # https://mozilla-hub.atlassian.net/wiki/spaces/FAAMT/pages/1727725665/Thompson+Sampling+of+Subtopic+Sections
-PESSIMISTIC_PRIOR_ALPHA_SCALE = 0.25
+PESSIMISTIC_PRIOR_ALPHA_SCALE = 0.20
 
 
 class SubsectionsExperimentRescaler(ExperimentRescaler):

--- a/merino/curated_recommendations/prior_backends/experiment_rescaler.py
+++ b/merino/curated_recommendations/prior_backends/experiment_rescaler.py
@@ -6,13 +6,13 @@ from merino.curated_recommendations.prior_backends.protocol import ExperimentRes
 from merino.curated_recommendations.protocol import CuratedRecommendation
 
 SUBTOPIC_TOTAL_PERCENT = 0.13  # This may eventually be computed by an airflow job
-CRAWLED_TOPIC_TOTAL_PERCENT = 0.13
+CRAWLED_TOPIC_TOTAL_PERCENT = 0.2
 SUBTOPIC_EXPERIMENT_CURATED_ITEM_FLAG = "SUBTOPICS"
 
 # This is derived using data analysis on scores and existing priors
 # See more at:
 # https://mozilla-hub.atlassian.net/wiki/spaces/FAAMT/pages/1727725665/Thompson+Sampling+of+Subtopic+Sections
-PESSIMISTIC_PRIOR_ALPHA_SCALE = 0.20
+PESSIMISTIC_PRIOR_ALPHA_SCALE = 0.25
 
 
 class SubsectionsExperimentRescaler(ExperimentRescaler):

--- a/merino/curated_recommendations/protocol.py
+++ b/merino/curated_recommendations/protocol.py
@@ -88,6 +88,8 @@ class ExperimentName(str, Enum):
     RSS_VS_ZYTE_EXPERIMENT = "new-ranking-for-legacy-topics-in-new-tab-v1"
     # Experiment to display Daily Briefing section as the first section on New Tab
     DAILY_BRIEFING_EXPERIMENT = "daily-briefing-v1"
+    # Experiment slug for crawling with identical behavior/branches as RSS_VS_ZYTE_EXPERIMENT
+    NEW_TAB_CRAWLING_V2 = "new-tab-crawling-v2"
 
 
 @unique

--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -304,12 +304,17 @@ def get_crawl_experiment_branch(request: CuratedRecommendationsRequest) -> str |
 
     Handles both the regular experiment name and the optin- prefixed version for forced enrollment.
     """
-    experiment_name = ExperimentName.RSS_VS_ZYTE_EXPERIMENT.value
-    # Check for both the experiment name and the optin- prefixed version (forced enrollment)
-    if (
-        request.experimentName == experiment_name
-        or request.experimentName == f"optin-{experiment_name}"
-    ):
+    if not request.experimentName:
+        return None
+
+    # Remove optin- prefix if present and check if it matches any crawl experiment
+    experiment_name = request.experimentName.removeprefix("optin-")
+    crawl_experiments = [
+        ExperimentName.RSS_VS_ZYTE_EXPERIMENT.value,
+        ExperimentName.NEW_TAB_CRAWLING_V2.value,
+    ]
+
+    if experiment_name in crawl_experiments:
         return request.experimentBranch
     return None
 

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -1428,6 +1428,14 @@ class TestSections:
                 "experimentName": ExperimentName.RSS_VS_ZYTE_EXPERIMENT.value,
                 "experimentBranch": CrawlExperimentBranchName.TREATMENT_CRAWL.value,
             },
+            {
+                "experimentName": ExperimentName.NEW_TAB_CRAWLING_V2.value,
+                "experimentBranch": CrawlExperimentBranchName.CONTROL.value,
+            },
+            {
+                "experimentName": ExperimentName.NEW_TAB_CRAWLING_V2.value,
+                "experimentBranch": CrawlExperimentBranchName.TREATMENT_CRAWL.value,
+            },
         ],
     )
     def test_curated_recommendations_with_sections_feed_boost_followed_sections(
@@ -1502,6 +1510,8 @@ class TestSections:
         if experiment_name in [
             ExperimentName.RSS_VS_ZYTE_EXPERIMENT.value,
             f"optin-{ExperimentName.RSS_VS_ZYTE_EXPERIMENT.value}",
+            ExperimentName.NEW_TAB_CRAWLING_V2.value,
+            f"optin-{ExperimentName.NEW_TAB_CRAWLING_V2.value}",
         ]:
             for section_id in sections:
                 if section_id != "top_stories_section":
@@ -1528,6 +1538,22 @@ class TestSections:
             },
             {
                 "experimentName": f"optin-{ExperimentName.RSS_VS_ZYTE_EXPERIMENT.value}",
+                "experimentBranch": CrawlExperimentBranchName.TREATMENT_CRAWL.value,
+            },
+            {
+                "experimentName": ExperimentName.NEW_TAB_CRAWLING_V2.value,
+                "experimentBranch": CrawlExperimentBranchName.CONTROL.value,
+            },
+            {
+                "experimentName": ExperimentName.NEW_TAB_CRAWLING_V2.value,
+                "experimentBranch": CrawlExperimentBranchName.TREATMENT_CRAWL.value,
+            },
+            {
+                "experimentName": f"optin-{ExperimentName.NEW_TAB_CRAWLING_V2.value}",
+                "experimentBranch": CrawlExperimentBranchName.CONTROL.value,
+            },
+            {
+                "experimentName": f"optin-{ExperimentName.NEW_TAB_CRAWLING_V2.value}",
                 "experimentBranch": CrawlExperimentBranchName.TREATMENT_CRAWL.value,
             },
         ],
@@ -1583,6 +1609,8 @@ class TestSections:
         is_crawl_treatment = experiment_name in [
             ExperimentName.RSS_VS_ZYTE_EXPERIMENT.value,
             f"optin-{ExperimentName.RSS_VS_ZYTE_EXPERIMENT.value}",
+            ExperimentName.NEW_TAB_CRAWLING_V2.value,
+            f"optin-{ExperimentName.NEW_TAB_CRAWLING_V2.value}",
         ] and experiment_payload.get("experimentBranch") in [
             CrawlExperimentBranchName.TREATMENT_CRAWL.value,
             CrawlExperimentBranchName.TREATMENT_CRAWL_PLUS_SUBTOPICS.value,

--- a/tests/unit/curated_recommendations/test_sections.py
+++ b/tests/unit/curated_recommendations/test_sections.py
@@ -240,6 +240,27 @@ class TestMlSectionsExperiment:
         )
         assert is_subtopics_experiment(req_treatment_with_subtopics) is True
 
+        # NEW_TAB_CRAWLING_V2 - Control branch - should not include subtopics
+        req_v2_control = SimpleNamespace(
+            experimentName=ExperimentName.NEW_TAB_CRAWLING_V2.value,
+            experimentBranch=CrawlExperimentBranchName.CONTROL.value,
+        )
+        assert is_subtopics_experiment(req_v2_control) is False
+
+        # NEW_TAB_CRAWLING_V2 - Treatment crawl (no subtopics) - should not include subtopics
+        req_v2_treatment_no_subtopics = SimpleNamespace(
+            experimentName=ExperimentName.NEW_TAB_CRAWLING_V2.value,
+            experimentBranch=CrawlExperimentBranchName.TREATMENT_CRAWL.value,
+        )
+        assert is_subtopics_experiment(req_v2_treatment_no_subtopics) is False
+
+        # NEW_TAB_CRAWLING_V2 - Treatment crawl WITH subtopics - should include subtopics
+        req_v2_treatment_with_subtopics = SimpleNamespace(
+            experimentName=ExperimentName.NEW_TAB_CRAWLING_V2.value,
+            experimentBranch=CrawlExperimentBranchName.TREATMENT_CRAWL_PLUS_SUBTOPICS.value,
+        )
+        assert is_subtopics_experiment(req_v2_treatment_with_subtopics) is True
+
         # Not enrolled in crawl experiment - should return False
         req_not_enrolled = SimpleNamespace(
             experimentName="other",
@@ -262,6 +283,13 @@ class TestMlSectionsExperiment:
             experimentBranch=CrawlExperimentBranchName.TREATMENT_CRAWL_PLUS_SUBTOPICS.value,
         )
         assert is_subtopics_experiment(req_crawl_subtopics) is True
+
+        # NEW_TAB_CRAWLING_V2 Crawl subtopics enabled - should include subtopics regardless of ML sections
+        req_v2_crawl_subtopics = SimpleNamespace(
+            experimentName=ExperimentName.NEW_TAB_CRAWLING_V2.value,
+            experimentBranch=CrawlExperimentBranchName.TREATMENT_CRAWL_PLUS_SUBTOPICS.value,
+        )
+        assert is_subtopics_experiment(req_v2_crawl_subtopics) is True
 
         # Neither enabled - should not include subtopics
         req_neither = SimpleNamespace(
@@ -305,6 +333,38 @@ class TestCrawlExperiment:
             ),
             (
                 f"optin-{ExperimentName.RSS_VS_ZYTE_EXPERIMENT.value}",
+                CrawlExperimentBranchName.CONTROL.value,
+                False,
+            ),
+            # NEW_TAB_CRAWLING_V2 tests
+            (
+                ExperimentName.NEW_TAB_CRAWLING_V2.value,
+                CrawlExperimentBranchName.TREATMENT_CRAWL.value,
+                True,
+            ),
+            (
+                ExperimentName.NEW_TAB_CRAWLING_V2.value,
+                CrawlExperimentBranchName.TREATMENT_CRAWL_PLUS_SUBTOPICS.value,
+                True,
+            ),
+            (
+                ExperimentName.NEW_TAB_CRAWLING_V2.value,
+                CrawlExperimentBranchName.CONTROL.value,
+                False,
+            ),
+            # Test with optin- prefix for NEW_TAB_CRAWLING_V2
+            (
+                f"optin-{ExperimentName.NEW_TAB_CRAWLING_V2.value}",
+                CrawlExperimentBranchName.TREATMENT_CRAWL.value,
+                True,
+            ),
+            (
+                f"optin-{ExperimentName.NEW_TAB_CRAWLING_V2.value}",
+                CrawlExperimentBranchName.TREATMENT_CRAWL_PLUS_SUBTOPICS.value,
+                True,
+            ),
+            (
+                f"optin-{ExperimentName.NEW_TAB_CRAWLING_V2.value}",
                 CrawlExperimentBranchName.CONTROL.value,
                 False,
             ),
@@ -352,6 +412,38 @@ class TestCrawlExperiment:
                 CrawlExperimentBranchName.TREATMENT_CRAWL_PLUS_SUBTOPICS.value,
                 CrawlExperimentBranchName.TREATMENT_CRAWL_PLUS_SUBTOPICS.value,
             ),
+            # NEW_TAB_CRAWLING_V2 tests
+            (
+                ExperimentName.NEW_TAB_CRAWLING_V2.value,
+                CrawlExperimentBranchName.CONTROL.value,
+                CrawlExperimentBranchName.CONTROL.value,
+            ),
+            (
+                ExperimentName.NEW_TAB_CRAWLING_V2.value,
+                CrawlExperimentBranchName.TREATMENT_CRAWL.value,
+                CrawlExperimentBranchName.TREATMENT_CRAWL.value,
+            ),
+            (
+                ExperimentName.NEW_TAB_CRAWLING_V2.value,
+                CrawlExperimentBranchName.TREATMENT_CRAWL_PLUS_SUBTOPICS.value,
+                CrawlExperimentBranchName.TREATMENT_CRAWL_PLUS_SUBTOPICS.value,
+            ),
+            # Test with optin- prefix for NEW_TAB_CRAWLING_V2
+            (
+                f"optin-{ExperimentName.NEW_TAB_CRAWLING_V2.value}",
+                CrawlExperimentBranchName.CONTROL.value,
+                CrawlExperimentBranchName.CONTROL.value,
+            ),
+            (
+                f"optin-{ExperimentName.NEW_TAB_CRAWLING_V2.value}",
+                CrawlExperimentBranchName.TREATMENT_CRAWL.value,
+                CrawlExperimentBranchName.TREATMENT_CRAWL.value,
+            ),
+            (
+                f"optin-{ExperimentName.NEW_TAB_CRAWLING_V2.value}",
+                CrawlExperimentBranchName.TREATMENT_CRAWL_PLUS_SUBTOPICS.value,
+                CrawlExperimentBranchName.TREATMENT_CRAWL_PLUS_SUBTOPICS.value,
+            ),
             ("other", "treatment", None),
         ],
     )
@@ -382,6 +474,27 @@ class TestCrawlExperiment:
             ),
             (
                 f"optin-{ExperimentName.RSS_VS_ZYTE_EXPERIMENT.value}",
+                CrawlExperimentBranchName.CONTROL.value,
+                None,
+            ),
+            # NEW_TAB_CRAWLING_V2 tests
+            (
+                ExperimentName.NEW_TAB_CRAWLING_V2.value,
+                CrawlExperimentBranchName.CONTROL.value,
+                None,
+            ),
+            (
+                ExperimentName.NEW_TAB_CRAWLING_V2.value,
+                CrawlExperimentBranchName.TREATMENT_CRAWL.value,
+                CrawlerExperimentRescaler,
+            ),
+            (
+                ExperimentName.NEW_TAB_CRAWLING_V2.value,
+                CrawlExperimentBranchName.TREATMENT_CRAWL_PLUS_SUBTOPICS.value,
+                CrawlerExperimentRescaler,
+            ),
+            (
+                f"optin-{ExperimentName.NEW_TAB_CRAWLING_V2.value}",
                 CrawlExperimentBranchName.CONTROL.value,
                 None,
             ),

--- a/tests/unit/prior_backends/test_experiment_rescaler.py
+++ b/tests/unit/prior_backends/test_experiment_rescaler.py
@@ -35,7 +35,7 @@ class TestSubsectionsExperimentRescaler:
         assert no_opens == expected_no_opens
 
         alpha, beta = self.rescaler.rescale_prior(rec, 10, 20)
-        assert alpha == 10 / 4.0
+        assert alpha == 10 * PESSIMISTIC_PRIOR_ALPHA_SCALE
         assert beta == 20
 
     def test_rescale_when_not_in_experiment(self):


### PR DESCRIPTION
## References

JIRA: [HNT-1063](https://mozilla-hub.atlassian.net/browse/HNT-1063)
Experimenter: [new-tab-crawling-v2](https://experimenter.services.mozilla.com/nimbus/new-tab-crawling-v2/update_overview/)
[Slack thread](https://mozilla.slack.com/archives/C08BYJWUC2E/p1758737132929059)

## Description
Start an another crawling experiment as a way to increase the audience for Thompson Sampling for the treatment branch.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[HNT-1063]: https://mozilla-hub.atlassian.net/browse/HNT-1063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1884)
