### PR TITLE
[DISCO-3785] fix:Update asyncclient for polygon to follow redirects

### DIFF
--- a/merino/providers/suggest/manager.py
+++ b/merino/providers/suggest/manager.py
@@ -240,6 +240,7 @@ def _create_provider(provider_id: str, setting: Settings) -> BaseProvider:
                     http_client=create_http_client(
                         base_url=settings.polygon.url_base,
                         connect_timeout=settings.providers.polygon.connect_timeout_sec,
+                        follow_redirects=True,
                     ),
                     url_param_api_key=settings.polygon.url_param_api_key,
                     url_single_ticker_snapshot=settings.polygon.url_single_ticker_snapshot,

--- a/merino/utils/http_client.py
+++ b/merino/utils/http_client.py
@@ -12,6 +12,7 @@ def create_http_client(
     request_timeout: float = 5.0,
     pool_timeout: float = 1.0,
     proxy: str | None = None,
+    follow_redirects: bool = False,
 ) -> AsyncClient:
     """Crete a new `httpx.AsyncClient` with common configurations.
 
@@ -31,4 +32,5 @@ def create_http_client(
         limits=Limits(max_connections=max_connections),
         timeout=Timeout(request_timeout, connect=connect_timeout, pool=pool_timeout),
         proxy=Proxy(proxy) if proxy else None,
+        follow_redirects=follow_redirects,
     )


### PR DESCRIPTION
## References

JIRA: [DISCO-3785](https://mozilla-hub.atlassian.net/browse/DISCO-3785)

## Description
This PR fixes a recent failure in the polygon airflow job where logo image downloads began returning HTTP 308 Permanent Redirect responses instead of direct image data.

Possible cause:
Polygon (or its CDN provider) might have introduced a permanent redirect for branding asset URLs (e.g., logo_url, icon_url) returned by the /v3/reference/tickers/{ticker} endpoint. Since our HTTP client (httpx.AsyncClient) did not follow redirects by default, image fetches were failing with HTTPStatusError: 308 Permanent Redirect.

I updated the config for `httpx.AsyncClient` to accept `follow_redirects`.

Tested locally and it worked so i'm hoping this fixes it on airflow

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3785]: https://mozilla-hub.atlassian.net/browse/DISCO-3785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1926)
