### PR TITLE
[DISCO-3751] Retrieve and store flight numbers in memory

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -801,6 +801,17 @@ query_timeout_sec = 5.0
 # flightaware backend http client to establish a connection to the host.
 connect_timeout_sec = 3.0
 
+# MERINO_PROVIDERS__FLIGHTAWARE__CRON_INTERVAL_SEC
+# The interval of the FlightawareFilemanager cron job (in seconds)
+# The cron job should tick more frequently than `resync_interval_sec` so that
+# the resync failure can be retried soon.
+cron_interval_sec = 60
+
+# MERINO_PROVIDERS__FLIGHTAWARE__RESYNC_INTERVAL_SEC
+# Time between re-syncs of the flightaware flight numbers file, in seconds.
+# Set to daily.
+resync_interval_sec = 86400
+
 # MERINO_PROVIDERS__FLIGHTAWARE__CIRCUIT_BREAKER_FAILURE_THRESHOLD
 # The circuit breaker will open when the failure is over this threshold.
 circuit_breaker_failure_threshold = 10

--- a/merino/providers/suggest/flightaware/backends/filemanager.py
+++ b/merino/providers/suggest/flightaware/backends/filemanager.py
@@ -1,0 +1,65 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+"""A Filemanager to retrieve data for the Flightaware Provider."""
+
+import orjson
+import logging
+
+from json import JSONDecodeError
+from gcloud.aio.storage import Blob, Bucket, Storage
+
+from merino.providers.suggest.flightaware.backends.protocol import (
+    GetFlightNumbersResultCode,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class FlightawareFilemanager:
+    """Filemanager for fetching flight data from GCS asynchronously and storing in memory."""
+
+    gcs_bucket_path: str
+    blob_name: str
+    gcs_client: Storage | None = None
+    bucket: Bucket | None = None
+
+    def __init__(self, gcs_bucket_path: str, blob_name: str) -> None:
+        """:param gcs_bucket_path: GCS bucket name to fetch from.
+        :param blob_name: Name of the blob in the GCS bucket.
+        """
+        self.gcs_bucket_path = gcs_bucket_path
+        self.blob_name = blob_name
+
+    async def get_bucket(self) -> Bucket:
+        """Lazily instantiate the GCS client and return the configured bucket"""
+        if self.bucket is not None:
+            return self.bucket
+
+        if self.gcs_client is None:
+            self.gcs_client = Storage()
+
+        self.bucket = Bucket(storage=self.gcs_client, name=self.gcs_bucket_path)
+        return self.bucket
+
+    async def get_file(self) -> tuple[GetFlightNumbersResultCode, list[str] | None]:
+        """Fetch the flight numbers file from GCS"""
+        try:
+            bucket = await self.get_bucket()
+            blob: Blob = await bucket.get_blob(self.blob_name)
+            blob_data = await blob.download()
+
+            flight_numbers: list[str] = orjson.loads(blob_data)
+
+            logger.info(
+                f"Successfully loaded {len(flight_numbers)} flight numbers from {self.blob_name}"
+            )
+
+            return GetFlightNumbersResultCode.SUCCESS, flight_numbers
+
+        except JSONDecodeError as json_error:
+            logger.error(f"Failed to decode flight numbers JSON: {json_error}")
+
+        except Exception as e:
+            logger.error(f"Error fetching flight numbers file {self.blob_name}: {e}")
+        return GetFlightNumbersResultCode.FAIL, None

--- a/merino/providers/suggest/flightaware/backends/protocol.py
+++ b/merino/providers/suggest/flightaware/backends/protocol.py
@@ -1,7 +1,7 @@
 """Protocol for flight aware provider backends."""
 
 from datetime import datetime
-from enum import StrEnum
+from enum import Enum, StrEnum
 from typing import Any, Protocol
 
 from pydantic import BaseModel, HttpUrl
@@ -56,6 +56,13 @@ class FlightSummary(BaseModel):
     airline: AirlineDetails
 
 
+class GetFlightNumbersResultCode(Enum):
+    """Enum to capture the result of getting flight numbers file."""
+
+    SUCCESS = 0
+    FAIL = 1
+
+
 class FlightBackendProtocol(Protocol):
     """Protocol for a flight aware backend that this provider depends on.
 
@@ -71,6 +78,11 @@ class FlightBackendProtocol(Protocol):
     async def fetch_flight_details(self, flight_num: str) -> Any | None:
         """Fetch flight details by flight number through aeroAPI"""
 
+    async def fetch_flight_numbers(
+        self,
+    ) -> tuple[GetFlightNumbersResultCode, list[str] | None]:
+        """Fetch flight numbers file from GCS through the filemanager."""
+
     async def shutdown(self) -> None:  # pragma: no cover
-        """Close down any open connections."""
+        """Close http client connections."""
         ...

--- a/merino/providers/suggest/manager.py
+++ b/merino/providers/suggest/manager.py
@@ -306,6 +306,8 @@ def _create_provider(provider_id: str, setting: Settings) -> BaseProvider:
                 name=provider_id,
                 query_timeout_sec=setting.query_timeout_sec,
                 enabled_by_default=setting.enabled_by_default,
+                resync_interval_sec=setting.resync_interval_sec,
+                cron_interval_sec=setting.cron_interval_sec,
             )
         case _:
             raise InvalidProviderError(f"Unknown provider type: {setting.type}")

--- a/tests/unit/providers/suggest/flightaware/backend/test_filemanager.py
+++ b/tests/unit/providers/suggest/flightaware/backend/test_filemanager.py
@@ -1,0 +1,94 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Unit tests for the Flightaware filemanager module."""
+
+import orjson
+import pytest
+import logging
+from unittest.mock import AsyncMock
+from tests.types import FilterCaplogFixture
+
+from merino.providers.suggest.flightaware.backends.filemanager import (
+    FlightawareFilemanager,
+)
+from merino.providers.suggest.flightaware.backends.protocol import (
+    GetFlightNumbersResultCode,
+)
+
+
+@pytest.mark.asyncio
+async def test_get_file_success(
+    caplog: pytest.LogCaptureFixture, filter_caplog: FilterCaplogFixture
+):
+    """Ensure get_file successfully parses valid flight number data."""
+    mock_blob = AsyncMock()
+    mock_blob.download.return_value = orjson.dumps(["UA123", "AA100", "AC701"])
+
+    mock_bucket = AsyncMock()
+    mock_bucket.get_blob.return_value = mock_blob
+
+    filemanager = FlightawareFilemanager("test-bucket", "test-blob")
+    filemanager.bucket = mock_bucket
+
+    with caplog.at_level(logging.INFO):
+        result_code, result = await filemanager.get_file()
+
+    assert result_code is GetFlightNumbersResultCode.SUCCESS
+    assert isinstance(result, list)
+    assert result == ["UA123", "AA100", "AC701"]
+
+    records = filter_caplog(
+        caplog.records, "merino.providers.suggest.flightaware.backends.filemanager"
+    )
+    assert any("Successfully loaded" in r.message for r in records)
+
+
+@pytest.mark.asyncio
+async def test_get_file_json_decode_error(
+    caplog: pytest.LogCaptureFixture, filter_caplog: FilterCaplogFixture
+):
+    """Ensure get_file gracefully handles JSON decode errors."""
+    mock_blob = AsyncMock()
+    mock_blob.download.return_value = b"not valid json"
+
+    mock_bucket = AsyncMock()
+    mock_bucket.get_blob.return_value = mock_blob
+
+    filemanager = FlightawareFilemanager("test-bucket", "test-blob")
+    filemanager.bucket = mock_bucket
+
+    result_code, result = await filemanager.get_file()
+
+    assert result_code is GetFlightNumbersResultCode.FAIL
+    assert result is None
+
+    with caplog.at_level(logging.ERROR):
+        records = filter_caplog(
+            caplog.records, "merino.providers.suggest.flightaware.backends.filemanager"
+        )
+        assert any("Failed to decode flight numbers JSON" in r.message for r in records)
+
+
+@pytest.mark.asyncio
+async def test_get_file_exception(
+    caplog: pytest.LogCaptureFixture, filter_caplog: FilterCaplogFixture
+):
+    """Ensure get_file handles unexpected exceptions gracefully."""
+    mock_bucket = AsyncMock()
+    mock_bucket.get_blob.side_effect = Exception("Unexpected error")
+
+    filemanager = FlightawareFilemanager("test-bucket", "test-blob")
+    filemanager.bucket = mock_bucket
+
+    result_code, result = await filemanager.get_file()
+
+    assert result_code is GetFlightNumbersResultCode.FAIL
+    assert result is None
+
+    with caplog.at_level(logging.ERROR):
+        records = filter_caplog(
+            caplog.records, "merino.providers.suggest.flightaware.backends.filemanager"
+        )
+        assert any("Error fetching flight numbers file" in r.message for r in records)


### PR DESCRIPTION
## References

JIRA: [DISCO-3751](https://mozilla-hub.atlassian.net/browse/DISCO-3751)

## Description
This PR connects the FlightAware provider to the GCS-based flight numbers cache generated by the `fetch_schedules` airflow job. The provider now dynamically loads flight numbers from GCS instead of using the hardcoded temp cache.

### Changes
- Removed temporary in-code cache
- Added `FlightawareFilemanager` which retrieves files from gcs and returns a list of flight numbers
- Hooked up cache to provider

### How to QA
1. Enable the provider:
   * Remove `"flightaware"` from the `disabled_providers` list in `default.toml`.
2. Configure the API key:
   * Replace the `"api_key"` field in `default.toml` with a real FlightAware API key.
3. In `default.toml`, under `[default.image_gcs]`, define `gcs_bucket` and `gcs_project`
4. Authenticate with google cloud (`gcloud auth application-default login`)
5. Find a flight:
   * Use Flightaware's [flight finder ](https://www.flightaware.com/live/findflight/) to look up flights that have arrived or are en route with future instances (within the next 24 hours)
6. Call the endpoint:
   * Hit the Merino suggest endpoint with the flight code as the query and `"flightaware"` as the provider.
7. Verify behavior:
   * The provider should return results based on flight numbers in the cache (gcs file)

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3751]: https://mozilla-hub.atlassian.net/browse/DISCO-3751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1899)
