### PR TITLE
GENAI-3487 Implment simpler default behavor in inferred when there are no user clicks

### DIFF
--- a/merino/curated_recommendations/rankers/contextual_ranker.py
+++ b/merino/curated_recommendations/rankers/contextual_ranker.py
@@ -36,9 +36,6 @@ CONTEXTAL_LIMIT_PERCENTAGE_ADJUSTMENT = (
     0.5  # Underscored items tend to scale higher, leading to too much fresh content
 )
 
-# Hard coded cohot for users with no clicks. We handle differently
-NO_CLICKS_COHORT_ID = "1"
-
 logger = logging.getLogger(__name__)
 
 
@@ -80,11 +77,7 @@ class ContextualRanker(Ranker):
             utcOffset = None
 
         contextual_scores: ContextualArticleRankings | None
-
-        if cohort == NO_CLICKS_COHORT_ID:
-            contextual_scores = self.ml_backend.get(region=region, utcOffset=None, cohort=None)
-        else:
-            contextual_scores = self.ml_backend.get(region, str(utcOffset), cohort)
+        contextual_scores = self.ml_backend.get(region, str(utcOffset), cohort)
 
         k = randint(0, contextual_scores.K - 1) if contextual_scores is not None else 0
         for rec in recs:


### PR DESCRIPTION
## References

JIRA: https://mozilla-hub.atlassian.net/browse/GENAI-3487

## Description
We will always default to the 'US' cohort for users who have never clicked because they have lower CTRs.
This PR provides a standard way to handle it, using the contexual ranker but having a '-1' cohort will cause a fallback to US.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2060)
