### PR TITLE
[DISCO-3781] fix: Handle the empty bucket case for  DomainDiff

### DIFF
--- a/merino/jobs/navigational_suggestions/__init__.py
+++ b/merino/jobs/navigational_suggestions/__init__.py
@@ -455,7 +455,7 @@ def _run_normal_mode(
     )
 
     if old_top_picks is None:
-        old_top_picks = {}
+        old_top_picks = {"domains": []}
 
     domain_diff = DomainDiff(latest_domain_data=final_top_picks, old_domain_data=old_top_picks)
     (


### PR DESCRIPTION
## References

JIRA: [DISCO-3781](https://mozilla-hub.atlassian.net/browse/DISCO-3781)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->

There is a special case when the bucket is empty, `DomainDiff` will complain about a missing key.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3781]: https://mozilla-hub.atlassian.net/browse/DISCO-3781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1920)
