### PR TITLE
GENAI-3164 - Redo of GENAI-3164 Add support for cloned Inferred v3 experiment #1229

### DIFF
--- a/merino/curated_recommendations/ml_backends/static_local_model.py
+++ b/merino/curated_recommendations/ml_backends/static_local_model.py
@@ -14,6 +14,7 @@ from merino.curated_recommendations.protocol import ExperimentName
 INFERRED_LOCAL_EXPERIMENT_NAME = ExperimentName.INFERRED_LOCAL_EXPERIMENT.value
 INFERRED_LOCAL_EXPERIMENT_NAME_V2 = ExperimentName.INFERRED_LOCAL_EXPERIMENT_V2.value
 INFERRED_LOCAL_EXPERIMENT_NAME_V3 = ExperimentName.INFERRED_LOCAL_EXPERIMENT_V3.value
+INFERRED_LOCAL_EXPERIMENT_NAME_V4 = ExperimentName.INFERRED_LOCAL_EXPERIMENT_V4.value
 
 LOCAL_AND_SERVER_V1_MODEL_ID = "local-and-server"
 LOCAL_ONLY_V1_MODEL_ID = "local-only"
@@ -276,7 +277,9 @@ class SuperInferredModel(LocalModelBackend):
         if model_id is None:  ## this is the "get" call for building the model sent in the response
             ## switch on experiment name, not using util because we have string name instead of request object
             if (
-                experiment_name == INFERRED_LOCAL_EXPERIMENT_NAME_V3
+                experiment_name == INFERRED_LOCAL_EXPERIMENT_NAME_V4
+                or experiment_name == f"optin-{INFERRED_LOCAL_EXPERIMENT_NAME_V4}"
+                or experiment_name == INFERRED_LOCAL_EXPERIMENT_NAME_V3
                 or experiment_name == f"optin-{INFERRED_LOCAL_EXPERIMENT_NAME_V3}"
             ):
                 # We don't have to check for branch here as control won't call inferred code

--- a/merino/curated_recommendations/protocol.py
+++ b/merino/curated_recommendations/protocol.py
@@ -108,6 +108,7 @@ class ExperimentName(str, Enum):
     INFERRED_LOCAL_EXPERIMENT = "new-tab-automated-personalization-local-ranking"
     INFERRED_LOCAL_EXPERIMENT_V2 = "new-tab-automated-personalization-local-ranking-2"
     INFERRED_LOCAL_EXPERIMENT_V3 = "new-tab-automated-personalization-v3"
+    INFERRED_LOCAL_EXPERIMENT_V4 = "new-tab-automated-personalization-v4"
 
 
 class DailyBriefingBranch(str, Enum):

--- a/tests/unit/curated_recommendations/ml_backends/test_static_local_model.py
+++ b/tests/unit/curated_recommendations/ml_backends/test_static_local_model.py
@@ -24,7 +24,7 @@ from merino.curated_recommendations.provider import (
 
 from merino.curated_recommendations.protocol import ExperimentName
 
-INFERRED_V3_EXPERIMENT_NAME = ExperimentName.INFERRED_LOCAL_EXPERIMENT_V3.value
+INFERRED_V4_EXPERIMENT_NAME = ExperimentName.INFERRED_LOCAL_EXPERIMENT_V4.value
 
 TEST_SURFACE = "test_surface"
 
@@ -130,7 +130,7 @@ def test_model_experiment_name_and_branch_name(model_limited):
     """Caller should not decode when the model id doesn't match."""
     model = model_limited.get(
         "surface",
-        experiment_name=INFERRED_V3_EXPERIMENT_NAME,
+        experiment_name=INFERRED_V4_EXPERIMENT_NAME,
         experiment_branch="any",
     )
     assert model.model_matches_interests(SERVER_V3_MODEL_ID)
@@ -492,13 +492,13 @@ def test_process_passthrough_when_values_missing_even_with_matching_model(
     "experiment,branch,model_id,expect_private_nonempty",
     [
         (
-            "optin-" + INFERRED_V3_EXPERIMENT_NAME,
+            "optin-" + INFERRED_V4_EXPERIMENT_NAME,
             "any_branch",
             SERVER_V3_MODEL_ID,
             True,
         ),
         (
-            INFERRED_V3_EXPERIMENT_NAME,
+            INFERRED_V4_EXPERIMENT_NAME,
             "any_branch",
             SERVER_V3_MODEL_ID,
             True,


### PR DESCRIPTION


## References

https://mozilla-hub.atlassian.net/browse/GENAI-3164

## Description
This PR was merged earlier today https://github.com/mozilla-services/merino-py/pull/1229, and then reverted in haste because there was a Merino outage and we thought it could be the cause.

It was not the cause, so the PR has been re-created.

We are adding support for a new experiment ID.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2025)
