### PR TITLE
GENAI-3096 Disable inferred cohort ranking

### DIFF
--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -64,6 +64,7 @@ TOP_STORIES_SECTION_EXTRA_COUNT = 5  # Extra top stories pulled from later secti
 HEADLINES_SECTION_KEY = "headlines"
 # Require enough recommendations to fill the layout plus a single fallback item
 SECTION_FALLBACK_BUFFER = 1
+IS_COHORT_FEATURE_DISABLED = True  # To be used when we want to disable the feature quickly
 
 
 def map_section_item_to_recommendation(
@@ -295,6 +296,9 @@ def is_inferred_contextual_ranking(personal_interests: ProcessedInterests | None
     We are using the property of the interest vector to evenly split users to contextual ranking.
     25% of inferred users are going to go to the contextual ranking via the modulo of the interest bits total
     """
+    if IS_COHORT_FEATURE_DISABLED:
+        return False
+
     INFERRED_ENABLED_MOD_SELECTOR = 4
     return (
         personal_interests is not None

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -65,6 +65,7 @@ from merino.curated_recommendations.protocol import (
     Locale,
     CoarseOS,
 )
+from merino.curated_recommendations.sections import IS_COHORT_FEATURE_DISABLED
 from merino.main import app
 from merino.providers.manifest import get_provider as get_manifest_provider
 from merino.providers.manifest.backends.protocol import Domain
@@ -1853,9 +1854,15 @@ class TestSections:
 
         # top_stories_section should always be present
         assert "top_stories_section" in sections
-        assert sections["top_stories_section"]["recommendations"][0][
-            "corpusItemId"
-        ] == ml_recommendations_backend.get_most_popular_content_id_by_cohort(8)
+
+        if IS_COHORT_FEATURE_DISABLED:
+            assert sections["top_stories_section"]["recommendations"][0][
+                "corpusItemId"
+            ] != ml_recommendations_backend.get_most_popular_content_id_by_cohort(8)
+        else:
+            assert sections["top_stories_section"]["recommendations"][0][
+                "corpusItemId"
+            ] == ml_recommendations_backend.get_most_popular_content_id_by_cohort(8)
 
         response = client.post(
             "/api/v1/curated-recommendations",

--- a/tests/unit/curated_recommendations/test_sections.py
+++ b/tests/unit/curated_recommendations/test_sections.py
@@ -38,6 +38,7 @@ from merino.curated_recommendations.protocol import (
 )
 from merino.curated_recommendations.rankers import ThompsonSamplingRanker
 from merino.curated_recommendations.sections import (
+    IS_COHORT_FEATURE_DISABLED,
     adjust_ads_in_sections,
     exclude_recommendations_from_blocked_sections,
     is_subtopics_experiment,
@@ -398,7 +399,10 @@ class TestIsInferredContextualRankingExperiment:
 
         # Test case where all conditions are met
         pi_selected = ProcessedInterests(cohort="test", numerical_value=4)  # 4 % 4 == 0
-        assert is_inferred_contextual_ranking(pi_selected)
+        if IS_COHORT_FEATURE_DISABLED:
+            assert not is_inferred_contextual_ranking(pi_selected)
+        else:
+            assert is_inferred_contextual_ranking(pi_selected)
 
 
 class TestUpdateReceivedFeedRank:


### PR DESCRIPTION
## References

https://mozilla-hub.atlassian.net/browse/GENAI-3096

## Description
We have been testing contextual ranking based on user cohorts for the past day for a subset of inferred users, and have discovered several bugs in our pipeline around training of the cohort model, and training of the contextual ranker.

We are disabling the feature until Monday when we have verified the remaining bugs have been fixed. Topic boosting for for personalization is still being performed.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2036)
