### PR TITLE
GENAI-3347 tweak - Randomize shard per response

### DIFF
--- a/merino/curated_recommendations/rankers/contextual_ranker.py
+++ b/merino/curated_recommendations/rankers/contextual_ranker.py
@@ -72,9 +72,8 @@ class ContextualRanker(Ranker):
         contextual_scores: ContextualArticleRankings | None = self.ml_backend.get(
             region, str(utcOffset), cohort
         )
+        k = randint(0, contextual_scores.K - 1) if contextual_scores is not None else 0
         for rec in recs:
-            if contextual_scores:
-                k = randint(0, contextual_scores.K - 1)
             opens, no_opens, a_prior, b_prior, non_rescaled_b_prior = self.compute_interactions(
                 rec, rescaler, region
             )


### PR DESCRIPTION
## References

There was a minor issue in the earlier GENAI-3347 PR https://github.com/mozilla-services/merino-py/pull/1248. We are supposed to randomize slate selection once per response to a user, not per item.

JIRA: [DISCO-TODO](https://mozilla-hub.atlassian.net/browse/DISCO-TODO)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2043)
