### PR TITLE
GENAI-2235 tweak priors in crwler rollout

### DIFF
--- a/merino/curated_recommendations/prior_backends/experiment_rescaler.py
+++ b/merino/curated_recommendations/prior_backends/experiment_rescaler.py
@@ -11,7 +11,7 @@ SUBTOPIC_EXPERIMENT_CURATED_ITEM_FLAG = "SUBTOPICS"
 # Subtopic prior scaling is derived using data analysis on scores and existing priors
 # See more at:
 # https://mozilla-hub.atlassian.net/wiki/spaces/FAAMT/pages/1727725665/Thompson+Sampling+of+Subtopic+Sections
-PESSIMISTIC_PRIOR_ALPHA_SCALE = 0.4
+PESSIMISTIC_PRIOR_ALPHA_SCALE = 0.3
 PESSIMISTIC_PRIOR_ALPHA_SCALE_SUBTOPIC = 0.25
 
 


### PR DESCRIPTION
## References

JIRA: https://mozilla-hub.atlassian.net/browse/GENAI-2235

## Description
For the rollout of crawled sections, in the evening there are too many new stories published, so that other popular news stories don't get coverage.

See the JIRA ticket for details behind the change.

A long term fix is outlined in this doc https://mozilla-hub.atlassian.net/wiki/spaces/FAAMT/pages/1795457076/HNT+Content+Experiment+Tracking

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1918)
