### PR TITLE
HNT-1115: enable 1 row for popular today for contextual experiments

### DIFF
--- a/merino/curated_recommendations/protocol.py
+++ b/merino/curated_recommendations/protocol.py
@@ -87,12 +87,17 @@ class ExperimentName(str, Enum):
     ML_SECTIONS_EXPERIMENT = "new-tab-ml-sections"
     # Experiment to compare RSS vs. Zyte content sources for legacy topic sections
     RSS_VS_ZYTE_EXPERIMENT = "new-ranking-for-legacy-topics-in-new-tab-v1"
-    # Experiment to apply 1 row layout for Popular Today for contextual ads
-    CONTEXTUAL_AD_EXPERIMENT = "new-tab-ad-updates-nightly"
     # Experiment to display Daily Briefing section as the first section on New Tab
     DAILY_BRIEFING_EXPERIMENT = "daily-briefing-v1"
     # Experiment slug for crawling with identical behavior/branches as RSS_VS_ZYTE_EXPERIMENT
     NEW_TAB_CRAWLING_V2 = "new-tab-crawling-v2"
+    # The following are 6 experiments to apply 1 row layout for Popular Today for contextual ads
+    CONTEXTUAL_AD_NIGHTLY_EXPERIMENT = "new-tab-ad-updates-nightly"
+    CONTEXTUAL_AD_V2_NIGHTLY_EXPERIMENT = "new-tab-contextual-ad-updates-v2-nightly"
+    CONTEXTUAL_AD_BETA_EXPERIMENT = "new-tab-contextual-ad-updates-beta"
+    CONTEXTUAL_AD_V2_BETA_EXPERIMENT = "new-tab-contextual-ad-updates-v2-beta"
+    CONTEXTUAL_AD_RELEASE_EXPERIMENT = "new-tab-contextual-ad-updates-release"
+    CONTEXTUAL_AD_V2_RELEASE_EXPERIMENT = "new-tab-contextual-ad-updates-v2-release"
 
 
 @unique

--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -281,6 +281,7 @@ def is_contextual_ads_experiment(request: CuratedRecommendationsRequest) -> bool
         for exp_name in contextual_ads_experiments
     )
 
+
 def is_daily_briefing_experiment(request: CuratedRecommendationsRequest) -> bool:
     """Return True if the Daily Briefing Section experiment is enabled."""
     return is_enrolled_in_experiment(

--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -267,11 +267,19 @@ def adjust_ads_in_sections(sections: dict[str, Section]) -> None:
 
 
 def is_contextual_ads_experiment(request: CuratedRecommendationsRequest) -> bool:
-    """Return True if the Contextual Ads experiment is enabled."""
-    return is_enrolled_in_experiment(
-        request, ExperimentName.CONTEXTUAL_AD_EXPERIMENT.value, "treatment"
+    """Return True if any of the 6 Contextual Ads experiments are enabled."""
+    contextual_ads_experiments = [
+        ExperimentName.CONTEXTUAL_AD_NIGHTLY_EXPERIMENT.value,
+        ExperimentName.CONTEXTUAL_AD_V2_NIGHTLY_EXPERIMENT.value,
+        ExperimentName.CONTEXTUAL_AD_BETA_EXPERIMENT.value,
+        ExperimentName.CONTEXTUAL_AD_V2_BETA_EXPERIMENT.value,
+        ExperimentName.CONTEXTUAL_AD_RELEASE_EXPERIMENT.value,
+        ExperimentName.CONTEXTUAL_AD_V2_RELEASE_EXPERIMENT.value,
+    ]
+    return any(
+        is_enrolled_in_experiment(request, exp_name, "treatment")
+        for exp_name in contextual_ads_experiments
     )
-
 
 def is_daily_briefing_experiment(request: CuratedRecommendationsRequest) -> bool:
     """Return True if the Daily Briefing Section experiment is enabled."""

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -1422,8 +1422,8 @@ class TestSections:
         assert first_section["title"] == "Popular Today"
         print(experiment_payload.get("experimentName"))
         if (
-            experiment_payload.get("experimentName")
-            == ExperimentName.ML_SECTIONS_EXPERIMENT.value or experiment_payload.get("experimentName") is None
+            experiment_payload.get("experimentName") == ExperimentName.ML_SECTIONS_EXPERIMENT.value
+            or experiment_payload.get("experimentName") is None
         ):
             assert first_section["layout"]["name"] == "7-double-row-2-ad"
         else:

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -1373,7 +1373,27 @@ class TestSections:
                 "experimentBranch": "control",
             },
             {
-                "experimentName": ExperimentName.CONTEXTUAL_AD_EXPERIMENT.value,
+                "experimentName": ExperimentName.CONTEXTUAL_AD_NIGHTLY_EXPERIMENT.value,
+                "experimentBranch": "treatment",
+            },
+            {
+                "experimentName": ExperimentName.CONTEXTUAL_AD_V2_NIGHTLY_EXPERIMENT.value,
+                "experimentBranch": "treatment",
+            },
+            {
+                "experimentName": ExperimentName.CONTEXTUAL_AD_BETA_EXPERIMENT.value,
+                "experimentBranch": "treatment",
+            },
+            {
+                "experimentName": ExperimentName.CONTEXTUAL_AD_V2_BETA_EXPERIMENT.value,
+                "experimentBranch": "treatment",
+            },
+            {
+                "experimentName": ExperimentName.CONTEXTUAL_AD_RELEASE_EXPERIMENT.value,
+                "experimentBranch": "treatment",
+            },
+            {
+                "experimentName": ExperimentName.CONTEXTUAL_AD_V2_RELEASE_EXPERIMENT.value,
                 "experimentBranch": "treatment",
             },
         ],
@@ -1400,9 +1420,10 @@ class TestSections:
 
         # Assert layout of the first section (Popular Today).
         assert first_section["title"] == "Popular Today"
+        print(experiment_payload.get("experimentName"))
         if (
             experiment_payload.get("experimentName")
-            != ExperimentName.CONTEXTUAL_AD_EXPERIMENT.value
+            == ExperimentName.ML_SECTIONS_EXPERIMENT.value or experiment_payload.get("experimentName") is None
         ):
             assert first_section["layout"]["name"] == "7-double-row-2-ad"
         else:


### PR DESCRIPTION
## References

JIRA: https://mozilla-hub.atlassian.net/browse/HNT-1115

## Description
Enable 1-row for Popular Today for the following contextual ad experiments:
"new-tab-ad-updates-nightly"
"new-tab-contextual-ad-updates-v2-nightly"
"new-tab-contextual-ad-updates-beta"
"new-tab-contextual-ad-updates-v2-beta"
"new-tab-contextual-ad-updates-release"
"new-tab-contextual-ad-updates-v2-release"


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1894)
