### PR TITLE
[DISCO-3716] Fix bug and persist flight number set

### DIFF
--- a/merino/jobs/flightaware/__init__.py
+++ b/merino/jobs/flightaware/__init__.py
@@ -23,15 +23,22 @@ def fetch_and_store():
     logger.info("Starting flight schedules pipeline...")
 
     base_url = settings.flightaware.base_url
+    flight_number_set = set()
+    api_call_count = 0
 
     try:
         with httpx.Client(base_url=base_url) as client:
             flight_number_set, api_call_count = fetch_schedules.fetch_schedules(client)
 
-            asyncio.run(fetch_schedules.store_flight_numbers(flight_number_set))
-            logger.info(
-                f"Successfully fetched {len(flight_number_set)} flights with {api_call_count} API calls"
-            )
-
     except Exception as ex:
         logger.error(f"Failed to fetch schedules: {ex.__class__.__name__}", exc_info=True)
+
+    finally:
+        # Always try to persist whatever we have
+        if flight_number_set:
+            logger.info(f"Persisting {len(flight_number_set)} flight numbers (even if partial)")
+            asyncio.run(fetch_schedules.store_flight_numbers(flight_number_set))
+
+    logger.info(
+        f"Fetch finished with {len(flight_number_set)} flights after {api_call_count} API calls"
+    )

--- a/merino/jobs/flightaware/fetch_schedules.py
+++ b/merino/jobs/flightaware/fetch_schedules.py
@@ -11,7 +11,12 @@ from merino.cache.redis import RedisAdapter, create_redis_clients
 from merino.configs import settings
 from merino.exceptions import CacheAdapterError
 from merino.utils.gcs.gcs_uploader import GcsUploader
-from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_exception_type
+from tenacity import (
+    retry,
+    stop_after_attempt,
+    wait_exponential,
+    retry_if_exception_type,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -77,8 +82,8 @@ def fetch_schedules(client: httpx.Client) -> tuple[set[str], int]:
 
             process_flight_numbers(flight_number_set, scheduled_flights)
 
-            url = data.get("links", {}).get("next", None)
-            page += 1
+            links = data.get("links") or {}
+            url = links.get("next", None)
 
         except httpx.HTTPStatusError as ex:
             logger.error(

--- a/tests/unit/jobs/flightaware/test_fetch_schedules.py
+++ b/tests/unit/jobs/flightaware/test_fetch_schedules.py
@@ -94,3 +94,23 @@ async def test_store_flight_numbers_in_gcs_merges_existing():
 
     uploaded = json.loads(mock_uploader.upload_content.call_args[1]["content"])
     assert sorted(uploaded) == ["AA123", "UA456"]
+
+
+def test_fetch_schedules_handles_links_null(caplog):
+    """Ensure fetch_schedules handles a response with 'links': null without crashing."""
+    caplog.set_level("INFO")
+
+    mock_client = MagicMock()
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "scheduled": [{"ident_iata": "AA123"}],
+        "links": None,
+    }
+    mock_response.raise_for_status.return_value = None
+
+    with patch.object(fetch_schedules, "_get_with_retry", return_value=mock_response):
+        flights, calls = fetch_schedules.fetch_schedules(mock_client)
+
+    assert flights == {"AA123"}
+    assert calls == 1
+    assert "Page 1: 1 flights" in caplog.text


### PR DESCRIPTION
## References

JIRA: [DISCO-3716](https://mozilla-hub.atlassian.net/browse/DISCO-3716)

## Description
I just did a test run of the `fetch_schedules` job for flight numbers in Airflow. The good news is, it was able to fetch about 60k flight numbers. Bad news is, when it got to the last page, we hit an error and lost all that good data.

This PR fixes a bug in the  job where responses containing `"links": null` caused an `AttributeError` and aborted the task before flight numbers were persisted. It also ensures that partially collected flight numbers are always stored, even if the job encounters unexpected responses.

### What happened
- The code used data.get("links", {}).get("next", None) to follow pagination.
- When FlightAware returned `"links": null, data.get("links", {})` evaluated to `None` (because the key existed but was explicitly `null`), and calling `.get()` on `None` raised an exception.
- This happened after thousands of flights were already collected, but because the job crashed, none of them were stored in GCS.

### Fix
- Updated the job to safely handle the case where `links` is `None`
- Wrapped the CLI entrypoint with a finally block so that `store_flight_numbers(...)` is called even if the fetch loop fails, guaranteeing persistence of whatever flight numbers were collected.
- Added unit and integration tests.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
