### PR TITLE
DISCO 3756 - Fix a circular import issue in domain_category_mapping

### DIFF
--- a/merino/jobs/navigational_suggestions/__init__.py
+++ b/merino/jobs/navigational_suggestions/__init__.py
@@ -16,7 +16,7 @@ from merino.configs import settings as config
 from merino.jobs.navigational_suggestions.partner_favicons import PARTNER_FAVICONS
 from merino.jobs.navigational_suggestions.utils import AsyncFaviconDownloader
 from merino.utils.gcs.gcs_uploader import GcsUploader
-from merino.jobs.utils.domain_category_mapping import DOMAIN_MAPPING
+from merino.utils.domain_categories.domain_category_mapping import DOMAIN_MAPPING
 from merino.jobs.navigational_suggestions.domain_data_downloader import (
     DomainDataDownloader,
 )
@@ -27,7 +27,7 @@ from merino.jobs.navigational_suggestions.domain_metadata_extractor import (
 from merino.jobs.navigational_suggestions.domain_metadata_uploader import (
     DomainMetadataUploader,
 )
-from merino.providers.suggest.base import Category
+from merino.utils.domain_categories.models import Category
 from merino.utils.blocklists import TOP_PICKS_BLOCKLIST
 from merino.jobs.navigational_suggestions.custom_favicons import get_custom_favicon_url
 

--- a/merino/jobs/relevancy_uploader/__init__.py
+++ b/merino/jobs/relevancy_uploader/__init__.py
@@ -6,45 +6,19 @@ import csv
 import json
 import io
 from collections import defaultdict
-from enum import Enum
 from hashlib import md5
 
 import typer
 
 from merino.configs import settings as config
+from merino.utils.domain_categories.models import Category
 from merino.jobs.relevancy_uploader.chunked_rs_uploader import (
     ChunkedRemoteSettingsRelevancyUploader,
 )
-from merino.jobs.utils.domain_category_mapping import DOMAIN_MAPPING
+from merino.utils.domain_categories.domain_category_mapping import DOMAIN_MAPPING
 
 CLASSIFICATION_CURRENT_VERSION = 1
 CATEGORY_SCORE_THRESHOLD = 0.3
-
-
-class Category(Enum):
-    """Enum of possible interests for a domain."""
-
-    Inconclusive = 0
-    Animals = 1
-    Arts = 2
-    Autos = 3
-    Business = 4
-    Career = 5
-    Education = 6
-    Fashion = 7
-    Finance = 8
-    Food = 9
-    Government = 10
-    # Disable this per policy consultation
-    # Health = 11
-    Hobbies = 12
-    Home = 13
-    News = 14
-    RealEstate = 15
-    Society = 16
-    Sports = 17
-    Tech = 18
-    Travel = 19
 
 
 RELEVANCY_RECORD_TYPE = "category_to_domains"

--- a/merino/providers/suggest/adm/provider.py
+++ b/merino/providers/suggest/adm/provider.py
@@ -15,10 +15,12 @@ from moz_merino_ext.amp import AmpIndexManager
 from pydantic import HttpUrl
 from tldextract.tldextract import ExtractResult
 
+from merino.utils.domain_categories.domain_category_mapping import DOMAIN_MAPPING
 from merino.providers.suggest.adm.backends.remotesettings import FormFactor
 from merino.utils import cron
 from merino.providers.suggest.adm.backends.protocol import AdmBackend, SuggestionContent
-from merino.providers.suggest.base import BaseProvider, BaseSuggestion, Category, SuggestionRequest
+from merino.providers.suggest.base import BaseProvider, BaseSuggestion, SuggestionRequest
+from merino.utils.domain_categories.models import Category
 
 logger = logging.getLogger(__name__)
 
@@ -159,8 +161,6 @@ class Provider(BaseProvider):
             `domain`: the domain of a URL.
         Returns a list of SERP categories if any or else an empty list.
         """
-        from merino.jobs.utils.domain_category_mapping import DOMAIN_MAPPING
-
         hash = base64.b64encode(
             hashlib.md5(domain.encode(), usedforsecurity=False).digest()
         ).decode()

--- a/merino/providers/suggest/base.py
+++ b/merino/providers/suggest/base.py
@@ -1,7 +1,6 @@
 """Abstract class for Providers"""
 
 from abc import ABC, abstractmethod
-from enum import Enum
 
 from pydantic import BaseModel, Field, HttpUrl
 
@@ -9,6 +8,7 @@ from merino.configs import settings
 from merino.middleware.geolocation import Location
 from merino.middleware.user_agent import UserAgent
 from merino.providers.suggest.custom_details import CustomDetails
+from merino.utils.domain_categories.models import Category
 
 
 class SuggestionRequest(BaseModel):
@@ -25,32 +25,6 @@ class SuggestionRequest(BaseModel):
     source: str | None = None
     google_suggest_params: str | None = None
     session_id: str | None = None
-
-
-class Category(Enum):
-    """Enum of possible interests for a suggestion."""
-
-    Inconclusive = 0
-    Animals = 1
-    Arts = 2
-    Autos = 3
-    Business = 4
-    Career = 5
-    Education = 6
-    Fashion = 7
-    Finance = 8
-    Food = 9
-    Government = 10
-    # Disable this per policy consultation
-    # Health = 11
-    Hobbies = 12
-    Home = 13
-    News = 14
-    RealEstate = 15
-    Society = 16
-    Sports = 17
-    Tech = 18
-    Travel = 19
 
 
 class BaseSuggestion(BaseModel):

--- a/merino/utils/domain_categories/__init__.py
+++ b/merino/utils/domain_categories/__init__.py
@@ -1,0 +1,1 @@
+"""Module for domain to SERP categories."""

--- a/merino/utils/domain_categories/domain_category_mapping.py
+++ b/merino/utils/domain_categories/domain_category_mapping.py
@@ -1,7 +1,7 @@
 """Mapping of domain to serp categories"""
 
 from merino.configs import settings
-from merino.providers.suggest.base import Category
+from merino.utils.domain_categories.models import Category
 
 _mapping: dict[str, list[Category]]
 if settings.env_for_dynaconf in ["testing", "ci"]:

--- a/merino/utils/domain_categories/models.py
+++ b/merino/utils/domain_categories/models.py
@@ -1,0 +1,29 @@
+"""Models & enums for SERP categories."""
+
+from enum import Enum
+
+
+class Category(Enum):
+    """Enum of possible SERP categories (interests) for a suggestion."""
+
+    Inconclusive = 0
+    Animals = 1
+    Arts = 2
+    Autos = 3
+    Business = 4
+    Career = 5
+    Education = 6
+    Fashion = 7
+    Finance = 8
+    Food = 9
+    Government = 10
+    # Disable this per policy consultation
+    # Health = 11
+    Hobbies = 12
+    Home = 13
+    News = 14
+    RealEstate = 15
+    Society = 16
+    Sports = 17
+    Tech = 18
+    Travel = 19

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,9 +42,9 @@ source = ["merino"]
 branch = true
 relative_files = true
 omit = [
-  "merino/jobs/utils/domain_category_mapping.py",
   "merino/jobs/utils/domain_tester.py",
   "merino/jobs/utils/system_monitor.py",
+  "merino/utils/domain_categories/domain_category_mapping.py",
 ]
 
 [dependency-groups]
@@ -122,7 +122,7 @@ lint.pydocstyle = { convention = "pep257" }
 skips = ["B101", "B104", "B311"]
 exclude_dirs = [
   # Data file only
-  "merino/jobs/utils/domain_category_mapping.py"
+  "merino/utils/domain_categories/domain_category_mapping.py",
 ]
 
 [tool.mypy]

--- a/tests/integration/api/v1/suggest/test_suggest_top_picks.py
+++ b/tests/integration/api/v1/suggest/test_suggest_top_picks.py
@@ -13,10 +13,10 @@ from fastapi.testclient import TestClient
 from pydantic import HttpUrl
 
 from merino.configs import settings
-from merino.providers.suggest.base import Category
 from merino.providers.suggest.top_picks.backends.top_picks import TopPicksBackend
 from merino.providers.suggest.top_picks.provider import Provider, Suggestion
 from tests.integration.api.v1.types import Providers
+from merino.utils.domain_categories.models import Category
 
 
 @pytest.fixture(name="domain_blocklist")

--- a/tests/integration/jobs/navigational_suggestions/conftest.py
+++ b/tests/integration/jobs/navigational_suggestions/conftest.py
@@ -8,17 +8,6 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-# Avoid a circular import error that happens when a single test is run:
-# pytest tests/integration/jobs/navigational_suggestions/test_domain_metadata_extractor.py
-# E   ImportError: cannot import name 'DOMAIN_MAPPING' from partially initialized module
-# 'merino.jobs.utils.domain_category_mapping' (most likely due to a circular import)
-import sys
-import types
-
-_stub = types.ModuleType("merino.jobs.utils.domain_category_mapping")
-setattr(_stub, "DOMAIN_MAPPING", {})
-sys.modules["merino.jobs.utils.domain_category_mapping"] = _stub
-
 from merino.jobs.navigational_suggestions.domain_metadata_extractor import Scraper  # noqa
 
 

--- a/tests/integration/jobs/navigational_suggestions/test_init.py
+++ b/tests/integration/jobs/navigational_suggestions/test_init.py
@@ -19,8 +19,8 @@ from merino.jobs.navigational_suggestions import (
 from merino.jobs.navigational_suggestions.domain_metadata_diff import DomainDiff
 from merino.jobs.navigational_suggestions.domain_data_downloader import DomainDataDownloader
 from merino.jobs.navigational_suggestions.utils import AsyncFaviconDownloader
-from merino.providers.suggest.base import Category
 from merino.jobs.utils.system_monitor import SystemMonitor
+from merino.utils.domain_categories.models import Category
 
 
 @pytest.fixture

--- a/tests/unit/jobs/navigational_suggestions/test_get_serp_categories.py
+++ b/tests/unit/jobs/navigational_suggestions/test_get_serp_categories.py
@@ -10,7 +10,7 @@ import hashlib
 from unittest.mock import patch
 
 from merino.jobs.navigational_suggestions import _get_serp_categories
-from merino.providers.suggest.base import Category
+from merino.utils.domain_categories.models import Category
 
 
 def test_get_serp_categories_with_valid_url():

--- a/tests/unit/jobs/navigational_suggestions/test_init.py
+++ b/tests/unit/jobs/navigational_suggestions/test_init.py
@@ -15,8 +15,8 @@ from merino.jobs.navigational_suggestions import (
     _construct_top_picks,
     _write_xcom_file,
 )
-from merino.providers.suggest.base import Category
 from merino.jobs.navigational_suggestions import _run_normal_mode
+from merino.utils.domain_categories.models import Category
 
 
 def test_write_xcom_file(mocker):

--- a/tests/unit/jobs/navigational_suggestions/test_navigational_suggestions.py
+++ b/tests/unit/jobs/navigational_suggestions/test_navigational_suggestions.py
@@ -17,7 +17,7 @@ from merino.jobs.navigational_suggestions import (
     _construct_partner_manifest,
     _construct_top_picks,
 )
-from merino.providers.suggest.base import Category
+from merino.utils.domain_categories.models import Category
 
 
 def test_prepare_domain_metadata_top_picks_construction():

--- a/tests/unit/providers/suggest/adm/test_provider.py
+++ b/tests/unit/providers/suggest/adm/test_provider.py
@@ -14,7 +14,7 @@ from merino.middleware.geolocation import Location
 from merino.middleware.user_agent import UserAgent
 from merino.providers.suggest.adm.backends.remotesettings import FormFactor
 from merino.providers.suggest.adm.provider import NonsponsoredSuggestion, Provider
-from merino.providers.suggest.base import Category
+from merino.utils.domain_categories.models import Category
 from tests.types import FilterCaplogFixture
 from tests.unit.types import SuggestionRequestFixture
 

--- a/tests/unit/providers/suggest/top_picks/test_provider.py
+++ b/tests/unit/providers/suggest/top_picks/test_provider.py
@@ -13,11 +13,12 @@ from pytest import LogCaptureFixture
 
 from merino.configs import settings
 from merino.exceptions import BackendError
-from merino.providers.suggest.base import BaseSuggestion, Category
 from merino.providers.suggest.top_picks.backends.filemanager import GetFileResultCode
 from merino.providers.suggest.top_picks.backends.protocol import TopPicksData
 from merino.providers.suggest.top_picks.backends.top_picks import TopPicksBackend
 from merino.providers.suggest.top_picks.provider import Provider, Suggestion
+from merino.providers.suggest.base import BaseSuggestion
+from merino.utils.domain_categories.models import Category
 from tests.types import FilterCaplogFixture
 from tests.unit.types import SuggestionRequestFixture
 

--- a/tests/unit/providers/suggest/wikipedia/test_provider.py
+++ b/tests/unit/providers/suggest/wikipedia/test_provider.py
@@ -6,7 +6,6 @@ from pytest_mock import MockerFixture
 
 from merino.configs import settings
 from merino.exceptions import BackendError
-from merino.providers.suggest.base import Category
 from merino.providers.suggest.wikipedia.backends.fake_backends import FakeEchoWikipediaBackend
 from merino.providers.suggest.wikipedia.provider import (
     ADVERTISER,
@@ -14,6 +13,7 @@ from merino.providers.suggest.wikipedia.provider import (
     Provider,
     WikipediaSuggestion,
 )
+from merino.utils.domain_categories.models import Category
 from tests.unit.types import SuggestionRequestFixture
 
 


### PR DESCRIPTION
## References

JIRA: [DISCO-3756](https://mozilla-hub.atlassian.net/browse/DISCO-3756)

## Description
This fixes a tricky circular import in Merino. Note this branch is created off #1101 . 



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3756]: https://mozilla-hub.atlassian.net/browse/DISCO-3756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1897)
