### PR TITLE
GENAI-3432 Update fresh threshold and prevalence limit in top stories for contexual ranker

### DIFF
--- a/merino/curated_recommendations/rankers/contextual_ranker.py
+++ b/merino/curated_recommendations/rankers/contextual_ranker.py
@@ -29,9 +29,12 @@ from merino.curated_recommendations.rankers.utils import (
 )
 
 # We are still learning how to compute how many impressions before we can trust the ranker score completely
-# So far, 3000 impressions seems to be a reasonable average beta value to use as a threshold
-# This means that items with less than 3000 impressions will be marked as fresh.
-CONTEXUAL_AVG_BETA_VALUE = 3000
+# So far, 4000 impressions seems to be a reasonable average beta value to use as a threshold
+# This means that items with less than 4000 impressions will be marked as fresh.
+CONTEXUAL_AVG_BETA_VALUE = 4000
+CONTEXTAL_LIMIT_PERCENTAGE_ADJUSTMENT = (
+    0.5  # Underscored items tend to scale higher, leading to too much fresh content
+)
 
 logger = logging.getLogger(__name__)
 
@@ -136,6 +139,7 @@ class ContextualRanker(Ranker):
             """Create score based on top items in section"""
             fresh_retain_likelyhood = (
                 rescaler.fresh_items_section_ranking_max_percentage
+                * CONTEXTAL_LIMIT_PERCENTAGE_ADJUSTMENT
                 if rescaler is not None
                 else 0.0
             )


### PR DESCRIPTION
## References

https://mozilla-hub.atlassian.net/browse/GENAI-3432

## Description
According to our health dashboard, contextual ranking is exposing fresh stories 2x as much as thompson sampling.
https://sql.telemetry.mozilla.org/dashboard/live-content-ranking-health

We are adjusting limits somewhat to bend the curve down. This is required because each cohort has very different priors and behavior with contexual ranking.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
