### PR TITLE
[DISCO-3809] Establish a common Elasticsearch adapter for providers and jobs

### DIFF
--- a/merino/jobs/wikipedia_indexer/utils.py
+++ b/merino/jobs/wikipedia_indexer/utils.py
@@ -5,7 +5,6 @@ from io import StringIO
 from logging import Logger
 
 import requests
-from elasticsearch import Elasticsearch
 
 
 class ProgressReporter:
@@ -50,15 +49,3 @@ def create_blocklist(blocklist_file_url: str) -> set[str]:
     file_like_io = StringIO(block_list)
     csv_reader = csv.DictReader(file_like_io, delimiter=",")
     return set(row["name"] for row in csv_reader)
-
-
-def create_elasticsearch_client(
-    elasticsearch_url: str,
-    elasticsearch_api_key: str,
-) -> Elasticsearch:
-    """Create the Elasticsearch client."""
-    return Elasticsearch(
-        elasticsearch_url,
-        api_key=elasticsearch_api_key,
-        request_timeout=60,
-    )

--- a/merino/search/async_elastic.py
+++ b/merino/search/async_elastic.py
@@ -1,0 +1,158 @@
+"""Async Elasticsearch service utilities."""
+
+from typing import Any, Optional, cast
+
+from elasticsearch import AsyncElasticsearch
+
+
+class AsyncElasticSearchAdapter:
+    """Wrapper around AsyncElasticsearch.
+
+    - Lazily creates and caches an AsyncElasticsearch client instance.
+    - Exposes async helpers for operations (search, close).
+    """
+
+    def __init__(
+        self,
+        *,
+        url: str,
+        api_key: str,
+    ) -> None:
+        self._url = url
+        self._api_key = api_key
+        self._client: Optional[AsyncElasticsearch] = None
+
+    def create_client(self) -> AsyncElasticsearch:
+        """Create an AsyncElasticsearch client."""
+        self._client = AsyncElasticsearch(self._url, api_key=self._api_key)
+        return self._client
+
+    def get_client(self) -> AsyncElasticsearch:
+        """Return the cached AsyncElasticsearch client, creating it if needed."""
+        if self._client is None:
+            self._client = self.create_client()
+        return self._client
+
+    async def shutdown(self) -> None:
+        """Close the async client connection."""
+        if self._client is not None:
+            await self._client.close()
+            self._client = None
+
+    async def search(
+        self,
+        *,
+        index: str,
+        body: Optional[dict[str, Any]] = None,
+        suggest: Optional[dict[str, Any]] = None,
+        timeout: Optional[str] = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        """Run an async search request."""
+        client = self.get_client()
+
+        return cast(
+            dict[str, Any],
+            await client.search(
+                index=index, body=body, suggest=suggest, timeout=timeout, **kwargs
+            ),
+        )
+
+    async def create_index(
+        self,
+        *,
+        index: str,
+        mappings: Optional[dict[str, Any]] = None,
+        settings: Optional[dict[str, Any]] = None,
+        aliases: Optional[dict[str, Any]] = None,
+        wait_for_active_shards: Optional[str | int] = "1",
+    ) -> bool:
+        """Create an index.
+
+        Args:
+            index: Index name.
+            mappings: Optional mappings body.
+            settings: Optional settings body.
+            aliases: Optional aliases body.
+            wait_for_active_shards: Passed through to ES to control shard
+                availability before returning (e.g., "1", "all", or an int).
+
+        Returns:
+            True if Elasticsearch acknowledged index creation, otherwise False.
+        """
+        client = self.get_client()
+
+        res = await client.indices.create(
+            index=index,
+            mappings=mappings,
+            settings=settings,
+            aliases=aliases,
+            wait_for_active_shards=wait_for_active_shards,
+        )
+
+        return bool(res.get("acknowledged", False))
+
+    async def refresh_index(self, *, index: str) -> None:
+        """Refresh an index to make recent operations visible to search."""
+        client = self.get_client()
+
+        await client.indices.refresh(
+            index=index,
+        )
+
+    async def delete_index(self, *, index: str, ignore_unavailable: bool = True) -> bool:
+        """Delete an index.
+
+        Args:
+            index: Name of the index to delete.
+            ignore_unavailable: If True, do not raise when the index does not exist.
+
+        Returns:
+            True if the delete request was acknowledged by Elasticsearch.
+            False if the index did not exist and `ignore_unavailable` is True.
+        """
+        client = self.get_client()
+
+        res = await client.indices.delete(
+            index=index,
+            ignore_unavailable=ignore_unavailable,
+        )
+
+        return bool(res.get("acknowledged", False))
+
+    async def delete_by_query(
+        self,
+        *,
+        index: str,
+        query: dict[str, Any],
+        refresh: bool | None = None,
+        conflicts: str | None = None,
+        wait_for_completion: bool | None = None,
+        timeout: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Delete documents matching a query.
+
+        Args:
+            index: Name of the index (or index pattern) to delete documents from.
+            query: Elasticsearch query DSL describing documents to delete.
+            refresh: If True, refresh affected shards to make the deletion visible
+                to search.
+            conflicts: What to do when version conflicts occur. Valid values are
+                'abort' or 'proceed'.
+            wait_for_completion: If False, the request is executed asynchronously
+                and returns a task ID instead of waiting for completion.
+
+        Returns:
+            The raw delete-by-query response from Elasticsearch
+        """
+        client = self.get_client()
+
+        result = await client.delete_by_query(
+            index=index,
+            query=query,
+            refresh=refresh,
+            conflicts=conflicts,
+            wait_for_completion=wait_for_completion,
+            timeout=timeout,
+        )
+        return cast(dict[str, Any], result)

--- a/merino/search/elastic.py
+++ b/merino/search/elastic.py
@@ -1,0 +1,139 @@
+"""Elasticsearch service utilities."""
+
+from typing import Any, Mapping, Sequence, cast
+
+from elasticsearch import Elasticsearch
+
+
+class ElasticSearchAdapter:
+    """A wrapper around the Elasticsearch Python client.
+
+    Instances are configured with a URL and API key and lazily create the
+    underlying Elasticsearch client on first use..
+    """
+
+    def __init__(
+        self,
+        *,
+        url: str,
+        api_key: str,
+    ) -> None:
+        self._url = url
+        self._api_key = api_key
+        self._client: Elasticsearch | None = None
+
+    def create_client(self) -> Elasticsearch:
+        """Create a new Elasticsearch client instance."""
+        return Elasticsearch(
+            self._url,
+            api_key=self._api_key,
+        )
+
+    def get_client(self) -> Elasticsearch:
+        """Return the underlying Elasticsearch client, creating it if needed.
+
+        The client is created lazily and cached on the service instance.
+        """
+        if self._client is None:
+            self._client = self.create_client()
+        return self._client
+
+    def index_exists(self, *, index: str) -> bool:
+        """Return True if the index exists."""
+        return bool(self.get_client().indices.exists(index=index))
+
+    def create_index(
+        self,
+        *,
+        index: str,
+        mappings: dict[str, Any] | None = None,
+        settings: dict[str, Any] | None = None,
+        aliases: dict[str, Any] | None = None,
+        wait_for_active_shards: str | int = "1",
+    ) -> bool:
+        """Create an index and return whether the operation was acknowledged.
+
+        Note: This does not check for existence. Call `index_exists()` if needed.
+        """
+        res = self.get_client().indices.create(
+            index=index,
+            mappings=mappings,
+            settings=settings,
+            aliases=aliases,
+            wait_for_active_shards=wait_for_active_shards,
+        )
+        return bool(res.get("acknowledged", False))
+
+    def refresh_index(self, *, index: str) -> None:
+        """Refresh an index to make recent operations visible to search."""
+        self.get_client().indices.refresh(index=index)
+
+    def bulk(
+        self,
+        *,
+        operations: Sequence[Mapping[str, Any]],
+        raise_on_error: bool = True,
+    ) -> dict[str, Any]:
+        """Execute a bulk operation against Elasticsearch.
+
+        Args:
+            operations: Iterable of bulk operations, typically action/document
+                pairs as expected by the Elasticsearch bulk API.
+            raise_on_error: If True, raise an exception when Elasticsearch reports
+                one or more failed bulk items. If False, return the raw response
+                and allow the caller to inspect partial failures.
+
+        Returns:
+            The raw bulk API response from Elasticsearch.
+
+        Raises:
+            RuntimeError: If raise_on_error=True and the bulk response contains
+                one or more failed items.
+        """
+        res = cast(
+            dict[str, Any],
+            self.get_client().bulk(
+                operations=operations,
+            ),
+        )
+
+        if raise_on_error and res.get("errors"):
+            items = res.get("items", []) or []
+            first_err: dict[str, Any] | None = None
+
+            for it in items:
+                action = next(
+                    (k for k in ("index", "create", "update", "delete") if k in it),
+                    None,
+                )
+                if not action:
+                    continue
+                meta = it[action] or {}
+                if meta.get("error"):
+                    first_err = {
+                        "action": action,
+                        "status": meta.get("status"),
+                        "index": meta.get("_index"),
+                        "id": meta.get("_id"),
+                        "error": meta.get("error"),
+                    }
+                    break
+
+            raise RuntimeError(f"Bulk failed. First error: {first_err}")
+
+        return res
+
+    def alias_exists(self, *, alias: str) -> bool:
+        """Return True if the alias exists."""
+        return bool(self.get_client().indices.exists_alias(name=alias))
+
+    def get_indices_for_alias(self, *, alias: str) -> list[str]:
+        """Return a list of index names currently associated with an alias."""
+        indices = cast(dict[str, Any], self.get_client().indices.get_alias(name=alias))
+        return list(indices.keys())
+
+    def update_aliases(self, *, actions: list[dict[str, Any]]) -> None:
+        """Apply alias update actions atomically."""
+        self.get_client().indices.update_aliases(
+            actions=actions,
+        )

--- a/tests/unit/jobs/wikipedia_indexer/test_utils.py
+++ b/tests/unit/jobs/wikipedia_indexer/test_utils.py
@@ -1,17 +1,13 @@
 """Unit tests for the utils module in wikipedia-indexer job"""
 
 import logging
-from unittest.mock import ANY
 
 import pytest
-from elasticsearch import Elasticsearch
 from pytest import LogCaptureFixture
-from pytest_mock import MockerFixture
 
 from merino.jobs.wikipedia_indexer.utils import (
     ProgressReporter,
     create_blocklist,
-    create_elasticsearch_client,
 )
 
 
@@ -78,16 +74,3 @@ def test_progress_reporter(
         else:
             assert len(caplog.records) == 1
             assert caplog.records[0].message == f"Test progress: {expected_perc}%"
-
-
-def test_create_elasticsearch_client_url(mocker: MockerFixture):
-    """Test that Elasticsearch client is created with the URL."""
-    es_new_mock = mocker.patch.object(Elasticsearch, "__new__")
-
-    api_key = "mMyY2E2ZDA0MjI0OWFmMGNjN2Q3YTllOTYyNTc0Mw=="
-    url = "http://localhost:9200"
-
-    create_elasticsearch_client(url, api_key)
-
-    # First argument is "self", which I've stubbed with ANY
-    es_new_mock.assert_called_with(ANY, url, api_key=api_key, request_timeout=60)

--- a/tests/unit/search/test_async_elastic.py
+++ b/tests/unit/search/test_async_elastic.py
@@ -1,0 +1,214 @@
+"""Unit tests for async elastic search adapter module"""
+
+from unittest.mock import AsyncMock, MagicMock
+import pytest
+from merino.search.async_elastic import AsyncElasticSearchAdapter
+
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def adapter() -> AsyncElasticSearchAdapter:
+    """Return an AsyncElasticSearchAdapter configured with dummy connection settings."""
+    return AsyncElasticSearchAdapter(url="https://example:9200", api_key="abc123")
+
+
+def _mock_async_client() -> MagicMock:
+    """Return a mocked AsyncElasticsearch client with async methods and nested indices client.
+
+    Provides:
+      - client.search (async)
+      - client.delete_by_query (async)
+      - client.close (async)
+      - client.indices.create/refresh/delete (async)
+    """
+    client = MagicMock(name="AsyncElasticsearchClient")
+    client.search = AsyncMock(name="search")
+    client.delete_by_query = AsyncMock(name="delete_by_query")
+    client.close = AsyncMock(name="close")
+
+    client.indices = MagicMock(name="IndicesClient")
+    client.indices.create = AsyncMock(name="indices.create")
+    client.indices.refresh = AsyncMock(name="indices.refresh")
+    client.indices.delete = AsyncMock(name="indices.delete")
+
+    return client
+
+
+async def test_get_client_is_lazy_and_cached(
+    adapter: AsyncElasticSearchAdapter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Ensure get_client lazily creates the AsyncElasticsearch client and returns
+    the same cached instance on subsequent calls.
+    """
+    client = _mock_async_client()
+    create_client = MagicMock(return_value=client)
+    monkeypatch.setattr(adapter, "create_client", create_client)
+
+    c1 = adapter.get_client()
+    c2 = adapter.get_client()
+
+    assert c1 is client
+    assert c2 is client
+    create_client.assert_called_once_with()
+
+
+async def test_shutdown_closes_client_and_clears_cache(
+    adapter: AsyncElasticSearchAdapter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Verify shutdown closes the cached client and resets the adapter to an
+    uninitialized state.
+    """
+    client = _mock_async_client()
+    adapter._client = client  # simulate initialized client
+
+    await adapter.shutdown()
+
+    client.close.assert_awaited_once()
+    assert adapter._client is None
+
+
+async def test_shutdown_noop_when_no_client(adapter: AsyncElasticSearchAdapter) -> None:
+    """Verify shutdown is a no-op when the adapter has not created a client yet."""
+    assert adapter._client is None
+    await adapter.shutdown()
+    assert adapter._client is None
+
+
+async def test_search_delegates_to_client_search(
+    adapter: AsyncElasticSearchAdapter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Verify search forwards parameters to AsyncElasticsearch.search and returns
+    the raw response.
+    """
+    client = _mock_async_client()
+    client.search.return_value = {"hits": {"hits": []}}
+    monkeypatch.setattr(adapter, "get_client", MagicMock(return_value=client))
+
+    res = await adapter.search(
+        index="my-index",
+        body={"query": {"match_all": {}}},
+        suggest={"s": {"prefix": "a"}},
+        timeout="1000ms",
+        source_includes=["title"],
+    )
+
+    assert res == {"hits": {"hits": []}}
+    client.search.assert_awaited_once_with(
+        index="my-index",
+        body={"query": {"match_all": {}}},
+        suggest={"s": {"prefix": "a"}},
+        timeout="1000ms",
+        source_includes=["title"],
+    )
+
+
+async def test_create_index_sends_body_when_present(
+    adapter: AsyncElasticSearchAdapter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Verify create_index builds a body with mappings/settings/aliases and passes it
+    to indices.create, returning the acknowledged flag.
+    """
+    client = _mock_async_client()
+    client.indices.create.return_value = {"acknowledged": True}
+    monkeypatch.setattr(adapter, "get_client", MagicMock(return_value=client))
+
+    ok = await adapter.create_index(
+        index="my-index",
+        mappings={"properties": {"title": {"type": "keyword"}}},
+        settings={"number_of_shards": 1},
+        aliases={"my-alias": {}},
+        wait_for_active_shards="all",
+    )
+
+    assert ok is True
+    client.indices.create.assert_awaited_once_with(
+        index="my-index",
+        mappings={"properties": {"title": {"type": "keyword"}}},
+        settings={"number_of_shards": 1},
+        aliases={"my-alias": {}},
+        wait_for_active_shards="all",
+    )
+
+
+async def test_create_index_omits_body_when_empty(
+    adapter: AsyncElasticSearchAdapter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Verify create_index does not pass a body when no mappings/settings/aliases are
+    provided, and returns False when not acknowledged.
+    """
+    client = _mock_async_client()
+    client.indices.create.return_value = {"acknowledged": False}
+    monkeypatch.setattr(adapter, "get_client", MagicMock(return_value=client))
+
+    ok = await adapter.create_index(index="my-index")
+
+    assert ok is False
+    client.indices.create.assert_awaited_once_with(
+        index="my-index",
+        mappings=None,
+        settings=None,
+        aliases=None,
+        wait_for_active_shards="1",
+    )
+
+
+async def test_refresh_index_delegates_to_indices_refresh(
+    adapter: AsyncElasticSearchAdapter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Verify refresh_index delegates to indices.refresh with the provided index name."""
+    client = _mock_async_client()
+    monkeypatch.setattr(adapter, "get_client", MagicMock(return_value=client))
+
+    await adapter.refresh_index(index="my-index")
+    client.indices.refresh.assert_awaited_once_with(index="my-index")
+
+
+async def test_delete_index_delegates_to_indices_delete(
+    adapter: AsyncElasticSearchAdapter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Verify delete_index calls indices.delete with ignore_unavailable and returns
+    the acknowledged flag.
+    """
+    client = _mock_async_client()
+    client.indices.delete.return_value = {"acknowledged": True}
+    monkeypatch.setattr(adapter, "get_client", MagicMock(return_value=client))
+
+    ok = await adapter.delete_index(index="my-index", ignore_unavailable=True)
+
+    assert ok is True
+    client.indices.delete.assert_awaited_once_with(
+        index="my-index",
+        ignore_unavailable=True,
+    )
+
+
+async def test_delete_by_query_delegates_to_client(
+    adapter: AsyncElasticSearchAdapter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Verify delete_by_query forwards all parameters to AsyncElasticsearch.delete_by_query
+    and returns the raw response.
+    """
+    client = _mock_async_client()
+    client.delete_by_query.return_value = {"deleted": 10, "failures": []}
+    monkeypatch.setattr(adapter, "get_client", MagicMock(return_value=client))
+
+    res = await adapter.delete_by_query(
+        index="my-index",
+        query={"term": {"language": "en"}},
+        refresh=True,
+        conflicts="proceed",
+        wait_for_completion=False,
+        timeout="30s",
+    )
+
+    assert res == {"deleted": 10, "failures": []}
+    client.delete_by_query.assert_awaited_once_with(
+        index="my-index",
+        query={"term": {"language": "en"}},
+        refresh=True,
+        conflicts="proceed",
+        wait_for_completion=False,
+        timeout="30s",
+    )

--- a/tests/unit/search/test_elastic.py
+++ b/tests/unit/search/test_elastic.py
@@ -1,0 +1,251 @@
+"""Unit tests for the elastic search adapter module"""
+
+from typing import Any
+from unittest.mock import MagicMock
+import pytest
+from merino.search.elastic import ElasticSearchAdapter
+
+
+@pytest.fixture
+def adapter() -> ElasticSearchAdapter:
+    """Return an ElasticSearchAdapter configured with dummy connection settings."""
+    return ElasticSearchAdapter(url="https://example:9200", api_key="abc123")
+
+
+def _mock_client() -> MagicMock:
+    """Return a mocked Elasticsearch client"""
+    client = MagicMock(name="ElasticsearchClient")
+    client.indices = MagicMock(name="IndicesClient")
+    return client
+
+
+def test_get_client_is_lazy_and_cached(
+    adapter: ElasticSearchAdapter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test that get_client lazily creates the Elasticsearch client and
+    returns the same cached instance on subsequent calls.
+    """
+    client = _mock_client()
+    create_client = MagicMock(return_value=client)
+    monkeypatch.setattr(adapter, "create_client", create_client)
+
+    c1 = adapter.get_client()
+    c2 = adapter.get_client()
+
+    assert c1 is client
+    assert c2 is client
+    create_client.assert_called_once_with()
+
+
+def test_index_exists_calls_indices_exists(
+    adapter: ElasticSearchAdapter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Verify that index_exists calls indices.exists and returns its
+    boolean result.
+    """
+    client = _mock_client()
+    client.indices.exists.return_value = True
+    monkeypatch.setattr(adapter, "get_client", MagicMock(return_value=client))
+
+    assert adapter.index_exists(index="my-index") is True
+    client.indices.exists.assert_called_once_with(index="my-index")
+
+
+def test_create_index_returns_acknowledged_true(
+    adapter: ElasticSearchAdapter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Verify that create_index returns True when Elasticsearch acknowledges
+    index creation.
+    """
+    client = _mock_client()
+    client.indices.create.return_value = {"acknowledged": True}
+    monkeypatch.setattr(adapter, "get_client", MagicMock(return_value=client))
+
+    ok = adapter.create_index(
+        index="my-index",
+        mappings={"properties": {"title": {"type": "keyword"}}},
+        settings={"number_of_shards": 1},
+        aliases={"my-alias": {}},
+        wait_for_active_shards="all",
+    )
+
+    assert ok is True
+    client.indices.create.assert_called_once_with(
+        index="my-index",
+        mappings={"properties": {"title": {"type": "keyword"}}},
+        settings={"number_of_shards": 1},
+        aliases={"my-alias": {}},
+        wait_for_active_shards="all",
+    )
+
+
+def test_create_index_returns_acknowledged_false_when_missing(
+    adapter: ElasticSearchAdapter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Verify that create_index returns False when the Elasticsearch response
+    does not include an acknowledgement.
+    """
+    client = _mock_client()
+    client.indices.create.return_value = {"acknowledged": False}
+    monkeypatch.setattr(adapter, "get_client", MagicMock(return_value=client))
+
+    ok = adapter.create_index(index="my-index")
+    assert ok is False
+
+    client.indices.create.assert_called_once_with(
+        index="my-index",
+        mappings=None,
+        settings=None,
+        aliases=None,
+        wait_for_active_shards="1",
+    )
+
+
+def test_refresh_index_calls_indices_refresh(
+    adapter: ElasticSearchAdapter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Ensure that refresh_index calls indices.refresh with the
+    provided index name.
+    """
+    client = _mock_client()
+    monkeypatch.setattr(adapter, "get_client", MagicMock(return_value=client))
+
+    adapter.refresh_index(index="my-index")
+    client.indices.refresh.assert_called_once_with(index="my-index")
+
+
+def test_bulk_success_returns_response(
+    adapter: ElasticSearchAdapter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Verify that bulk returns the raw Elasticsearch response when there are
+    no per-item errors.
+    """
+    client = _mock_client()
+    resp = {"errors": False, "items": [{"index": {"status": 201}}]}
+    client.bulk.return_value = resp
+    monkeypatch.setattr(adapter, "get_client", MagicMock(return_value=client))
+
+    ops: list[dict[str, Any]] = [{"index": {"_index": "my-index", "_id": "1"}}, {"title": "hello"}]
+    res = adapter.bulk(operations=ops, raise_on_error=True)
+
+    assert res is resp
+    client.bulk.assert_called_once_with(operations=ops)
+
+
+def test_bulk_errors_raises_with_first_error(
+    adapter: ElasticSearchAdapter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Verify that bulk raises a RuntimeError when raise_on_error is True and
+    the response contains per-item failures, including details of the
+    first failing item.
+    """
+    client = _mock_client()
+    client.bulk.return_value = {
+        "errors": True,
+        "items": [
+            {"index": {"status": 201}},
+            {
+                "index": {
+                    "status": 400,
+                    "_index": "my-index",
+                    "_id": "2",
+                    "error": {"type": "mapper_parsing_exception", "reason": "bad"},
+                }
+            },
+        ],
+    }
+    monkeypatch.setattr(adapter, "get_client", MagicMock(return_value=client))
+
+    with pytest.raises(RuntimeError) as exc:
+        adapter.bulk(
+            operations=[{"index": {"_index": "my-index", "_id": "2"}}, {"title": 123}],
+            raise_on_error=True,
+        )
+
+    msg = str(exc.value)
+    assert "Bulk failed. First error:" in msg
+    assert "'action': 'index'" in msg
+    assert "'status': 400" in msg
+    assert "'index': 'my-index'" in msg
+    assert "'id': '2'" in msg
+
+
+def test_bulk_errors_does_not_raise_when_raise_on_error_false(
+    adapter: ElasticSearchAdapter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Verify that bulk returns the raw response and does not raise when
+    raise_on_error is False, even if per-item errors are present.
+    """
+    client = _mock_client()
+    resp = {
+        "errors": True,
+        "items": [
+            {
+                "index": {
+                    "status": 400,
+                    "_index": "my-index",
+                    "_id": "1",
+                    "error": {"type": "x"},
+                }
+            }
+        ],
+    }
+    client.bulk.return_value = resp
+    monkeypatch.setattr(adapter, "get_client", MagicMock(return_value=client))
+
+    res = adapter.bulk(
+        operations=[{"index": {"_index": "my-index", "_id": "1"}}, {"t": "x"}],
+        raise_on_error=False,
+    )
+
+    assert res is resp
+
+
+def test_alias_exists_calls_exists_alias(
+    adapter: ElasticSearchAdapter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Verify that alias_exists calls indices.exists_alias and returns
+    its boolean result.
+    """
+    client = _mock_client()
+    client.indices.exists_alias.return_value = True
+    monkeypatch.setattr(adapter, "get_client", MagicMock(return_value=client))
+
+    assert adapter.alias_exists(alias="my-alias") is True
+    client.indices.exists_alias.assert_called_once_with(name="my-alias")
+
+
+def test_get_indices_for_alias_returns_keys(
+    adapter: ElasticSearchAdapter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Verify that get_indices_for_alias returns a list of index names associated
+    with the given alias.
+    """
+    client = _mock_client()
+    client.indices.get_alias.return_value = {
+        "index-a": {"aliases": {"my-alias": {}}},
+        "index-b": {"aliases": {"my-alias": {}}},
+    }
+    monkeypatch.setattr(adapter, "get_client", MagicMock(return_value=client))
+
+    indices = adapter.get_indices_for_alias(alias="my-alias")
+    assert indices == ["index-a", "index-b"]
+    client.indices.get_alias.assert_called_once_with(name="my-alias")
+
+
+def test_update_aliases_calls_indices_update_aliases(
+    adapter: ElasticSearchAdapter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Verify that update_aliases calls indices.update_aliases with
+    the provided actions.
+    """
+    client = _mock_client()
+    monkeypatch.setattr(adapter, "get_client", MagicMock(return_value=client))
+
+    actions: list[dict[str, Any]] = [
+        {"add": {"index": "index-new", "alias": "my-alias"}},
+        {"remove": {"index": "index-old", "alias": "my-alias"}},
+    ]
+
+    adapter.update_aliases(actions=actions)
+    client.indices.update_aliases.assert_called_once_with(actions=actions)


### PR DESCRIPTION
## References

JIRA: [DISCO-3809](https://mozilla-hub.atlassian.net/browse/DISCO-3809)

## Description
This PR introduces a common Elasticsearch adapter. As more components rely on Elasticsearch, we want to standardize how clients are initialized and how common operations (index lifecycle, bulk, search, etc.) are handled, while still leaving room for future flexibility.

### Direction
We are keeping the Elasticsearch adapter configurable, allowing it to be initialized with an arbitrary DSN and API key. If Merino providers and jobs are using the same Elasticsearch cluster, the intended direction is that they should also use a shared credential set (DSN + API key), rather than defining provider-specific credentials. We may need to distinguish read vs write access (e.g., separate API keys). We can confirm if we do, but the goal is to keep the number of credentials small and well-defined.

As a follow-up, we plan to:
- Consolidate Elasticsearch credentials into one or two shared config variables (e.g. read and write).
- Update providers and jobs to consume these shared credentials by default.
- Update Airflow jobs to use the unified credentials.

This approach allows us to:
- Standardize behavior and reduce duplication.
- Avoid locking ourselves into a single global client prematurely.
- Preserve flexibility for future multi-cluster or least-privilege needs.

Followup 
- update sports provider to use the new adapter
- consolidate credentials for all providers (make them point to one config)

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3809]: https://mozilla-hub.atlassian.net/browse/DISCO-3809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2052)
