### PR TITLE
HNT-1065: curated-recs: Popular Today is 1 row for contextual ads experiment

### DIFF
--- a/merino/curated_recommendations/protocol.py
+++ b/merino/curated_recommendations/protocol.py
@@ -86,6 +86,8 @@ class ExperimentName(str, Enum):
     ML_SECTIONS_EXPERIMENT = "new-tab-ml-sections"
     # Experiment to compare RSS vs. Zyte content sources for legacy topic sections
     RSS_VS_ZYTE_EXPERIMENT = "new-ranking-for-legacy-topics-in-new-tab-v1"
+    # Experiment to apply 1 row layout for Popular Today for contextual ads
+    CONTEXTUAL_AD_EXPERIMENT = "new-tab-ad-updates-nightly"
 
 
 @unique

--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -232,6 +232,13 @@ def adjust_ads_in_sections(sections: dict[str, Section]) -> None:
                 tile.hasAd = False
 
 
+def is_contextual_ads_experiment(request: CuratedRecommendationsRequest) -> bool:
+    """Return True if the Contextual Ads experiment is enabled."""
+    return is_enrolled_in_experiment(
+        request, ExperimentName.CONTEXTUAL_AD_EXPERIMENT.value, "treatment"
+    )
+
+
 def is_subtopics_experiment(request: CuratedRecommendationsRequest) -> bool:
     """Return True if subtopics should be included based on experiments.
 
@@ -562,6 +569,8 @@ async def get_sections(
     # Use 2-row layout as default for Popular Today
     top_stories_count = DOUBLE_ROW_TOP_STORIES_COUNT
     popular_today_layout = layout_7_tiles_2_ads
+    if is_contextual_ads_experiment(request):
+        popular_today_layout = layout_4_large
 
     top_stories = get_top_story_list(
         all_ranked_corpus_recommendations, top_stories_count, TOP_STORIES_SECTION_EXTRA_COUNT

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -1362,6 +1362,10 @@ class TestSections:
                 "experimentName": ExperimentName.ML_SECTIONS_EXPERIMENT.value,
                 "experimentBranch": "control",
             },
+            {
+                "experimentName": ExperimentName.CONTEXTUAL_AD_EXPERIMENT.value,
+                "experimentBranch": "treatment",
+            },
         ],
     )
     def test_sections_layouts(self, sections_payload, experiment_payload, client: TestClient):
@@ -1386,7 +1390,13 @@ class TestSections:
 
         # Assert layout of the first section (Popular Today).
         assert first_section["title"] == "Popular Today"
-        assert first_section["layout"]["name"] == "7-double-row-2-ad"
+        if (
+            experiment_payload.get("experimentName")
+            != ExperimentName.CONTEXTUAL_AD_EXPERIMENT.value
+        ):
+            assert first_section["layout"]["name"] == "7-double-row-2-ad"
+        else:
+            assert first_section["layout"]["name"] == "4-large-small-medium-1-ad"
 
         # Assert layouts are cycled
         assert_section_layouts_are_cycled(sections)


### PR DESCRIPTION
## References

JIRA: https://mozilla-hub.atlassian.net/browse/HNT-1065

## Description
Assign the `4-large-small-medium-1-ad` layout to Popular Today if contextual ads (`new-tab-ad-updates-nightly`) is enabled for treatment branch.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
