### PR TITLE
bug: Add missing default.toml arg for sports.

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -331,6 +331,8 @@ team_index="sports_{lang}_team"
 max_suggestions = 5
 # Disable this provider by default
 enabled_by_default = false
+# General timeout
+query_timeout_sec = 3.0
 
 [default.providers.sports.es]
 # MERINO_PROVIDERS__SPORTS__ES_dsn


### PR DESCRIPTION
Closes DISCO-3782

## References

JIRA: [DISCO-3782](https://mozilla-hub.atlassian.net/browse/DISCO-3782)

## Description
Adds missing `query_timeout_sec` argument for `default.providers.sports` in `default.toml`

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3782]: https://mozilla-hub.atlassian.net/browse/DISCO-3782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1921)
