### PR TITLE
GENAI-3316 Disable contexual+inferred as we adjust priors/exploration

### DIFF
--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -64,7 +64,7 @@ TOP_STORIES_SECTION_EXTRA_COUNT = 5  # Extra top stories pulled from later secti
 HEADLINES_SECTION_KEY = "headlines"
 # Require enough recommendations to fill the layout plus a single fallback item
 SECTION_FALLBACK_BUFFER = 1
-IS_COHORT_FEATURE_DISABLED = False  # To be used when we want to disable the feature quickly
+IS_COHORT_FEATURE_DISABLED = True  # To be used when we want to disable the feature quickly
 
 
 def map_section_item_to_recommendation(


### PR DESCRIPTION
## References

https://mozilla-hub.atlassian.net/browse/GENAI-3316

## Description
We're in the process of adjusting priors + exploration with inferred personalization and contexual ranking.

It's been hart to get the parameters correct, so it's best to revert to the legacy personalization until complete.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2044)
