### PR TITLE
[DISCO-3691] Add caching for ticker snapshots

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -636,12 +636,12 @@ backend = "polygon"
 # MERINO_PROVIDERS__POLYGON__CACHE
 # The store used to finance data. Either `redis` or `none`.
 # If `redis`, the global Redis settings must be set. See redis.server.
-cache = "redis"
+cache = "none"
 
 # MERINO_PROVIDERS__POLYGON__CACHE_DB
 # The db within the redis instance that the clients should connect to.
 # Default is `0`. See redis.py.
-cache_db = 1
+cache_db = 0
 
 # MERINO_PROVIDERS__POLYGON__ENABLED_BY_DEFAULT
 # Whether this provider is enabled by default.

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -636,7 +636,12 @@ backend = "polygon"
 # MERINO_PROVIDERS__POLYGON__CACHE
 # The store used to finance data. Either `redis` or `none`.
 # If `redis`, the global Redis settings must be set. See redis.server.
-cache = "none"
+cache = "redis"
+
+# MERINO_PROVIDERS__POLYGON__CACHE_DB
+# The db within the redis instance that the clients should connect to.
+# Default is `0`. See redis.py.
+cache_db = 1
 
 # MERINO_PROVIDERS__POLYGON__ENABLED_BY_DEFAULT
 # Whether this provider is enabled by default.
@@ -676,13 +681,10 @@ circuit_breaker_failure_threshold = 10
 circuit_breaker_recover_timeout_sec = 30
 
 [default.providers.polygon.cache_ttls]
-# Cache TTLs for finance data.
+# Cache TTLs for Polygon ticker snapshots.
 
-# MERINO_PROVIDERS__POLYGON__CACHE_TTLS__STOCK_TICKER_TTL_SEC
-stock_ticker_ttl_sec = 900 # 15 minutes
-
-# MERINO_PROVIDERS__POLYGON__CACHE_TTLS__INDEX_TICKER_TTL_SEC
-index_ticker_ttl_sec = 900 # 15 minutes
+# MERINO_PROVIDERS__POLYGON__CACHE_TTLS__TICKER_TTL_SEC
+ticker_ttl_sec = 300 # 5 minutes
 
 [default.polygon]
 # MERINO_POLYGON__API_KEY

--- a/merino/configs/production.toml
+++ b/merino/configs/production.toml
@@ -47,3 +47,9 @@ bucket_name = "merino-airflow-data-prodpy"
 # MERINO__CURATED_RECOMMENDATIONS__GCS__GCP_PROJECT
 # GCP project name where the GCS bucket lives.
 gcp_project = "moz-fx-merino-prod-1c2f"
+
+[production.providers.polygon]
+# MERINO_PROVIDERS__POLYGON__CACHE
+# The store used to finance data. Either `redis` or `none`.
+# If `redis`, the global Redis settings must be set. See redis.server.
+cache = "redis"

--- a/merino/configs/testing.toml
+++ b/merino/configs/testing.toml
@@ -64,6 +64,7 @@ url_base = "http://test-polygon"
 [testing.providers.polygon]
 enabled_by_default = false
 backend="polygon"
+# cache = "none"
 
 [testing.providers.yelp]
 enabled_by_default = false

--- a/merino/configs/testing.toml
+++ b/merino/configs/testing.toml
@@ -64,7 +64,6 @@ url_base = "http://test-polygon"
 [testing.providers.polygon]
 enabled_by_default = false
 backend="polygon"
-# cache = "none"
 
 [testing.providers.yelp]
 enabled_by_default = false

--- a/merino/jobs/polygon/polygon_ingestion.py
+++ b/merino/jobs/polygon/polygon_ingestion.py
@@ -1,5 +1,6 @@
 """Downloads and uploads ticker images for polygon"""
 
+from merino.cache.none import NoCacheAdapter
 from merino.providers.suggest.finance.backends.polygon.backend import PolygonBackend
 from merino.providers.suggest.finance.backends.protocol import FinanceBackend
 from merino.providers.suggest.finance.provider import Provider
@@ -33,11 +34,13 @@ class PolygonIngestion:
                 url_param_api_key=settings.polygon.url_param_api_key,
                 url_single_ticker_snapshot=settings.polygon.url_single_ticker_snapshot,
                 url_single_ticker_overview=settings.polygon.url_single_ticker_overview,
+                ticker_ttl_sec=setting.ticker_ttl_sec,
                 gcs_uploader=GcsUploader(
                     settings.image_gcs.gcs_project,
                     settings.image_gcs.gcs_bucket,
                     settings.image_gcs.cdn_hostname,
                 ),
+                cache=NoCacheAdapter(),
             ),
             metrics_client=get_metrics_client(),
             score=setting.score,

--- a/merino/jobs/polygon/polygon_ingestion.py
+++ b/merino/jobs/polygon/polygon_ingestion.py
@@ -34,7 +34,7 @@ class PolygonIngestion:
                 url_param_api_key=settings.polygon.url_param_api_key,
                 url_single_ticker_snapshot=settings.polygon.url_single_ticker_snapshot,
                 url_single_ticker_overview=settings.polygon.url_single_ticker_overview,
-                ticker_ttl_sec=setting.ticker_ttl_sec,
+                ticker_ttl_sec=settings.providers.polygon.cache_ttls.ticker_ttl_sec,
                 gcs_uploader=GcsUploader(
                     settings.image_gcs.gcs_project,
                     settings.image_gcs.gcs_bucket,

--- a/merino/providers/suggest/finance/backends/polygon/utils.py
+++ b/merino/providers/suggest/finance/backends/polygon/utils.py
@@ -3,6 +3,7 @@
 import logging
 import re
 from typing import Any
+import hashlib
 
 from pydantic import HttpUrl
 from merino.providers.suggest.finance.backends.protocol import TickerSnapshot, TickerSummary
@@ -140,3 +141,12 @@ def build_ticker_summary(snapshot: TickerSnapshot, image_url: HttpUrl | None) ->
         image_url=image_url,
         exchange=exchange,
     )
+
+
+def generate_cache_key_for_ticker(ticker: str) -> str:
+    """Generate cache key for a ticker."""
+    hasher = hashlib.blake2s()
+    hasher.update(ticker.upper().encode("utf-8"))
+    ticker_hash = hasher.hexdigest()
+
+    return f"PolygonBackend:v1:ticker_snapshot:{ticker_hash}"

--- a/merino/providers/suggest/manager.py
+++ b/merino/providers/suggest/manager.py
@@ -191,6 +191,20 @@ def _create_provider(provider_id: str, setting: Settings) -> BaseProvider:
                 enabled_by_default=setting.enabled_by_default,
             )
         case ProviderType.POLYGON:
+            cache = (
+                RedisAdapter(
+                    *create_redis_clients(
+                        settings.redis.server,
+                        settings.redis.replica,
+                        settings.redis.max_connections,
+                        settings.redis.socket_connect_timeout_sec,
+                        settings.redis.socket_timeout_sec,
+                        settings.providers.polygon.cache_db,
+                    )
+                )
+                if setting.cache == "redis"
+                else NoCacheAdapter()
+            )
             return PolygonProvider(
                 backend=PolygonBackend(
                     api_key=settings.polygon.api_key,
@@ -208,6 +222,8 @@ def _create_provider(provider_id: str, setting: Settings) -> BaseProvider:
                         settings.image_gcs.gcs_bucket,
                         settings.image_gcs.cdn_hostname,
                     ),
+                    ticker_ttl_sec=settings.providers.polygon.cache_ttls.ticker_ttl_sec,
+                    cache=cache,
                 ),
                 metrics_client=get_metrics_client(),
                 score=setting.score,

--- a/tests/integration/providers/suggest/finance/backends/test_polygon.py
+++ b/tests/integration/providers/suggest/finance/backends/test_polygon.py
@@ -1,0 +1,152 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Integration tests for the Polygon backend module."""
+
+import logging
+from typing import Any, AsyncGenerator
+from merino.configs import settings
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from pytest_mock import MockerFixture
+from redis.asyncio import Redis
+from testcontainers.core.waiting_utils import wait_for_logs
+from testcontainers.redis import AsyncRedisContainer
+
+from merino.cache.redis import RedisAdapter
+
+from merino.providers.suggest.finance.backends.protocol import TickerSnapshot
+from merino.providers.suggest.finance.backends.polygon import PolygonBackend
+
+logger = logging.getLogger(__name__)
+
+URL_SINGLE_TICKER_SNAPSHOT = settings.polygon.url_single_ticker_snapshot
+URL_SINGLE_TICKER_OVERVIEW = settings.polygon.url_single_ticker_overview
+TICKER_TTL_SEC = settings.providers.polygon.cache_ttls.ticker_ttl_sec
+
+
+@pytest.fixture(scope="module")
+def redis_container() -> AsyncRedisContainer:
+    """Create and return a docker container for Redis. Tear it down after all the tests have
+    finished running
+    """
+    logger.info("Starting up redis container")
+    container = AsyncRedisContainer().start()
+
+    # wait for the container to start and emit logs
+    delay = wait_for_logs(container, "Server initialized")
+    logger.info(f"\n Redis server started with delay: {delay} seconds on port: {container.port}")
+
+    yield container
+
+    container.stop()
+    logger.info("\n Redis container stopped")
+
+
+@pytest_asyncio.fixture(name="redis_client")
+async def fixture_redis_client(
+    redis_container: AsyncRedisContainer,
+) -> AsyncGenerator[Redis, None]:
+    """Create and return a Redis client"""
+    client = await redis_container.get_async_client()
+
+    yield client
+
+    await client.flushall()
+
+
+@pytest.fixture(name="polygon_parameters")
+def fixture_polygon_parameters(
+    mocker: MockerFixture, statsd_mock: Any, redis_client: Redis
+) -> dict[str, Any]:
+    """Create constructor parameters for Polygon backend module."""
+    return {
+        "api_key": "api_key",
+        "metrics_client": statsd_mock,
+        "http_client": mocker.AsyncMock(spec=AsyncClient),
+        "metrics_sample_rate": 1,
+        "url_param_api_key": "apiKey",
+        "url_single_ticker_snapshot": URL_SINGLE_TICKER_SNAPSHOT,
+        "url_single_ticker_overview": URL_SINGLE_TICKER_OVERVIEW,
+        "gcs_uploader": mocker.MagicMock(),
+        "cache": RedisAdapter(redis_client),
+        "ticker_ttl_sec": TICKER_TTL_SEC,
+    }
+
+
+@pytest.fixture(name="polygon")
+def fixture_polygon(
+    polygon_parameters: dict[str, Any],
+    mocker: MockerFixture,
+) -> PolygonBackend:
+    """Create a Polygon backend module object."""
+    mock_filemanager = mocker.MagicMock()
+    mocker.patch(
+        "merino.providers.suggest.finance.backends.polygon.backend.PolygonFilemanager",
+        return_value=mock_filemanager,
+    )
+    return PolygonBackend(**polygon_parameters)
+
+
+@pytest.fixture(name="ticker_snapshot_AAPL")
+def fixture_ticker_snapshot_AAPL() -> TickerSnapshot:
+    """Create a ticker snapshot object for AAPL."""
+    # these values are based on the above single_ticker_snapshot_response fixture.
+    return TickerSnapshot(
+        ticker="AAPL",
+        last_trade_price="120.47",
+        todays_change_percent="0.82",
+    )
+
+
+@pytest.fixture(name="ticker_snapshot_NFLX")
+def fixture_ticker_snapshot_NFLX() -> TickerSnapshot:
+    """Create a ticker snapshot object for AAPL."""
+    # these values are based on the above single_ticker_snapshot_response fixture.
+    return TickerSnapshot(
+        ticker="NFLX",
+        last_trade_price="555.01",
+        todays_change_percent="1.82",
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_snapshots_from_cache_success(
+    polygon: PolygonBackend, ticker_snapshot_AAPL: TickerSnapshot, ticker_snapshot_NFLX
+) -> None:
+    """Test that get_snapshots_from_cache method successfully returns the correct snapshots with TTLs."""
+    expected = [(ticker_snapshot_AAPL, TICKER_TTL_SEC), (ticker_snapshot_NFLX, TICKER_TTL_SEC)]
+
+    # write to cache
+    await polygon.store_snapshots_in_cache([ticker_snapshot_AAPL, ticker_snapshot_NFLX])
+
+    # call backend method
+    actual = await polygon.get_snapshots_from_cache(["AAPL", "NFLX"])
+
+    assert actual is not None
+    assert actual == expected
+
+    assert actual[0] == expected[0]
+    assert actual[1] == expected[1]
+
+
+@pytest.mark.asyncio
+async def test_get_snapshots_from_cache_returns_empty_list(
+    polygon: PolygonBackend, ticker_snapshot_AAPL: TickerSnapshot, ticker_snapshot_NFLX
+) -> None:
+    """Test that get_snapshots_from_cache method returns an empty list for keys not found."""
+    # write to cache
+    await polygon.store_snapshots_in_cache([ticker_snapshot_AAPL, ticker_snapshot_NFLX])
+
+    # call backend method with non-existent keys
+    actual = await polygon.get_snapshots_from_cache(["TSLA", "QQQ"])
+
+    assert actual is not None
+    assert actual == []
+
+
+# TODO add test for cache adapter error
+# TODO add test for validation error

--- a/tests/integration/providers/suggest/finance/backends/test_polygon.py
+++ b/tests/integration/providers/suggest/finance/backends/test_polygon.py
@@ -169,9 +169,6 @@ async def test_get_snapshots_from_cache_raises_cache_error(
     redis_error_mock = mocker.patch.object(polygon.cache, "run_script", new_callable=AsyncMock)
     redis_error_mock.side_effect = CacheAdapterError("test cache error")
 
-    # write to cache
-    await polygon.store_snapshots_in_cache([ticker_snapshot_AAPL])
-
     # get from cache
     actual = await polygon.get_snapshots_from_cache(["AAPL"])
 

--- a/tests/unit/providers/suggest/finance/backends/test_polygon.py
+++ b/tests/unit/providers/suggest/finance/backends/test_polygon.py
@@ -30,6 +30,7 @@ from merino.providers.suggest.finance.backends.protocol import (
 
 URL_SINGLE_TICKER_SNAPSHOT = settings.polygon.url_single_ticker_snapshot
 URL_SINGLE_TICKER_OVERVIEW = settings.polygon.url_single_ticker_overview
+TICKER_TTL_SEC = settings.providers.polygon.cache_ttls.ticker_ttl_sec
 
 
 @pytest.fixture(name="mock_gcs_uploader")
@@ -67,6 +68,8 @@ def fixture_polygon_parameters(
         "url_single_ticker_snapshot": URL_SINGLE_TICKER_SNAPSHOT,
         "url_single_ticker_overview": URL_SINGLE_TICKER_OVERVIEW,
         "gcs_uploader": mock_gcs_uploader,
+        "cache": mocker.MagicMock(),
+        "ticker_ttl_sec": TICKER_TTL_SEC,
     }
 
 


### PR DESCRIPTION
## References

JIRA: [DISCO-3691](https://mozilla-hub.atlassian.net/browse/DISCO-3691)

## Description
**This PR adds the initial cache setup to support ticker snapshots in Redis. Included changes:**
- Added a Redis Lua script for bulk fetching ticker snapshots with their TTLs.
- Implemented cache key generation helper for ticker symbols.
- Added method to write snapshots into the cache with TTL.
- Added method to get snapshots with TTL and parse results back from cache.
- Added initial integration testcontainers tests for redis caching

**Notes:**
- The request-handling logic is not yet hooked up to the cache.
- Added TODOs in the code for error handling, metrics, and improved TTL warming strategy.

**Next steps:**
- Wire the cache logic into the main request flow.
- Address the TODOs for retries, metrics, and TTL handling.
- Expand integration tests to cover more cache scenarios.

## PR Review Checklist
- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)

[DISCO-3691]: https://mozilla-hub.atlassian.net/browse/DISCO-3691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ