### PR TITLE
[DISCO-3733] Query AeroAPI for live flight info

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -820,11 +820,19 @@ storage = "gcs"
 
 # MERINO_FLIGHTAWARE__BASE_URL
 # The base URL of FlightAware API endpoints.
-base_url = "https://aeroapi.flightaware.com/aeroapi"
+base_url = "https://aeroapi.flightaware.com/aeroapi/"
 
 # MERINO_FLIGHTAWARE__SCHEDULES_URL
 # The URL path of FlightAware schedules endpoint.
 schedules_url_path = "/schedules/{start}/{end}?max_pages=20"
+
+# MERINO_FLIGHTAWARE__IDENT_URL
+# The URL path of FlightAware ident endpoint.
+ident_url_path = "flights/{ident}?ident_type=designator&start={start}&end={end}&max_pages=1"
+
+# MERINO_FLIGHTAWARE__LANDING_PAGE_URL
+# The url to the live FlightAware landing page.
+landing_page_url = "https://www.flightaware.com/live/flight/{ident}"
 
 [default.curated_recommendations.gcs]
 # MERINO__CURATED_RECOMMENDATIONS__GCS__BUCKET_NAME

--- a/merino/configs/testing.toml
+++ b/merino/configs/testing.toml
@@ -61,6 +61,11 @@ api_key = "test"
 # anyway to make sure the production server isn't accidentally pinged.
 url_base = "http://test-polygon"
 
+[testing.flightaware]
+api_key = "test"
+
+base_url = "http://test-flightaware.com"
+
 [testing.providers.polygon]
 enabled_by_default = false
 backend="polygon"

--- a/merino/providers/suggest/custom_details.py
+++ b/merino/providers/suggest/custom_details.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel
 
 from merino.middleware.geolocation import Coordinates
 from merino.providers.suggest.finance.backends.protocol import TickerSummary
+from merino.providers.suggest.flightaware.backends.protocol import FlightSummary
 from merino.providers.suggest.google_suggest.backends.protocol import GoogleSuggestResponse
 from merino.providers.suggest.yelp.backends.protocol import YelpBusinessDetails
 
@@ -39,6 +40,12 @@ class PolygonDetails(BaseModel):
     values: list[TickerSummary]
 
 
+class FlightAwareDetails(BaseModel):
+    """FlightAware specific fields."""
+
+    values: list[FlightSummary]
+
+
 class YelpDetails(BaseModel):
     """Yelp specific fields."""
 
@@ -63,3 +70,4 @@ class CustomDetails(BaseModel, arbitrary_types_allowed=False):
     polygon: PolygonDetails | None = None
     yelp: YelpDetails | None = None
     google_suggest: GoogleSuggestDetails | None = None
+    flightaware: FlightAwareDetails | None = None

--- a/merino/providers/suggest/flightaware/backends/flightaware.py
+++ b/merino/providers/suggest/flightaware/backends/flightaware.py
@@ -1,8 +1,19 @@
 """A wrapper for Flight Aware API interactions."""
 
-from httpx import AsyncClient
+import datetime
+from typing import Any
+from httpx import AsyncClient, HTTPStatusError
 
-from merino.providers.suggest.flightaware.backends.protocol import FlightBackendProtocol
+import logging
+from merino.providers.suggest.flightaware.backends.protocol import (
+    FlightBackendProtocol,
+    FlightSummary,
+)
+from merino.providers.suggest.flightaware.backends.utils import (
+    build_flight_summary,
+)
+
+logger = logging.getLogger(__name__)
 
 
 class FlightAwareBackend(FlightBackendProtocol):
@@ -10,13 +21,57 @@ class FlightAwareBackend(FlightBackendProtocol):
 
     api_key: str
     http_client: AsyncClient
+    ident_url: str
 
     def __init__(
         self,
         api_key: str,
+        http_client: AsyncClient,
+        ident_url: str,
     ) -> None:
         """Initialize the flight aware backend."""
         self.api_key = api_key
+        self.http_client = http_client
+        self.ident_url = ident_url
+
+    async def fetch_flight_details(self, flight_num: str) -> Any | None:
+        """Fetch flight details through aeroAPI"""
+        try:
+            header = {
+                "x-apikey": self.api_key,
+                "Accept": "application/json",
+            }
+
+            now = datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0)
+            start = (now - datetime.timedelta(hours=20)).isoformat().replace("+00:00", "Z")
+            end = (now + datetime.timedelta(hours=20)).isoformat().replace("+00:00", "Z")
+
+            formatted_url = self.ident_url.format(ident=flight_num, start=start, end=end)
+
+            response = await self.http_client.get(formatted_url, headers=header)
+            response.raise_for_status()
+
+        except HTTPStatusError as ex:
+            logger.warning(
+                f"Flightware request error for flight details: {ex.response.status_code} {ex.response.reason_phrase}"
+            )
+            return None
+
+        return response.json()
+
+    def get_flight_summaries(self, flight_response: Any | None, query: str) -> list[FlightSummary]:
+        """Return a prioritized list of summaries of a flight instance."""
+        if flight_response is None:
+            return []
+
+        flights = flight_response["flights"] or []
+        # prioritized_flights = pick_best_flights(flights) # TODO this will be uncommented in DISCO-3736
+
+        return [
+            summary
+            for flight in flights
+            if (summary := build_flight_summary(flight, query)) is not None
+        ]
 
     async def shutdown(self) -> None:
         """Shutdown any persistent connections. Currently a no-op."""

--- a/merino/providers/suggest/flightaware/backends/protocol.py
+++ b/merino/providers/suggest/flightaware/backends/protocol.py
@@ -1,6 +1,51 @@
 """Protocol for flight aware provider backends."""
 
-from typing import Protocol
+from datetime import datetime
+from enum import StrEnum
+from typing import Any, Protocol
+
+from pydantic import BaseModel, HttpUrl
+
+
+class AirportDetails(BaseModel):
+    """Details of origin/destination airport"""
+
+    code: str
+    city: str
+
+
+class FlightScheduleSegment(BaseModel):
+    """Scheduled date and time details for a flight segment (e.g., departure or arrival)."""
+
+    scheduled_time: datetime
+    estimated_time: datetime
+
+
+# TODO these will be properly deducted in DISCO-3736
+class FlightStatus(StrEnum):
+    """Status of a specific flight instance"""
+
+    SCHEDULED = "Scheduled"
+    EN_ROUTE = "En Route"
+    ARRIVED = "Arrived"
+    CANCELLED = "Cancelled"
+    DELAYED = "Delayed"
+
+
+class FlightSummary(BaseModel):
+    """Information about a specific flight instance"""
+
+    flight_number: str
+    destination: AirportDetails
+    origin: AirportDetails
+    departure: FlightScheduleSegment
+    arrival: FlightScheduleSegment
+    status: str  # TODO string for now, will replace with enum in DISCO-3736
+    progress_percent: int | None
+    # TODO these will be properly deducted in DISCO-3736
+    # delayed_until: datetime | None
+    # time_left_minutes: int | None
+    url: HttpUrl
 
 
 class FlightBackendProtocol(Protocol):
@@ -10,6 +55,13 @@ class FlightBackendProtocol(Protocol):
     might define additional methods and attributes which this provider doesn't
     directly depend on.
     """
+
+    def get_flight_summaries(self, flight_response: Any, query: str) -> list[FlightSummary]:
+        """Return a prioritized list of summaries of a flight instance."""
+        ...
+
+    async def fetch_flight_details(self, flight_num: str) -> Any | None:
+        """Fetch flight details by flight number through aeroAPI"""
 
     async def shutdown(self) -> None:  # pragma: no cover
         """Close down any open connections."""

--- a/merino/providers/suggest/flightaware/backends/utils.py
+++ b/merino/providers/suggest/flightaware/backends/utils.py
@@ -1,0 +1,199 @@
+"""Utilities for the flight aware backend"""
+
+import datetime
+import logging
+import re
+from typing import Any
+
+from pydantic import HttpUrl
+from merino.providers.suggest.flightaware.backends.protocol import (
+    AirportDetails,
+    FlightScheduleSegment,
+    FlightStatus,
+    FlightSummary,
+)
+from merino.configs import settings
+
+logger = logging.getLogger(__name__)
+
+LANDING_PAGE_URL: str = settings.flightaware.landing_page_url
+FLIGHT_NUM_PATTERN_1 = re.compile(
+    r"^[A-Za-z]{1,3}\s*\d{1,5}$", re.IGNORECASE
+)  # matches 1-3 letters followed by 1-5 digits e.g 'UAL101', 'A1234'.
+FLIGHT_NUM_PATTERN_2 = re.compile(
+    r"^\d\s*[A-Za-z]\s*\d{1,4}$", re.IGNORECASE
+)  # matches 1 digit, 1 letter, followed by 1-4 digits e.g '3U 1001'
+
+
+# TODO this will be implemented in DISCO-3736
+def derive_flight_status(flight: dict) -> FlightStatus:
+    """Determine a flight's operational status from its timestamp fields."""
+    return FlightStatus.EN_ROUTE  # hardcoded for now
+
+
+def parse_timestamp(timestamp: str | None) -> datetime.datetime | None:
+    """Parse an ISO 8601 UTC timestamp string into a datetime object."""
+    if not timestamp:
+        return None
+    try:
+        return datetime.datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def minutes_from_now(timestamp: str | None, now: datetime.datetime) -> float:
+    """Return the absolute difference in minutes between the given timestamp and now."""
+    dt = parse_timestamp(timestamp)
+    return abs((dt - now).total_seconds()) / 60 if dt else float("inf")
+
+
+def is_within_two_hours(timestamp: str | None, now: datetime.datetime) -> bool:
+    """Return True if the timestamp is within 2 hours of now."""
+    dt = parse_timestamp(timestamp)
+    return abs(now - dt) <= datetime.timedelta(hours=2) if dt else False
+
+
+def pick_best_flights(flights: list[dict], limit: int = 3) -> list[dict]:
+    """Select up to `limit` flight instances based on status and proximity to now.
+
+    Flights from these statuses are included:
+    - En Route - all eligible, top priority
+    - Scheduled/Delayed - all eligible, sorted by proximity
+    - Arrived - only the most recent (within 2h)
+    - Cancelled - only the most recent (within 2h)
+
+    All candidates are sorted by their time distance from now and top-N are returned.
+    """
+    now = datetime.datetime.now(datetime.timezone.utc)
+
+    priority_order = {
+        FlightStatus.EN_ROUTE: 0,
+        FlightStatus.SCHEDULED: 1,
+        FlightStatus.DELAYED: 1,
+        FlightStatus.ARRIVED: 2,
+        FlightStatus.CANCELLED: 3,
+    }
+
+    # Final list of all eligible flights with _distance_minutes annotated
+    candidates = []
+    arrived_candidates = []
+    cancelled_candidates = []
+
+    for flight in flights:
+        status: FlightStatus = derive_flight_status(flight)
+
+        if status == FlightStatus.EN_ROUTE:
+            # Force it to the top by assigning small negative distance
+            flight["_distance_minutes"] = -1
+            candidates.append(flight)
+
+        elif status == FlightStatus.SCHEDULED or status == FlightStatus.DELAYED:
+            timestamp = flight.get("estimated_out") or flight.get("scheduled_out")
+            if timestamp:
+                flight["_distance_minutes"] = minutes_from_now(timestamp, now)
+                candidates.append(flight)
+
+        elif status == FlightStatus.ARRIVED:
+            timestamp = flight.get("actual_on") or flight.get("actual_in")
+            if timestamp and is_within_two_hours(timestamp, now):
+                flight["_distance_minutes"] = minutes_from_now(timestamp, now)
+                arrived_candidates.append(flight)
+
+        elif status == FlightStatus.CANCELLED:
+            timestamp = flight.get("scheduled_out")
+            if timestamp and is_within_two_hours(timestamp, now):
+                flight["_distance_minutes"] = minutes_from_now(timestamp, now)
+                cancelled_candidates.append(flight)
+
+    if arrived_candidates:
+        closest_arrived = min(arrived_candidates, key=lambda f: f["_distance_minutes"])
+        candidates.append(closest_arrived)
+
+    if cancelled_candidates:
+        closest_cancelled = min(cancelled_candidates, key=lambda f: f["_distance_minutes"])
+        candidates.append(closest_cancelled)
+
+    # Sort by distance to now
+    candidates.sort(
+        key=lambda f: (f["_distance_minutes"], priority_order[derive_flight_status(f)])
+    )
+
+    return candidates[:limit]
+
+
+def build_flight_summary(flight: Any, normalized_query: str) -> FlightSummary | None:
+    """Build and return a flight summary from the flight response"""
+    try:
+        flight_number = normalized_query
+
+        destination_code = flight["destination"]["code_iata"]
+        destination_city = flight["destination"]["city"]
+
+        origin_code = flight["origin"]["code_iata"]
+        origin_city = flight["origin"]["city"]
+
+        destination = AirportDetails(code=destination_code, city=destination_city)
+        origin = AirportDetails(code=origin_code, city=origin_city)
+
+        scheduled_departure = flight["scheduled_out"]
+        estimated_departure = flight["estimated_out"]
+
+        scheduled_arrival = flight["scheduled_in"]
+        estimated_arrival = flight["estimated_in"]
+
+        departure = FlightScheduleSegment(
+            scheduled_time=scheduled_departure, estimated_time=estimated_departure
+        )
+        arrival = FlightScheduleSegment(
+            scheduled_time=scheduled_arrival, estimated_time=estimated_arrival
+        )
+
+        status = flight["status"]  # TODO would change to use derive_flight_status in DISCO-3736
+        progress_percent = flight["progress_percent"]
+
+        url = get_live_url(normalized_query, flight)
+
+        # TODO
+        # delayed_until = ""
+        # time_left_minutes =
+
+        return FlightSummary(
+            flight_number=flight_number,
+            destination=destination,
+            origin=origin,
+            departure=departure,
+            arrival=arrival,
+            status=status,
+            progress_percent=progress_percent,
+            url=url,
+        )
+
+    except (KeyError, IndexError, TypeError):
+        logger.warning(f"Flightaware response json has incorrect shape: {flight}")
+        return None
+
+
+def get_live_url(query: str, flight: Any) -> HttpUrl:
+    """Return the FlightAware live tracking URL for the queried flight.
+
+    If the query does not match the primary IATA ident of the flight (i.e., it's a codeshare),
+    this function attempts to resolve the correct ICAO ident using the codeshare mapping.
+    If a matching codeshare is found, the corresponding ident is used to construct the URL.
+    Otherwise, the primary ICAO ident for the flight is used.
+    """
+    if query != flight["ident_iata"]:
+        codeshares_iata = flight["codeshares_iata"]
+        codeshares_icao = flight["codeshares"]
+
+        if codeshares_iata and codeshares_icao:
+            codeshare_map = codeshare_map = dict(zip(codeshares_iata, codeshares_icao))
+
+            if query in codeshare_map:
+                return HttpUrl(LANDING_PAGE_URL.format(ident=codeshare_map.get(query)))
+
+    return HttpUrl(LANDING_PAGE_URL.format(ident=flight["ident_icao"]))
+
+
+def is_valid_flight_number_pattern(query: str) -> bool:
+    """Return true if flight number matches either of the two valid flight regex patterns"""
+    return bool(FLIGHT_NUM_PATTERN_1.match(query) or FLIGHT_NUM_PATTERN_2.match(query))

--- a/merino/providers/suggest/flightaware/provider.py
+++ b/merino/providers/suggest/flightaware/provider.py
@@ -1,9 +1,24 @@
 """FlightAware Integration"""
 
+import logging
 import aiodogstatsd
 from fastapi import HTTPException
-from merino.providers.suggest.base import BaseProvider, SuggestionRequest
-from merino.providers.suggest.flightaware.backends.protocol import FlightBackendProtocol
+from pydantic import HttpUrl
+from merino.providers.suggest.base import (
+    BaseProvider,
+    BaseSuggestion,
+    SuggestionRequest,
+)
+from merino.providers.suggest.custom_details import CustomDetails, FlightAwareDetails
+from merino.providers.suggest.flightaware.backends.protocol import (
+    FlightBackendProtocol,
+    FlightSummary,
+)
+from merino.providers.suggest.flightaware.backends.utils import (
+    is_valid_flight_number_pattern,
+)
+
+logger = logging.getLogger(__name__)
 
 
 class Provider(BaseProvider):
@@ -28,6 +43,7 @@ class Provider(BaseProvider):
         self._name = name
         self._query_timeout_sec = query_timeout_sec
         self._enabled_by_default = enabled_by_default
+        self.url = HttpUrl("https://merino.services.mozilla.com/")
         super().__init__()
 
     async def initialize(self) -> None:
@@ -42,6 +58,42 @@ class Provider(BaseProvider):
                 detail="Invalid query parameters: `q` is missing",
             )
 
-    async def query(self, request: SuggestionRequest):
+    def normalize_query(self, query: str) -> str:
+        """Remove trailing spaces from query and transform to uppercase"""
+        return query.strip().upper()
+
+    async def query(self, request: SuggestionRequest) -> list[BaseSuggestion]:
         """Retrieve flight suggestions"""
-        return []
+        try:
+            temp_cache = set(
+                ["3U1001", "AC701", "AA100", "UA3711", "AC432"]
+            )  # to be replaced with in-memory cache
+
+            if not is_valid_flight_number_pattern(request.query):
+                return []
+            else:
+                query = request.query.replace(" ", "")
+
+                if query in temp_cache:
+                    result = await self.backend.fetch_flight_details(query)
+
+                    if result:
+                        flight_summaries: list[FlightSummary] = self.backend.get_flight_summaries(
+                            result, query
+                        )
+                        return [self.build_suggestion(flight_summaries)]
+            return []
+        except Exception as e:
+            logger.warning(f"Exception occurred for FlightAware provider: {e}")
+            return []
+
+    def build_suggestion(self, relevant_flights: list[FlightSummary]) -> BaseSuggestion:
+        """Build a base suggestion with custom flight details"""
+        return BaseSuggestion(
+            title="Flight Suggestion",
+            url=HttpUrl(self.url),
+            provider=self.name,
+            is_sponsored=False,
+            score=self.score,
+            custom_details=CustomDetails(flightaware=FlightAwareDetails(values=relevant_flights)),
+        )

--- a/merino/providers/suggest/manager.py
+++ b/merino/providers/suggest/manager.py
@@ -19,22 +19,32 @@ from merino.providers.suggest.amo.backends.dynamic import DynamicAmoBackend
 from merino.providers.suggest.amo.backends.static import StaticAmoBackend
 from merino.providers.suggest.amo.provider import Provider as AmoProvider
 from merino.providers.suggest.base import BaseProvider
-from merino.providers.suggest.geolocation.provider import Provider as GeolocationProvider
+from merino.providers.suggest.geolocation.provider import (
+    Provider as GeolocationProvider,
+)
 from merino.providers.suggest.top_picks.backends.top_picks import TopPicksBackend
 from merino.providers.suggest.top_picks.provider import Provider as TopPicksProvider
 from merino.providers.suggest.weather.backends.accuweather import AccuweatherBackend
 from merino.providers.suggest.weather.backends.fake_backends import FakeWeatherBackend
 from merino.providers.suggest.weather.provider import Provider as WeatherProvider
 from merino.providers.suggest.wikipedia.backends.elastic import ElasticBackend
-from merino.providers.suggest.wikipedia.backends.fake_backends import FakeWikipediaBackend
+from merino.providers.suggest.wikipedia.backends.fake_backends import (
+    FakeWikipediaBackend,
+)
 from merino.providers.suggest.wikipedia.provider import Provider as WikipediaProvider
 from merino.providers.suggest.finance.provider import Provider as PolygonProvider
 from merino.providers.suggest.yelp.provider import Provider as YelpProvider
-from merino.providers.suggest.flightaware.provider import Provider as FlightAwareProvider
+from merino.providers.suggest.flightaware.provider import (
+    Provider as FlightAwareProvider,
+)
 from merino.providers.suggest.flightaware.backends.flightaware import FlightAwareBackend
 from merino.providers.suggest.yelp.backends.yelp import YelpBackend
-from merino.providers.suggest.google_suggest.provider import Provider as GoogleSuggestProvider
-from merino.providers.suggest.google_suggest.backends.google_suggest import GoogleSuggestBackend
+from merino.providers.suggest.google_suggest.provider import (
+    Provider as GoogleSuggestProvider,
+)
+from merino.providers.suggest.google_suggest.backends.google_suggest import (
+    GoogleSuggestBackend,
+)
 from merino.utils.blocklists import TOP_PICKS_BLOCKLIST, WIKIPEDIA_TITLE_BLOCKLIST
 from merino.utils.http_client import create_http_client
 from merino.utils.icon_processor import IconProcessor
@@ -272,6 +282,8 @@ def _create_provider(provider_id: str, setting: Settings) -> BaseProvider:
             return FlightAwareProvider(
                 backend=FlightAwareBackend(
                     api_key=settings.flightaware.api_key,
+                    http_client=create_http_client(base_url=settings.flightaware.base_url),
+                    ident_url=settings.flightaware.ident_url_path,
                 ),
                 metrics_client=get_metrics_client(),
                 score=setting.score,

--- a/tests/unit/providers/suggest/flightaware/__init__.py
+++ b/tests/unit/providers/suggest/flightaware/__init__.py
@@ -1,0 +1,5 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Modules dedicated to unit testing the flightaware provider."""

--- a/tests/unit/providers/suggest/flightaware/backend/__init__.py
+++ b/tests/unit/providers/suggest/flightaware/backend/__init__.py
@@ -1,0 +1,5 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Modules dedicated to unit testing the flightaware backends."""

--- a/tests/unit/providers/suggest/flightaware/backend/test_flightaware.py
+++ b/tests/unit/providers/suggest/flightaware/backend/test_flightaware.py
@@ -1,0 +1,166 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Unit tests for the flightaware backend module."""
+
+from pydantic import HttpUrl
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from httpx import HTTPStatusError, Request, Response
+
+import merino.providers.suggest.flightaware.backends.flightaware as flightaware
+
+from merino.providers.suggest.flightaware.backends.protocol import (
+    AirportDetails,
+    FlightScheduleSegment,
+    FlightSummary,
+)
+from merino.providers.suggest.flightaware.backends.flightaware import FlightAwareBackend
+from merino.configs import settings
+
+
+def make_summary(flight_number: str) -> FlightSummary:
+    """Construct a minimal valid FlightSummary."""
+    return FlightSummary(
+        flight_number=flight_number,
+        destination=AirportDetails(code="EWR", city="Newark"),
+        origin=AirportDetails(code="SFO", city="San Francisco"),
+        departure=FlightScheduleSegment(
+            scheduled_time="2025-09-29T12:00:00Z", estimated_time="2025-09-29T12:05:00Z"
+        ),
+        arrival=FlightScheduleSegment(
+            scheduled_time="2025-09-29T16:00:00Z", estimated_time="2025-09-29T16:05:00Z"
+        ),
+        status="En Route",
+        progress_percent=50,
+        url=HttpUrl(f"https://www.flightaware.com/live/flight/{flight_number}"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_flight_details_success():
+    """Ensure fetch_flight_details returns parsed JSON when the API responds successfully."""
+    mock_http_client = AsyncMock()
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"flights": [{"ident": "UA123"}]}
+    mock_response.raise_for_status.return_value = None
+    mock_http_client.get.return_value = mock_response
+
+    backend = flightaware.FlightAwareBackend(
+        api_key=settings.flightaware.api_key,
+        http_client=mock_http_client,
+        ident_url="flights/{ident}?start={start}&end={end}",
+    )
+
+    result = await backend.fetch_flight_details("UA123")
+
+    assert result == {"flights": [{"ident": "UA123"}]}
+    mock_http_client.get.assert_called_once()
+
+    called_url = mock_http_client.get.call_args[0][0]
+    assert called_url.startswith("flights/UA123?start=")
+
+
+@pytest.mark.asyncio
+async def test_fetch_flight_details_http_error_logs_and_returns_none(caplog):
+    """Ensure fetch_flight_details logs a warning and returns None when HTTPStatusError is raised."""
+    mock_http_client = AsyncMock()
+    mock_response = MagicMock()
+    request = Request("GET", "http://test")
+    mock_response.raise_for_status.side_effect = HTTPStatusError(
+        "Bad Request",
+        request=request,
+        response=Response(400, request=request),
+    )
+    mock_http_client.get.return_value = mock_response
+
+    backend = flightaware.FlightAwareBackend(
+        api_key=settings.flightaware.api_key,
+        http_client=mock_http_client,
+        ident_url="flights/{ident}?start={start}&end={end}",
+    )
+
+    result = await backend.fetch_flight_details("UA123")
+
+    assert result is None
+    assert "Flightware request error for flight details" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_fetch_flight_details_uses_correct_headers():
+    """Verify fetch_flight_details sends the required API key and Accept headers."""
+    mock_http_client = AsyncMock()
+    mock_response = AsyncMock()
+    mock_response.json.return_value = {"flights": []}
+    mock_response.raise_for_status.return_value = None
+    mock_http_client.get.return_value = mock_response
+
+    backend = flightaware.FlightAwareBackend(
+        api_key=settings.flightaware.api_key,
+        http_client=mock_http_client,
+        ident_url="flights/{ident}?start={start}&end={end}",
+    )
+
+    await backend.fetch_flight_details("UA123")
+
+    _, kwargs = mock_http_client.get.call_args
+    headers = kwargs["headers"]
+    assert headers["x-apikey"] == settings.flightaware.api_key
+    assert headers["Accept"] == "application/json"
+
+
+def test_get_flight_summaries_returns_empty_list_when_response_is_none():
+    """Ensure get_flight_summaries returns empty list if flight_response is None."""
+    backend = FlightAwareBackend(api_key="k", http_client=MagicMock(), ident_url="url")
+    result = backend.get_flight_summaries(None, "UA123")
+    assert result == []
+
+
+def test_get_flight_summaries_returns_empty_list_when_no_flights():
+    """Ensure get_flight_summaries returns empty list if 'flights' is empty."""
+    backend = FlightAwareBackend(api_key="k", http_client=MagicMock(), ident_url="url")
+    result = backend.get_flight_summaries({"flights": []}, "UA123")
+    assert result == []
+
+
+def test_get_flight_summaries_filters_out_none_summaries():
+    """Ensure get_flight_summaries excludes flights where build_flight_summary returns None."""
+    backend = FlightAwareBackend(api_key="k", http_client=MagicMock(), ident_url="url")
+    flights = [{"id": "good"}, {"id": "bad"}]
+
+    summary = make_summary("UA123")
+
+    with patch(
+        "merino.providers.suggest.flightaware.backends.flightaware.build_flight_summary"
+    ) as mock_build:
+        mock_build.side_effect = [
+            summary,
+            None,
+        ]
+        result = backend.get_flight_summaries({"flights": flights}, "UA123")
+
+    assert len(result) == 1
+    assert isinstance(result[0], FlightSummary)
+    assert result[0].flight_number == "UA123"
+    assert result[0].origin.city == "San Francisco"
+    assert result[0].destination.code == "EWR"
+
+
+def test_get_flight_summaries_returns_multiple_valid_summaries():
+    """Ensure get_flight_summaries returns multiple summaries when build_flight_summary succeeds."""
+    backend = FlightAwareBackend(api_key="k", http_client=MagicMock(), ident_url="url")
+    flights = [{"id": "f1"}, {"id": "f2"}]
+
+    summary1 = make_summary("UA111")
+    summary2 = make_summary("UA222")
+
+    with patch(
+        "merino.providers.suggest.flightaware.backends.flightaware.build_flight_summary"
+    ) as mock_build:
+        mock_build.side_effect = [summary1, summary2]
+        result = backend.get_flight_summaries({"flights": flights}, "UA123")
+
+    assert len(result) == 2
+    assert all(isinstance(s, FlightSummary) for s in result)
+    assert {s.flight_number for s in result} == {"UA111", "UA222"}

--- a/tests/unit/providers/suggest/flightaware/backend/test_utils.py
+++ b/tests/unit/providers/suggest/flightaware/backend/test_utils.py
@@ -1,0 +1,544 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Unit tests for the Flightaware utils module."""
+
+import datetime
+from unittest.mock import patch
+from pydantic import HttpUrl
+import pytest
+
+from merino.providers.suggest.flightaware.backends.protocol import (
+    AirportDetails,
+    FlightScheduleSegment,
+    FlightStatus,
+    FlightSummary,
+)
+from merino.providers.suggest.flightaware.backends.utils import (
+    build_flight_summary,
+    get_live_url,
+    is_valid_flight_number_pattern,
+    is_within_two_hours,
+    minutes_from_now,
+    parse_timestamp,
+    pick_best_flights,
+)
+
+import merino.providers.suggest.flightaware.backends.utils as utils
+
+
+@pytest.mark.parametrize(
+    "ts, expected",
+    [
+        (
+            "2025-09-29T12:34:56Z",
+            datetime.datetime(2025, 9, 29, 12, 34, 56, tzinfo=datetime.timezone.utc),
+        ),
+        (
+            "2025-09-29T12:34:56+00:00",
+            datetime.datetime(2025, 9, 29, 12, 34, 56, tzinfo=datetime.timezone.utc),
+        ),
+        (None, None),
+        ("", None),
+        ("not-a-timestamp", None),
+    ],
+)
+def test_parse_timestamp(ts, expected):
+    """Ensure parse_timestamp correctly parses valid ISO-8601 UTC strings and returns None for invalid or empty input."""
+    assert parse_timestamp(ts) == expected
+
+
+@pytest.mark.parametrize(
+    "description, timestamp, now, expected",
+    [
+        (
+            "future timestamp 30 minutes later",
+            "2025-09-29T12:30:00Z",
+            datetime.datetime(2025, 9, 29, 12, 0, tzinfo=datetime.timezone.utc),
+            30.0,
+        ),
+        (
+            "past timestamp 30 minutes earlier",
+            "2025-09-29T11:30:00Z",
+            datetime.datetime(2025, 9, 29, 12, 0, tzinfo=datetime.timezone.utc),
+            30.0,
+        ),
+        (
+            "same timestamp as now",
+            "2025-09-29T12:00:00Z",
+            datetime.datetime(2025, 9, 29, 12, 0, tzinfo=datetime.timezone.utc),
+            0.0,
+        ),
+        (
+            "None input returns infinity",
+            None,
+            datetime.datetime(2025, 9, 29, 12, 0, tzinfo=datetime.timezone.utc),
+            float("inf"),
+        ),
+        (
+            "invalid string returns infinity",
+            "not-a-timestamp",
+            datetime.datetime(2025, 9, 29, 12, 0, tzinfo=datetime.timezone.utc),
+            float("inf"),
+        ),
+    ],
+)
+def test_minutes_from_now(description, timestamp, now, expected):
+    """Verify minutes_from_now returns the absolute difference in minutes, or infinity for None/invalid timestamps."""
+    result = minutes_from_now(timestamp, now)
+    assert result == expected, f"Failed: {description}"
+
+
+@pytest.mark.parametrize(
+    "description, timestamp, now, expected",
+    [
+        (
+            "timestamp exactly now",
+            "2025-09-29T12:00:00Z",
+            datetime.datetime(2025, 9, 29, 12, 0, tzinfo=datetime.timezone.utc),
+            True,
+        ),
+        (
+            "timestamp 1 hour in the future",
+            "2025-09-29T13:00:00Z",
+            datetime.datetime(2025, 9, 29, 12, 0, tzinfo=datetime.timezone.utc),
+            True,
+        ),
+        (
+            "timestamp 1 hour in the past",
+            "2025-09-29T11:00:00Z",
+            datetime.datetime(2025, 9, 29, 12, 0, tzinfo=datetime.timezone.utc),
+            True,
+        ),
+        (
+            "timestamp exactly 2 hours in the future",
+            "2025-09-29T14:00:00Z",
+            datetime.datetime(2025, 9, 29, 12, 0, tzinfo=datetime.timezone.utc),
+            True,
+        ),
+        (
+            "timestamp exactly 2 hours in the past",
+            "2025-09-29T10:00:00Z",
+            datetime.datetime(2025, 9, 29, 12, 0, tzinfo=datetime.timezone.utc),
+            True,
+        ),
+        (
+            "timestamp just over 2 hours in the future",
+            "2025-09-29T14:01:00Z",
+            datetime.datetime(2025, 9, 29, 12, 0, tzinfo=datetime.timezone.utc),
+            False,
+        ),
+        (
+            "timestamp just over 2 hours in the past",
+            "2025-09-29T09:59:00Z",
+            datetime.datetime(2025, 9, 29, 12, 0, tzinfo=datetime.timezone.utc),
+            False,
+        ),
+        (
+            "None input",
+            None,
+            datetime.datetime(2025, 9, 29, 12, 0, tzinfo=datetime.timezone.utc),
+            False,
+        ),
+        (
+            "invalid timestamp string",
+            "not-a-timestamp",
+            datetime.datetime(2025, 9, 29, 12, 0, tzinfo=datetime.timezone.utc),
+            False,
+        ),
+    ],
+)
+def test_is_within_two_hours(description, timestamp, now, expected):
+    """Check that is_within_two_hours correctly detects timestamps within 2 hours of now."""
+    result = is_within_two_hours(timestamp, now)
+    assert result == expected, f"Failed: {description}"
+
+
+def test_build_flight_summary_valid():
+    """Confirm build_flight_summary returns a valid FlightSummary for a complete flight dict."""
+    flight = {
+        "ident_iata": "UA123",
+        "ident_icao": "UAL123",
+        "codeshares_iata": [],
+        "codeshares": [],
+        "destination": {"code_iata": "EWR", "city": "Newark"},
+        "origin": {"code_iata": "SFO", "city": "San Francisco"},
+        "scheduled_out": "2025-09-29T12:00:00Z",
+        "estimated_out": "2025-09-29T12:05:00Z",
+        "scheduled_in": "2025-09-29T16:00:00Z",
+        "estimated_in": "2025-09-29T16:05:00Z",
+        "status": "En Route",
+        "progress_percent": 50,
+    }
+
+    summary = build_flight_summary(flight, normalized_query="UA123")
+
+    assert isinstance(summary, FlightSummary)
+    assert summary.flight_number == "UA123"
+    assert summary.destination == AirportDetails(code="EWR", city="Newark")
+    assert summary.origin == AirportDetails(code="SFO", city="San Francisco")
+    assert summary.departure == FlightScheduleSegment(
+        scheduled_time="2025-09-29T12:00:00Z", estimated_time="2025-09-29T12:05:00Z"
+    )
+    assert summary.arrival == FlightScheduleSegment(
+        scheduled_time="2025-09-29T16:00:00Z", estimated_time="2025-09-29T16:05:00Z"
+    )
+    assert summary.status == "En Route"
+    assert summary.progress_percent == 50
+    assert summary.url == HttpUrl("https://www.flightaware.com/live/flight/UAL123")
+
+
+def test_build_flight_summary_with_codeshare():
+    """Confirm build_flight_summary resolves codeshare queries to the correct ICAO ident in the live URL."""
+    flight = {
+        "ident_iata": "UA123",
+        "ident_icao": "UAL123",
+        "codeshares_iata": ["AC9876"],
+        "codeshares": ["ACA9876"],
+        "destination": {"code_iata": "EWR", "city": "Newark"},
+        "origin": {"code_iata": "SFO", "city": "San Francisco"},
+        "scheduled_out": "2025-09-29T12:00:00Z",
+        "estimated_out": "2025-09-29T12:05:00Z",
+        "scheduled_in": "2025-09-29T16:00:00Z",
+        "estimated_in": "2025-09-29T16:05:00Z",
+        "status": "En Route",
+        "progress_percent": 50,
+    }
+
+    summary = build_flight_summary(flight, normalized_query="AC9876")
+
+    assert isinstance(summary, FlightSummary)
+    assert summary.url == HttpUrl("https://www.flightaware.com/live/flight/ACA9876")
+
+
+def test_build_flight_summary_missing_key_returns_none(caplog):
+    """Ensure build_flight_summary returns None and logs a warning when required fields are missing."""
+    flight = {
+        # missing destination
+        "origin": {"code_iata": "SFO", "city": "San Francisco"},
+        "codeshares_iata": [],
+        "codeshares": [],
+        "scheduled_out": "2025-09-29T12:00:00Z",
+        "estimated_out": "2025-09-29T12:05:00Z",
+        "scheduled_in": "2025-09-29T16:00:00Z",
+        "estimated_in": "2025-09-29T16:05:00Z",
+        "status": "Scheduled",
+        "progress_percent": 0,
+    }
+
+    result = build_flight_summary(flight, normalized_query="UA123")
+    assert result is None
+    assert "incorrect shape" in caplog.text
+
+
+def test_build_flight_summary_invalid_type_returns_none(caplog):
+    """Ensure build_flight_summary returns None and logs a warning when input is not a dict."""
+    flight = "not-a-dict"
+    result = build_flight_summary(flight, normalized_query="UA123")
+    assert result is None
+    assert "incorrect shape" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "description, query, flight, expected",
+    [
+        (
+            "query matches primary IATA ident - fall back to ICAO",
+            "UA123",
+            {
+                "ident_iata": "UA123",
+                "ident_icao": "UAL123",
+                "codeshares_iata": ["AC9876"],
+                "codeshares": ["ACA9876"],
+            },
+            HttpUrl("https://www.flightaware.com/live/flight/UAL123"),
+        ),
+        (
+            "query matches codeshare AC9876 - resolves to ACA9876",
+            "AC9876",
+            {
+                "ident_iata": "UA123",
+                "ident_icao": "UAL123",
+                "codeshares_iata": ["AC9876", "LH4321"],
+                "codeshares": ["ACA9876", "DLH4321"],
+            },
+            HttpUrl("https://www.flightaware.com/live/flight/ACA9876"),
+        ),
+        (
+            "query matches codeshare LH4321 - resolves to DLH4321",
+            "LH4321",
+            {
+                "ident_iata": "UA123",
+                "ident_icao": "UAL123",
+                "codeshares_iata": ["AC9876", "LH4321"],
+                "codeshares": ["ACA9876", "DLH4321"],
+            },
+            HttpUrl("https://www.flightaware.com/live/flight/DLH4321"),
+        ),
+        (
+            "query not in codeshares - fall back to ICAO",
+            "SOMEOTHER",
+            {
+                "ident_iata": "UA123",
+                "ident_icao": "UAL123",
+                "codeshares_iata": ["AC9876"],
+                "codeshares": ["ACA9876"],
+            },
+            HttpUrl("https://www.flightaware.com/live/flight/UAL123"),
+        ),
+        (
+            "empty codeshares - should fall back to ICAO",
+            "AC9876",
+            {
+                "ident_iata": "UA123",
+                "ident_icao": "UAL123",
+                "codeshares_iata": [],
+                "codeshares": [],
+            },
+            HttpUrl("https://www.flightaware.com/live/flight/UAL123"),
+        ),
+    ],
+)
+def test_get_live_url(description, query, flight, expected):
+    """Verify get_live_url builds the correct FlightAware URL."""
+    result: HttpUrl = get_live_url(query, flight)
+    assert result == expected, f"Failed: {description}"
+
+
+@pytest.fixture
+def fixed_now():
+    """Provide a fixed UTC datetime (2025-09-29T12:00:00Z) for testing."""
+    return datetime.datetime(2025, 9, 29, 12, 0, tzinfo=datetime.timezone.utc)
+
+
+def test_pick_best_flight_en_route_always_top():
+    """Check that en route flights are always prioritized to the top regardless of other flights."""
+    flights = [
+        {"id": "scheduled", "scheduled_out": "2025-09-29T12:30:00Z"},
+        {"id": "enroute"},
+    ]
+
+    def fake_status(flight):
+        return FlightStatus.EN_ROUTE if flight["id"] == "enroute" else FlightStatus.SCHEDULED
+
+    with patch.object(utils, "derive_flight_status", side_effect=fake_status):
+        results = pick_best_flights(flights, limit=2)
+
+    assert results[0]["id"] == "enroute"
+
+
+def test_pick_best_flight_scheduled_sorted_by_proximity(fixed_now):
+    """Ensure scheduled flights are ordered by proximity to now, with nearer flights first."""
+    flights = [
+        {"id": "later", "scheduled_out": "2025-09-29T13:00:00Z"},
+        {"id": "sooner", "scheduled_out": "2025-09-29T12:15:00Z"},
+    ]
+
+    with (
+        patch.object(utils, "derive_flight_status", return_value=FlightStatus.SCHEDULED),
+        patch.object(utils.datetime, "datetime", wraps=datetime.datetime) as mock_datetime,
+    ):
+        mock_datetime.now.return_value = fixed_now
+
+        results = pick_best_flights(flights, limit=2)
+
+    assert [f["id"] for f in results] == ["sooner", "later"]
+
+
+def test_pick_best_flight_arrived_included_if_within_two_hours(fixed_now):
+    """Confirm arrived flights within the past 2 hours are included in results."""
+    flights = [
+        {"id": "arrived", "actual_on": "2025-09-29T11:30:00Z"},
+    ]
+
+    with (
+        patch.object(utils, "derive_flight_status", return_value=FlightStatus.ARRIVED),
+        patch.object(utils.datetime, "datetime", wraps=datetime.datetime) as mock_datetime,
+    ):
+        mock_datetime.now.return_value = fixed_now
+
+        results = pick_best_flights(flights, limit=1)
+
+    assert results[0]["id"] == "arrived"
+    assert "_distance_minutes" in results[0]
+
+
+def test_pick_best_flight_cancelled_included_if_within_two_hours(fixed_now):
+    """Confirm cancelled flights scheduled within the past 2 hours are included in results."""
+    flights = [
+        {"id": "cancelled", "scheduled_out": "2025-09-29T11:30:00Z"},
+    ]
+
+    with (
+        patch.object(utils, "derive_flight_status", return_value=FlightStatus.CANCELLED),
+        patch.object(utils.datetime, "datetime", wraps=datetime.datetime) as mock_datetime,
+    ):
+        mock_datetime.now.return_value = fixed_now
+
+        results = pick_best_flights(flights, limit=1)
+
+    assert results[0]["id"] == "cancelled"
+    assert "_distance_minutes" in results[0]
+
+
+def test_pick_best_flight_arrived_prioritized_over_scheduled_if_closer_to_now(
+    fixed_now,
+):
+    """Validate that an arrived flight closer to now is prioritized ahead of a scheduled flight further away."""
+    flights = [
+        # Scheduled 90 minutes from now
+        {"id": "scheduled", "scheduled_out": "2025-09-29T13:30:00Z"},
+        # Arrived 30 minutes ago
+        {"id": "arrived", "actual_on": "2025-09-29T11:30:00Z"},
+    ]
+
+    def fake_status(f):
+        if f["id"] == "scheduled":
+            return FlightStatus.SCHEDULED
+        if f["id"] == "arrived":
+            return FlightStatus.ARRIVED
+
+    with (
+        patch.object(utils, "derive_flight_status", side_effect=fake_status),
+        patch.object(utils.datetime, "datetime", wraps=datetime.datetime) as mock_datetime,
+    ):
+        mock_datetime.now.return_value = fixed_now
+        results = pick_best_flights(flights, limit=2)
+
+    # Expect arrived (closer to now) before scheduled
+    assert [f["id"] for f in results] == ["arrived", "scheduled"]
+
+
+def test_pick_best_flights_mixed_statuses_prioritized(fixed_now):
+    """Check that flights are prioritized in order: En Route > Scheduled > Arrived > Cancelled."""
+    flights = [
+        # En Route should always win
+        {"id": "enroute"},
+        # Scheduled flight 30m from now
+        {"id": "scheduled", "scheduled_out": "2025-09-29T12:30:00Z"},
+        # Arrived flight 30m ago (within 2h, but after scheduled)
+        {"id": "arrived", "actual_on": "2025-09-29T11:30:00Z"},
+        # Cancelled flight 1h ago (within 2h, but lowest priority)
+        {"id": "cancelled", "scheduled_out": "2025-09-29T11:00:00Z"},
+    ]
+
+    def fake_status(f):
+        if f["id"] == "enroute":
+            return FlightStatus.EN_ROUTE
+        if f["id"] == "scheduled":
+            return FlightStatus.SCHEDULED
+        if f["id"] == "arrived":
+            return FlightStatus.ARRIVED
+        if f["id"] == "cancelled":
+            return FlightStatus.CANCELLED
+
+    with (
+        patch.object(utils, "derive_flight_status", side_effect=fake_status),
+        patch.object(utils.datetime, "datetime", wraps=datetime.datetime) as mock_datetime,
+    ):
+        mock_datetime.now.return_value = fixed_now
+        results = pick_best_flights(flights, limit=4)
+
+    assert [f["id"] for f in results] == [
+        "enroute",
+        "scheduled",
+        "arrived",
+        "cancelled",
+    ]
+
+
+def test_pick_best_flight_limit_respected(fixed_now):
+    """Ensure the pick_best_flights function respects the limit and only returns up to N flights."""
+    flights = [
+        {"id": "f1", "scheduled_out": "2025-09-29T12:00:00Z"},
+        {"id": "f2", "scheduled_out": "2025-09-29T12:05:00Z"},
+        {"id": "f3", "scheduled_out": "2025-09-29T12:10:00Z"},
+    ]
+
+    with (
+        patch.object(utils, "derive_flight_status", return_value=FlightStatus.SCHEDULED),
+        patch.object(utils.datetime, "datetime", wraps=datetime.datetime) as mock_datetime,
+    ):
+        mock_datetime.now.return_value = fixed_now
+
+        results = pick_best_flights(flights, limit=2)
+
+    assert len(results) == 2
+
+
+def test_multiple_arrived_only_most_recent_kept(fixed_now):
+    """Ensure that only the most recent ARRIVED flight (closest to now) is returned."""
+    flights = [
+        {"id": "arrived1", "actual_on": "2025-09-29T11:00:00Z"},  # 1h ago
+        {"id": "arrived2", "actual_on": "2025-09-29T11:30:00Z"},  # 30m ago (closer)
+    ]
+
+    def fake_status(f):
+        return FlightStatus.ARRIVED
+
+    with (
+        patch.object(utils, "derive_flight_status", side_effect=fake_status),
+        patch.object(utils.datetime, "datetime", wraps=datetime.datetime) as mock_dt,
+    ):
+        mock_dt.now.return_value = fixed_now
+        results = utils.pick_best_flights(flights, limit=3)
+
+    # Only one ARRIVED flight should be present, and it should be the closer one
+    arrived_ids = [f["id"] for f in results if fake_status(f) == FlightStatus.ARRIVED]
+    assert arrived_ids == ["arrived2"]
+
+
+def test_multiple_cancelled_only_most_recent_kept(fixed_now):
+    """Ensure that only the most recent CANCELLED flight (closest to now) is returned."""
+    flights = [
+        {"id": "cancelled1", "scheduled_out": "2025-09-29T11:00:00Z"},  # 1h ago
+        {
+            "id": "cancelled2",
+            "scheduled_out": "2025-09-29T11:30:00Z",
+        },  # 30m ago (closer)
+    ]
+
+    def fake_status(f):
+        return FlightStatus.CANCELLED
+
+    with (
+        patch.object(utils, "derive_flight_status", side_effect=fake_status),
+        patch.object(utils.datetime, "datetime", wraps=datetime.datetime) as mock_dt,
+    ):
+        mock_dt.now.return_value = fixed_now
+        results = utils.pick_best_flights(flights, limit=3)
+
+    # Only one CANCELLED flight should be present, and it should be the closer one
+    cancelled_ids = [f["id"] for f in results if fake_status(f) == FlightStatus.CANCELLED]
+    assert cancelled_ids == ["cancelled2"]
+
+
+@pytest.mark.parametrize(
+    "description, query, expected",
+    [
+        # valid flight numbers
+        ("2-letter code + 3-digit number", "UA123", True),
+        ("3-letter code + 3-digit number", "ACA432", True),
+        ("2-letter lowercase + 3-digit", "ua123", True),
+        ("2-letter + space + 3-digit", "UA 123", True),
+        ("2-letter + multiple spaces + 3-digit", "UA    123", True),
+        ("2-char alphanumeric (3U) + 4-digit", "3U1001", True),
+        ("2-char alphanumeric + space + 4-digit", "3U 1001", True),
+        ("mixed case + spacing", "aC 701", True),
+        ("single letter code", "A3101", True),
+        # invalid flight numbers
+        ("only digits", "123", False),
+        ("too many letters", "UAAZ123", False),
+        ("too many digits", "UA123456", False),
+        ("symbols in code", "UA!123", False),
+        ("empty string", "", False),
+        ("only code, no number", "UA", False),
+        ("only number, no code", "1234", False),
+        ("space only", "   ", False),
+    ],
+)
+def test_is_valid_flight_number_pattern(description, query, expected):
+    """Test the is_valid_flight_number_pattern function against a range of inputs."""
+    result = is_valid_flight_number_pattern(query)
+    assert result == expected, f"Failed: {description} (input: '{query}')"

--- a/tests/unit/providers/suggest/flightaware/test_provider.py
+++ b/tests/unit/providers/suggest/flightaware/test_provider.py
@@ -1,0 +1,165 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Unit tests for the flightaware provider module."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+import aiodogstatsd
+from fastapi import HTTPException
+from pydantic import HttpUrl
+
+from merino.middleware.geolocation import Location
+from merino.providers.suggest.flightaware.provider import Provider
+from merino.providers.suggest.base import BaseSuggestion, SuggestionRequest
+from merino.providers.suggest.custom_details import CustomDetails, FlightAwareDetails
+from merino.providers.suggest.flightaware.backends.protocol import FlightSummary
+
+
+@pytest.fixture
+def backend_mock():
+    """Return mock flight aware backend"""
+    backend = MagicMock()
+    backend.fetch_flight_details = AsyncMock()
+    backend.get_flight_summaries = MagicMock()
+    return backend
+
+
+@pytest.fixture(name="geolocation")
+def fixture_geolocation() -> Location:
+    """Return a test Location."""
+    return Location(
+        country="CA",
+        regions=["ON"],
+        city="Toronto",
+        dma=613,
+        postal_code="M5G2B6",
+    )
+
+
+@pytest.fixture
+def provider(backend_mock):
+    """Return a mock provider"""
+    return Provider(
+        backend=backend_mock,
+        name="flightaware",
+        metrics_client=MagicMock(spec=aiodogstatsd.Client),
+        query_timeout_sec=1.0,
+        score=0.8,
+    )
+
+
+def test_validate_rejects_missing_query(provider, geolocation):
+    """Validate should raise if query is missing."""
+    req = SuggestionRequest(query="", geolocation=geolocation)
+    with pytest.raises(HTTPException) as exc:
+        provider.validate(req)
+    assert exc.value.status_code == 400
+    assert "Invalid query parameters" in exc.value.detail
+
+
+def test_validate_accepts_valid_query(provider, geolocation):
+    """Validate should pass if query is present."""
+    req = SuggestionRequest(query="UA123", geolocation=geolocation)
+    provider.validate(req)
+
+
+def test_normalize_query_strips_and_uppercases(provider):
+    """Normalize_query should strip spaces and uppercase."""
+    assert provider.normalize_query(" ua123 ") == "UA123"
+
+
+@pytest.mark.asyncio
+async def test_query_returns_empty_if_query_does_not_match_pattern(provider, geolocation):
+    """Query should return empty list if query doesn't match flight number regex."""
+    request = SuggestionRequest(query="notaflight", geolocation=geolocation)
+    results = await provider.query(request)
+    assert results == []
+
+
+# TODO update to gcs cache solution
+@pytest.mark.asyncio
+async def test_query_returns_empty_if_not_in_temp_cache(provider, geolocation):
+    """Query should return empty list if query matches pattern but not in cache."""
+    request = SuggestionRequest(
+        query="LH9999", geolocation=geolocation
+    )  # matches pattern but not in temp_cache
+    results = await provider.query(request)
+    assert results == []
+
+
+# TODO update to gcs cache solution
+@pytest.mark.asyncio
+async def test_query_fetches_and_builds_suggestion(provider, backend_mock, geolocation):
+    """Query should call backend and return a built suggestion if query is valid and cached."""
+    request = SuggestionRequest(query="UA3711", geolocation=geolocation)  # in temp_cache
+    backend_mock.fetch_flight_details.return_value = {"flights": [{"ident": "UA3711"}]}
+
+    fake_summary = FlightSummary(
+        flight_number="UA3711",
+        destination={"code": "EWR", "city": "Newark"},
+        origin={"code": "SFO", "city": "San Francisco"},
+        departure={
+            "scheduled_time": "2025-09-29T12:00:00Z",
+            "estimated_time": "2025-09-29T12:05:00Z",
+        },
+        arrival={
+            "scheduled_time": "2025-09-29T16:00:00Z",
+            "estimated_time": "2025-09-29T16:05:00Z",
+        },
+        status="En Route",
+        progress_percent=50,
+        url="https://www.flightaware.com/live/flight/UA3711",
+    )
+    backend_mock.get_flight_summaries.return_value = [fake_summary]
+
+    results = await provider.query(request)
+
+    assert len(results) == 1
+    suggestion = results[0]
+    assert isinstance(suggestion, BaseSuggestion)
+    assert suggestion.title == "Flight Suggestion"
+    assert suggestion.provider == "flightaware"
+    assert suggestion.custom_details.flightaware.values[0].flight_number == "UA3711"
+
+
+@pytest.mark.asyncio
+async def test_query_handles_backend_exception(provider, backend_mock, caplog, geolocation):
+    """Query should catch exceptions and return empty list if backend fails."""
+    request = SuggestionRequest(query="UA3711", geolocation=geolocation)
+    backend_mock.fetch_flight_details.side_effect = Exception("boom")
+
+    results = await provider.query(request)
+
+    assert results == []
+    assert "Exception occurred for FlightAware provider" in caplog.text
+
+
+def test_build_suggestion_creates_expected_object(provider):
+    """Build_suggestion should wrap flight summaries into BaseSuggestion with FlightAwareDetails."""
+    summary = FlightSummary(
+        flight_number="AA100",
+        destination={"code": "JFK", "city": "New York"},
+        origin={"code": "LAX", "city": "Los Angeles"},
+        departure={
+            "scheduled_time": "2025-09-29T12:00:00Z",
+            "estimated_time": "2025-09-29T12:05:00Z",
+        },
+        arrival={
+            "scheduled_time": "2025-09-29T16:00:00Z",
+            "estimated_time": "2025-09-29T16:05:00Z",
+        },
+        status="Scheduled",
+        progress_percent=None,
+        url="https://www.flightaware.com/live/flight/AA100",
+    )
+    suggestion = provider.build_suggestion([summary])
+
+    assert isinstance(suggestion, BaseSuggestion)
+    assert suggestion.title == "Flight Suggestion"
+    assert suggestion.url == HttpUrl("https://merino.services.mozilla.com/")
+    assert isinstance(suggestion.custom_details, CustomDetails)
+    assert isinstance(suggestion.custom_details.flightaware, FlightAwareDetails)
+    assert suggestion.custom_details.flightaware.values[0].flight_number == "AA100"


### PR DESCRIPTION
## References

JIRA: [DISCO-3733](https://mozilla-hub.atlassian.net/browse/DISCO-3733)

## Description
This PR implements the logic for querying aeroAPI to return flight suggestions through merino's suggest endpoint.

#### What’s included

* **Fetch live flight info from AeroAPI**:
  * Regex-based query validation to match valid flight numbers.
  * Queries are checked against a temp hardcoded cache of flight numbers before calling AeroAPI. We are using this temp cache until [DISCO-3716](https://mozilla-hub.atlassian.net/browse/DISCO-3716) is completed. That work is currently blocked, pending Data-Eng’s help to configure the Flightaware secret in Airflow.

* **Partial response fields**:
  * Certain fields (e.g. `status`) are commented out for now. The work of calculating flight status based on timestamps (`scheduled_out`, `actual_off`, etc.) will be implemented in [DISCO-3736](https://mozilla-hub.atlassian.net/browse/DISCO-3736).

* **Prioritization logic for flight selection**:
  * Added a method to prioritize which flights to display based on their status and proximity to “now.”
  * This logic is currently commented out, as the product team is still finalizing the exact prioritization rules.


#### How to QA
1. Enable the provider:
   * Remove `"flightaware"` from the `disabled_providers` list in `default.toml`.
2. Configure the API key:
   * Replace the `"api_key"` field in `default.toml` with a real FlightAware API key.
3. Find a flight:
   * Use Google to look up flights scheduled to depart within the next 20 hours.
   * Add your chosen flight number to the `temp_cache` in the provider.
4. Call the endpoint:
   * Hit the Merino suggest endpoint with the flight code as the query and `"flightaware"` as the provider.
5. Verify behavior:
   * The query method should only respond to valid flight queries that exist in the temp cache and match a valid flight code pattern


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3733]: https://mozilla-hub.atlassian.net/browse/DISCO-3733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1886)


[DISCO-3716]: https://mozilla-hub.atlassian.net/browse/DISCO-3716?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DISCO-3736]: https://mozilla-hub.atlassian.net/browse/DISCO-3736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ