### PR TITLE
[DISCO-3794] Capitalize airline name in flight response

### DIFF
--- a/merino/providers/suggest/flightaware/backends/airline_mappings.py
+++ b/merino/providers/suggest/flightaware/backends/airline_mappings.py
@@ -2066,7 +2066,7 @@ AIRLINE_CODE_TO_NAME_MAPPING = {
     "PA": {"name": "parmiss airlines", "color": "#003B5C"},
     "PB": {"name": "pal airlines", "color": "#003366"},
     "PC": {"name": "pegasus airlines", "color": "#D71920"},
-    "PD": {"name": "porter airlines", "color": "#E4002B"},
+    "PD": {"name": "porter airlines", "color": "#112855"},
     "PE": {"name": "air europe", "color": "#003366"},
     "PF": {"name": "primera air", "color": "#D71920"},
     "PFL": {"name": "pacific flier", "color": "#003B5C"},

--- a/merino/providers/suggest/flightaware/backends/utils.py
+++ b/merino/providers/suggest/flightaware/backends/utils.py
@@ -346,6 +346,7 @@ def get_airline_details(flight_number: str) -> AirlineDetails:
     airline_data = AIRLINE_CODE_TO_NAME_MAPPING.get(code, {}) if code else {}
 
     name = airline_data.get("name")
+    name = name.title() if name else None
     color = airline_data.get("color")
 
     return AirlineDetails(

--- a/tests/unit/providers/suggest/flightaware/backend/test_utils.py
+++ b/tests/unit/providers/suggest/flightaware/backend/test_utils.py
@@ -250,7 +250,7 @@ def test_build_flight_summary_valid(flight_with_codeshare):
     assert summary.url == HttpUrl("https://www.flightaware.com/live/flight/UAL123")
 
     assert summary.airline.code == "UA"
-    assert summary.airline.name == "united airlines"
+    assert summary.airline.name == "United Airlines"
     assert summary.airline.color == "#005DAA"
 
 
@@ -884,12 +884,12 @@ def test_get_flight_number_from_query_if_valid(description, query, mapping, expe
 @pytest.mark.parametrize(
     "description, flight_number, expected_code, expected_name, expected_color",
     [
-        ("valid 2-letter IATA code", "AA123", "AA", "american airlines", "#cc0000"),
+        ("valid 2-letter IATA code", "AA123", "AA", "American Airlines", "#cc0000"),
         (
             "valid 3-letter ICAO code fallback when IATA not matched",
             "UAL789",
             "UAL",
-            "united airlines",
+            "United Airlines",
             "#003366",
         ),
         ("unknown airline code returns None values", "ZZ999", None, None, None),


### PR DESCRIPTION
## References

JIRA: [DISCO-3794](https://mozilla-hub.atlassian.net/browse/DISCO-3794)

## Description
Addresses [this bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1997682). This PR capitalized the airline name returned as part of the flight aware suggestion response.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3794]: https://mozilla-hub.atlassian.net/browse/DISCO-3794?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1935)
