### PR TITLE
[DISCO-3803] chore: Update the fallback link for wiki indexer

### DIFF
--- a/merino/jobs/wikipedia_indexer/__init__.py
+++ b/merino/jobs/wikipedia_indexer/__init__.py
@@ -98,5 +98,5 @@ def copy_export(
     latest = file_manager.stream_latest_dump_to_gcs()
     if latest is None or not getattr(latest, "name", ""):
         raise RuntimeError(
-            f"No {language} CirrusSearch dump found in current/ or fallback (20250818)."
+            f"No {language} CirrusSearch dump found in current/ or fallback (20251027)."
         )

--- a/merino/jobs/wikipedia_indexer/filemanager.py
+++ b/merino/jobs/wikipedia_indexer/filemanager.py
@@ -99,7 +99,7 @@ class FileManager:
             logger.warning(f"Failed to fetch listing from {self.base_url}: {e}")
 
         # 2. Fallback to dated directory (bandaid)
-        fallback_url = "https://dumps.wikimedia.org/other/cirrussearch/20250818/"
+        fallback_url = "https://dumps.wikimedia.org/other/cirrussearch/20251027/"
         try:
             resp = requests.get(fallback_url)  # nosec
             parser = DirectoryParser(self.file_pattern)

--- a/tests/integration/jobs/wikipedia_indexer/test_filemanager.py
+++ b/tests/integration/jobs/wikipedia_indexer/test_filemanager.py
@@ -214,8 +214,8 @@ def test_get_latest_dump_fallback_used_when_current_empty(requests_mock):
     requests_mock.get(base_url, text="<html><body>No matches</body></html>")  # nosec
 
     # fallback listing has one match
-    fallback_url = "https://dumps.wikimedia.org/other/cirrussearch/20250818/"
-    file_name = "enwiki-20250818-cirrussearch-content.json.gz"
+    fallback_url = "https://dumps.wikimedia.org/other/cirrussearch/20251027/"
+    file_name = "enwiki-20251027-cirrussearch-content.json.gz"
     requests_mock.get(
         fallback_url,
         text=f"<html><body><a href='{file_name}'>{file_name}</a></body></html>",
@@ -238,7 +238,7 @@ def test_get_latest_dump_fallback_skips_if_not_newer(requests_mock):
     requests_mock.get(base_url, text="<html><body>No matches</body></html>")  # nosec
 
     # fallback listing has one match, but it's older than GCS
-    fallback_url = "https://dumps.wikimedia.org/other/cirrussearch/20250818/"
+    fallback_url = "https://dumps.wikimedia.org/other/cirrussearch/20251027/"
     older_file = "enwiki-20240101-cirrussearch-content.json.gz"
     requests_mock.get(
         fallback_url,

--- a/tests/unit/jobs/wikipedia_indexer/test_filemanager.py
+++ b/tests/unit/jobs/wikipedia_indexer/test_filemanager.py
@@ -319,7 +319,7 @@ def test_get_latest_dump_uses_fallback_when_current_has_no_match(mock_get):
     resp_fallback = MagicMock()
     resp_fallback.content = """
     <html><body>
-      <a href="frwiki-20250818-cirrussearch-content.json.gz">frwiki-20250818-cirrussearch-content.json.gz</a>
+      <a href="frwiki-20251027-cirrussearch-content.json.gz">frwiki-20251027-cirrussearch-content.json.gz</a>
     </body></html>
     """
 
@@ -339,7 +339,7 @@ def test_get_latest_dump_uses_fallback_when_current_has_no_match(mock_get):
 
     assert (
         result
-        == "https://dumps.wikimedia.org/other/cirrussearch/20250818/frwiki-20250818-cirrussearch-content.json.gz"
+        == "https://dumps.wikimedia.org/other/cirrussearch/20251027/frwiki-20251027-cirrussearch-content.json.gz"
     )
 
 


### PR DESCRIPTION
## References

JIRA: [DISCO-3803](https://mozilla-hub.atlassian.net/browse/DISCO-3803)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->

The `current` link is still failing with HTTP 404, update the fallback link to point to the most recent one.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3803]: https://mozilla-hub.atlassian.net/browse/DISCO-3803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1942)
