### PR TITLE
[DISCO-3798] Relax flight search matching logic

### DIFF
--- a/merino/providers/suggest/flightaware/provider.py
+++ b/merino/providers/suggest/flightaware/provider.py
@@ -110,8 +110,11 @@ class Provider(BaseProvider):
             )
 
     def normalize_query(self, query: str) -> str:
-        """Remove trailing spaces from query and convert to lowercase"""
-        return query.strip()
+        """Trim leading/trailing whitespace, converts to lowercase,
+        and normalizes multiple internal spaces to a single space.
+        """
+        query = " ".join(query.lower().split())
+        return query
 
     async def query(self, request: SuggestionRequest) -> list[BaseSuggestion]:
         """Retrieve flight suggestions"""

--- a/tests/unit/providers/suggest/flightaware/test_provider.py
+++ b/tests/unit/providers/suggest/flightaware/test_provider.py
@@ -75,9 +75,26 @@ def test_validate_accepts_valid_query(provider, geolocation):
     provider.validate(req)
 
 
-def test_normalize_query_strips(provider):
-    """Normalize_query should strip spaces"""
-    assert provider.normalize_query(" ua123 ") == "ua123"
+@pytest.mark.parametrize(
+    "input_query,expected",
+    [
+        (" ua123 ", "ua123"),
+        ("Flight   AC100", "flight ac100"),
+        ("  flight status   AC100  ", "flight status ac100"),
+        ("AC100     flight", "ac100 flight"),
+        ("   AIR   CANADA   250   ", "air canada 250"),
+        (
+            "   fLiGhT    StAtUs   UnItEd   aIrLiNeS   300   ",
+            "flight status united airlines 300",
+        ),
+        ("    Multiple     Spaces     Here    ", "multiple spaces here"),
+        ("  Mixed   Case  And   Extra Spaces ", "mixed case and extra spaces"),
+        ("", ""),  # empty string stays empty
+    ],
+)
+def test_normalize_query_normalizes_spacing_and_case(provider, input_query, expected):
+    """Test that normalize_query lowercases text and collapses multiple spaces into single spaces."""
+    assert provider.normalize_query(input_query) == expected
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## References

JIRA: [DISCO-3798](https://mozilla-hub.atlassian.net/browse/DISCO-3798)

## Description
This PR updates the flight suggestion matching logic to recognize queries that include the terms "flight" or "flight status" before or after the airline or flight number. It also would match to  any prefix in "flight status"
Examples of newly supported queries:
- `flight AC100`
- `flight status ua 300`
- `ac250 fli`

This will improve cache hit rates for FlightAware suggestions.

### How to QA:
1. Configure the API key:
   * Replace the `"api_key"` field in `default.toml` with a real FlightAware API key.
2. In `default.toml`, under `[default.image_gcs]`, define `gcs_bucket` and `gcs_project` (should be similar values in `production.toml`)
3. Authenticate with google cloud (`gcloud auth application-default login`)
4. Find a flight:
   * Use Flightaware's [flight finder ](https://www.flightaware.com/live/findflight/) to look up flights that are en route /scheduled/ delayed with future instances (within the next 24 hours)
5. Call the endpoint:
   * Hit the Merino suggest endpoint with the chosen flight number as the query (e.g `AC700`) and `flightaware` as the provider.
6. Verify behavior:
   * The provider should return results for queries with the additional keywords mentioned above

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3798]: https://mozilla-hub.atlassian.net/browse/DISCO-3798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1965)
