### PR TITLE
[DISCO-3927] Sport Test Container adjustments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,7 @@ unit-test-fixtures: $(INSTALL_STAMP)  ##  List fixtures in use per unit test
 integration-tests: $(INSTALL_STAMP)  ##  Run integration tests
 	COVERAGE_FILE=$(TEST_RESULTS_DIR)/.coverage.integration \
 	    MERINO_ENV=testing \
+	    TESTCONTAINERS_RYUK_DISABLED=true \
 	    $(UV) run pytest $(INTEGRATION_TEST_DIR) $(XTRA) \
 	    --junit-xml=$(INTEGRATION_JUNIT_XML)
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,120 +1,132 @@
 """Module for test configurations for the integration test directory."""
 
-#
-# import asyncio
-# import os
-# import time
-# import threading
-# import requests
-# import pytest
-# import pytest_asyncio
-#
-# # need this env before importing test containers
-# # ryuk is a container that helps with clean up, but since we explicitly stop test containers, it should be okay.
-# os.environ["TESTCONTAINERS_RYUK_DISABLED"] = "true"
-# from testcontainers.elasticsearch import ElasticSearchContainer  # noqa
-# from elasticsearch import AsyncElasticsearch  # noqa
-#
-#
-# Temporary skip for further investigation
-collect_ignore = ["providers/suggest/sports/backends/test_sportsdata.py"]
-#
-# ES_PROP = {
-#     "container": None,
-#     "base_url": None,
-#     "started": threading.Event(),
-#     "done": threading.Event(),
-#     "error": None,
-# }
-#
-#
-# def _start_container_in_thread(timeout=120):
-#     """Start container in thread and update container status with ES_PROP."""
-#     try:
-#         container = ElasticSearchContainer("docker.elastic.co/elasticsearch/elasticsearch:8.13.4")
-#         container.with_env("discovery.type", "single-node")
-#         container.start()
-#
-#         host = container.get_container_host_ip()
-#         port = container.get_exposed_port(9200)
-#         base_url = f"http://{host}:{port}"
-#
-#         ES_PROP["container"] = container
-#         ES_PROP["base_url"] = base_url
-#
-#         ES_PROP["started"].set()
-#
-#         # time to give up to wait for green status (2mins from now)
-#         time_to_give_up = time.time() + timeout
-#         health_url = f"{base_url}/_cluster/health?wait_for_status=green&timeout=1s"
-#         while time.time() < time_to_give_up:
-#             try:
-#                 r = requests.get(health_url, timeout=2)
-#                 if r.status_code == 200 and r.json().get("status") == "green":
-#                     ES_PROP["done"].set()
-#                     return
-#             except requests.RequestException:
-#                 pass
-#             time.sleep(0.5)
-#
-#         ES_PROP["error"] = RuntimeError("Elasticsearch status did not turn green")
-#         ES_PROP["done"].set()
-#
-#     except Exception as e:
-#         ES_PROP["error"] = e
-#         ES_PROP["done"].set()
-#
-#
-# @pytest.fixture(scope="session", autouse=True)
-# def start_es_background():
-#     """Start the ES container on a background thread at session start."""
-#     t = threading.Thread(target=_start_container_in_thread, daemon=True)
-#     t.start()
-#
-#     yield
-#
-#     container = ES_PROP.get("container")
-#     if container:
-#         container.stop()
-#
-#
-# @pytest.fixture
-# def es_base_url():
-#     """Return base_url if container.start() has been called"""
-#     ES_PROP["started"].wait(timeout=10)
-#     if ES_PROP.get("error") and not ES_PROP.get("base_url"):
-#         raise ES_PROP["error"]
-#     return ES_PROP.get("base_url")
-#
-#
-# @pytest_asyncio.fixture
-# async def es_ready():
-#     """Async fixture that waits for the ES cluster to be green or raises startup error."""
-#     await asyncio_wait_for_thread_event(ES_PROP["started"], timeout=10)
-#     if ES_PROP.get("error") and not ES_PROP.get("base_url"):
-#         raise ES_PROP["error"]
-#
-#     await asyncio_wait_for_thread_event(ES_PROP["done"], timeout=120)
-#
-#     if ES_PROP.get("error"):
-#         raise ES_PROP["error"]
-#
-#     base_url = ES_PROP.get("base_url")
-#     if not base_url:
-#         raise RuntimeError("Elasticsearch did not start correctly")
-#     return base_url
-#
-#
-# @pytest_asyncio.fixture
-# async def es_client(es_ready):
-#     """Elasticsearch client fixture."""
-#     client = AsyncElasticsearch(hosts=[es_ready])
-#     try:
-#         yield client
-#     finally:
-#         await client.close()
-#
-#
-# def asyncio_wait_for_thread_event(evt: threading.Event, timeout: float):
-#     """Return coroutine that resolves when evt.wait() returns."""
-#     return asyncio.wait_for(asyncio.to_thread(evt.wait, timeout), timeout=timeout)
+import asyncio
+import time
+import threading
+import requests
+import pytest
+import pytest_asyncio
+
+from testcontainers.elasticsearch import ElasticSearchContainer
+from elasticsearch import AsyncElasticsearch
+
+ES_PROP = {
+    "container": None,
+    "base_url": None,
+    "started": threading.Event(),
+    "done": threading.Event(),
+    "error": None,
+    "should_start": False,
+}
+
+SPORT_TESTS = "test_sportsdata"
+
+
+def pytest_collection_modifyitems(session, config, items):
+    """Move sports tests to the end."""
+    sports_tests = []
+    other_tests = []
+    for item in items:
+        if SPORT_TESTS in item.nodeid:
+            sports_tests.append(item)
+        else:
+            other_tests.append(item)
+    ES_PROP["should_start"] = len(sports_tests) > 0
+    items[:] = other_tests + sports_tests
+
+
+def _start_container_in_thread(timeout=120):
+    """Start container in thread and update container status with ES_PROP."""
+    try:
+        container = ElasticSearchContainer("docker.elastic.co/elasticsearch/elasticsearch:8.13.4")
+        container.with_env("discovery.type", "single-node")
+        container.with_env("ES_JAVA_OPTS", "-Xms256m -Xmx256m")
+        container.start()
+
+        host = container.get_container_host_ip()
+        port = container.get_exposed_port(9200)
+        base_url = f"http://{host}:{port}"
+
+        ES_PROP["container"] = container
+        ES_PROP["base_url"] = base_url
+
+        ES_PROP["started"].set()
+
+        # time to give up to wait for green status (2mins from now)
+        time_to_give_up = time.time() + timeout
+        health_url = f"{base_url}/_cluster/health?wait_for_status=green&timeout=1s"
+        while time.time() < time_to_give_up:
+            try:
+                r = requests.get(health_url, timeout=2)
+                if r.status_code == 200 and r.json().get("status") == "green":
+                    ES_PROP["done"].set()
+                    return
+            except requests.RequestException:
+                pass
+            time.sleep(0.5)
+
+        ES_PROP["error"] = RuntimeError("Elasticsearch status did not turn green")
+        ES_PROP["done"].set()
+
+    except Exception as e:
+        ES_PROP["error"] = e
+        ES_PROP["done"].set()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def start_es_background():
+    """Start the ES container on a background thread at session start."""
+    if not ES_PROP["should_start"]:
+        yield
+        return
+
+    t = threading.Thread(target=_start_container_in_thread, daemon=True)
+    t.start()
+
+    yield
+
+    container = ES_PROP.get("container")
+    if container:
+        container.stop()
+
+
+@pytest.fixture
+def es_base_url():
+    """Return base_url if container.start() has been called"""
+    ES_PROP["started"].wait(timeout=10)
+    if ES_PROP.get("error") and not ES_PROP.get("base_url"):
+        raise ES_PROP["error"]
+    return ES_PROP.get("base_url")
+
+
+@pytest_asyncio.fixture
+async def es_ready():
+    """Async fixture that waits for the ES cluster to be green or raises startup error."""
+    await asyncio_wait_for_thread_event(ES_PROP["started"], timeout=10)
+    if ES_PROP.get("error") and not ES_PROP.get("base_url"):
+        raise ES_PROP["error"]
+
+    await asyncio_wait_for_thread_event(ES_PROP["done"], timeout=120)
+
+    if ES_PROP.get("error"):
+        raise ES_PROP["error"]
+
+    base_url = ES_PROP.get("base_url")
+    if not base_url:
+        raise RuntimeError("Elasticsearch did not start correctly")
+    return base_url
+
+
+@pytest_asyncio.fixture
+async def es_client(es_ready):
+    """Elasticsearch client fixture."""
+    client = AsyncElasticsearch(hosts=[es_ready])
+    try:
+        yield client
+    finally:
+        await client.close()
+
+
+def asyncio_wait_for_thread_event(evt: threading.Event, timeout: float):
+    """Return coroutine that resolves when evt.wait() returns."""
+    return asyncio.wait_for(asyncio.to_thread(evt.wait, timeout), timeout=timeout)

--- a/tests/integration/providers/suggest/sports/backends/test_sportsdata.py
+++ b/tests/integration/providers/suggest/sports/backends/test_sportsdata.py
@@ -138,6 +138,10 @@ async def test_sportsdata_na_query(sportsdata: SportsDataBackend, sports_league:
     await sportsdata.data_store.build_indexes(clear=True)
 
     await sportsdata.data_store.store_events(sport=sports_league, language_code="en")
+    if sportsdata.data_store.client:
+        # refresh makes recent operations performed available for search
+        await sportsdata.data_store.client.indices.refresh()
+
     result = await sportsdata.query("fakehome")
 
     expected_result = SportSummary(
@@ -172,6 +176,10 @@ async def test_sportsdata_query_with_no_result(sportsdata: SportsDataBackend, sp
     await sportsdata.data_store.build_indexes(clear=True)
 
     await sportsdata.data_store.store_events(sport=sports_league, language_code="en")
+    if sportsdata.data_store.client:
+        # refresh makes recent operations performed available for search
+        await sportsdata.data_store.client.indices.refresh()
+
     response = await sportsdata.query("something else")
     assert len(response) == 0
 


### PR DESCRIPTION
- Adjusting configuration for heap size
- ENV var to disable RYUK container when running whole test suite
- Conditionally running the sports es container only when there are sport tests executing
- Moving sports related test to the end for the best possibility for the test container to be ready

## References

JIRA: [DISCO-3927](https://mozilla-hub.atlassian.net/browse/DISCO-3927)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3927]: https://mozilla-hub.atlassian.net/browse/DISCO-3927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2037)
