### PR TITLE
Bump up max size for contextual ranking data

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -969,7 +969,7 @@ cron_interval_seconds = 30
 [default.curated_recommendations.gcs.prior]
 # MERINO__CURATED_RECOMMENDATIONS__GCS__PRIOR__MAX_SIZE
 # The maximum size in bytes of the GCS prior blob. If exceeded, an error will be logged.
-max_size = 2_000_000
+max_size = 1_000_000
 
 # MERINO__CURATED_RECOMMENDATIONS__GCS__PRIOR__BLOB_PREFIX
 # GCS path of the priors JSON file.
@@ -990,8 +990,8 @@ gcp_project = ""
 bucket_name = ""
 
 # MERINO__ML_RECOMMENDATIONS__GCS__PRIOR__MAX_SIZE
-# The maximum size in bytes of the GCS prior blob. If exceeded, an error will be logged.
-max_size = 1_000_000
+# The maximum size in bytes of the contextual ranking scores file. If exceeded, an error will be logged.
+max_size = 2_000_000
 
 # MERINO__ML_RECOMMENDATIONS__GCS__PRIOR__BLOB_PREFIX
 # GCS path of the priors JSON file.


### PR DESCRIPTION
## References

https://mozilla-hub.atlassian.net/browse/GENAI-3451


## Description
Sentry reports error with contextual ranking artifacts being too large in Merino

We are moving to smaller artifacts later this week, so it is safe to bump up to 2mb for the next few days.
Likely they will remain around 1 MB.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2059)
