### PR TITLE
GENAI-2318 contextual ranking - redo of PR

### DIFF
--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -574,28 +574,21 @@ class TestCuratedRecommendationsRequestParameters:
 
     @pytest.mark.parametrize("utcOffset", [0, 12, 24])
     def test_curated_recommendations_valid_utc_offset(self, utcOffset, client: TestClient):
-        """Test the curated recommendations endpoint accepts valid utc_offset values."""
-        response = client.post(
-            "/api/v1/curated-recommendations",
-            json={"locale": Locale.EN_US, "utc_offset": utcOffset},
-        )
-        assert response.status_code == 200
-
-    @pytest.mark.parametrize("utcOffset", [-1, 11.5, 25, "Z"])
-    def test_curated_recommendations_invalid_utc_offset(self, utcOffset, client: TestClient):
-        """Test the curated recommendations endpoint rejects invalid utc_offset values
-        and is looking both camel and snake inputs.
-        """
-        response = client.post(
-            "/api/v1/curated-recommendations",
-            json={"locale": Locale.EN_US, "utc_offset": utcOffset},
-        )
-        assert response.status_code == 400
+        """Test the curated recommendations endpoint accepts valid utcOffset values."""
         response = client.post(
             "/api/v1/curated-recommendations",
             json={"locale": Locale.EN_US, "utcOffset": utcOffset},
         )
-        assert response.status_code == 400
+        assert response.status_code == 200
+
+    @pytest.mark.parametrize("utcOffset", [-1, 11.5, 25, None, "Z"])
+    def test_curated_recommendations_invalid_utc_offset(self, utcOffset, client: TestClient):
+        """Test the curated recommendations endpoint doesn't reject malformed utc offsets."""
+        response = client.post(
+            "/api/v1/curated-recommendations",
+            json={"locale": Locale.EN_US, "utcOffset": utcOffset},
+        )
+        assert response.status_code == 200
 
     @pytest.mark.parametrize("count", [10, 50, 100])
     def test_curated_recommendations_count(

--- a/tests/unit/curated_recommendations/test_protocol.py
+++ b/tests/unit/curated_recommendations/test_protocol.py
@@ -8,6 +8,7 @@ from merino.curated_recommendations.protocol import (
     ResponsiveLayout,
     Tile,
     TileSize,
+    CuratedRecommendationsRequest,
 )
 
 
@@ -120,3 +121,63 @@ class TestLayout:
         """Test that Layout creation fails when responsiveLayouts do not include exactly one layout for column counts 1–4."""
         with pytest.raises(ValidationError):
             Layout(name="Invalid Layout", responsiveLayouts=invalid_responsive_layouts)
+
+
+class TestCuratedRecommendationsRequestsProtocol:
+    """Tests for CuratedRecommendationsRequestsProtocol validations."""
+
+    def test_validate_utc_offset(self):
+        """Test that utcOffset validation works correctly."""
+        # Valid utcOffset values
+        valid_offsets = [0, 5.3, 3, 12, 23]
+        for offset in valid_offsets:
+            request = CuratedRecommendationsRequest(
+                locale="en-US",
+                utcOffset=offset,
+            )
+            assert request.utcOffset == round(offset)
+            request = CuratedRecommendationsRequest(
+                locale="en-US",
+                utc_offset=offset,
+            )
+            assert request.utcOffset == round(offset)
+
+        # Invalid or None utcOffset values
+        invalid_offsets = [None, -10, 24, 100, "invalid", float("nan"), float("inf")]
+        for offset in invalid_offsets:
+            request = CuratedRecommendationsRequest(
+                locale="en-US",
+                utcOffset=offset,
+            )
+            assert request.utcOffset is None
+            request = CuratedRecommendationsRequest(
+                locale="en-US",
+                utc_offset=offset,
+            )
+            assert request.utcOffset is None
+
+    def test_topics_validation(self):
+        """Test that topics validation works correctly."""
+        # Valid topics
+        valid_topics = [
+            [],
+            ["government", "arts"],
+        ]
+        for topics in valid_topics:
+            request = CuratedRecommendationsRequest(
+                locale="en-US",
+                topics=topics,
+            )
+            assert request.topics == topics
+
+        invalid_topics_or_types = [
+            [None],
+            [123],
+            ["invalid_topic"],
+        ]
+        for topics in invalid_topics_or_types:
+            request = CuratedRecommendationsRequest(
+                locale="en-US",
+                topics=topics,
+            )
+            assert request.topics == []


### PR DESCRIPTION
## References

This is a re-commit of previously merged and backed out 
https://github.com/mozilla-services/merino-py/pull/1195
https://mozilla-hub.atlassian.net/browse/GENAI-2318

After merging I noticed a small jump in 400 errors that seemed to accelerate over time as a small percentage of clients retried.

The change was backed out, and this PR is the same with the following changes:
-we don't reject the request if utc_offset values are invalid (nan, out of range, string etc) 
-we only alias the utcOffset field as utc_offset. None of the other fields are aliased.
-Unit tests were created for CuratedRecommendationRequest

Merino was re-tested locally with a custom Firefox build and the utc_offset continued to be passed through.

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1994)
