### PR TITLE
[DISCO-3770] Add caching layer for flightaware backend

### DIFF
--- a/merino/configs/__init__.py
+++ b/merino/configs/__init__.py
@@ -25,6 +25,7 @@ _validators = [
     Validator("metrics.port", gte=0, is_type_of=int),
     Validator("image_gcs.gcs_project", is_type_of=str),
     Validator("image_gcs.gcs_bucket", is_type_of=str),
+    Validator("image_gcs.gcs_enabled", is_type_of=bool),
     Validator("image_gcs.cdn_hostname", is_type_of=str),
     Validator("image_gcs_v2.gcs_project", is_type_of=str),
     Validator("image_gcs_v2.gcs_bucket", is_type_of=str),

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -860,7 +860,7 @@ type = "flightaware"
 backend = "flightaware"
 
 # MERINO_PROVIDERS__FLIGHTAWARE__CACHE
-# The store used to flightaware data. Either `redis` or `none`.
+# The store used for flightaware data. Either `redis` or `none`.
 # If `redis`, the global Redis settings must be set. See redis.server.
 cache = "none"
 

--- a/merino/configs/production.toml
+++ b/merino/configs/production.toml
@@ -68,3 +68,9 @@ gcp_project = "moz-fx-merino-prod-1c2f"
 # The store used to finance data. Either `redis` or `none`.
 # If `redis`, the global Redis settings must be set. See redis.server.
 cache = "redis"
+
+[production.providers.flightaware]
+# MERINO_PROVIDERS__FLIGHTAWARE__CACHE
+# The store used for flightaware data. Either `redis` or `none`.
+# If `redis`, the global Redis settings must be set. See redis.server.
+cache = "redis"

--- a/merino/providers/suggest/flightaware/backends/cache.py
+++ b/merino/providers/suggest/flightaware/backends/cache.py
@@ -1,0 +1,66 @@
+"""Provides a caching layer for FlightAware flight summaries."""
+
+import json
+import logging
+import datetime
+
+from pydantic import BaseModel
+
+from merino.cache.protocol import CacheAdapter
+from merino.providers.suggest.flightaware.backends.protocol import FlightSummary
+from merino.exceptions import CacheAdapterError
+
+logger = logging.getLogger(__name__)
+
+CACHE_KEY = "flight_status:{ident}"
+
+
+class CachedFlightData(BaseModel):
+    """Schema for stored flight data in Redis."""
+
+    summaries: list[FlightSummary]
+
+
+class FlightCache:
+    """Redis-backed cache for FlightAware flight summaries and metadata."""
+
+    redis: CacheAdapter
+
+    def __init__(self, redis_adapter: CacheAdapter):
+        self.redis = redis_adapter
+
+    async def get_flight(self, flight_num: str) -> CachedFlightData | None:
+        """Retrieve cached flight summaries and metadata."""
+        key = CACHE_KEY.format(ident=flight_num)
+
+        try:
+            data = await self.redis.get(key)
+            if not data:
+                return None
+
+            data_json = json.loads(data.decode("utf-8"))
+            return CachedFlightData.model_validate(data_json)
+        except (json.JSONDecodeError, UnicodeDecodeError, ValueError):
+            return None
+        except CacheAdapterError as e:
+            logger.warning(f"Error while getting flight summaries for {flight_num} : {e}")
+            return None
+
+    async def set_flight(
+        self, flight_num: str, summaries: list[FlightSummary], ttl_seconds: int
+    ) -> None:
+        """Store flight summaries and metadata in redis."""
+        key = CACHE_KEY.format(ident=flight_num)
+
+        payload = {
+            "summaries": [s.model_dump(mode="json") for s in summaries],
+        }
+
+        try:
+            await self.redis.set(
+                key,
+                json.dumps(payload).encode("utf-8"),
+                ttl=datetime.timedelta(seconds=ttl_seconds),
+            )
+        except CacheAdapterError as e:
+            logger.warning(f"Error while setting flight summaries for {flight_num}: {e}")

--- a/merino/providers/suggest/flightaware/backends/protocol.py
+++ b/merino/providers/suggest/flightaware/backends/protocol.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 from enum import Enum, StrEnum
-from typing import Any, Protocol
+from typing import Protocol
 
 from pydantic import BaseModel, HttpUrl
 
@@ -76,8 +76,13 @@ class FlightBackendProtocol(Protocol):
         """Return a prioritized list of summaries of a flight instance."""
         ...
 
-    async def fetch_flight_details(self, flight_num: str) -> Any | None:
-        """Fetch flight details by flight number through aeroAPI"""
+    async def fetch_flight_details(self, flight_num: str) -> list[FlightSummary] | None:
+        """Fetch flight summaries for a given flight number.
+
+        Checks Redis cache first. On cache miss, fetches from AeroAPI,
+        builds flight summaries, caches the result,
+        and returns the summaries.
+        """
 
     async def fetch_flight_numbers(
         self,

--- a/merino/providers/suggest/flightaware/provider.py
+++ b/merino/providers/suggest/flightaware/provider.py
@@ -128,10 +128,7 @@ class Provider(BaseProvider):
                 result = await self.backend.fetch_flight_details(flight_number)
 
                 if result:
-                    flight_summaries: list[FlightSummary] = self.backend.get_flight_summaries(
-                        result, flight_number
-                    )
-                    return [self.build_suggestion(flight_summaries)]
+                    return [self.build_suggestion(result)]
             return []
         except Exception as e:
             logger.warning(f"Exception occurred for FlightAware provider: {e}")

--- a/merino/providers/suggest/manager.py
+++ b/merino/providers/suggest/manager.py
@@ -311,12 +311,26 @@ def _create_provider(provider_id: str, setting: Settings) -> BaseProvider:
                 enabled_by_default=setting.enabled_by_default,
             )
         case ProviderType.FLIGHTAWARE:
+            cache = (
+                RedisAdapter(
+                    *create_redis_clients(
+                        settings.redis.server,
+                        settings.redis.replica,
+                        settings.redis.max_connections,
+                        settings.redis.socket_connect_timeout_sec,
+                        settings.redis.socket_timeout_sec,
+                    )
+                )
+                if setting.cache == "redis"
+                else NoCacheAdapter()
+            )
             return FlightAwareProvider(
                 backend=FlightAwareBackend(
                     api_key=settings.flightaware.api_key,
                     http_client=create_http_client(base_url=settings.flightaware.base_url),
                     ident_url=settings.flightaware.ident_url_path,
                     metrics_client=get_metrics_client(),
+                    cache=cache,
                 ),
                 metrics_client=get_metrics_client(),
                 score=setting.score,

--- a/tests/unit/providers/suggest/flightaware/backend/test_cache.py
+++ b/tests/unit/providers/suggest/flightaware/backend/test_cache.py
@@ -1,0 +1,137 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Unit tests for the Flightaware cache module."""
+
+import json
+import datetime
+import pytest
+from unittest.mock import AsyncMock
+
+from merino.providers.suggest.flightaware.backends.cache import (
+    FlightCache,
+    CachedFlightData,
+)
+from merino.providers.suggest.flightaware.backends.protocol import (
+    FlightSummary,
+    AirportDetails,
+    AirlineDetails,
+    FlightScheduleSegment,
+)
+from merino.exceptions import CacheAdapterError
+
+
+def make_summary() -> FlightSummary:
+    """Return a sample FlightSummary."""
+    return FlightSummary(
+        flight_number="UA123",
+        destination=AirportDetails(code="EWR", city="Newark"),
+        origin=AirportDetails(code="SFO", city="San Francisco"),
+        departure=FlightScheduleSegment(
+            scheduled_time="2025-09-29T12:00:00Z",
+            estimated_time="2025-09-29T12:05:00Z",
+        ),
+        arrival=FlightScheduleSegment(
+            scheduled_time="2025-09-29T16:00:00Z",
+            estimated_time="2025-09-29T16:05:00Z",
+        ),
+        status="Scheduled",
+        delayed=False,
+        airline=AirlineDetails(code="UA", name="United Airlines", icon=None),
+        progress_percent=0,
+        time_left_minutes=None,
+        url="https://www.flightaware.com/live/flight/UA123",
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_flight_returns_valid_cached_data(caplog):
+    """Ensure get_flight parses valid JSON into CachedFlightData."""
+    mock_redis = AsyncMock()
+    payload = {"summaries": [make_summary().model_dump(mode="json")]}
+    mock_redis.get.return_value = json.dumps(payload).encode("utf-8")
+
+    cache = FlightCache(mock_redis)
+    result = await cache.get_flight("UA123")
+
+    assert isinstance(result, CachedFlightData)
+    assert result.summaries[0].flight_number == "UA123"
+    mock_redis.get.assert_awaited_once_with("flight_status:UA123")
+    assert "Error" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_get_flight_returns_none_if_no_data():
+    """Return None when redis.get returns None or empty."""
+    mock_redis = AsyncMock()
+    mock_redis.get.return_value = None
+
+    cache = FlightCache(mock_redis)
+    result = await cache.get_flight("UA123")
+
+    assert result is None
+    mock_redis.get.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_data", [b"not-json", b"{bad}", b"[]"])
+async def test_get_flight_returns_none_on_invalid_json(bad_data):
+    """Return None if redis returns invalid JSON or wrong structure."""
+    mock_redis = AsyncMock()
+    mock_redis.get.return_value = bad_data
+
+    cache = FlightCache(mock_redis)
+    result = await cache.get_flight("UA123")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_flight_logs_and_returns_none_on_cache_adapter_error(caplog):
+    """Return None and log warning if CacheAdapterError is raised."""
+    mock_redis = AsyncMock()
+    mock_redis.get.side_effect = CacheAdapterError("boom")
+
+    cache = FlightCache(mock_redis)
+    result = await cache.get_flight("UA123")
+
+    assert result is None
+    assert "Error while getting flight summaries" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_set_flight_writes_correct_payload():
+    """Verify set_flight serializes summaries and sets Redis with proper TTL."""
+    mock_redis = AsyncMock()
+    cache = FlightCache(mock_redis)
+
+    summaries = [make_summary()]
+    ttl_seconds = 600
+
+    await cache.set_flight("UA123", summaries, ttl_seconds)
+
+    mock_redis.set.assert_awaited_once()
+    call_args = mock_redis.set.await_args
+    key, value = call_args.args
+    ttl = call_args.kwargs["ttl"]
+
+    assert key == "flight_status:UA123"
+    assert isinstance(ttl, datetime.timedelta)
+    assert ttl.total_seconds() == ttl_seconds
+
+    decoded = json.loads(value.decode("utf-8"))
+    assert "summaries" in decoded
+    assert decoded["summaries"][0]["flight_number"] == "UA123"
+
+
+@pytest.mark.asyncio
+async def test_set_flight_logs_warning_on_cache_adapter_error(caplog):
+    """If redis.set raises CacheAdapterError, warning should be logged."""
+    mock_redis = AsyncMock()
+    mock_redis.set.side_effect = CacheAdapterError("write failed")
+
+    cache = FlightCache(mock_redis)
+    await cache.set_flight("UA123", [make_summary()], 600)
+
+    assert "Error while setting flight summaries" in caplog.text

--- a/tests/unit/providers/suggest/flightaware/test_provider.py
+++ b/tests/unit/providers/suggest/flightaware/test_provider.py
@@ -112,8 +112,6 @@ async def test_query_validates_keyword_pattern_and_fetches(provider, backend_moc
         provider.flight_numbers = {"AC250"}
         request = SuggestionRequest(query="Air Canada 250", geolocation=geolocation)
 
-        backend_mock.fetch_flight_details.return_value = {"flights": [{"ident": "AC250"}]}
-
         fake_summary = FlightSummary(
             flight_number="AC250",
             destination={"code": "YYZ", "city": "Toronto"},
@@ -132,7 +130,8 @@ async def test_query_validates_keyword_pattern_and_fetches(provider, backend_moc
             delayed=False,
             url="https://www.flightaware.com/live/flight/AC250",
         )
-        backend_mock.get_flight_summaries.return_value = [fake_summary]
+
+        backend_mock.fetch_flight_details.return_value = [fake_summary]
 
         results = await provider.query(request)
 
@@ -175,7 +174,6 @@ async def test_query_fetches_and_builds_suggestion_from_cached_numbers(
     provider.flight_numbers = {"UA3711", "AA100", "AC701"}
 
     request = SuggestionRequest(query="UA3711", geolocation=geolocation)
-    backend_mock.fetch_flight_details.return_value = {"flights": [{"ident": "UA3711"}]}
 
     fake_summary = FlightSummary(
         flight_number="UA3711",
@@ -195,7 +193,7 @@ async def test_query_fetches_and_builds_suggestion_from_cached_numbers(
         delayed=False,
         url="https://www.flightaware.com/live/flight/UA3711",
     )
-    backend_mock.get_flight_summaries.return_value = [fake_summary]
+    backend_mock.fetch_flight_details.return_value = [fake_summary]
 
     results = await provider.query(request)
 


### PR DESCRIPTION
## References

JIRA: [DISCO-3770](https://mozilla-hub.atlassian.net/browse/DISCO-3770)

## Description
This PR adds a caching layer for FlightAware flight summaries to improve latency and reduce AeroAPI requests.
- Adds adaptive TTLs using a helper `derive_ttl_for_summaries()`:
   - EN_ROUTE: until ETA + 2 min
   - SCHEDULED/DELAYED: until departure or 12 h max
   - ARRIVED/CANCELLED: up to 1 h 15 m post arrival/departure
- Computes live progress for cached en-route flights (`compute_enroute_progress`).
- Adds cache metrics for hits, misses, and writes.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3770]: https://mozilla-hub.atlassian.net/browse/DISCO-3770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1945)
