### PR TITLE
fix: Soft fail if sports are not able to start

### DIFF
--- a/merino/jobs/sportsdata_jobs/__init__.py
+++ b/merino/jobs/sportsdata_jobs/__init__.py
@@ -119,9 +119,7 @@ class SportDataUpdater:
         self.read_timeout = read_timeout
         logger.debug(f"{LOGGING_TAG}: Starting up...")
 
-    async def update(
-        self, include_teams: bool = True, client: AsyncClient | None = None
-    ) -> bool:
+    async def update(self, include_teams: bool = True, client: AsyncClient | None = None) -> bool:
         """Perform sport specific updates."""
         logger = logging.getLogger(__name__)
         logger.debug(f"{LOGGING_TAG} Initializing database")
@@ -177,9 +175,7 @@ sports_settings = settings.providers.sports
 # NOTE: eventually, this will be replaced when the elasticsearch code
 # is moved to `/utils`
 if not sports_settings.es.get("api_key"):
-    logger.warning(
-        f"{LOGGING_TAG} No sport elasticsearch API key found, using alternate"
-    )
+    logger.warning(f"{LOGGING_TAG} No sport elasticsearch API key found, using alternate")
     sports_settings.es["api_key"] = settings.jobs.wikipedia_indexer.get(
         "es_api_key", settings.providers.wikipedia.get("es_api_key")
     )


### PR DESCRIPTION
Issue DISCO-3806

## References

JIRA: [DISCO-3806](https://mozilla-hub.atlassian.net/browse/DISCO-3806)

## Description
Soft fail if the elastic search credentials aren't specified.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3806]: https://mozilla-hub.atlassian.net/browse/DISCO-3806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1949)
