### PR TITLE
[DISCO-3799] fix doube write by switching gcs configs

### DIFF
--- a/merino/configs/__init__.py
+++ b/merino/configs/__init__.py
@@ -26,9 +26,9 @@ _validators = [
     Validator("image_gcs.gcs_project", is_type_of=str),
     Validator("image_gcs.gcs_bucket", is_type_of=str),
     Validator("image_gcs.cdn_hostname", is_type_of=str),
-    Validator("image_gcs_v1.gcs_project", is_type_of=str),
-    Validator("image_gcs_v1.gcs_bucket", is_type_of=str),
-    Validator("image_gcs_v1.cdn_hostname", is_type_of=str),
+    Validator("image_gcs_v2.gcs_project", is_type_of=str),
+    Validator("image_gcs_v2.gcs_bucket", is_type_of=str),
+    Validator("image_gcs_v2.cdn_hostname", is_type_of=str),
     Validator("accuweather.url_location_key_placeholder", is_type_of=str, must_exist=True),
     Validator(
         "accuweather.url_param_partner_code",

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -243,16 +243,16 @@ env = "dev"
 # If set to `debug`, the DSN will be set to a testing value recommended by Sentry,
 # and extra output will be included in the logs.
 
-[default.image_gcs_v1]
-# MERINO_IMAGE_GCS_V1__GCS_PROJECT
+[default.image_gcs_v2]
+# MERINO_IMAGE_GCS_V2__GCS_PROJECT
 # GCS project name that contains domain data
 gcs_project = ""
 
-# MERINO_IMAGE_GCS_V1__GCS_BUCKET
+# MERINO_IMAGE_GCS_V2__GCS_BUCKET
 # GCS bucket that contains domain data files
 gcs_bucket = ""
 
-# MERINO_IMAGE_GCS_V1__CDN_HOSTNAME
+# MERINO_IMAGE_GCS_V2__CDN_HOSTNAME
 # CDN hostname used for public URLs of stored images
 cdn_hostname = ""
 

--- a/merino/configs/production.toml
+++ b/merino/configs/production.toml
@@ -20,30 +20,31 @@ skip_gcp_client_auth = true
 [production.accuweather]
 url_base = "https://api.accuweather.com"
 
-[production.image_gcs_v1]
-# MERINO_IMAGE_GCS_V1__GCS_PROJECT
+# TODO - update this to GCPV2 values before removing image_gcs_v2 below
+[production.image_gcs]
+# MERINO_IMAGE_GCS__GCS_PROJECT
 # GCS project name that contains domain data
 gcs_project = "moz-fx-merino-prod-1c2f"
 
-# MERINO_IMAGE_GCS_V1__GCS_BUCKET
+# MERINO_IMAGE_GCS__GCS_BUCKET
 # GCS bucket that contains domain data files
 gcs_bucket = "merino-images-prodpy"
 
-# MERINO_IMAGE_GCS_V1__CDN_HOSTNAME
+# MERINO_IMAGE_GCS__CDN_HOSTNAME
 # CDN hostname used for public URLs of stored images
 cdn_hostname = "merino-images.services.mozilla.com"
 
 
-[production.image_gcs]
-# MERINO_IMAGE_GCS__GCS_PROJECT
+[production.image_gcs_v2]
+# MERINO_IMAGE_GCS_V2__GCS_PROJECT
 # GCS project name that contains domain data
 gcs_project = "moz-fx-merino-prod-5de4"
 
-# MERINO_IMAGE_GCS__GCS_BUCKET
+# MERINO_IMAGE_GCS_V2__GCS_BUCKET
 # GCS bucket that contains domain data files
 gcs_bucket = "merino-images-prod"
 
-# MERINO_IMAGE_GCS__CDN_HOSTNAME
+# MERINO_IMAGE_GCS_V2__CDN_HOSTNAME
 # CDN hostname used for public URLs of stored images
 cdn_hostname = "prod-images.merino.prod.webservices.mozgcp.net"
 

--- a/merino/configs/stage.toml
+++ b/merino/configs/stage.toml
@@ -33,11 +33,11 @@ gcs_bucket = "merino-images-stagepy"
 gcs_enabled = false
 
 
-[stage.image_gcs_v1]
-# MERINO_IMAGE_GCS_V1__GCS_PROJECT
+[stage.image_gcs_v2]
+# MERINO_IMAGE_GCS_V2__GCS_PROJECT
 gcs_project = "moz-fx-merino-nonprod-ee93"
 
-# MERINO_IMAGE_GCS_V1__GCS_BUCKET
+# MERINO_IMAGE_GCS_V2__GCS_BUCKET
 gcs_bucket = "merino-images-stagepy"
 
 [stage.providers.top_picks]

--- a/merino/configs/testing.toml
+++ b/merino/configs/testing.toml
@@ -27,7 +27,7 @@ gcs_project = "test_gcp_uploader_project"
 gcs_bucket = "test_gcp_uploader_bucket"
 cdn_hostname = "test-cdn.mozilla.net"
 
-[testing.image_gcs_v1]
+[testing.image_gcs_v2]
 gcs_project = "test_gcp_uploader_project"
 gcs_bucket = "test_gcp_uploader_bucket"
 cdn_hostname = "test-cdn.mozilla.net"

--- a/merino/jobs/flightaware/fetch_schedules.py
+++ b/merino/jobs/flightaware/fetch_schedules.py
@@ -142,20 +142,20 @@ async def store_flight_numbers_in_redis(flight_number_set: set[str]) -> None:
 async def store_flight_numbers_in_gcs(flight_number_set: set[str]) -> None:
     """Add new unique flight numbers in GCS and log additions."""
     try:
-        uploader_v1 = GcsUploader(
-            settings.image_gcs_v1.gcs_project,
-            settings.image_gcs_v1.gcs_bucket,
-            settings.image_gcs_v1.cdn_hostname,
-        )
-
-        # upload file to GCPV2
         uploader = GcsUploader(
             settings.image_gcs.gcs_project,
             settings.image_gcs.gcs_bucket,
             settings.image_gcs.cdn_hostname,
         )
 
-        existing_blob = uploader_v1.get_most_recent_file(
+        # upload file to GCPV2
+        uploader_v2 = GcsUploader(
+            settings.image_gcs_v2.gcs_project,
+            settings.image_gcs_v2.gcs_bucket,
+            settings.image_gcs_v2.cdn_hostname,
+        )
+
+        existing_blob = uploader.get_most_recent_file(
             match="flight_numbers",
             sort_key=lambda b: b.updated,
         )
@@ -170,7 +170,7 @@ async def store_flight_numbers_in_gcs(flight_number_set: set[str]) -> None:
         newly_added = combined - existing_numbers
         content = json.dumps(sorted(combined), indent=2)
 
-        uploader_v1.upload_content(
+        uploader.upload_content(
             content=content,
             destination_name="flight_numbers_latest.json",
             content_type="application/json",
@@ -178,7 +178,7 @@ async def store_flight_numbers_in_gcs(flight_number_set: set[str]) -> None:
         )
 
         # upload file to GCPV2
-        uploader.upload_content(
+        uploader_v2.upload_content(
             content=content,
             destination_name="flight_numbers_latest.json",
             content_type="application/json",

--- a/merino/jobs/polygon/polygon_ingestion.py
+++ b/merino/jobs/polygon/polygon_ingestion.py
@@ -41,10 +41,10 @@ class PolygonIngestion:
                     settings.image_gcs.gcs_bucket,
                     settings.image_gcs.cdn_hostname,
                 ),
-                gcs_uploader_v1=GcsUploader(
-                    settings.image_gcs_v1.gcs_project,
-                    settings.image_gcs_v1.gcs_bucket,
-                    settings.image_gcs_v1.cdn_hostname,
+                gcs_uploader_v2=GcsUploader(
+                    settings.image_gcs_v2.gcs_project,
+                    settings.image_gcs_v2.gcs_bucket,
+                    settings.image_gcs_v2.cdn_hostname,
                 ),
                 cache=NoCacheAdapter(),
             ),

--- a/merino/providers/manifest/backends/manifest.py
+++ b/merino/providers/manifest/backends/manifest.py
@@ -34,7 +34,7 @@ class ManifestBackend:
     ) -> tuple[GetManifestResultCode, ManifestData | None]:
         """Fetch manifest data from GCS through the remote filemanager."""
         remote_filemanager = ManifestRemoteFilemanager(
-            gcs_bucket_path=settings.image_gcs_v1.gcs_bucket,
+            gcs_bucket_path=settings.image_gcs.gcs_bucket,
             blob_name=GCS_BLOB_NAME,
         )
 

--- a/merino/providers/suggest/adm/backends/remotesettings.py
+++ b/merino/providers/suggest/adm/backends/remotesettings.py
@@ -61,7 +61,6 @@ class RemoteSettingsBackend:
     """Backend that connects to a live Remote Settings server."""
 
     kinto_http_client: kinto_http.AsyncClient
-    icon_processor_v1: IconProcessor
     icon_processor: IconProcessor
     # A map to record the last modified timestamp for each "amp" type record.
     # The key stores the record ID and the value stores the "last_modified" field
@@ -75,7 +74,6 @@ class RemoteSettingsBackend:
         server: str | None,
         collection: str | None,
         bucket: str | None,
-        icon_processor_v1: IconProcessor,
         icon_processor: IconProcessor,
     ) -> None:
         """Init the Remote Settings backend and create a new client.
@@ -99,7 +97,6 @@ class RemoteSettingsBackend:
             server_url=server, bucket=bucket, collection=collection
         )
 
-        self.icon_processor_v1 = icon_processor_v1
         self.icon_processor = icon_processor
         self.last_modified_timestamps = dict()
         self.suggestion_content = SuggestionContent(index_manager=AmpIndexManager(), icons={})  # type: ignore[no-untyped-call]
@@ -168,22 +165,12 @@ class RemoteSettingsBackend:
 
         # Process all icons concurrently using TaskGroup
         try:
-            async with asyncio.TaskGroup() as task_group_v1:
-                for _, url in icon_data:
-                    tasks.append(
-                        task_group_v1.create_task(self.icon_processor_v1.process_icon_url(url))
-                    )
-        except ExceptionGroup as eg:
-            # If an unhandled exception occurs in TaskGroup
-            logger.error(f"Errors during icon processing (v1): {eg}")
-
-        try:
             async with asyncio.TaskGroup() as task_group:
                 for _, url in icon_data:
-                    task_group.create_task(self.icon_processor.process_icon_url(url))
+                    tasks.append(task_group.create_task(self.icon_processor.process_icon_url(url)))
         except ExceptionGroup as eg:
             # If an unhandled exception occurs in TaskGroup
-            logger.error(f"Errors during icon processing (v2): {eg}")
+            logger.error(f"Errors during icon processing: {eg}")
 
         # Map results back to their IDs, handling any exceptions
         for (id, original_url), task in zip(icon_data, tasks):

--- a/merino/providers/suggest/finance/backends/protocol.py
+++ b/merino/providers/suggest/finance/backends/protocol.py
@@ -94,8 +94,8 @@ class FinanceBackend(Protocol):
         ...
 
     async def bulk_download_and_upload_ticker_images(
-        self, tickers: list[str], prefix: str = "tickers"
-    ) -> dict[str, str]:
+        self, tickers: list[str], prefix: str = "polygon"
+    ) -> dict[str, dict[str, str]]:
         """Download and upload images for a list of ticker symbols.
         Uses content hash to deduplicate and skips upload if destination blob already exists.
         """

--- a/merino/providers/suggest/flightaware/backends/flightaware.py
+++ b/merino/providers/suggest/flightaware/backends/flightaware.py
@@ -46,7 +46,7 @@ class FlightAwareBackend(FlightBackendProtocol):
         self.http_client = http_client
         self.ident_url = ident_url
         self.filemanager = FlightawareFilemanager(
-            gcs_bucket_path=settings.image_gcs_v1.gcs_bucket,
+            gcs_bucket_path=settings.image_gcs.gcs_bucket,
             blob_name=GCS_BLOB_NAME,
         )
         self.metrics_client = metrics_client

--- a/merino/providers/suggest/manager.py
+++ b/merino/providers/suggest/manager.py
@@ -158,14 +158,6 @@ def _create_provider(provider_id: str, setting: Settings) -> BaseProvider:
                         server=settings.remote_settings.server,
                         collection=settings.remote_settings.collection_amp,
                         bucket=settings.remote_settings.bucket,
-                        icon_processor_v1=IconProcessor(
-                            gcs_project=settings.image_gcs_v1.gcs_project,
-                            gcs_bucket=settings.image_gcs_v1.gcs_bucket,
-                            cdn_hostname=settings.image_gcs_v1.cdn_hostname,
-                            http_client=create_http_client(
-                                request_timeout=settings.icon.http_timeout,
-                            ),
-                        ),
                         icon_processor=IconProcessor(
                             gcs_project=settings.image_gcs.gcs_project,
                             gcs_bucket=settings.image_gcs.gcs_bucket,
@@ -251,10 +243,10 @@ def _create_provider(provider_id: str, setting: Settings) -> BaseProvider:
                         settings.image_gcs.gcs_bucket,
                         settings.image_gcs.cdn_hostname,
                     ),
-                    gcs_uploader_v1=GcsUploader(
-                        settings.image_gcs_v1.gcs_project,
-                        settings.image_gcs_v1.gcs_bucket,
-                        settings.image_gcs_v1.cdn_hostname,
+                    gcs_uploader_v2=GcsUploader(
+                        settings.image_gcs_v2.gcs_project,
+                        settings.image_gcs_v2.gcs_bucket,
+                        settings.image_gcs_v2.cdn_hostname,
                     ),
                     ticker_ttl_sec=settings.providers.polygon.cache_ttls.ticker_ttl_sec,
                     cache=cache,

--- a/merino/providers/suggest/top_picks/backends/top_picks.py
+++ b/merino/providers/suggest/top_picks/backends/top_picks.py
@@ -168,8 +168,8 @@ class TopPicksBackend:
         match DomainDataSource(domain_data_source):
             case DomainDataSource.REMOTE:
                 remote_filemanager = TopPicksRemoteFilemanager(
-                    gcs_project_path=settings.image_gcs_v1.gcs_project,
-                    gcs_bucket_path=settings.image_gcs_v1.gcs_bucket,
+                    gcs_project_path=settings.image_gcs.gcs_project,
+                    gcs_bucket_path=settings.image_gcs.gcs_bucket,
                 )
 
                 get_file_result_code, remote_domains = remote_filemanager.get_file()

--- a/tests/integration/providers/suggest/adm/backends/test_remotesettings_icon.py
+++ b/tests/integration/providers/suggest/adm/backends/test_remotesettings_icon.py
@@ -197,7 +197,6 @@ async def test_remotesettings_with_icon_processor(
         collection=rs_parameters["collection"],
         bucket=rs_parameters["bucket"],
         icon_processor=mock_processor,
-        icon_processor_v1=mock_processor,
     )
 
     # Mock the Remote Settings client methods
@@ -247,7 +246,6 @@ async def test_remotesettings_icon_processor_error_handling(
         collection=rs_parameters["collection"],
         bucket=rs_parameters["bucket"],
         icon_processor=mock_processor,
-        icon_processor_v1=mock_processor,
     )
 
     # Mock the Remote Settings client methods
@@ -297,7 +295,7 @@ async def test_remotesettings_with_gcs_integration(
         icon_processor = IconProcessor(
             gcs_project=gcs_storage_client.project,
             gcs_bucket=gcs_storage_bucket.name,
-            cdn_hostname=settings.image_gcs_v1.cdn_hostname,
+            cdn_hostname=settings.image_gcs.cdn_hostname,
             http_client=mock_http_client,
         )
 
@@ -317,7 +315,6 @@ async def test_remotesettings_with_gcs_integration(
             collection=rs_parameters["collection"],
             bucket=rs_parameters["bucket"],
             icon_processor=icon_processor,
-            icon_processor_v1=icon_processor,
         )
 
         # Mock the Remote Settings client methods

--- a/tests/integration/providers/suggest/finance/backends/test_polygon.py
+++ b/tests/integration/providers/suggest/finance/backends/test_polygon.py
@@ -77,7 +77,7 @@ def fixture_polygon_parameters(
         "url_single_ticker_snapshot": URL_SINGLE_TICKER_SNAPSHOT,
         "url_single_ticker_overview": URL_SINGLE_TICKER_OVERVIEW,
         "gcs_uploader": mocker.MagicMock(),
-        "gcs_uploader_v1": mocker.MagicMock(),
+        "gcs_uploader_v2": mocker.MagicMock(),
         "cache": RedisAdapter(redis_client),
         "ticker_ttl_sec": TICKER_TTL_SEC,
     }

--- a/tests/load/locustfiles/locustfile.py
+++ b/tests/load/locustfiles/locustfile.py
@@ -194,9 +194,9 @@ async def get_adm_queries(
     )
 
     icon_processor = IconProcessor(
-        gcs_project=settings.image_gcs_v1.gcs_project,
-        gcs_bucket=settings.image_gcs_v1.gcs_bucket,
-        cdn_hostname=settings.image_gcs_v1.cdn_hostname,
+        gcs_project=settings.image_gcs.gcs_project,
+        gcs_bucket=settings.image_gcs.gcs_bucket,
+        cdn_hostname=settings.image_gcs.cdn_hostname,
         http_client=http_client,
     )
     backend: RemoteSettingsBackend = RemoteSettingsBackend(
@@ -204,7 +204,6 @@ async def get_adm_queries(
         collection=collection,
         bucket=bucket,
         icon_processor=icon_processor,
-        icon_processor_v1=icon_processor,
     )
     records: list[dict[str, Any]] = await backend.get_records()
     amp_records: list[dict[str, Any]] = backend.filter_records("amp", records)

--- a/tests/unit/providers/suggest/adm/backends/test_remotesettings.py
+++ b/tests/unit/providers/suggest/adm/backends/test_remotesettings.py
@@ -61,7 +61,6 @@ def fixture_rs_backend(
         collection=rs_parameters["collection"],
         bucket=rs_parameters["bucket"],
         icon_processor=mock_icon_processor,
-        icon_processor_v1=mock_icon_processor,
     )
 
 
@@ -268,7 +267,6 @@ def test_init_invalid_remote_settings_parameter_error(
             collection=rs_parameters.get("collection"),
             bucket=rs_parameters.get("bucket"),
             icon_processor=mock_icon_processor,
-            icon_processor_v1=mock_icon_processor,
         )
 
     assert str(error.value) == expected_error_value

--- a/tests/unit/providers/suggest/top_picks/backends/test_filemanager.py
+++ b/tests/unit/providers/suggest/top_picks/backends/test_filemanager.py
@@ -46,8 +46,8 @@ def fixture_top_picks_remote_filemanager_parameters() -> dict[str, Any]:
     """Define TopPicksRemoteFilemanager parameters for test."""
     # These settings read from testing.toml, not default.toml.
     return {
-        "gcs_project_path": settings.image_gcs_v1.gcs_project,
-        "gcs_bucket_path": settings.image_gcs_v1.gcs_bucket,
+        "gcs_project_path": settings.image_gcs.gcs_project,
+        "gcs_bucket_path": settings.image_gcs.gcs_bucket,
     }
 
 

--- a/tests/unit/providers/suggest/top_picks/conftest.py
+++ b/tests/unit/providers/suggest/top_picks/conftest.py
@@ -26,8 +26,8 @@ def fixture_top_picks_domain_blocklist() -> set[str]:
 def fixture_top_picks_remote_filemanager_parameters() -> dict[str, Any]:
     """Define TopPicksRemoteFilemanager parameters for test."""
     return {
-        "gcs_project_path": settings.image_gcs_v1.gcs_project,
-        "gcs_bucket_path": settings.image_gcs_v1.gcs_bucket,
+        "gcs_project_path": settings.image_gcs.gcs_project,
+        "gcs_bucket_path": settings.image_gcs.gcs_bucket,
     }
 
 

--- a/tests/unit/utils/test_icon_processor.py
+++ b/tests/unit/utils/test_icon_processor.py
@@ -29,9 +29,9 @@ def icon_processor(mocker):
     mock_http_client = AsyncMock()
 
     processor = IconProcessor(
-        gcs_project=settings.image_gcs_v1.gcs_project,
-        gcs_bucket=settings.image_gcs_v1.gcs_bucket,
-        cdn_hostname=settings.image_gcs_v1.cdn_hostname,
+        gcs_project=settings.image_gcs.gcs_project,
+        gcs_bucket=settings.image_gcs.gcs_bucket,
+        cdn_hostname=settings.image_gcs.cdn_hostname,
         http_client=mock_http_client,
     )
 
@@ -57,15 +57,15 @@ def test_init(mocker):
     mock_client = AsyncMock()
 
     processor = IconProcessor(
-        gcs_project=settings.image_gcs_v1.gcs_project,
-        gcs_bucket=settings.image_gcs_v1.gcs_bucket,
-        cdn_hostname=settings.image_gcs_v1.cdn_hostname,
+        gcs_project=settings.image_gcs.gcs_project,
+        gcs_bucket=settings.image_gcs.gcs_bucket,
+        cdn_hostname=settings.image_gcs.cdn_hostname,
         http_client=mock_client,
     )
 
     assert processor.uploader is not None
     assert processor.content_hash_cache == {}
-    assert processor.uploader.cdn_hostname == settings.image_gcs_v1.cdn_hostname
+    assert processor.uploader.cdn_hostname == settings.image_gcs.cdn_hostname
     assert processor.http_client is mock_client
 
 
@@ -482,7 +482,10 @@ async def test_fetch_with_icon_processing_errors():
     # Create instance with mock icon processor
     icon_processor_mock = MagicMock(spec=IconProcessor)
     backend = RemoteSettingsBackend(
-        "server", "collection", "bucket", icon_processor_mock, icon_processor_mock
+        "server",
+        "collection",
+        "bucket",
+        icon_processor_mock,
     )
 
     # Mock the methods directly on the instance


### PR DESCRIPTION
## References

JIRA: [DISCO-3799](https://mozilla-hub.atlassian.net/browse/DISCO-3799)

## Description
In [DISCO-3746](https://mozilla-hub.atlassian.net/browse/DISCO-3746) we updated the airflow jobs to write to both gcpv1 and gcpv2 buckets. An additional change was made to `remotesettings.py` which is run in merino and not airflow. So when merino is deployed to both gcpv1 and gcpv2, gcpv2 tries to write to gcpv1 and vice-versa which leads to [permission errors](https://mozilla.sentry.io/issues/6780035214/?environment=prod&project=6622434&query=is%3Aunresolved&referrer=issue-stream) in Sentry. This ticket is to fix this by writing to gcpv1 only and switching the config variable name for gcpv1 back to `image_gcs`.  This is because we are already overriding those values for GCPV2 [here](https://github.com/mozilla/webservices-infra/blob/main/merino/k8s/merino/values-prod.yaml#L43-L45).



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3746]: https://mozilla-hub.atlassian.net/browse/DISCO-3746?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1940)


[DISCO-3799]: https://mozilla-hub.atlassian.net/browse/DISCO-3799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ