### PR TITLE
fix: remove bad merge (extra `meta` in map) flag empty settings

### DIFF
--- a/merino/jobs/sportsdata_jobs/__init__.py
+++ b/merino/jobs/sportsdata_jobs/__init__.py
@@ -193,7 +193,7 @@ if elastic_credentials.validate():
             credentials=elastic_credentials,
             platform=platform,
             languages=[lang for lang in sports_settings.get("languages", ["en"])],
-            index_map={"event": event_map, "meta": meta_map},
+            index_map={"event": event_map},
         )
         provider = SportDataUpdater(
             settings=sports_settings,

--- a/merino/providers/suggest/sports/backends/sportsdata/common/elastic.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/elastic.py
@@ -192,6 +192,7 @@ class ElasticCredentials:
         self.dsn = dsn
         self.api_key = api_key
         if not settings:
+            logger.warning(f"{LOGGING_TAG} Empty settings.")
             return
         try:
             logger.info(


### PR DESCRIPTION
Issue DISCO-3806

## References

JIRA: [DISCO-3806](https://mozilla-hub.atlassian.net/browse/DISCO-3806)

## Description
fix: remove bad merge (extra `meta` in map) flag empty settings)

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3806]: https://mozilla-hub.atlassian.net/browse/DISCO-3806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1956)
