### PR TITLE
GENAI-3316 Part 2 - Turn off thompson sampling for non-interested inferred users.

### DIFF
--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -251,9 +251,7 @@ class CuratedRecommendationsProvider:
                     for k, v in decoded.items()
                     if k != LOCAL_MODEL_MODEL_ID_KEY and isinstance(v, (int, float))
                 }
-                # Don't apply cohort model if we have no known interests (clicks) at all
-                is_empty_scores = all(value < 0.3 for value in scores.values())
-                if interest_cohort_model_backend is not None and not is_empty_scores:
+                if interest_cohort_model_backend is not None:
                     cohort = interest_cohort_model_backend.get_cohort_for_interests(
                         interests=dp_values_joined,
                         model_id=model_id,


### PR DESCRIPTION
## References

https://mozilla-hub.atlassian.net/browse/GENAI-3316


## Description
For inferred personalization we were retaining thompson sampling when there were no click preferences.
That can be revised now... Using the contexual ranker when there is no click preference should have different rankings (i.e. less sports stories that are covered on the other cohort)

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2051)
