### PR TITLE
GENAI-3316 (re-enable) Turn contextual ranking back on for content recommendations

### DIFF
--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -64,7 +64,7 @@ TOP_STORIES_SECTION_EXTRA_COUNT = 5  # Extra top stories pulled from later secti
 HEADLINES_SECTION_KEY = "headlines"
 # Require enough recommendations to fill the layout plus a single fallback item
 SECTION_FALLBACK_BUFFER = 1
-IS_COHORT_FEATURE_DISABLED = True  # To be used when we want to disable the feature quickly
+IS_COHORT_FEATURE_DISABLED = False  # To be used when we want to disable the feature quickly
 
 
 def map_section_item_to_recommendation(


### PR DESCRIPTION
## References

https://mozilla-hub.atlassian.net/browse/GENAI-3316

## Description
In https://github.com/mozilla-services/merino-py/pull/1251 we turned off contexual ranking for inferred personalization because we were having trouble selecting the correct exploration values. These values control how much randomness users see in the results.

We have now resolved all issues and are seeing healthy variation in the data artifacts used by Merino.... so we can turn the feature back on.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2045)
