### PR TITLE
[DISCO-3811] Fix sports data job failing on initialization

### DIFF
--- a/merino/jobs/sportsdata_jobs/__init__.py
+++ b/merino/jobs/sportsdata_jobs/__init__.py
@@ -206,7 +206,8 @@ try:
         connect_timeout=sports_settings.get("connect_timeout"),
         read_timeout=sports_settings.get("read_timeout"),
     )
-except SportsDataError as ex:
+except Exception as ex:
+    # except SportsDataError as ex:
     logger.error(f"{LOGGING_TAG} Sports Unavailable: {ex}")
 
 


### PR DESCRIPTION
## References

JIRA: [DISCO-3811](https://mozilla-hub.atlassian.net/browse/DISCO-3811)

## Description
Temp fix for this [failing airflow job](https://workflow.telemetry.mozilla.org/log?dag_id=merino_flightaware_schedules&task_id=fetch_flightaware_schedules_prod&execution_date=2025-11-11T06%3A00%3A00%2B00%3A00).


## PR Review Checklist
- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3811]: https://mozilla-hub.atlassian.net/browse/DISCO-3811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1951)
