### PR TITLE
DISCO-3558 Add documentation in docs/manifest.md for probe-images CLI

### DIFF
--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -75,3 +75,95 @@ To add yours:
 3. Create a PR against the `merino-py` repo with your changes
 
 The custom domains will be picked up during the next run (every Wednesday). This job can also be run manually by following instructions [here](https://github.com/mozilla-services/merino-py/blob/main/docs/operations/jobs/navigational_suggestions.md#running-the-job-in-airflow).
+
+## Add custom favicons
+
+Some websites block automated scrapers or have unreliable favicon detection. For these domains, you can specify a direct favicon URL that will be used instead of attempting to scrape it.
+
+### What are custom favicons?
+
+Custom favicons are pre-defined favicon URLs stored in `merino/jobs/navigational_suggestions/enrichments/custom_favicons.py`. When the job processes a domain, it checks this file **first** before attempting to scrape the favicon. This ensures reliable favicon delivery for domains that would otherwise fail.
+
+### Where is this file used?
+
+The `CUSTOM_FAVICONS` dictionary is imported and used by the domain processor (`processing/domain_processor.py`) during the favicon extraction phase. If a domain is found in the custom favicons mapping, the job will:
+1. Download the specified favicon URL
+2. Upload it to the CDN
+3. Skip the web scraping step entirely for that domain's favicon
+
+### Adding custom favicons with the CLI (Recommended)
+
+The easiest way to add custom favicons is using the `probe-images` command-line tool. This tool will automatically test a domain, find the best favicon, and save it to the `CUSTOM_FAVICONS` dictionary.
+
+**Basic usage:**
+
+```bash
+# Test a domain and save its best favicon
+probe-images example.com --save
+```
+
+**With options:**
+
+```bash
+# Specify minimum favicon width (default is 32px)
+probe-images example.com --save --min-width 64
+
+# Test multiple domains at once
+probe-images example.com mozilla.org github.com --save
+```
+
+**What the CLI does:**
+
+When you run `probe-images` with the `--save` flag, it will:
+1. Scrape the domain and extract all available favicons
+2. Apply the same selection logic used in production to find the best favicon
+3. Automatically update `merino/jobs/navigational_suggestions/enrichments/custom_favicons.py`
+4. Add the domain (without TLD) as the key and the best favicon URL as the value
+
+**Example output:**
+
+```
+Testing domain: mozilla.org
+✅ Success!
+ Title           Internet for people, not profit — Mozilla Global
+ Best Icon       https://www.mozilla.org/media/img/favicons/mozilla/favicon-196x196.png
+ Total Favicons  5
+
+All favicons found:
+- https://www.mozilla.org/media/img/favicons/mozilla/apple-touch-icon.png (rel=apple-touch-icon size=180x180)
+- https://www.mozilla.org/media/img/favicons/mozilla/favicon-196x196.png (rel=icon size=196x196)
+- https://www.mozilla.org/media/img/favicons/mozilla/favicon.ico (rel=shortcut,icon)
+
+Save Results:
+ Saved Domain  mozilla
+ Saved URL     https://www.mozilla.org/media/img/favicons/mozilla/favicon-196x196.png
+ Save PATH     merino/jobs/navigational_suggestions/enrichments/custom_favicons.py
+
+Summary: 1/1 domains processed successfully
+```
+
+### Adding custom favicons manually
+
+You can also manually edit the `CUSTOM_FAVICONS` dictionary if you already know the favicon URL:
+
+1. `git clone git@github.com:mozilla-services/merino-py.git`
+2. Edit `merino/jobs/navigational_suggestions/enrichments/custom_favicons.py`
+3. Add a new entry to the `CUSTOM_FAVICONS` dictionary:
+
+```python
+CUSTOM_FAVICONS: dict[str, str] = {
+    "axios": "https://static.axios.com/icons/favicon.svg",
+    "espn": "https://a.espncdn.com/favicon.ico",
+    "yoursite": "https://yoursite.com/path/to/favicon.png",  # Add your domain here
+    # ...
+}
+```
+
+**Important notes:**
+- Use the second-level domain name **without** the TLD (e.g., use `"mozilla"` not `"mozilla.org"`)
+- Use the direct URL to the favicon file
+- Ensure the URL is publicly accessible and won't break over time
+
+4. Create a PR against the `merino-py` repo with your changes
+
+The custom favicons will be used during the next job run (every Wednesday), or can be triggered manually.


### PR DESCRIPTION
## References

JIRA: [DISCO-3558](https://mozilla-hub.atlassian.net/browse/DISCO-3558)

## Description
Updated the manifest.md docs to cover how to add custom favicons. Previously we only documented adding custom domains, but now that we have the `probe-images` CLI with the `--save` flag, it made sense to document that workflow. Also added info on where the CUSTOM_FAVICONS.py file is used and how to manually edit it if needed.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3558]: https://mozilla-hub.atlassian.net/browse/DISCO-3558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1996)
