### PR TITLE
HNT-1111: Optimize sections performance

### DIFF
--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -699,14 +699,15 @@ async def get_sections(
 
     # 10. Create a global rank lookup from the already-ranked recommendations
     # This preserves the Thompson sampling ranking done at step 7 without expensive re-sampling
-    global_rank_map = {rec.corpusItemId: rank for rank, rec in enumerate(all_ranked_corpus_recommendations)}
+    global_rank_map = {
+        rec.corpusItemId: rank for rank, rec in enumerate(all_ranked_corpus_recommendations)
+    }
 
     # 11. Sort each section's recommendations by their global rank (preserves Thompson sampling order)
     # This is much faster than re-running Thompson sampling for each section
     for cs in corpus_sections.values():
         cs.recommendations = sorted(
-            cs.recommendations,
-            key=lambda rec: global_rank_map.get(rec.corpusItemId, float('inf'))
+            cs.recommendations, key=lambda rec: global_rank_map.get(rec.corpusItemId, float("inf"))
         )
         # Renumber recommendations within each section
         for idx, rec in enumerate(cs.recommendations):


### PR DESCRIPTION
## References

JIRA: [HNT-1111](https://mozilla-hub.atlassian.net/browse/HNT-1111)

## Description
Remove per-section Thompson sampling calls that were re-ranking recommendations that had already been globally ranked. This was causing significant CPU overhead in the sections endpoint.

Performance improvement:
- Before: ~14-15ms avg (~85-90% overhead vs non-sections baseline)
- After: ~11-12ms avg (~50-60% overhead vs non-sections baseline)
- Speed up: ~21-22% faster (~3ms saved per request)

The optimization preserves the global Thompson sampling ranking by sorting section recommendations based on their global rank instead of re-sampling beta distributions for each section independently.

# Performance Optimization QA

Download [profile_curated_recommendations.py](https://github.com/user-attachments/files/22782213/profile_curated_recommendations.py) and save it in the project root directory.


## Test 1: Verify optimized performance

1. Ensure you're on the branch with the optimization:
   ```bash
   git checkout hnt-1111-section-performance-analysis
   ```

2. Start the FastAPI server:
   ```bash
   .venv/bin/python -m uvicorn merino.main:app --host 127.0.0.1 --port 8000
   ```
   (Keep this running in a separate terminal)

3. Run the profiling script:
   ```bash
   .venv/bin/python profile_curated_recommendations.py
   ```

**Expectations:**
- [x] Section overhead is approximately 50-60%

```
================================================================================
SUMMARY
================================================================================
Baseline (no sections):  7.54ms
With sections:           11.37ms
Overhead:                3.83ms (50.9% increase)
================================================================================
```

## Test 2: Compare with original implementation

1. Check out the main branch (before the optimization):
   ```bash
   git checkout main
   ```

2. Restart the FastAPI server (Ctrl+C, then re-run the uvicorn command)

3. Run the profiling script again:
   ```bash
   .venv/bin/python profile_curated_recommendations.py
   ```

**Expectations:**
- [x] Section overhead is approximately 80-90%
- [x] This demonstrates **~20% performance improvement** from the optimization

```
================================================================================
SUMMARY
================================================================================
Baseline (no sections):  7.68ms
With sections:           14.49ms
Overhead:                6.81ms (88.7% increase)
================================================================================
```

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[HNT-1111]: https://mozilla-hub.atlassian.net/browse/HNT-1111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1901)
