### PR TITLE
GENAI-3398 Limit number of sections in response

### DIFF
--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -552,11 +552,11 @@ def rank_sections(
     if include_headlines_section:
         put_headlines_first_then_top_stories(sections)
 
+    # Sort sections by receivedFeedRank and limit to MAX_SECTIONS_PER_RESPONSE
     sorted_sections = sorted(sections.items(), key=lambda kv: kv[1].receivedFeedRank)[
         :MAX_SECTIONS_PER_RESPONSE
     ]
 
-    # Sort sections by receivedFeedRank
     sections = {sid: section for sid, section in sorted_sections}
 
     return sections


### PR DESCRIPTION
## References

https://mozilla-hub.atlassian.net/browse/GENAI-3398

## Description
The editorial team keeps adding new sections, but that is causing number of returned items to go up, possibly having unintended consequences for bandwidth, server costs, and inferred personalization (randomness is influenced by number of items returned).

We add a liberal limit of 20 sections to start.

This just limits the number of sections returned, not the item candidates for top stories.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2055)
