### PR TITLE
GENAI-3347 Fix sharding bug with contextual ranking

### DIFF
--- a/merino/curated_recommendations/ml_backends/protocol.py
+++ b/merino/curated_recommendations/ml_backends/protocol.py
@@ -181,8 +181,11 @@ class ContextualArticleRankings(BaseModel):
 
     @model_validator(mode="after")
     def set_k(self) -> "ContextualArticleRankings":
-        """Set K based on shards data. K represents the number of shards per article."""
-        self.K = len(self.shards.get("", [])) if "" in self.shards else 1
+        """Set K (number of shards per article) based on shards data"""
+        self.K = 1
+        for _key, v in self.shards.items():
+            self.K = len(v)
+            break
         return self
 
     def has_item_score(self, corpus_item_id: str) -> bool:


### PR DESCRIPTION
## References

https://mozilla-hub.atlassian.net/browse/GENAI-3347

## Description
We were getting the incorrect number of shards to alternate between.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2041)
