### PR TITLE
[GENAI-2282] fixed experiment name and handle optin- prefix

### DIFF
--- a/merino/curated_recommendations/ml_backends/static_local_model.py
+++ b/merino/curated_recommendations/ml_backends/static_local_model.py
@@ -9,8 +9,9 @@ from merino.curated_recommendations.ml_backends.protocol import (
     ModelType,
     DayTimeWeightingConfig,
 )
+from merino.curated_recommendations.protocol import ExperimentName
 
-INFERRED_LOCAL_EXPERIMENT_NAME = "new-tab-automated-personalization-local-ranking"
+INFERRED_LOCAL_EXPERIMENT_NAME = ExperimentName.INFERRED_LOCAL_EXPERIMENT.value
 LOCAL_AND_SERVER_V1 = "local-and-server"
 LOCAL_ONLY_V1 = "local-only"
 LOCAL_ONLY_BRANCH_NAME = LOCAL_ONLY_V1

--- a/merino/curated_recommendations/protocol.py
+++ b/merino/curated_recommendations/protocol.py
@@ -101,6 +101,8 @@ class ExperimentName(str, Enum):
     CONTEXTUAL_AD_RELEASE_EXPERIMENT = "new-tab-contextual-ad-updates-release"
     CONTEXTUAL_AD_V2_RELEASE_EXPERIMENT = "new-tab-contextual-ad-updates-v2-release"
     NEW_TAB_CUSTOM_SECTIONS_EXPERIMENT = "new-tab-custom-sections"
+    # Experiment for doing local reranking of popular today via inferred interests
+    INFERRED_LOCAL_EXPERIMENT = "new-tab-automated-personalization-local-ranking"
 
 
 @unique

--- a/tests/unit/curated_recommendations/ml_backends/test_static_local_model.py
+++ b/tests/unit/curated_recommendations/ml_backends/test_static_local_model.py
@@ -12,7 +12,6 @@ from merino.curated_recommendations.ml_backends.static_local_model import (
     CTR_SECTION_MODEL_ID,
     CTR_LIMITED_TOPIC_MODEL_ID_V1_B,
     CTR_LIMITED_TOPIC_MODEL_ID_V1_A,
-    INFERRED_LOCAL_EXPERIMENT_NAME,
     LOCAL_AND_SERVER_V1,
     LOCAL_ONLY_V1,
     LOCAL_AND_SERVER_BRANCH_NAME,
@@ -28,6 +27,10 @@ from merino.curated_recommendations.provider import (
     CuratedRecommendationsProvider,
     LOCAL_MODEL_DB_VALUES_KEY,
 )
+
+from merino.curated_recommendations.protocol import ExperimentName
+
+INFERRED_LOCAL_EXPERIMENT_NAME = ExperimentName.INFERRED_LOCAL_EXPERIMENT.value
 
 TEST_SURFACE = "test_surface"
 


### PR DESCRIPTION
## References

JIRA: [DISCO-TODO](https://mozilla-hub.atlassian.net/browse/DISCO-TODO)

## Description
The experiment name is bugged for the local reranking experiment. Did not handle "optin-" prefix correctly.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1938)
