### PR TITLE
[DISCO-3755] Add metrics for flightaware provider

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -805,7 +805,7 @@ enabled_by_default = false
 
 # MERINO_PROVIDERS__FLIGHTAWARE__SCORE
 # The ranking score for this provider as a floating point number.
-score = 0 # TODO
+score = 0.29
 
 # MERINO_PROVIDERS__FLIGHTAWARE__QUERY_TIMEOUT_SEC
 # A floating point (in seconds) indicating the maximum waiting period when Merino queries

--- a/merino/providers/suggest/manager.py
+++ b/merino/providers/suggest/manager.py
@@ -300,6 +300,7 @@ def _create_provider(provider_id: str, setting: Settings) -> BaseProvider:
                     api_key=settings.flightaware.api_key,
                     http_client=create_http_client(base_url=settings.flightaware.base_url),
                     ident_url=settings.flightaware.ident_url_path,
+                    metrics_client=get_metrics_client(),
                 ),
                 metrics_client=get_metrics_client(),
                 score=setting.score,

--- a/metrics.yaml
+++ b/metrics.yaml
@@ -229,3 +229,54 @@ suggest/google_suggest:
     scope: |
       The "api/v1/suggest" API endpoint.
     alert_policy: []
+suggest/flightaware:
+  flightaware_request_summary_get:
+    description: |
+      A counter to measure the total number of API requests made to AeroAPI
+    type: counter
+    labels: []
+    scope: |
+      The "api/v1/suggest" API endpoint.
+    alert_policy: []
+  flightaware_request_summary_get_latency:
+    description: |
+      A histogram to measure the latency of API requests to AeroAPI
+    type: histogram
+    labels: []
+    scope: |
+      The "api/v1/suggest" API endpoint.
+    alert_policy: []
+  flightaware_request_summary_get_status:
+    description: |
+      A counter to measure the number of AeroAPI responses, labeled by HTTP status code.
+    type: counter
+    labels:
+      - name: status_code
+        description: |
+          The HTTP status code returned by the API request (e.g., 200, 400, 500).
+    scope: |
+      The "api/v1/suggest" API endpoint.
+    alert_policy: []
+  providers_flightaware_flight_no_pattern_match_count:
+    description: |
+      A counter to measure how many user queries matched a valid flight number pattern
+      and successfully triggered a FlightAware lookup.
+    type: counter
+    labels: []
+    scope: |
+      The "api/v1/suggest" API endpoint
+    alert_policy: []
+  providers_flightaware_query_exception:
+    description: |
+      A counter to track unexpected errors raised during the FlightAware provider query flow.
+    type: counter
+    labels: []
+    scope: |
+      The "api/v1/suggest" API endpoint
+    alert_policy: []
+
+
+
+
+
+

--- a/tests/unit/providers/suggest/flightaware/test_provider.py
+++ b/tests/unit/providers/suggest/flightaware/test_provider.py
@@ -204,6 +204,10 @@ async def test_query_fetches_and_builds_suggestion_from_cached_numbers(
     assert suggestion.provider == "flightaware"
     assert suggestion.custom_details.flightaware.values[0].flight_number == "UA3711"
 
+    provider.metrics_client.increment.assert_any_call(
+        "providers.flightaware.flight_no_pattern.match_count"
+    )
+
 
 @pytest.mark.asyncio
 async def test_query_handles_backend_exception(provider, backend_mock, caplog, geolocation):
@@ -217,6 +221,7 @@ async def test_query_handles_backend_exception(provider, backend_mock, caplog, g
 
     assert results == []
     assert "Exception occurred for FlightAware provider" in caplog.text
+    provider.metrics_client.increment.assert_any_call("providers.flightaware.query.exception")
 
 
 def test_build_suggestion_creates_expected_object(provider):


### PR DESCRIPTION
## References

JIRA: [DISCO-3755](https://mozilla-hub.atlassian.net/browse/DISCO-3755)

## Description
This PR adds metrics for the flightaware provider to support performance monitoring and observability.

The following metrics were added:
Provider (`provider.py`)
- `providers.flightaware.cache.hit.flightnumbers` - incremented when a valid flight number is found in the in-memory cache.
- `providers.flightaware.cache.miss.flightnumbers` - incremented when a valid flight number is not found in cache.
- `providers.flightaware.query.exception` - incremented when an exception occurs in the provider query path.
- `providers.flightaware.query.backend.get` - measures time spent fetching flight details from the backend.

Backend (`flightaware.py`)
- `flightaware.request.summary.get.count` - total number of backend API requests made.
- `flightaware.request.summary.get.latency` - measures latency of each HTTP request.
- `flightaware.request.summary.get.status.<code>` - increments for each HTTP status code.
- `flightaware.request.summary.get.failed` - increments when an HTTP error occurs.
- `flightaware.request.summary.get.exception` - increments when a network or unexpected client-side error occurs.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1911)


[DISCO-3755]: https://mozilla-hub.atlassian.net/browse/DISCO-3755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ