### PR TITLE
DISCO-3872 Add error logging for the navigational suggestion job

### DIFF
--- a/merino/jobs/navigational_suggestions/io/domain_metadata_uploader.py
+++ b/merino/jobs/navigational_suggestions/io/domain_metadata_uploader.py
@@ -48,6 +48,19 @@ class DomainMetadataUploader:
 
         return dated_blob
 
+    def upload_errors(self, errors: str) -> Blob:
+        """Upload the errors manifest to GCS.
+        One file is prepended by a timestamp for record keeping,
+        the other file is the latest entry.
+        """
+        timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
+        timestamp_file_name = f"{timestamp}_errors.json"
+
+        self.uploader.upload_content(errors, "errors_latest.json", forced_upload=True)
+        dated_blob: Blob = self.uploader.upload_content(errors, timestamp_file_name)
+
+        return dated_blob
+
     def get_latest_file_for_diff(
         self,
     ) -> dict[str, list[dict[str, str]]] | None:

--- a/merino/jobs/navigational_suggestions/models.py
+++ b/merino/jobs/navigational_suggestions/models.py
@@ -29,3 +29,11 @@ class ProcessingResult(BaseModel):
     success: bool
     metadata: Optional[DomainMetadata] = None
     error: Optional[str] = None
+    error_reason: Optional[str] = None
+
+
+class DomainError(BaseModel):
+    """Error information for a domain that failed processing."""
+
+    domain: str
+    error_reason: str

--- a/merino/jobs/navigational_suggestions/scrapers/web_scraper.py
+++ b/merino/jobs/navigational_suggestions/scrapers/web_scraper.py
@@ -15,6 +15,14 @@ from merino.jobs.navigational_suggestions.constants import REQUEST_HEADERS, TIME
 
 logger = logging.getLogger(__name__)
 
+# HTML elements commonly used by bot protection services (Cloudflare, etc.)
+# Structure: list of (attribute_name, attribute_value) tuples for div elements
+# Future: expand this list as new bot-blocking patterns are discovered
+BOT_BLOCKING_ELEMENTS = [
+    ("id", "challenge-form"),  # Cloudflare challenge
+    ("class_", "cf-browser-verification"),  # Cloudflare verification
+]
+
 
 class WebScraper:
     """Website scraper using MechanicalSoup. Use as context manager."""
@@ -38,8 +46,22 @@ class WebScraper:
     def open(self, url: str) -> Optional[str]:
         """Open URL and return final URL after redirects, or None if failed."""
         try:
-            self.browser.open(url, timeout=TIMEOUT, allow_redirects=ALLOW_REDIRECTS)
+            response = self.browser.open(url, timeout=TIMEOUT, allow_redirects=ALLOW_REDIRECTS)
+            if response and response.status_code >= 400:
+                logger.debug(f"HTTP {response.status_code} error for URL {url}")
             return str(self.browser.url)
+        except requests.exceptions.Timeout:
+            logger.debug(f"Timeout opening URL {url}")
+            return None
+        except requests.exceptions.ConnectionError as e:
+            logger.debug(f"Connection error opening URL {url}: {e}")
+            return None
+        except requests.exceptions.TooManyRedirects:
+            logger.debug(f"Too many redirects for URL {url}")
+            return None
+        except requests.exceptions.SSLError as e:
+            logger.debug(f"SSL error opening URL {url}: {e}")
+            return None
         except Exception as e:
             logger.debug(f"Failed to open URL {url}: {e}")
             return None
@@ -65,6 +87,54 @@ class WebScraper:
             return str(self.browser.url) if self.browser.url else None
         except Exception:
             return None
+
+    def get_status_code(self) -> Optional[int]:
+        """Get HTTP status code of the last response."""
+        try:
+            if hasattr(self.browser, "response") and self.browser.response:
+                return int(self.browser.response.status_code)
+            return None
+        except Exception:
+            return None
+
+    def is_bot_blocked(self) -> bool:
+        """Check if page appears to be a bot-blocking or challenge page."""
+        try:
+            page = self.get_page()
+            if not page:
+                return False
+
+            title = self.scrape_title()
+            if title:
+                title_lower = title.lower()
+                # Check page title for common phrases used by bot-blocking services
+                # (e.g., Cloudflare, Akamai, captcha pages, access denied pages)
+                bot_indicators = [
+                    "access denied",
+                    "captcha",
+                    "cloudflare",
+                    "security check",
+                    "robot or human",
+                    "just a moment",
+                    "checking your browser",
+                    "ddos protection",
+                    "are you a robot",
+                    "bot protection",
+                    "please verify",
+                    "attention required",
+                ]
+                if any(indicator in title_lower for indicator in bot_indicators):
+                    return True
+
+            # Check for specific HTML elements commonly used by bot protection services
+            # These elements are typically present on challenge/verification pages
+            for attr, value in BOT_BLOCKING_ELEMENTS:
+                if page.find("div", attrs={attr: value}):
+                    return True
+
+            return False
+        except Exception:
+            return False
 
     def close(self) -> None:
         """Close browser session and clean up resources."""

--- a/tests/integration/jobs/navigational_suggestions/test_favicon_pipeline_integration.py
+++ b/tests/integration/jobs/navigational_suggestions/test_favicon_pipeline_integration.py
@@ -333,7 +333,7 @@ class TestFaviconProcessorIntegration:
             favicons, min_width=16, uploader=mock_uploader
         )
 
-        assert result == "https://cdn.example.com/favicon.svg"
+        assert result == ("https://cdn.example.com/favicon.svg", None)
         mock_downloader.download_multiple_favicons.assert_called_once()
         mock_uploader.upload_image.assert_called_once()
 
@@ -374,7 +374,7 @@ class TestFaviconProcessorIntegration:
             favicons, min_width=16, uploader=mock_uploader
         )
 
-        assert result == "https://cdn.example.com/favicon.png"
+        assert result == ("https://cdn.example.com/favicon.png", None)
         mock_downloader.download_multiple_favicons.assert_called_once()
         mock_uploader.upload_image.assert_called_once()
 
@@ -422,7 +422,7 @@ class TestFaviconProcessorIntegration:
         )
 
         # Should prioritize SVG over bitmap, even if bitmap is higher resolution
-        assert result == "https://cdn.example.com/favicon.svg"
+        assert result == ("https://cdn.example.com/favicon.svg", None)
         # Only one download call should be made (for SVG), since SVG succeeds
         assert mock_downloader.download_multiple_favicons.call_count == 1
         mock_uploader.upload_image.assert_called_once_with(
@@ -467,7 +467,7 @@ class TestFaviconProcessorIntegration:
             favicons, min_width=16, uploader=mock_uploader
         )
 
-        assert result == "https://cdn.example.com/favicon.png"
+        assert result == ("https://cdn.example.com/favicon.png", None)
         # Should be called twice due to batching
         assert mock_downloader.download_multiple_favicons.call_count == 2
         # Should upload the largest (best) favicon
@@ -503,7 +503,8 @@ class TestFaviconProcessorIntegration:
         )
 
         # Should return empty string when no favicon meets minimum width
-        assert result == ""
+        assert result[0] == ""
+        # Error reason is provided
 
     @pytest.mark.asyncio
     async def test_process_and_upload_url_processing_integration(self):
@@ -529,7 +530,8 @@ class TestFaviconProcessorIntegration:
         )
 
         # Should process relative URL but result in empty due to no valid images
-        assert result == ""
+        assert result[0] == ""
+        # Error reason is provided
 
     @pytest.mark.asyncio
     async def test_process_and_upload_upload_failure_fallback(self):
@@ -559,7 +561,7 @@ class TestFaviconProcessorIntegration:
         )
 
         # Should fallback to original URL when upload fails
-        assert result == "https://example.com/favicon.svg"
+        assert result == ("https://example.com/favicon.svg", None)
 
     @pytest.mark.asyncio
     async def test_process_and_upload_download_error_handling(self):
@@ -580,8 +582,8 @@ class TestFaviconProcessorIntegration:
             favicons, min_width=16, uploader=mock_uploader
         )
 
-        # Should return empty string when download fails
-        assert result == ""
+        # Should return empty string with error reason when download fails
+        assert result == ("", "no_suitable_favicon_found")
 
     @pytest.mark.asyncio
     async def test_process_and_upload_mixed_content_types(self):
@@ -617,7 +619,7 @@ class TestFaviconProcessorIntegration:
         )
 
         # Should successfully process the valid image and skip the invalid one
-        assert result == "https://cdn.example.com/favicon.png"
+        assert result == ("https://cdn.example.com/favicon.png", None)
 
     @pytest.mark.asyncio
     async def test_process_and_upload_empty_favicons_list(self):
@@ -633,7 +635,7 @@ class TestFaviconProcessorIntegration:
             [], min_width=16, uploader=mock_uploader
         )
 
-        assert result == ""
+        assert result == ("", "no_valid_favicon_urls")
         mock_downloader.download_multiple_favicons.assert_not_called()
 
     @pytest.mark.asyncio
@@ -654,7 +656,7 @@ class TestFaviconProcessorIntegration:
             favicons, min_width=16, uploader=mock_uploader
         )
 
-        assert result == ""
+        assert result == ("", "no_valid_favicon_urls")
         mock_downloader.download_multiple_favicons.assert_not_called()
 
 

--- a/tests/unit/jobs/navigational_suggestions/test_web_scraper.py
+++ b/tests/unit/jobs/navigational_suggestions/test_web_scraper.py
@@ -41,6 +41,9 @@ class TestWebScraperOpen:
         """Test successful URL opening."""
         scraper = WebScraper()
         mock_browser = mocker.MagicMock()
+        mock_response = mocker.MagicMock()
+        mock_response.status_code = 200
+        mock_browser.open.return_value = mock_response
         mock_browser.url = "https://example.com"
         scraper.browser = mock_browser
 
@@ -55,6 +58,9 @@ class TestWebScraperOpen:
         """Test opening URL that redirects."""
         scraper = WebScraper()
         mock_browser = mocker.MagicMock()
+        mock_response = mocker.MagicMock()
+        mock_response.status_code = 200
+        mock_browser.open.return_value = mock_response
         mock_browser.url = "https://www.example.com/redirected"
         scraper.browser = mock_browser
 


### PR DESCRIPTION
## References

JIRA: [DISCO-3872](https://mozilla-hub.atlassian.net/browse/DISCO-3872)

## Description
We want to track if and why domains couldn't be scraped, so we can take an informed decision on how to further improve the job/service. This adds error tracking to various functions, which now return a tuple with a possible error reason.

The main goal is to produce, next to a `top_picks.json` file, an `error.json` file, where we list the `domain` + `error`. This gives us an insight why and where we can improve the job going forward.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3872]: https://mozilla-hub.atlassian.net/browse/DISCO-3872?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-1997)
