### PR TITLE
bug: Switch to `America/New_York` for tz data

### DIFF
--- a/merino/jobs/sportsdata_jobs/__init__.py
+++ b/merino/jobs/sportsdata_jobs/__init__.py
@@ -22,8 +22,9 @@ hardcoded in the calling function for now, but is based on the file creation tim
 import asyncio
 import logging
 import typer
+import sys
 from time import time
-from httpx import AsyncClient, Timeout
+from httpx import AsyncClient
 from dynaconf.base import LazySettings
 from typing import cast
 
@@ -81,6 +82,7 @@ class SportDataUpdater:
         **kwargs,
     ) -> None:
         logger = logging.getLogger(__name__)
+        logger.info(f"{LOGGING_TAG} Python: {sys.version}")
         active_sports = [sport.strip().upper() for sport in settings.sports]
         sport: Sport | None = None
         sports: dict[str, Sport] = {}

--- a/merino/providers/suggest/sports/backends/sportsdata/common/sports.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/sports.py
@@ -215,7 +215,7 @@ class NFL(Sport):
         logger = logging.getLogger(__name__)
         await self.get_season(client=client)
         logger.debug(f"{LOGGING_TAG} Getting Events for {self.name}")
-        local_timezone = ZoneInfo("US/Eastern")
+        local_timezone = ZoneInfo("America/New_York")
         # get this week and next week
         for week in [int(self.week), int(self.week) + 1]:
             url = f"{self.base_url}/ScoresBasic/{self.season}/{week}?key={self.api_key}"
@@ -310,7 +310,7 @@ class NHL(Sport):
         logger = logging.getLogger(__name__)
         logger.debug(f"{LOGGING_TAG} Getting {self.name} schedules")
         url = f"{self.base_url}/SchedulesBasic/{self.season}?key={self.api_key}"
-        local_timezone = ZoneInfo("US/Eastern")
+        local_timezone = ZoneInfo("America/New_York")
         response = await get_data(
             client=client,
             url=url,
@@ -397,7 +397,7 @@ class NBA(Sport):
         if self.season is None:
             logger.info(f"{LOGGING_TAG} Skipping out of season {self.name}")
         logger.debug(f"{LOGGING_TAG} Getting {self.name} schedules")
-        local_timezone = ZoneInfo("US/Eastern")
+        local_timezone = ZoneInfo("America/New_York")
         url = f"{self.base_url}/SchedulesBasic/{self.season}?key={self.api_key}"
         response = await get_data(
             client=client,
@@ -572,7 +572,7 @@ class UCL(Sport):
 #            },
 #        ...]
 #        """
-#        date = datetime.now(tz=ZoneInfo("US/Eastern")).strftime("%Y-%b-%d")
+#        date = datetime.now(tz=ZoneInfo("America/New_York")).strftime("%Y-%b-%d")
 #        season = str(date)
 #        url = f"{self.base_url}/ScoresBasic/{season}?key={self.api_key}"
 #        await get_data(client, url)

--- a/tests/unit/providers/suggest/sports/backends/common/test_data.py
+++ b/tests/unit/providers/suggest/sports/backends/common/test_data.py
@@ -222,7 +222,7 @@ def test_load_schedules_from_source_filters_and_populates(
     mod_event["DateTime"] = None
     sport.events = {}
     mod_events = sport.load_schedules_from_source(
-        [mod_event], event_timezone=ZoneInfo("US/Eastern")
+        [mod_event], event_timezone=ZoneInfo("America/New_York")
     )
     assert len(mod_events) == 0
 


### PR DESCRIPTION
Also dump python version info, because I'm not sure what version airflow is running

## References

JIRA: [DISCO-3805](https://mozilla-hub.atlassian.net/browse/DISCO-3805)

## Description
* Switch to `America/New_York` for tz data
* dump python.version info

Error: ZoneInfoNotFoundError: 'No time zone found with key US/Eastern'

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3805]: https://mozilla-hub.atlassian.net/browse/DISCO-3805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1943)
