### PR TITLE
[DISCO-3888] Improve wiki indexer logging

### DIFF
--- a/tests/integration/jobs/wikipedia_indexer/test_indexer.py
+++ b/tests/integration/jobs/wikipedia_indexer/test_indexer.py
@@ -2,6 +2,7 @@
 
 import datetime
 import json
+import logging
 
 import freezegun
 import pytest
@@ -41,6 +42,12 @@ def es_client(mocker):
     """Return a mock Elasticsearch client."""
     es_mock = mocker.patch("elasticsearch.Elasticsearch")
     return es_mock.return_value
+
+
+@pytest.fixture
+def indexer(file_manager, es_client, category_blocklist, title_blocklist):
+    """Return a mock indexer instance"""
+    return Indexer("v1", category_blocklist, title_blocklist, file_manager, es_client)
 
 
 @pytest.mark.parametrize(
@@ -372,3 +379,96 @@ def test_index_from_export_with_title_blocklist_content_filter(
     indexer.index_from_export(1, "enwiki")
 
     es_client.bulk.assert_called_once()
+
+
+def _set_queue(indexer, n=1):
+    # queue is [op, doc, op, doc, ...]
+    indexer.queue.clear()
+    for i in range(n):
+        indexer.queue.append({"index": {"_index": "test-idx", "_id": str(i)}})
+        indexer.queue.append({"title": f"Doc {i}"})
+
+
+def test_index_docs_raises_with_first_failing_item(indexer, es_client, caplog):
+    """Test that when errors=True, raise with the first item that actually failed, not just items[0]."""
+    _set_queue(indexer, n=2)
+
+    # first item is a success, second item is a failure
+    es_client.bulk.return_value = {
+        "took": 12,
+        "errors": True,
+        "items": [
+            {
+                "index": {
+                    "_index": "test-idx",
+                    "_id": "0",
+                    "status": 201,
+                    "result": "created",
+                }
+            },
+            {
+                "index": {
+                    "_index": "test-idx",
+                    "_id": "1",
+                    "status": 400,
+                    "error": {
+                        "type": "mapper_parsing_exception",
+                        "reason": "failed to parse field [suggest]",
+                    },
+                }
+            },
+        ],
+    }
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(RuntimeError) as exc:
+            indexer._index_docs(force=True)
+
+    msg = str(exc.value)
+    assert "Bulk failed" in msg
+    assert "mapper_parsing_exception" in msg
+    assert '"status": 400' in msg
+    assert indexer.queue == []
+    assert any("Bulk operation had errors" in rec.message for rec in caplog.records)
+
+
+def test_index_docs_handles_non_index_actions(indexer, es_client):
+    """Test that index_docs works when ES returns actions like 'update'"""
+    _set_queue(indexer, n=1)
+    es_client.bulk.return_value = {
+        "errors": True,
+        "items": [
+            {
+                "update": {
+                    "_index": "test-idx",
+                    "_id": "42",
+                    "status": 404,
+                    "error": {
+                        "type": "document_missing_exception",
+                        "reason": "[42]: document missing",
+                    },
+                }
+            }
+        ],
+    }
+    with pytest.raises(RuntimeError) as exc:
+        indexer._index_docs(force=True)
+    assert "document_missing_exception" in str(exc.value)
+    assert indexer.queue == []
+
+
+def test_index_docs_success_returns_item_count(indexer, es_client):
+    """Test that when errors=False, return count and do not raise."""
+    _set_queue(indexer, n=3)
+    es_client.bulk.return_value = {
+        "took": 5,
+        "errors": False,
+        "items": [
+            {"index": {"_index": "test-idx", "_id": "0", "status": 201}},
+            {"index": {"_index": "test-idx", "_id": "1", "status": 201}},
+            {"index": {"_index": "test-idx", "_id": "2", "status": 201}},
+        ],
+    }
+    count = indexer._index_docs(force=True)
+    assert count == 3
+    assert indexer.queue == []


### PR DESCRIPTION
## References

JIRA: [DISCO-3888](https://mozilla-hub.atlassian.net/browse/DISCO-3888)

## Description
The [wikipedia airflow job](https://workflow.telemetry.mozilla.org/log?dag_id=merino_jobs&task_id=wikipedia_indexer_de.wikipedia_indexer_build_index_staging_de&execution_date=2025-12-30T05%3A00%3A00%2B00%3A00) is currently failing for all languages at the bulk indexing point. Previously we were raising an exception with an error message that resolved to `True` which didn't help debugging. This PR improves on this by logging the first failing item with more details. This would help us figure out why the job is failing now and in the future



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3888]: https://mozilla-hub.atlassian.net/browse/DISCO-3888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2013)
