### PR TITLE
GENAI-2368 Use correct section features for local inferred personalization based on sections

### DIFF
--- a/merino/curated_recommendations/ml_backends/static_local_model.py
+++ b/merino/curated_recommendations/ml_backends/static_local_model.py
@@ -148,6 +148,7 @@ THRESHOLDS_V1_B = [0.005, 0.010, 0.015]
 
 CRAWL_SUFFIX = "_crawl"
 
+
 # Creates a limited model based on topics. Topics features are stored with a t_
 # in telemetry.
 class SuperInferredModel(LocalModelBackend):
@@ -173,6 +174,7 @@ class SuperInferredModel(LocalModelBackend):
     @staticmethod
     def _clean_section(section_name: str):
         return section_name.replace(CRAWL_SUFFIX, "")
+
     @staticmethod
     def _get_topic(topic: str, thresholds: list[float]) -> InterestVectorConfig:
         return InterestVectorConfig(
@@ -242,7 +244,8 @@ class SuperInferredModel(LocalModelBackend):
         else:
             return None
         category_fields = {
-            self._clean_section(a): self._get_section(a, model_thresholds) for a in BASE_SECTIONS_FOR_LOCAL_MODEL
+            self._clean_section(a): self._get_section(a, model_thresholds)
+            for a in BASE_SECTIONS_FOR_LOCAL_MODEL
         }  ## all sections
         model_data: ModelData = ModelData(
             model_type=ModelType.CTR,


### PR DESCRIPTION
## References

https://mozilla-hub.atlassian.net/browse/GENAI-2368

## Description
We recently launched our [v2 personalization experiment](https://mozilla-hub.atlassian.net/wiki/spaces/FPS/pages/1575092266/New+Tab+Inferred+Personalization+Contextual+Ranking+Project+Page?search_id=7aaf09f3-a50a-4c11-89d1-9c2059756572)  that includes private local ranking of sections.

Around the same as the experiment launch, the crawl rollout was released that uses a different section pool. These sections have a '_crawl' suffix on them.

These _crawl suffix features are being sent with the articles, but our local model was not using the crawl suffix. Hence the experiment wasn't looking at any section features, with the exceptions of a few subtopics.

This PR remedies the situation by having the model look at the correct features.

We may want to find a different long-term solution. It takes a week for user interactions to be built up, so this this fix is good quickest results.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1950)
