### PR TITLE
fix: Look for the elastic search credentials in all the places

### DIFF
--- a/merino/jobs/sportsdata_jobs/__init__.py
+++ b/merino/jobs/sportsdata_jobs/__init__.py
@@ -30,7 +30,7 @@ from typing import cast
 from aiodogstatsd import Client
 
 from merino.configs import settings
-from merino.providers.suggest.sports import init_logs, LOGGING_TAG
+from merino.providers.suggest.sports import LOGGING_TAG
 from merino.providers.suggest.sports.backends.sportsdata.common.data import Sport
 from merino.providers.suggest.sports.backends.sportsdata.common.elastic import (
     SportsDataStore,
@@ -76,27 +76,16 @@ class SportDataUpdater:
     def __init__(
         self,
         settings: LazySettings,
+        store: SportsDataStore,
+        connect_timeout: int = 1,
+        read_timeout: int = 1,
         *args,
-        store: SportsDataStore | None = None,
         **kwargs,
     ) -> None:
         logger = logging.getLogger(__name__)
         active_sports = [sport.strip().upper() for sport in settings.sports]
         sport: Sport | None = None
         sports: dict[str, Sport] = {}
-        platform = settings.get("platform", "sports")
-        store = store or SportsDataStore(
-            dsn=settings.es.dsn,
-            api_key=settings.es.api_key,
-            languages=[lang.strip().lower() for lang in settings.get("languages", ["en"])],
-            platform=f"{{lang}}_{platform}",
-            index_map={
-                "event": cast(
-                    str,
-                    settings.get("event_index", f"{platform}_event"),
-                ),
-            },
-        )
         # We could be clever here, but we'd have to fight the style and type checkers.
         # Basically, you import the merino...sports module, then
         # `getattr[sys.modules["merino...sports"],sport_name](settings,api_key)`
@@ -121,8 +110,8 @@ class SportDataUpdater:
             sports[sport_name] = sport
         self.sports = sports
         self.store = store
-        self.connect_timeout = settings.sportsdata.get("connect_timeout", 1)
-        self.read_timeout = settings.sportsdata.get("read_timeout", 1)
+        self.connect_timeout = connect_timeout
+        self.read_timeout = read_timeout
         logger.debug(f"{LOGGING_TAG}: Starting up...")
 
     async def update(self, include_teams: bool = True, client: AsyncClient | None = None) -> bool:
@@ -178,16 +167,38 @@ sports_settings = settings.providers.sports
 # is moved to `/utils`
 if not sports_settings.es.get("api_key"):
     logger.warning(f"{LOGGING_TAG} No sport elasticsearch API key found, using alternate")
-    sports_settings.es["api_key"] = settings.providers.wikipedia.es_api_key
+    sports_settings.es["api_key"] = settings.jobs.wikipedia_indexer.get(
+        "es_api_key", settings.providers.wikipedia.get("es_api_key")
+    )
 if not sports_settings.es.get("dsn"):
     logger.warning(f"{LOGGING_TAG} No sport elasticsearch DSN found, using alternative")
-    sports_settings.es["dsn"] = settings.providers.wikipedia.es_url
+    sports_settings.es["dsn"] = settings.jobs.wikipedia_indexer.get(
+        "es_url", settings.providers.wikipedia.get("es_url")
+    )
 app = Options(sports_settings).get_command()
 cli = typer.Typer(
     name="fetch_sports",
     help="Commands to fetch and store sport information",
 )
-provider = SportDataUpdater(sports_settings)
+name = sports_settings.get("platform", "sports")
+platform = f"{{lang}}_{name}"
+event_map = sports_settings.get("event_index", f"{platform}_event")
+dsn = sports_settings.es.get(
+    "dsn",
+)
+store = SportsDataStore(
+    dsn=sports_settings.es.dsn,
+    api_key=sports_settings.es.api_key,
+    platform=platform,
+    languages=[lang for lang in sports_settings.get("languages", ["en"])],
+    index_map={"event": event_map},
+)
+provider = SportDataUpdater(
+    settings=sports_settings,
+    store=store,
+    connect_timeout=sports_settings.get("connect_timeout"),
+    read_timeout=sports_settings.get("read_timeout"),
+)
 
 
 @cli.command("initialize")

--- a/merino/providers/suggest/sports/__init__.py
+++ b/merino/providers/suggest/sports/__init__.py
@@ -49,15 +49,3 @@ FOUR_HOURS = ONE_HOUR * 4  # For Team Profiles
 def utc_time_from_now(delta: timedelta) -> int:
     """Return the timestamp of the period from now"""
     return int((datetime.now(tz=timezone.utc) + delta).timestamp())
-
-
-def init_logs(level: str | None = None) -> logging.Logger:
-    """Initialize logging based on `PYTHON_LOG` environ)"""
-    #
-    # be very verbose because `mypy` does not understand
-    # `None or x.get(label, CONST_STR_VALUE)` does not produce a None value.
-    if not level:
-        level = os.environ.get("PYTHON_LOG", DEFAULT_LOGGING_LEVEL)
-    level = getattr(logging, level.upper())
-    logging.basicConfig(level=level)
-    return logging.getLogger(__name__)

--- a/merino/providers/suggest/sports/backends/sportsdata/common/elastic.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/elastic.py
@@ -3,12 +3,10 @@
 import copy
 import json
 import logging
-import os
 from abc import abstractmethod, ABC
 from datetime import datetime, timezone
 from typing import Any, Final
 
-from dynaconf.base import LazySettings
 from elasticsearch import (
     AsyncElasticsearch,
     BadRequestError,
@@ -181,51 +179,7 @@ class ElasticDataStore(ABC):
         api_key: str,
     ):
         """Create a core instance of elastic search"""
-        credentials = self.get_credentials(dsn, api_key)
-        self.client = AsyncElasticsearch(credentials["dsn"], api_key=credentials["api_key"])
-
-    def get_credentials(
-        self,
-        dsn: str | None = None,
-        api_key: str | None = None,
-        lsettings: LazySettings | None = None,
-    ) -> dict[str, str]:
-        """Try and fetch the API key and DSN from all the known sources.
-        Remember, this code is shared between suggest and jobs, so the credentials
-        can hide in lots of places.
-        """
-        if not lsettings:
-            lsettings = settings
-        if not dsn:
-            dsn = (
-                # Use the environment vars first, since the toml file may have
-                # "http://localhost:9200"
-                os.environ.get("MERINO_ELASTICSEARCH_DSN")
-                or os.environ.get("MERINO_JOBS__WIKIPEDIA_INDEXER__ES_URL")
-                or os.environ.get("MERINO_PROVIDERS__WIKIPEDIA__ES_URL")
-                or os.environ.get("MERINO_PROVIDERS__SPORTS__ES__DSN")
-                or lsettings.providers.sports.es.dsn
-                or lsettings.providers.wikipedia.es_url
-            )
-        if not api_key:
-            api_key = (
-                # Use the environment vars first, since the toml file may have
-                # ""
-                os.environ.get("MERINO_ELASTICSEARCH_API_KEY")
-                or os.environ.get("MERINO_JOBS__WIKIPEDIA_INDEXER__ES_API_KEY")
-                or os.environ.get("MERINO_PROVIDERS__WIKIPEDIA__ES_API_KEY")
-                or os.environ.get("MERINO_PROVIDERS__SPORTS__ES__API_KEY")
-                or settings.providers.sports.es.api_key
-                or settings.providers.wikipedia.es_api_key
-            )
-        logger = logging.getLogger(__name__)
-        if not dsn:
-            logger.error("No Elasticsearch DSN found!")
-            raise ElasticBackendError("No Elasticsearch DSN")
-        if not api_key:
-            logger.error("No Elasticsearch API Key found!")
-            raise ElasticBackendError("No Elasticsearch API Key")
-        return dict(dsn=dsn, api_key=api_key)
+        self.client = AsyncElasticsearch(dsn, api_key=api_key)
 
     @abstractmethod
     async def startup(self) -> bool:

--- a/merino/providers/suggest/sports/backends/sportsdata/common/sports.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/sports.py
@@ -9,7 +9,8 @@ from datetime import datetime, timedelta, timezone
 from typing import Any
 from zoneinfo import ZoneInfo
 
-
+# We use this for each Sport subclass, so that there's some flexibility for what config
+# values are used and passed.
 from dynaconf.base import LazySettings
 from httpx import AsyncClient
 

--- a/tests/unit/providers/suggest/sports/backends/test_sports_backend.py
+++ b/tests/unit/providers/suggest/sports/backends/test_sports_backend.py
@@ -11,7 +11,6 @@ from unittest.mock import patch, AsyncMock
 
 import httpx
 
-from dynaconf.base import LazySettings
 from unittest.mock import MagicMock
 from pytest_mock import MockerFixture
 from typing import cast
@@ -20,7 +19,6 @@ from merino.configs import settings
 from merino.providers.suggest.sports.backends import get_data
 from merino.providers.suggest.sports.backends.sportsdata.backend import (
     SportsDataBackend,
-    set_sports_es_creds,
 )
 from merino.providers.suggest.sports.backends.sportsdata.common import GameStatus
 from merino.providers.suggest.sports.backends.sportsdata.common.data import Team
@@ -367,21 +365,3 @@ async def test_sports_backend_startup(sport_data_store: SportsDataStore, mocker:
         mock["mock_instance"].update_teams.assert_called_once_with(client=mock_client)
         mock["mock_instance"].update_events.assert_called_once_with(client=mock_client)
         mock_store_events.assert_any_call(mock["mock_instance"], language_code="en")
-
-
-@pytest.mark.asyncio
-async def test_set_sports_es_creds(sport_data_store: SportsDataStore, mocker: MockerFixture):
-    """Test that we draw the API and DSN from the backup source if not defined"""
-    wiki_key = "WIKI_API_KEY"
-    wiki_url = "http://wiki_es_host.local:9200"
-
-    s2 = LazySettings()
-    s2.providers = LazySettings()
-    s2.providers.wikipedia = LazySettings()
-    s2.providers.wikipedia.es_api_key = wiki_key
-    s2.providers.wikipedia.es_url = wiki_url
-    s2.providers.sports = LazySettings()
-    sports = s2.providers.sports
-    set_sports_es_creds(s2, sports)
-    assert sports.es.api_key == wiki_key
-    assert sports.es.dsn == wiki_url

--- a/tests/unit/providers/suggest/sports/test_sports_provider.py
+++ b/tests/unit/providers/suggest/sports/test_sports_provider.py
@@ -3,7 +3,6 @@
 import pytest
 
 from datetime import datetime, timedelta, timezone
-from unittest.mock import patch
 from httpx import AsyncClient
 from typing import cast
 
@@ -18,7 +17,6 @@ from merino.utils.metrics import get_metrics_client
 from merino.providers.suggest.base import SuggestionRequest, BaseSuggestion
 from merino.providers.suggest.sports import (
     utc_time_from_now,
-    init_logs,
     IGNORED_SUGGESTION_URL,
     PROVIDER_ID,
     BASE_SUGGEST_SCORE,
@@ -48,21 +46,6 @@ async def test_sports_ttl_from_now():
     tomorrow = int((datetime.now(tz=timezone.utc) + timedelta(days=1)).timestamp())
     # Use a window because of clock skew.
     assert tomorrow - 1 <= result <= tomorrow + 1
-
-
-@pytest.mark.asyncio
-async def test_sports_init_logger():
-    """Test that we are generating the correct level for logs."""
-    with patch("logging.basicConfig") as logger:
-        # Note, dummy out the `getLogger` call as well to prevent accidental changes.
-        with patch("logging.getLogger") as _log2:
-            # pass in the argument for testing because `os.getenv` is defined before
-            # mock can patch it.
-            init_logs("DEBUG")
-            logger.assert_called_with(level=10)
-            logger.reset_mock()
-            init_logs("warning")
-            logger.assert_called_with(level=30)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Issue DISCO-3806

## References

JIRA: [DISCO-3806](https://mozilla-hub.atlassian.net/browse/DISCO-3806)

## Description

The `elastic.py` code is designed to be shared between suggest and jobs, meaning that there are a number of locations where the credentials might live. We need to search those in order to find the best value, since they may not always be defined in settings files. 

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3806]: https://mozilla-hub.atlassian.net/browse/DISCO-3806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1944)
