### PR TITLE
fix: Correct the default names used for the elastic search indices

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -344,8 +344,8 @@ type="sports"
 # e.g. ["NFL","NBA","NHL"]
 sports=["NFL","NBA","NHL"]
 # Index names for Elastic Search.
-event_index="sports_{lang}_event"
-team_index="sports_{lang}_team"
+event_index="sports-{lang}-event"
+team_index="sports-{lang}-team"
 max_suggestions = 5
 # Disable this provider by default
 enabled_by_default = false

--- a/merino/jobs/sportsdata_jobs/__init__.py
+++ b/merino/jobs/sportsdata_jobs/__init__.py
@@ -183,9 +183,9 @@ cli = typer.Typer(
     help="Commands to fetch and store sport information",
 )
 name = sports_settings.get("platform", "sports")
-platform = f"{name}_{{lang}}"
-event_map = sports_settings.get("event_index", f"{platform}_event")
-meta_map = sports_settings.get("meta_index", f"{name}_meta")
+platform = f"{name}-{{lang}}"
+event_map = sports_settings.get("event_index", f"{platform}-event")
+meta_map = sports_settings.get("meta_index", f"{name}-meta")
 try:
     store = SportsDataStore(
         credentials=elastic_credentials,

--- a/merino/providers/suggest/manager.py
+++ b/merino/providers/suggest/manager.py
@@ -353,8 +353,8 @@ def _create_provider(provider_id: str, setting: Settings) -> BaseProvider:
             credentials = ElasticCredentials(settings=settings)
 
             name = setting.get("platform", setting.type)
-            platform = f"{name}_{{lang}}"
-            event_map = setting.get("event_index", f"{platform}_event")
+            platform = f"{name}-{{lang}}"
+            event_map = setting.get("event_index", f"{platform}-event")
 
             store = SportsDataStore(
                 credentials=credentials,

--- a/merino/providers/suggest/sports/README.md
+++ b/merino/providers/suggest/sports/README.md
@@ -47,7 +47,7 @@ The Sports provider has a number of configuration options:
 # See `jobs.sportsdata_jobs.common` for list of supported sports
 sports = "NBA,NFL,NHL"
 # `{lang}` will be inline replaced with the supported languages. Currently only `en`
-event_index = "sports_{lang}_event"
-team_index = "sports_{lang}_team"
+event_index = "sports-{lang}-event"
+team_index = "sports-{lang}-team"
 max_suggestions = 5
 ```

--- a/merino/providers/suggest/sports/__main__.py
+++ b/merino/providers/suggest/sports/__main__.py
@@ -135,9 +135,9 @@ if __name__ == "__main__":
     # Perform the "load" job. This would normally be handled by a merino job function
     # This can be commented out once it's been run once, if you want to test query speed.
     name = "sports"
-    platform = f"{name}_{{lang}}"
-    event_map = settings.providers.sports.get("event_index", f"{platform}_event")
-    meta_map = settings.providers.sports.get("meta_index", f"{name}_meta")
+    platform = f"{name}-{{lang}}"
+    event_map = settings.providers.sports.get("event_index", f"{platform}-event")
+    meta_map = settings.providers.sports.get("meta_index", f"{name}-meta")
     try:
         credentials = ElasticCredentials(settings=settings)
     except (Exception, BaseException) as ex:

--- a/merino/providers/suggest/sports/backends/sportsdata/common/elastic.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/elastic.py
@@ -38,7 +38,7 @@ EN_INDEX_SETTINGS: dict = {
     "number_of_replicas": "1",
     "refresh_interval": "-1",
     "number_of_shards": "2",
-    "index.lifecycle.name": "sports_en_policy",
+    "index.lifecycle.name": "sports-en-policy",
     "analysis": {
         "filter": {
             "stop_filter": {

--- a/tests/integration/providers/suggest/sports/backends/test_sportsdata.py
+++ b/tests/integration/providers/suggest/sports/backends/test_sportsdata.py
@@ -72,7 +72,7 @@ def fixture_sport_data_store_parameters(es_client) -> dict[str, Any]:
         "languages": ["en"],
         "platform": "en_sports",
         "index_map": {
-            "event": "sports_{lang}_event",
+            "event": "sports-{lang}-event",
         },
     }
 


### PR DESCRIPTION
## References

JIRA: [DISCO-3806](https://mozilla-hub.atlassian.net/browse/DISCO-3806)

## Description
fix: Correct the default names used for the elastic search indices
Issue DISCO-3806

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3806]: https://mozilla-hub.atlassian.net/browse/DISCO-3806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1954)
