### PR TITLE
Fix/disco 3806 init

### DIFF
--- a/merino/jobs/sportsdata_jobs/__init__.py
+++ b/merino/jobs/sportsdata_jobs/__init__.py
@@ -116,9 +116,7 @@ class SportDataUpdater:
         self.read_timeout = read_timeout
         logger.debug(f"{LOGGING_TAG}: Starting up...")
 
-    async def update(
-        self, include_teams: bool = True, client: AsyncClient | None = None
-    ) -> bool:
+    async def update(self, include_teams: bool = True, client: AsyncClient | None = None) -> bool:
         """Perform sport specific updates."""
         logger = logging.getLogger(__name__)
         logger.debug(f"{LOGGING_TAG} Initializing database")
@@ -174,9 +172,7 @@ sports_settings = settings.providers.sports
 # NOTE: eventually, this will be replaced when the elasticsearch code
 # is moved to `/utils`
 if not sports_settings.es.get("api_key"):
-    logger.warning(
-        f"{LOGGING_TAG} No sport elasticsearch API key found, using alternate"
-    )
+    logger.warning(f"{LOGGING_TAG} No sport elasticsearch API key found, using alternate")
     sports_settings.es["api_key"] = settings.jobs.wikipedia_indexer.get(
         "es_api_key", settings.providers.wikipedia.get("es_api_key")
     )


### PR DESCRIPTION
Issue: DISCO-3806

## References

JIRA: [DISCO-3806](https://mozilla-hub.atlassian.net/browse/DISCO-3806)

## Description
Ensure that the database index is created. 
See error:
```
[2025-11-07, 21:01:51 UTC] {pod_manager.py:477} INFO - [base]     raise BulkIndexError(f"{len(errors)} document(s) failed to index.", errors)
[2025-11-07, 21:01:51 UTC] {pod_manager.py:477} INFO - [base] elasticsearch.helpers.BulkIndexError: 1 document(s) failed to index.
```


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3806]: https://mozilla-hub.atlassian.net/browse/DISCO-3806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1946)
