### PR TITLE
[DISCO-3791] chore: Flip enabled_by_default for top_picks

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -602,7 +602,7 @@ type = "top_picks"
 
 # MERINO_PROVIDERS__TOP_PICKS__ENABLED_BY_DEFAULT
 # Whether this provider is enabled by default. Defaults to true.
-enabled_by_default = true
+enabled_by_default = false
 
 # MERINO_PROVIDERS__TOP_PICKS__SCORE
 # Ranking score for this provider as a floating point number with a default of 0.25.


### PR DESCRIPTION
## References

JIRA: [DISCO-3791](https://mozilla-hub.atlassian.net/browse/DISCO-3791)

## Description
Bring `top_picks` to dark per product's request. Not disabling it as we will bring it back at a later time.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3791]: https://mozilla-hub.atlassian.net/browse/DISCO-3791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1931)
