### PR TITLE
[DISCO-3636] Ingest serp_categories from RS record

### DIFF
--- a/merino/providers/suggest/adm/backends/remotesettings.py
+++ b/merino/providers/suggest/adm/backends/remotesettings.py
@@ -45,6 +45,7 @@ class KintoSuggestion(BaseModel):
     click_url: str | None = None
     full_keywords: list[list[Any]] = []
     iab_category: str
+    serp_categories: list[int] = []
     icon: str
     impression_url: str | None = None
     keywords: list[str] = []

--- a/tests/unit/providers/suggest/adm/backends/test_remotesettings.py
+++ b/tests/unit/providers/suggest/adm/backends/test_remotesettings.py
@@ -290,6 +290,7 @@ async def test_fetch(
             ["firefox accounts de", 3],
         ],
         iab_category="5 - Education",
+        serp_categories=[0],
         icon="01",
         keywords=[
             "firefox",
@@ -525,6 +526,7 @@ async def test_get_suggestions(
                 "click_url": "https://example.org/click/mozilla",
                 "full_keywords": [["firefox accounts", 3], ["mozilla firefox accounts", 4]],
                 "iab_category": "5 - Education",
+                "serp_categories": [],
                 "icon": "01",
                 "impression_url": "https://example.org/impression/mozilla",
                 "keywords": [

--- a/tests/unit/providers/suggest/adm/conftest.py
+++ b/tests/unit/providers/suggest/adm/conftest.py
@@ -42,6 +42,7 @@ def fixture_rs_attachment_raw_us() -> str:
                 "full_keywords": [["firefox accounts", 3], ["mozilla firefox accounts", 4]],
                 "iab_category": "5 - Education",
                 "icon": "01",
+                "serp_categories": [],
                 "impression_url": "https://example.org/impression/mozilla",
                 "keywords": [
                     "firefox",
@@ -71,6 +72,7 @@ def fixture_rs_attachment_raw_de() -> str:
                 "full_keywords": [["firefox accounts de", 4], ["mozilla firefox accounts de", 5]],
                 "iab_category": "5 - Education",
                 "icon": "01",
+                "serp_categories": [],
                 "impression_url": "https://de.example.org/impression/mozilla",
                 "keywords": [
                     "firefox",

--- a/tests/unit/providers/suggest/adm/test_provider.py
+++ b/tests/unit/providers/suggest/adm/test_provider.py
@@ -14,7 +14,6 @@ from merino.middleware.geolocation import Location
 from merino.middleware.user_agent import UserAgent
 from merino.providers.suggest.adm.backends.remotesettings import FormFactor
 from merino.providers.suggest.adm.provider import NonsponsoredSuggestion, Provider
-from merino.providers.suggest.base import Category
 from tests.types import FilterCaplogFixture
 from tests.unit.types import SuggestionRequestFixture
 
@@ -154,18 +153,3 @@ async def test_query_with_missing_key(srequest: SuggestionRequestFixture, adm: P
     await adm.initialize()
 
     assert await adm.query(srequest("nope", None, None)) == []
-
-
-@pytest.mark.parametrize(
-    ["domain", "expected"],
-    [
-        ("testserpcategories.com", [Category.Education]),
-        ("nocategories.com", []),
-    ],
-)
-@pytest.mark.asyncio
-async def test_query_serp_categories(adm: Provider, domain: str, expected: list[Category]) -> None:
-    """Test for the serp_categories() method of the adM provider."""
-    categories = adm.serp_categories(domain)
-
-    assert categories == expected

--- a/tests/unit/utils/test_icon_processor.py
+++ b/tests/unit/utils/test_icon_processor.py
@@ -468,6 +468,7 @@ async def test_fetch_with_icon_processing_errors():
                 "iab_category": "5 - Education",
                 "icon": icon_id,
                 "impression_url": "test",
+                "serp_categories": [],
                 "keywords": [],
                 "title": "Test Suggestion",
                 "url": "https://example.org/test",


### PR DESCRIPTION
## References

JIRA: [DISCO-3636](https://mozilla-hub.atlassian.net/browse/DISCO-3636)

## Description
Related change https://github.com/mozilla-services/moz-merino-ext/pull/9
Will need to merge ^, cut a release and update extension version



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
