### PR TITLE
[DISCO-3736] Calculate flight status and prioritization

### DIFF
--- a/merino/providers/suggest/flightaware/backends/protocol.py
+++ b/merino/providers/suggest/flightaware/backends/protocol.py
@@ -14,14 +14,21 @@ class AirportDetails(BaseModel):
     city: str
 
 
+class AirlineDetails(BaseModel):
+    """Details of the operating airline for a flight"""
+
+    code: str | None = None
+    name: str | None = None
+    icon: HttpUrl | None = None
+
+
 class FlightScheduleSegment(BaseModel):
     """Scheduled date and time details for a flight segment (e.g., departure or arrival)."""
 
     scheduled_time: datetime
-    estimated_time: datetime
+    estimated_time: datetime | None
 
 
-# TODO these will be properly deducted in DISCO-3736
 class FlightStatus(StrEnum):
     """Status of a specific flight instance"""
 
@@ -30,6 +37,7 @@ class FlightStatus(StrEnum):
     ARRIVED = "Arrived"
     CANCELLED = "Cancelled"
     DELAYED = "Delayed"
+    UNKNOWN = "Unknown"
 
 
 class FlightSummary(BaseModel):
@@ -40,12 +48,12 @@ class FlightSummary(BaseModel):
     origin: AirportDetails
     departure: FlightScheduleSegment
     arrival: FlightScheduleSegment
-    status: str  # TODO string for now, will replace with enum in DISCO-3736
-    progress_percent: int | None
-    # TODO these will be properly deducted in DISCO-3736
-    # delayed_until: datetime | None
-    # time_left_minutes: int | None
+    status: FlightStatus
+    progress_percent: int = 0
+    time_left_minutes: int | None = None
+    delayed: bool
     url: HttpUrl
+    airline: AirlineDetails
 
 
 class FlightBackendProtocol(Protocol):
@@ -56,7 +64,7 @@ class FlightBackendProtocol(Protocol):
     directly depend on.
     """
 
-    def get_flight_summaries(self, flight_response: Any, query: str) -> list[FlightSummary]:
+    def get_flight_summaries(self, flight_response: dict, query: str) -> list[FlightSummary]:
         """Return a prioritized list of summaries of a flight instance."""
         ...
 

--- a/merino/providers/suggest/flightaware/backends/utils.py
+++ b/merino/providers/suggest/flightaware/backends/utils.py
@@ -3,10 +3,10 @@
 import datetime
 import logging
 import re
-from typing import Any
 
 from pydantic import HttpUrl
 from merino.providers.suggest.flightaware.backends.protocol import (
+    AirlineDetails,
     AirportDetails,
     FlightScheduleSegment,
     FlightStatus,
@@ -25,10 +25,44 @@ FLIGHT_NUM_PATTERN_2 = re.compile(
 )  # matches 1 digit, 1 letter, followed by 1-4 digits e.g '3U 1001'
 
 
-# TODO this will be implemented in DISCO-3736
 def derive_flight_status(flight: dict) -> FlightStatus:
-    """Determine a flight's operational status from its timestamp fields."""
-    return FlightStatus.EN_ROUTE  # hardcoded for now
+    """Derive a stable, backend-calculated flight status from AeroAPI fields.
+
+    This method determines a flight's operational status using a combination
+    of lifecycle timestamps and delay information, instead of relying on
+    AeroAPI's free-form status string. The mapping is:
+
+    - CANCELLED  : Flight is explicitly marked as cancelled by the AeroAPI flag.
+    - EN_ROUTE   : Flight has an actual departure time (`actual_out`) but
+                   no recorded arrival time (`actual_on`).
+    - ARRIVED    : Flight has an arrival timestamp (`actual_on` or `actual_in`).
+    - DELAYED    : Flight has not departed (`actual_out` is None) and
+                   `departure_delay` is greater than 15 minutes.
+    - SCHEDULED  : Flight has not departed (`actual out` is None and `scheduled_out` is set) and either
+                   - `departure_delay` is None, or
+                   - `departure_delay` is 15 minutes or less (on time or early).
+    - UNKNOWN    : Any case not covered by the above.
+    """
+    actual_out = flight.get("actual_out")
+    actual_on = flight.get("actual_on")
+    actual_in = flight.get("actual_in")
+    scheduled_out = flight.get("scheduled_out")
+    estimated_out = flight.get("estimated_out")
+
+    if flight.get("cancelled"):
+        return FlightStatus.CANCELLED
+
+    elif actual_out and not actual_on and not actual_in:
+        return FlightStatus.EN_ROUTE
+    elif actual_on or actual_in:
+        return FlightStatus.ARRIVED
+
+    elif actual_out is None:
+        if is_delayed(flight):
+            return FlightStatus.DELAYED
+        elif scheduled_out or estimated_out:
+            return FlightStatus.SCHEDULED
+    return FlightStatus.UNKNOWN
 
 
 def parse_timestamp(timestamp: str | None) -> datetime.datetime | None:
@@ -47,22 +81,23 @@ def minutes_from_now(timestamp: str | None, now: datetime.datetime) -> float:
     return abs((dt - now).total_seconds()) / 60 if dt else float("inf")
 
 
-def is_within_two_hours(timestamp: str | None, now: datetime.datetime) -> bool:
-    """Return True if the timestamp is within 2 hours of now."""
+def is_within_one_hour(timestamp: str | None, now: datetime.datetime) -> bool:
+    """Return True if the timestamp is within 1 hour of now."""
     dt = parse_timestamp(timestamp)
-    return abs(now - dt) <= datetime.timedelta(hours=2) if dt else False
+    return abs(now - dt) <= datetime.timedelta(hours=1) if dt else False
 
 
-def pick_best_flights(flights: list[dict], limit: int = 3) -> list[dict]:
+def pick_best_flights(flights: list[dict], limit: int = 2) -> list[dict]:
     """Select up to `limit` flight instances based on status and proximity to now.
 
     Flights from these statuses are included:
     - En Route - all eligible, top priority
     - Scheduled/Delayed - all eligible, sorted by proximity
-    - Arrived - only the most recent (within 2h)
-    - Cancelled - only the most recent (within 2h)
+    - Arrived - only the most recent (within 1h)
+    - Cancelled - only the most recent (within 1h)
 
     All candidates are sorted by their time distance from now and top-N are returned.
+    Flights with unknown statuses are skipped.
     """
     now = datetime.datetime.now(datetime.timezone.utc)
 
@@ -81,6 +116,7 @@ def pick_best_flights(flights: list[dict], limit: int = 3) -> list[dict]:
 
     for flight in flights:
         status: FlightStatus = derive_flight_status(flight)
+        flight["_status"] = status
 
         if status == FlightStatus.EN_ROUTE:
             # Force it to the top by assigning small negative distance
@@ -95,15 +131,17 @@ def pick_best_flights(flights: list[dict], limit: int = 3) -> list[dict]:
 
         elif status == FlightStatus.ARRIVED:
             timestamp = flight.get("actual_on") or flight.get("actual_in")
-            if timestamp and is_within_two_hours(timestamp, now):
+            if timestamp and is_within_one_hour(timestamp, now):
                 flight["_distance_minutes"] = minutes_from_now(timestamp, now)
                 arrived_candidates.append(flight)
 
         elif status == FlightStatus.CANCELLED:
             timestamp = flight.get("scheduled_out")
-            if timestamp and is_within_two_hours(timestamp, now):
+            if timestamp and is_within_one_hour(timestamp, now):
                 flight["_distance_minutes"] = minutes_from_now(timestamp, now)
                 cancelled_candidates.append(flight)
+        else:
+            continue
 
     if arrived_candidates:
         closest_arrived = min(arrived_candidates, key=lambda f: f["_distance_minutes"])
@@ -114,14 +152,12 @@ def pick_best_flights(flights: list[dict], limit: int = 3) -> list[dict]:
         candidates.append(closest_cancelled)
 
     # Sort by distance to now
-    candidates.sort(
-        key=lambda f: (f["_distance_minutes"], priority_order[derive_flight_status(f)])
-    )
+    candidates.sort(key=lambda f: (f["_distance_minutes"], priority_order[f["_status"]]))
 
     return candidates[:limit]
 
 
-def build_flight_summary(flight: Any, normalized_query: str) -> FlightSummary | None:
+def build_flight_summary(flight: dict, normalized_query: str) -> FlightSummary | None:
     """Build and return a flight summary from the flight response"""
     try:
         flight_number = normalized_query
@@ -148,14 +184,15 @@ def build_flight_summary(flight: Any, normalized_query: str) -> FlightSummary | 
             scheduled_time=scheduled_arrival, estimated_time=estimated_arrival
         )
 
-        status = flight["status"]  # TODO would change to use derive_flight_status in DISCO-3736
-        progress_percent = flight["progress_percent"]
+        # would be none for now until we can retrieve these details
+        airline = AirlineDetails(code=None, name=None, icon=None)
+
+        status = derive_flight_status(flight)
+        progress_percent = flight.get("progress_percent") or 0
+        delayed = is_delayed(flight)
 
         url = get_live_url(normalized_query, flight)
-
-        # TODO
-        # delayed_until = ""
-        # time_left_minutes =
+        time_left_minutes = calculate_time_left(flight)
 
         return FlightSummary(
             flight_number=flight_number,
@@ -164,16 +201,22 @@ def build_flight_summary(flight: Any, normalized_query: str) -> FlightSummary | 
             departure=departure,
             arrival=arrival,
             status=status,
+            airline=airline,
+            delayed=delayed,
             progress_percent=progress_percent,
+            time_left_minutes=time_left_minutes,
             url=url,
         )
 
     except (KeyError, IndexError, TypeError):
         logger.warning(f"Flightaware response json has incorrect shape: {flight}")
         return None
+    except Exception as e:
+        logger.warning(f"Unexpected error parsing flightaware response: {e}")
+        return None
 
 
-def get_live_url(query: str, flight: Any) -> HttpUrl:
+def get_live_url(query: str, flight: dict) -> HttpUrl:
     """Return the FlightAware live tracking URL for the queried flight.
 
     If the query does not match the primary IATA ident of the flight (i.e., it's a codeshare),
@@ -181,9 +224,9 @@ def get_live_url(query: str, flight: Any) -> HttpUrl:
     If a matching codeshare is found, the corresponding ident is used to construct the URL.
     Otherwise, the primary ICAO ident for the flight is used.
     """
-    if query != flight["ident_iata"]:
-        codeshares_iata = flight["codeshares_iata"]
-        codeshares_icao = flight["codeshares"]
+    if query != flight.get("ident_iata"):
+        codeshares_iata = flight.get("codeshares_iata")
+        codeshares_icao = flight.get("codeshares")
 
         if codeshares_iata and codeshares_icao:
             codeshare_map = codeshare_map = dict(zip(codeshares_iata, codeshares_icao))
@@ -197,3 +240,49 @@ def get_live_url(query: str, flight: Any) -> HttpUrl:
 def is_valid_flight_number_pattern(query: str) -> bool:
     """Return true if flight number matches either of the two valid flight regex patterns"""
     return bool(FLIGHT_NUM_PATTERN_1.match(query) or FLIGHT_NUM_PATTERN_2.match(query))
+
+
+def calculate_time_left(flight: dict) -> int | None:
+    """Calculate how much time (in minutes) is left until a flight arrives.
+
+    - Returns 0 if the flight has already arrived (`actual_on` or `actual_in`).
+    - Returns None if the flight has not departed (`actual_out` is None),
+      or if no arrival estimates are available.
+    - Otherwise, returns the number of minutes until arrival based on
+      `estimated_in` (preferred) or `scheduled_in` (fallback).
+    """
+    now = datetime.datetime.now(datetime.timezone.utc)
+    scheduled_in = flight.get("scheduled_in")
+    estimated_in = flight.get("estimated_in")
+
+    if flight.get("actual_in") or flight.get("actual_on"):
+        return 0
+
+    elif not flight.get("actual_out"):
+        return None
+
+    # use estimated arrival if available
+    elif estimated_in:
+        estimated_arrival = parse_timestamp(estimated_in)
+        if estimated_arrival:
+            minutes = max(int((estimated_arrival - now).total_seconds() // 60), 0)
+            return minutes if minutes >= 0 else None
+
+    # fallback to scheduled arrival
+    elif scheduled_in:
+        scheduled_arrival = parse_timestamp(scheduled_in)
+        if scheduled_arrival:
+            minutes = max(int((scheduled_arrival - now).total_seconds() // 60), 0)
+            return minutes if minutes >= 0 else None
+
+    return None
+
+
+def is_delayed(flight: dict) -> bool:
+    """Return True if a flight is delayed"""
+    departure_delay = flight.get("departure_delay")
+    if departure_delay is not None:
+        delay_minutes = departure_delay / 60.0
+        if delay_minutes > 15:
+            return True
+    return False

--- a/tests/unit/providers/suggest/flightaware/backend/test_flightaware.py
+++ b/tests/unit/providers/suggest/flightaware/backend/test_flightaware.py
@@ -4,16 +4,20 @@
 
 """Unit tests for the flightaware backend module."""
 
+import datetime
 from pydantic import HttpUrl
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 from httpx import HTTPStatusError, Request, Response
 
+from merino.providers.suggest.flightaware.backends import utils
 import merino.providers.suggest.flightaware.backends.flightaware as flightaware
 
 from merino.providers.suggest.flightaware.backends.protocol import (
+    AirlineDetails,
     AirportDetails,
     FlightScheduleSegment,
+    FlightStatus,
     FlightSummary,
 )
 from merino.providers.suggest.flightaware.backends.flightaware import FlightAwareBackend
@@ -33,9 +37,18 @@ def make_summary(flight_number: str) -> FlightSummary:
             scheduled_time="2025-09-29T16:00:00Z", estimated_time="2025-09-29T16:05:00Z"
         ),
         status="En Route",
+        delayed=False,
+        airline=AirlineDetails(code=None, name=None, icon=None),
+        time_left_minutes=60,
         progress_percent=50,
         url=HttpUrl(f"https://www.flightaware.com/live/flight/{flight_number}"),
     )
+
+
+@pytest.fixture
+def fixed_now():
+    """Provide a fixed UTC datetime (2025-09-29T12:00:00Z) for testing."""
+    return datetime.datetime(2025, 9, 29, 12, 0, tzinfo=datetime.timezone.utc)
 
 
 @pytest.mark.asyncio
@@ -127,40 +140,98 @@ def test_get_flight_summaries_returns_empty_list_when_no_flights():
 def test_get_flight_summaries_filters_out_none_summaries():
     """Ensure get_flight_summaries excludes flights where build_flight_summary returns None."""
     backend = FlightAwareBackend(api_key="k", http_client=MagicMock(), ident_url="url")
-    flights = [{"id": "good"}, {"id": "bad"}]
 
-    summary = make_summary("UA123")
+    good_flight = {
+        "ident_iata": "UA123",
+        "ident_icao": "UAL123",
+        "codeshares_iata": [],
+        "codeshares": [],
+        "destination": {"code_iata": "EWR", "city": "Newark"},
+        "origin": {"code_iata": "SFO", "city": "San Francisco"},
+        "scheduled_out": "2025-09-29T12:00:00Z",
+        "estimated_out": "2025-09-29T12:05:00Z",
+        "scheduled_in": "2025-09-29T16:00:00Z",
+        "estimated_in": "2025-09-29T16:05:00Z",
+        "status": "Scheduled",
+        "progress_percent": 0,
+    }
 
-    with patch(
-        "merino.providers.suggest.flightaware.backends.flightaware.build_flight_summary"
-    ) as mock_build:
-        mock_build.side_effect = [
-            summary,
-            None,
-        ]
-        result = backend.get_flight_summaries({"flights": flights}, "UA123")
+    bad_flight = {
+        "origin": {"code_iata": "SFO", "city": "San Francisco"},
+        "codeshares_iata": [],
+        "codeshares": [],
+        "scheduled_out": "2025-09-29T12:00:00Z",
+        "estimated_out": "2025-09-29T12:05:00Z",
+        "status": "Scheduled",
+        "progress_percent": 0,
+    }
+    flights = [good_flight, bad_flight]
+
+    result = backend.get_flight_summaries({"flights": flights}, "UA123")
 
     assert len(result) == 1
-    assert isinstance(result[0], FlightSummary)
-    assert result[0].flight_number == "UA123"
-    assert result[0].origin.city == "San Francisco"
-    assert result[0].destination.code == "EWR"
+    summary = result[0]
+    assert isinstance(summary, FlightSummary)
+    assert summary.flight_number == "UA123"
+    assert summary.origin.city == "San Francisco"
+    assert summary.destination.code == "EWR"
 
 
-def test_get_flight_summaries_returns_multiple_valid_summaries():
+def test_get_flight_summaries_returns_multiple_valid_summaries(fixed_now):
     """Ensure get_flight_summaries returns multiple summaries when build_flight_summary succeeds."""
     backend = FlightAwareBackend(api_key="k", http_client=MagicMock(), ident_url="url")
-    flights = [{"id": "f1"}, {"id": "f2"}]
 
-    summary1 = make_summary("UA111")
-    summary2 = make_summary("UA222")
+    flights = [
+        {
+            "ident_iata": "UA111",
+            "ident_icao": "UAL111",
+            "codeshares_iata": [],
+            "codeshares": [],
+            "destination": {"code_iata": "EWR", "city": "Newark"},
+            "origin": {"code_iata": "SFO", "city": "San Francisco"},
+            "scheduled_out": "2025-09-29T10:00:00Z",
+            "estimated_out": "2025-09-29T10:05:00Z",
+            "actual_out": "2025-09-29T10:05:00Z",
+            "actual_in": "2025-09-29T11:25:00Z",
+            "scheduled_in": "2025-09-29T10:00:00Z",
+            "estimated_in": "2025-09-29T10:05:00Z",
+            "status": "Arrived / At Gate",
+            "progress_percent": 0,
+        },
+        {
+            "ident_iata": "UA111",
+            "ident_icao": "UAL111",
+            "codeshares_iata": [],
+            "codeshares": [],
+            "destination": {"code_iata": "EWR", "city": "Newark"},
+            "origin": {"code_iata": "SFO", "city": "San Francisco"},
+            "scheduled_out": "2025-09-29T14:00:00Z",
+            "estimated_out": "2025-09-29T14:16:00Z",
+            "scheduled_in": "2025-09-29T18:00:00Z",
+            "estimated_in": "2025-09-29T18:20:00Z",
+            "status": "Scheduled / Not departed",
+            "departure_delay": 960,
+            "progress_percent": 0,
+        },
+    ]
 
-    with patch(
-        "merino.providers.suggest.flightaware.backends.flightaware.build_flight_summary"
-    ) as mock_build:
-        mock_build.side_effect = [summary1, summary2]
-        result = backend.get_flight_summaries({"flights": flights}, "UA123")
+    with (
+        patch.object(utils.datetime, "datetime", wraps=datetime.datetime) as mock_datetime,
+    ):
+        mock_datetime.now.return_value = fixed_now
 
-    assert len(result) == 2
-    assert all(isinstance(s, FlightSummary) for s in result)
-    assert {s.flight_number for s in result} == {"UA111", "UA222"}
+        results = backend.get_flight_summaries({"flights": flights}, "UA111")
+
+        assert len(results) == 2
+        assert all(isinstance(r, FlightSummary) for r in results)
+        summary_1 = results[0]
+        summary_2 = results[1]
+
+        assert summary_1.delayed is False
+        assert summary_2.delayed is True
+
+        assert summary_1.time_left_minutes == 0
+        assert summary_2.time_left_minutes is None
+
+        assert summary_1.status == FlightStatus.ARRIVED
+        assert summary_2.status == FlightStatus.DELAYED

--- a/tests/unit/providers/suggest/flightaware/backend/test_utils.py
+++ b/tests/unit/providers/suggest/flightaware/backend/test_utils.py
@@ -17,9 +17,11 @@ from merino.providers.suggest.flightaware.backends.protocol import (
 )
 from merino.providers.suggest.flightaware.backends.utils import (
     build_flight_summary,
+    calculate_time_left,
     get_live_url,
+    is_delayed,
     is_valid_flight_number_pattern,
-    is_within_two_hours,
+    is_within_one_hour,
     minutes_from_now,
     parse_timestamp,
     pick_best_flights,
@@ -100,38 +102,26 @@ def test_minutes_from_now(description, timestamp, now, expected):
             True,
         ),
         (
-            "timestamp 1 hour in the future",
+            "timestamp exactly 1 hour in the future",
             "2025-09-29T13:00:00Z",
             datetime.datetime(2025, 9, 29, 12, 0, tzinfo=datetime.timezone.utc),
             True,
         ),
         (
-            "timestamp 1 hour in the past",
+            "timestamp exactly 1 hour in the past",
             "2025-09-29T11:00:00Z",
             datetime.datetime(2025, 9, 29, 12, 0, tzinfo=datetime.timezone.utc),
             True,
         ),
         (
-            "timestamp exactly 2 hours in the future",
-            "2025-09-29T14:00:00Z",
-            datetime.datetime(2025, 9, 29, 12, 0, tzinfo=datetime.timezone.utc),
-            True,
-        ),
-        (
-            "timestamp exactly 2 hours in the past",
-            "2025-09-29T10:00:00Z",
-            datetime.datetime(2025, 9, 29, 12, 0, tzinfo=datetime.timezone.utc),
-            True,
-        ),
-        (
-            "timestamp just over 2 hours in the future",
-            "2025-09-29T14:01:00Z",
+            "timestamp just over 1 hour in the future",
+            "2025-09-29T13:01:00Z",
             datetime.datetime(2025, 9, 29, 12, 0, tzinfo=datetime.timezone.utc),
             False,
         ),
         (
-            "timestamp just over 2 hours in the past",
-            "2025-09-29T09:59:00Z",
+            "timestamp just over 1 hour in the past",
+            "2025-09-29T10:59:00Z",
             datetime.datetime(2025, 9, 29, 12, 0, tzinfo=datetime.timezone.utc),
             False,
         ),
@@ -149,9 +139,9 @@ def test_minutes_from_now(description, timestamp, now, expected):
         ),
     ],
 )
-def test_is_within_two_hours(description, timestamp, now, expected):
-    """Check that is_within_two_hours correctly detects timestamps within 2 hours of now."""
-    result = is_within_two_hours(timestamp, now)
+def test_is_within_one_hour(description, timestamp, now, expected):
+    """Check that is_within_one_hour correctly detects timestamps within 2 hours of now."""
+    result = is_within_one_hour(timestamp, now)
     assert result == expected, f"Failed: {description}"
 
 
@@ -168,6 +158,7 @@ def test_build_flight_summary_valid():
         "estimated_out": "2025-09-29T12:05:00Z",
         "scheduled_in": "2025-09-29T16:00:00Z",
         "estimated_in": "2025-09-29T16:05:00Z",
+        "actual_out": "2025-09-29T12:00:00Z",
         "status": "En Route",
         "progress_percent": 50,
     }
@@ -346,8 +337,8 @@ def test_pick_best_flight_scheduled_sorted_by_proximity(fixed_now):
     assert [f["id"] for f in results] == ["sooner", "later"]
 
 
-def test_pick_best_flight_arrived_included_if_within_two_hours(fixed_now):
-    """Confirm arrived flights within the past 2 hours are included in results."""
+def test_pick_best_flight_arrived_included_if_within_one_hour(fixed_now):
+    """Confirm arrived flights within the past 1 hours are included in results."""
     flights = [
         {"id": "arrived", "actual_on": "2025-09-29T11:30:00Z"},
     ]
@@ -364,8 +355,8 @@ def test_pick_best_flight_arrived_included_if_within_two_hours(fixed_now):
     assert "_distance_minutes" in results[0]
 
 
-def test_pick_best_flight_cancelled_included_if_within_two_hours(fixed_now):
-    """Confirm cancelled flights scheduled within the past 2 hours are included in results."""
+def test_pick_best_flight_cancelled_included_if_within_one_hour(fixed_now):
+    """Confirm cancelled flights scheduled within the past 1 hour are included in results."""
     flights = [
         {"id": "cancelled", "scheduled_out": "2025-09-29T11:30:00Z"},
     ]
@@ -417,9 +408,9 @@ def test_pick_best_flights_mixed_statuses_prioritized(fixed_now):
         {"id": "enroute"},
         # Scheduled flight 30m from now
         {"id": "scheduled", "scheduled_out": "2025-09-29T12:30:00Z"},
-        # Arrived flight 30m ago (within 2h, but after scheduled)
+        # Arrived flight 30m ago (within 1h, but after scheduled)
         {"id": "arrived", "actual_on": "2025-09-29T11:30:00Z"},
-        # Cancelled flight 1h ago (within 2h, but lowest priority)
+        # Cancelled flight 1h ago (within 1h, but lowest priority)
         {"id": "cancelled", "scheduled_out": "2025-09-29T11:00:00Z"},
     ]
 
@@ -542,3 +533,224 @@ def test_is_valid_flight_number_pattern(description, query, expected):
     """Test the is_valid_flight_number_pattern function against a range of inputs."""
     result = is_valid_flight_number_pattern(query)
     assert result == expected, f"Failed: {description} (input: '{query}')"
+
+
+@pytest.mark.parametrize(
+    "description, flight, expected",
+    [
+        (
+            "cancelled flight takes priority even if other fields present",
+            {
+                "cancelled": True,
+                "actual_out": "2025-09-29T12:00:00Z",
+                "actual_on": None,
+                "actual_in": None,
+                "scheduled_out": "2025-09-29T14:10:00Z",
+                "estimated_out": "2025-09-29T14:10:00Z",
+                "departure_delay": 1800,
+            },
+            FlightStatus.CANCELLED,
+        ),
+        (
+            "en route flight (actual_out set, no actual_on)",
+            {
+                "cancelled": False,
+                "actual_out": "2025-09-29T12:00:00Z",
+                "actual_on": None,
+                "actual_in": None,
+                "scheduled_out": "2025-09-29T14:10:00Z",
+                "estimated_out": "2025-09-29T14:10:00Z",
+                "departure_delay": 0,
+            },
+            FlightStatus.EN_ROUTE,
+        ),
+        (
+            "arrived flight (actual_on set, actual_in missing)",
+            {
+                "cancelled": False,
+                "actual_out": "2025-09-29T12:00:00Z",
+                "actual_on": "2025-09-29T14:00:00Z",
+                "scheduled_out": "2025-09-29T14:10:00Z",
+                "estimated_out": "2025-09-29T14:10:00Z",
+                "actual_in": None,
+                "departure_delay": 1800,
+            },
+            FlightStatus.ARRIVED,
+        ),
+        (
+            "arrived flight (actual_in set, actual_on missing)",
+            {
+                "cancelled": False,
+                "actual_out": "2025-09-29T12:00:00Z",
+                "actual_on": None,
+                "actual_in": "2025-09-29T14:10:00Z",
+                "scheduled_out": "2025-09-29T14:10:00Z",
+                "estimated_out": "2025-09-29T14:10:00Z",
+                "departure_delay": 0,
+            },
+            FlightStatus.ARRIVED,
+        ),
+        (
+            "scheduled flight (no actual_out, no delay)",
+            {
+                "cancelled": False,
+                "actual_out": None,
+                "actual_on": None,
+                "actual_in": None,
+                "scheduled_out": "2025-09-29T14:10:00Z",
+                "estimated_out": "2025-09-29T14:10:00Z",
+                "departure_delay": None,
+            },
+            FlightStatus.SCHEDULED,
+        ),
+        (
+            "scheduled but delayed flight (no actual_out, delay > 15 minutes)",
+            {
+                "cancelled": False,
+                "actual_out": None,
+                "actual_on": None,
+                "actual_in": None,
+                "scheduled_out": "2025-09-29T14:10:00Z",
+                "estimated_out": "2025-09-29T14:10:00Z",
+                "departure_delay": 1800,
+            },
+            FlightStatus.DELAYED,
+        ),
+        (
+            "scheduled but on time (no actual_out, delay < 15 minutes)",
+            {
+                "cancelled": False,
+                "actual_out": None,
+                "actual_on": None,
+                "actual_in": None,
+                "scheduled_out": "2025-09-29T14:10:00Z",
+                "estimated_out": "2025-09-29T14:10:00Z",
+                "departure_delay": 600,
+            },
+            FlightStatus.SCHEDULED,
+        ),
+        (
+            "unknown status - missing fields",
+            {
+                "cancelled": False,
+                "actual_out": None,
+                "actual_on": None,
+                "actual_in": None,
+                "scheduled_out": None,
+                "estimated_out": None,
+                "departure_delay": None,
+            },
+            FlightStatus.UNKNOWN,
+        ),
+    ],
+)
+def test_derive_flight_status(description, flight, expected):
+    """Verify derive_flight_status returns the correct FlightStatus for each scenario."""
+    result = utils.derive_flight_status(flight)
+    assert result == expected, f"Failed: {description}"
+
+
+@pytest.mark.parametrize(
+    "description, flight, expected",
+    [
+        (
+            "arrived flight with actual_in present returns 0",
+            {
+                "actual_out": "2025-09-29T10:00:00Z",
+                "actual_in": "2025-09-29T11:30:00Z",
+                "scheduled_in": "2025-09-29T12:30:00Z",
+            },
+            0,
+        ),
+        (
+            "arrived flight with actual_on present returns 0",
+            {
+                "actual_out": "2025-09-29T10:00:00Z",
+                "actual_on": "2025-09-29T11:45:00Z",
+                "scheduled_in": "2025-09-29T12:30:00Z",
+            },
+            0,
+        ),
+        (
+            "not departed (no actual_out) returns None",
+            {
+                "actual_out": None,
+                "scheduled_in": "2025-09-29T14:00:00Z",
+            },
+            None,
+        ),
+        (
+            "en route with estimated_in returns minutes until ETA",
+            {
+                "actual_out": "2025-09-29T11:00:00Z",
+                "estimated_in": "2025-09-29T13:00:00Z",  # 1 hour after fixed_now
+            },
+            60,
+        ),
+        (
+            "en route with scheduled_in returns minutes until scheduled arrival",
+            {
+                "actual_out": "2025-09-29T11:00:00Z",
+                "scheduled_in": "2025-09-29T13:30:00Z",  # 1.5 hours after fixed_now
+            },
+            90,
+        ),
+        (
+            "past arrival time returns 0",
+            {
+                "actual_out": "2025-09-29T10:00:00Z",
+                "estimated_in": "2025-09-29T11:00:00Z",  # 1 hour before fixed_now
+            },
+            0,
+        ),
+        (
+            "en route but no estimated_in or scheduled_in returns None",
+            {
+                "actual_out": "2025-09-29T11:00:00Z",
+            },
+            None,
+        ),
+    ],
+)
+def test_calculate_time_left(description, flight, expected, fixed_now):
+    """Test calculate_time_left across all lifecycle scenarios."""
+    with patch.object(utils.datetime, "datetime", wraps=datetime.datetime) as mock_datetime:
+        mock_datetime.now.return_value = fixed_now
+        result = calculate_time_left(flight)
+        assert result == expected, f"Failed: {description}"
+
+
+@pytest.mark.parametrize(
+    "description, flight, expected",
+    [
+        (
+            "no departure_delay field returns False",
+            {},
+            False,
+        ),
+        (
+            "departure_delay is None returns False",
+            {"departure_delay": None},
+            False,
+        ),
+        (
+            "departure_delay less than 15 minutes returns False",
+            {"departure_delay": 600},  # 10 minutes
+            False,
+        ),
+        (
+            "departure_delay equal to 15 minutes returns False",
+            {"departure_delay": 900},  # exactly 15 minutes
+            False,
+        ),
+        (
+            "departure_delay greater than 15 minutes returns True",
+            {"departure_delay": 1200},  # 20 minutes
+            True,
+        ),
+    ],
+)
+def test_is_delayed(description, flight, expected):
+    """Verify is_delayed correctly detects delays above 15 minutes."""
+    result = is_delayed(flight)
+    assert result == expected, f"Failed: {description}"

--- a/tests/unit/providers/suggest/flightaware/test_provider.py
+++ b/tests/unit/providers/suggest/flightaware/test_provider.py
@@ -15,7 +15,10 @@ from merino.middleware.geolocation import Location
 from merino.providers.suggest.flightaware.provider import Provider
 from merino.providers.suggest.base import BaseSuggestion, SuggestionRequest
 from merino.providers.suggest.custom_details import CustomDetails, FlightAwareDetails
-from merino.providers.suggest.flightaware.backends.protocol import FlightSummary
+from merino.providers.suggest.flightaware.backends.protocol import (
+    AirlineDetails,
+    FlightSummary,
+)
 
 
 @pytest.fixture
@@ -111,6 +114,8 @@ async def test_query_fetches_and_builds_suggestion(provider, backend_mock, geolo
         },
         status="En Route",
         progress_percent=50,
+        airline=AirlineDetails(code=None, name=None, icon=None),
+        delayed=False,
         url="https://www.flightaware.com/live/flight/UA3711",
     )
     backend_mock.get_flight_summaries.return_value = [fake_summary]
@@ -152,7 +157,10 @@ def test_build_suggestion_creates_expected_object(provider):
             "estimated_time": "2025-09-29T16:05:00Z",
         },
         status="Scheduled",
-        progress_percent=None,
+        progress_percent=0,
+        airline=AirlineDetails(code=None, name=None, icon=None),
+        delayed=False,
+        time_left_minutes=None,
         url="https://www.flightaware.com/live/flight/AA100",
     )
     suggestion = provider.build_suggestion([summary])


### PR DESCRIPTION
## References

JIRA: [DISCO-3736](https://mozilla-hub.atlassian.net/browse/DISCO-3736)

## Description
This PR uses a flight's lifecycle time fields to calculate it's current high level status. It also populates the `time_left_minutes` and `delayed` fields.

### Changes
- Flight status calculation (derive_flight_status)
   - Added stable backend-calculated statuses (Scheduled, Delayed, En Route, Arrived, Cancelled, Unknown).
   - Added `is_delayed` helper with a 15-minute threshold for flagging delays.
- Time left calculation (calculate_time_left): computes minutes remaining until arrival.
- Prioritization adjustments (pick_best_flights)
   - Arrived and cancelled flights are only included if they occurred within 1 hour (was previously 2 hours).




### How to QA
1. Enable the provider:
   * Remove `"flightaware"` from the `disabled_providers` list in `default.toml`.
2. Configure the API key:
   * Replace the `"api_key"` field in `default.toml` with a real FlightAware API key.
3. Find a flight:
   * Use Flightaware's [flight finder ](https://www.flightaware.com/live/findflight/) to look up flights that have arrived or are en route with future instances (within the next 24 hours)
   * Add your chosen flight number to the `temp_cache` in the provider.
4. Call the endpoint:
   * Hit the Merino suggest endpoint with the flight code as the query and `"flightaware"` as the provider.
5. Verify behavior:
   * The query method should only respond to valid flight queries that exist in the temp cache and match a valid flight code pattern
   * The prioritization method should return flights in the right order and with the right status.
   * The `time_left_minutes` should match what's on the flightaware live page.
   * The `url` should point to a valid flightaware page for the correct flight.
   * Bonus points if you're able to find a delayed flight to test



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
