### PR TITLE
[DISCO-3771] fix: provider initialization tests running too slow

### DIFF
--- a/tests/unit/providers/manifest/test_init_provider.py
+++ b/tests/unit/providers/manifest/test_init_provider.py
@@ -4,10 +4,24 @@
 
 """Unit tests for the __init__ manifest provider module."""
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 import pytest
 
-from merino.providers.manifest import get_provider, init_provider, Provider as ManifestProvider
+from merino.providers.manifest import (
+    get_provider,
+    init_provider,
+    Provider as ManifestProvider,
+)
+
+
+@pytest.fixture(autouse=True)
+def patch_manifest_fetch_data():
+    """Patch Manifest Provider._fetch_data to prevent real GCS calls during tests."""
+    with patch(
+        "merino.providers.manifest.provider.Provider._fetch_data",
+        new_callable=AsyncMock,
+    ) as mock_fetch_data:
+        yield mock_fetch_data
 
 
 @pytest.mark.asyncio

--- a/tests/unit/providers/suggest/flightaware/test_provider.py
+++ b/tests/unit/providers/suggest/flightaware/test_provider.py
@@ -29,6 +29,7 @@ def backend_mock():
     backend = MagicMock()
     backend.fetch_flight_details = AsyncMock()
     backend.get_flight_summaries = MagicMock()
+    backend.fetch_flight_numbers = AsyncMock()
     return backend
 
 

--- a/tests/unit/providers/suggest/test_init_providers.py
+++ b/tests/unit/providers/suggest/test_init_providers.py
@@ -5,6 +5,7 @@
 """Unit tests for the __init__ suggest provider module."""
 
 import logging
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from pytest import LogCaptureFixture
@@ -22,6 +23,26 @@ from merino.providers.suggest.manager import ProviderType
 from tests.types import FilterCaplogFixture
 
 DISABLED_PROVIDERS = settings.runtime.disabled_providers
+
+
+@pytest.fixture(autouse=True)
+def patch_flightaware_fetch_data():
+    """Patch FlightAware Provider._fetch_data to prevent real GCS calls."""
+    with patch(
+        "merino.providers.suggest.flightaware.provider.Provider._fetch_data",
+        new_callable=AsyncMock,
+    ) as mock_fetch_data:
+        yield mock_fetch_data
+
+
+@pytest.fixture(autouse=True)
+def patch_finance_fetch_manifest():
+    """Patch Finance Provider._fetch_manifest to prevent real GCS  calls."""
+    with patch(
+        "merino.providers.suggest.finance.provider.Provider._fetch_manifest",
+        new_callable=AsyncMock,
+    ) as mock_fetch_manifest:
+        yield mock_fetch_manifest
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## References

JIRA: [DISCO-3771](https://mozilla-hub.atlassian.net/browse/DISCO-3771)

## Description
This PR fixes a test performance issue caused by real provider initialization logic being executed during `init_providers()` tests. Multiple provider `initialize()` methods were making network calls (e.g., fetching data from GCS ), leading to slow or flaky test runs.

### Problem
`test_init_providers` tests were taking 30+ seconds to run. The slowdown was traced to real calls being made by provider initialization methods:

FlightAware -> `_fetch_data()` -> GCS `get_file()`
Finance -> `_fetch_manifest()` -> GCS `fetch_manifest_data()`
Manifest ->  `_fetch_data()` -> GCS `get_file()`

These async calls were triggered automatically when `await init_providers()` ran, even during unit tests, causing network timeouts and delayed test execution.

### Root Cause
- `init_providers()` creates and initializes all registered providers, including ones that start cron jobs or perform data fetching in their `initialize()` methods.
- Without mocking, those methods invoked real GCS or backend logic during tests.

### Fix
- Added autouse pytest fixtures to mock the slow async initialization methods for each provider

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1913)


[DISCO-3771]: https://mozilla-hub.atlassian.net/browse/DISCO-3771?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ