### PR TITLE
[DISCO-3883] Investigate snapshot get request metric not showing

### DIFF
--- a/merino/providers/suggest/finance/backends/polygon/backend.py
+++ b/merino/providers/suggest/finance/backends/polygon/backend.py
@@ -201,6 +201,8 @@ class PolygonBackend:
         params = {"ticker": ticker, self.url_param_api_key: self.api_key}
 
         try:
+            self.metrics_client.increment("polygon.request.snapshot.get")
+
             with self.metrics_client.timeit("polygon.request.snapshot.get.latency"):
                 response: Response = await self.http_client.get(
                     self.url_single_ticker_snapshot, params=params
@@ -214,7 +216,6 @@ class PolygonBackend:
             self.metrics_client.increment("polygon.request.snapshot.get.failed")
             return None
 
-        self.metrics_client.increment("polygon.request.snapshot.get")
         return response.json()
 
     async def get_ticker_image_url(self, ticker: str) -> str | None:

--- a/tests/unit/providers/suggest/finance/backends/test_polygon.py
+++ b/tests/unit/providers/suggest/finance/backends/test_polygon.py
@@ -270,7 +270,10 @@ async def test_fetch_ticker_snapshot_failure_for_http_500(
 
     assert records[0].message.startswith("Polygon request error")
     assert "500 Internal Server Error" in records[0].message
-    increment_metric_mock.assert_called_once_with("polygon.request.snapshot.get.failed")
+    increment_metric_mock.assert_has_calls(
+        [call("polygon.request.snapshot.get"), call("polygon.request.snapshot.get.failed")],
+        any_order=False,
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## References

JIRA: [DISCO-3883](https://mozilla-hub.atlassian.net/browse/DISCO-3883)

## Description
Yardstick graph is showing "No Data" for the metric `"polygon.request.snapshot.get"`. Hoping this will fix that issue.

## PR Review Checklist
- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3883]: https://mozilla-hub.atlassian.net/browse/DISCO-3883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2009)
