### PR TITLE
fix: Only build indexes on demand.

### DIFF
--- a/merino/jobs/sportsdata_jobs/__init__.py
+++ b/merino/jobs/sportsdata_jobs/__init__.py
@@ -125,6 +125,7 @@ class SportDataUpdater:
         logger = logging.getLogger(__name__)
         logger.debug(f"{LOGGING_TAG} Initializing database")
         await self.store.startup()
+        await self.store.build_indexes()
         client = create_http_client(
             connect_timeout=self.connect_timeout, request_timeout=self.read_timeout
         )
@@ -158,6 +159,8 @@ class SportDataUpdater:
         logger = logging.getLogger(__name__)
         logger.debug(f"{LOGGING_TAG} Initializing database")
         await self.store.startup()
+        await self.store.build_indexes()
+
         # Fetch the meta data for the sport, this includes if the sport is "active"
         # as well as any upcoming events for the sport.
         logger.debug(f"{LOGGING_TAG} Nightly update...")
@@ -167,7 +170,7 @@ class SportDataUpdater:
     async def initialize(self) -> None:
         """Initialize the ElasticSearch data store"""
         await self.store.startup()
-        await self.store.build_indexes(clear=False)
+        await self.store.build_indexes()
 
 
 logger = logging.getLogger(__name__)

--- a/merino/providers/suggest/sports/backends/sportsdata/common/elastic.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/elastic.py
@@ -395,8 +395,6 @@ class SportsDataStore(ElasticDataStore):
         """Kick start the data store for Sports"""
         await super().startup()
         logger = logging.getLogger(__name__)
-        await self.build_meta()
-        await self.build_indexes()
 
         val = await self.query_meta("update")
         if val is None or (float(val) or 0 < datetime.now(tz=timezone.utc).timestamp()):
@@ -460,6 +458,7 @@ class SportsDataStore(ElasticDataStore):
         """Create the meta data index. This is a very simple
         table that stores a non-searchable value under a key.
         """
+        logger = logging.getLogger(__name__)
         if not self.client:
             return
         try:
@@ -482,7 +481,9 @@ class SportsDataStore(ElasticDataStore):
             await self.client.indices.refresh(index=self.meta_map)
         except BadRequestError as ex:
             if ex.error != "resource_already_exists_exception":
-                raise ex
+                raise SportsDataError(f"Could not create {self.meta_map}") from ex
+            else:
+                logger.info(f"{LOGGING_TAG} {self.meta_map} already exists, skipping")
 
     async def build_indexes(self, clear: bool = False):
         """Build the indices here for stand-alone and testing reasons.
@@ -502,21 +503,13 @@ class SportsDataStore(ElasticDataStore):
                     index=self.meta_map,
                     ignore_unavailable=True,
                 )
-            await self.client.indices.create(
-                index=self.meta_map,
-                mappings={
-                    "dynamic": False,
-                    "properties": {
-                        "key": {"type": "keyword"},
-                        "value": {"type": "keyword", "index": False},
-                    },
-                },
-            )
+            await self.build_meta()
         except BadRequestError as ex:
             if ex.error != "resource_already_exists_exception":
                 raise SportsDataError(f"Could not create {self.meta_map}") from ex
             else:
                 logger.info(f"{LOGGING_TAG} {self.meta_map} already exists, skipping")
+
         for language_code in self.languages:
             mappings = self.build_event_mappings(language_code=language_code)
             for idx, index in self.index_map.items():

--- a/tests/unit/providers/suggest/sports/backends/common/test_elastic.py
+++ b/tests/unit/providers/suggest/sports/backends/common/test_elastic.py
@@ -326,7 +326,9 @@ async def test_startup(sport_data_store: SportsDataStore, es_client: AsyncMock):
     # Check for initial case.
     es_client.search.return_value = {"hits": {"hits": []}}
     await sport_data_store.startup()
-    assert es_client.indices.create.call_count == 3
+    assert es_client.indices.create.call_count == 0
+    await sport_data_store.build_indexes()
+    assert es_client.indices.create.call_count == 2
     assert any(
         [
             arg_list.kwargs.get("index") == META_INDEX


### PR DESCRIPTION
## References

JIRA: [DISCO-3806](https://mozilla-hub.atlassian.net/browse/DISCO-3806)

## Description
Because the query module does not have write access, only build the indexes on `build_indexes()` call, rather than as part of the general `startup()`. This will allow the read/write perms for `jobs` to work.

Issue DISCO-3806



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3806]: https://mozilla-hub.atlassian.net/browse/DISCO-3806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1959)
