### PR TITLE
[DISCO-3732] Investigate PLUG stock

### DIFF
--- a/merino/providers/suggest/finance/backends/polygon/stock_ticker_company_mapping.py
+++ b/merino/providers/suggest/finance/backends/polygon/stock_ticker_company_mapping.py
@@ -724,6 +724,7 @@ ALL_STOCK_TICKER_COMPANY_MAPPING: dict[str, dict[str, str]] = {
     "PLD": {"company": "Prologis Inc", "exchange": "NYSE"},
     "PLNT": {"company": "Planet Fitness", "exchange": "NYSE"},
     "PLTR": {"company": "Palantir Technologies Inc", "exchange": "NASDAQ"},
+    "PLUG": {"company": "Plug Power Inc", "exchange": "NASDAQ"},
     "PM": {"company": "Philip Morris International Inc", "exchange": "NYSE"},
     "PNC": {"company": "PNC Bank", "exchange": "NYSE"},
     "PNFP": {"company": "Pinnacle Finl Ptnrs", "exchange": "NASDAQ"},


### PR DESCRIPTION
## References

JIRA: [DISCO-3732](https://mozilla-hub.atlassian.net/browse/DISCO-3732)

## Description
We were getting a `KeyError` exception because the ticker symbol `PLUG` was not in the list of tickers.


## PR Review Checklist


- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3732]: https://mozilla-hub.atlassian.net/browse/DISCO-3732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2011)
