### PR TITLE
GENAI-3334 Re-enable contextual ranking, add impressions support

### DIFF
--- a/merino/curated_recommendations/ml_backends/empty_ml_recs.py
+++ b/merino/curated_recommendations/ml_backends/empty_ml_recs.py
@@ -31,6 +31,10 @@ class EmptyMLRecs(MLRecsBackend):
         """
         return None
 
+    def get_adjusted_impressions(self, corpus_item_id: str) -> int:
+        """Return the impression count for a given corpus item id (adjusted for propensity)"""
+        return 0
+
     def is_valid(self):
         """Return whether the backend is valid and ready to serve recommendations. In this case, always false."""
         return False

--- a/merino/curated_recommendations/ml_backends/protocol.py
+++ b/merino/curated_recommendations/ml_backends/protocol.py
@@ -225,6 +225,10 @@ class MLRecsBackend(Protocol):
         """Fetch the recommendations based on region and utc offset"""
         ...
 
+    def get_adjusted_impressions(self, corpus_item_id: str) -> int:
+        """Return the impression count for a given corpus item id (adjusted for propensity)"""
+        ...
+
     def get_cohort_training_run_id(self) -> str | None:
         """Return the training run ID for the cohort model used."""
         ...

--- a/merino/curated_recommendations/rankers/contextual_ranker.py
+++ b/merino/curated_recommendations/rankers/contextual_ranker.py
@@ -90,6 +90,12 @@ class ContextualRanker(Ranker):
                 beta_val = no_opens + max(b_prior, 1e-18)
                 score = float(beta.rvs(alpha_val, beta_val))
             else:
+                # Contextual ranker known imprssions override the computed no_opens based on engagement
+                # which runs on a different interval. We will need to potentially rescale the ml_backend
+                # impresions before completely ignoring the no_opens from the legacy engagement backend.
+                no_opens = max(
+                    self.ml_backend.get_adjusted_impressions(rec.corpusItemId), no_opens
+                )
                 score += random() * 0.0001
 
             if (

--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -64,7 +64,7 @@ TOP_STORIES_SECTION_EXTRA_COUNT = 5  # Extra top stories pulled from later secti
 HEADLINES_SECTION_KEY = "headlines"
 # Require enough recommendations to fill the layout plus a single fallback item
 SECTION_FALLBACK_BUFFER = 1
-IS_COHORT_FEATURE_DISABLED = True  # To be used when we want to disable the feature quickly
+IS_COHORT_FEATURE_DISABLED = False  # To be used when we want to disable the feature quickly
 
 
 def map_section_item_to_recommendation(

--- a/tests/integration/api/v1/curated_recommendations/ml_backends/test_gcs_ml_contextual.py
+++ b/tests/integration/api/v1/curated_recommendations/ml_backends/test_gcs_ml_contextual.py
@@ -78,6 +78,7 @@ def blob(gcs_bucket):
             "topN": 500,
             "model": {"name": "ContextualLinTS", "version": None},
             "slates": {"global": {"granularity": "global", "shards": {"": [1, 2], "aa": [3, 4]}}},
+            "impressions_by_id": {"aa": 1},
         },
     )
 
@@ -94,6 +95,7 @@ def old_blob(gcs_bucket):
             "topN": 500,
             "model": {"name": "ContextualLinTS", "version": None},
             "slates": {"global": {"granularity": "global", "shards": {"": [1, 2], "aa": [3, 4]}}},
+            "impressions_by_id": {"aa": 1},
         },
     )
 
@@ -142,6 +144,9 @@ async def test_gcs_ml_recs_fetches_data(gcs_storage_client, gcs_bucket, metrics_
     assert rankings.get_score("") == 1
     assert rankings.get_score("aa") == 3
     assert rankings.get_score("??") is None
+
+    assert gcs_engagement.get_adjusted_impressions("aa") == 1
+    assert gcs_engagement.get_adjusted_impressions("unknown") == 0
 
 
 @pytest.mark.asyncio

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -174,6 +174,10 @@ class MockMLRecommendationsBackend(MLRecsBackend):
         """Return whether the backend is valid."""
         return True
 
+    def get_adjusted_impressions(self, corpus_item_id: str) -> int:
+        """Return the impression count for a given corpus item id (adjusted for propensity)"""
+        return 100000
+
     def get_most_popular_content_id_by_timezone(self, utcOffset: int) -> str:
         """Return the most popular content ID for a given timezone offset."""
         if utcOffset == 16:


### PR DESCRIPTION
## References

JIRA: https://mozilla-hub.atlassian.net/browse/GENAI-3334

## Description
We throttle fresh content items from new tab at a max 15% rate, using data from the engagement GCS artifacts.

These artifacts are out of sync with the contextual ranker, so it is better to use impression data from the contextual ranker instead.

Currently the impressions are not all traffic, so we use a max() field to use the max of both jobs.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2038)
