### PR TITLE
[DISCO-3779] fix: disable GCS fetch in non-prod environments

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -269,6 +269,11 @@ gcs_bucket = ""
 # CDN hostname used for public URLs of stored images
 cdn_hostname = ""
 
+# MERINO_IMAGE_GCS__ENABLED
+# Whether to enable fetching from GCS.
+# Set to `true` in production and `false` in staging or development.
+gcs_enabled = true
+
 
 [default.icon]
 # Subdirectory within bucket for favicons

--- a/merino/configs/stage.toml
+++ b/merino/configs/stage.toml
@@ -27,12 +27,17 @@ gcs_project = "moz-fx-merino-nonprod-ee93"
 # MERINO_IMAGE_GCS__GCS_BUCKET
 gcs_bucket = "merino-images-stagepy"
 
+# MERINO_IMAGE_GCS__ENABLED
+# Whether to enable fetching from GCS.
+# Set to `true` in production and `false` in staging or development.
+gcs_enabled = false
+
 
 [stage.image_gcs_v1]
-# MERINO_IMAGE_GCS__GCS_PROJECT
+# MERINO_IMAGE_GCS_V1__GCS_PROJECT
 gcs_project = "moz-fx-merino-nonprod-ee93"
 
-# MERINO_IMAGE_GCS__GCS_BUCKET
+# MERINO_IMAGE_GCS_V1__GCS_BUCKET
 gcs_bucket = "merino-images-stagepy"
 
 [stage.providers.top_picks]

--- a/merino/providers/manifest/provider.py
+++ b/merino/providers/manifest/provider.py
@@ -17,6 +17,7 @@ from merino.providers.manifest.backends.protocol import (
     ManifestBackendError,
     ManifestData,
 )
+from merino.configs import settings
 
 logger = logging.getLogger(__name__)
 
@@ -54,15 +55,16 @@ class Provider:
 
     async def initialize(self) -> None:
         """Initialize Manifest provider."""
-        await self._fetch_data()
+        if settings.image_gcs.gcs_enabled:
+            await self._fetch_data()
 
-        cron_job = cron.Job(
-            name="resync_manifest",
-            interval=self.cron_interval_sec,
-            condition=self._should_fetch,
-            task=self._fetch_data,
-        )
-        self.cron_task = asyncio.create_task(cron_job())
+            cron_job = cron.Job(
+                name="resync_manifest",
+                interval=self.cron_interval_sec,
+                condition=self._should_fetch,
+                task=self._fetch_data,
+            )
+            self.cron_task = asyncio.create_task(cron_job())
 
     async def _fetch_data(self) -> None:
         """Cron fetch method to re-run after set interval.

--- a/merino/providers/suggest/finance/provider.py
+++ b/merino/providers/suggest/finance/provider.py
@@ -8,7 +8,11 @@ import aiodogstatsd
 from fastapi import HTTPException
 from pydantic import HttpUrl
 
-from merino.providers.suggest.base import BaseProvider, BaseSuggestion, SuggestionRequest
+from merino.providers.suggest.base import (
+    BaseProvider,
+    BaseSuggestion,
+    SuggestionRequest,
+)
 from merino.providers.suggest.custom_details import CustomDetails, PolygonDetails
 from merino.providers.suggest.finance.backends.protocol import (
     FinanceBackend,
@@ -68,7 +72,7 @@ class Provider(BaseProvider):
 
     async def initialize(self) -> None:
         """Initialize the provider."""
-        if settings.current_env.lower() == "production":
+        if settings.image_gcs.gcs_enabled:
             await self._fetch_manifest()
 
             cron_job_fetch = cron.Job(

--- a/merino/providers/suggest/flightaware/provider.py
+++ b/merino/providers/suggest/flightaware/provider.py
@@ -21,6 +21,7 @@ from merino.providers.suggest.flightaware.backends.utils import (
     get_flight_number_from_query_if_valid,
 )
 from merino.utils import cron
+from merino.configs import settings
 
 logger = logging.getLogger(__name__)
 
@@ -62,15 +63,16 @@ class Provider(BaseProvider):
 
     async def initialize(self) -> None:
         """Initialize flight aware provider."""
-        await self._fetch_data()
+        if settings.image_gcs.gcs_enabled:
+            await self._fetch_data()
 
-        cron_job = cron.Job(
-            name="resync_flightaware",
-            interval=self.cron_interval_sec,
-            condition=self._should_fetch,
-            task=self._fetch_data,
-        )
-        self.cron_task = asyncio.create_task(cron_job())
+            cron_job = cron.Job(
+                name="resync_flightaware",
+                interval=self.cron_interval_sec,
+                condition=self._should_fetch,
+                task=self._fetch_data,
+            )
+            self.cron_task = asyncio.create_task(cron_job())
 
     async def _fetch_data(self) -> None:
         """Cron fetch method to re-run after set interval.


### PR DESCRIPTION
## References

JIRA: [DISCO-3779](https://mozilla-hub.atlassian.net/browse/DISCO-3779)

## Description
This PR fixes recurring Sentry errors in the staging environment caused by providers attempting to fetch data from non-existent GCS folders.

Previously, a few providers (e.g., Manifest, Finance, Flightaware) automatically initialized cron jobs to fetch data from GCS during startup. In the staging environment, these jobs failed with 404 errors because the corresponding GCS files don’t exist in the staging GCP project.

I added a config flag `gcs_enabled` that is set to false in `staging.toml` to prevent fetches in staging



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3779]: https://mozilla-hub.atlassian.net/browse/DISCO-3779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1936)
