### PR TITLE
[DISCO-3903] Sports ES test container conditional start

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -29,11 +29,22 @@ ES_PROP = {
     "started": threading.Event(),
     "done": threading.Event(),
     "error": None,
+    "should_start": False,
 }
+
+SPORT_TESTS = "test_sportsdata"
+
+
+def pytest_collection_finish(session):
+    """Determine if we start the sport es test container based on whether it's needed."""
+    if any(SPORT_TESTS in item.nodeid for item in session.items):
+        ES_PROP["should_start"] = True
 
 
 def _start_container_in_thread(timeout=120):
     """Start container in thread and update container status with ES_PROP."""
+    if not ES_PROP["should_start"]:
+        return
     try:
         container = ElasticSearchContainer("docker.elastic.co/elasticsearch/elasticsearch:8.13.4")
         container.with_env("discovery.type", "single-node")


### PR DESCRIPTION
## References

JIRA: [DISCO-3903](https://mozilla-hub.atlassian.net/browse/DISCO-3903)

## Description
When running a subset of the test suite, the Sports ES container is started regardless if no Sports tests are included in the selected subset. As a result, the container remains running while waiting for the cluster status to turn green, even though the subset of tests have already finished executing.

To address this, a check is added after test collection to determine whether any Sports tests are in the subset, and only start the test container when they are needed.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3903]: https://mozilla-hub.atlassian.net/browse/DISCO-3903?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2028)
