### PR TITLE
[DISCO 3933] chore: Enable all carrot providers by default

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -348,7 +348,7 @@ event_index="sports-{lang}-event"
 team_index="sports-{lang}-team"
 max_suggestions = 5
 # Disable this provider by default
-enabled_by_default = false
+enabled_by_default = true
 # General timeout
 query_timeout_sec = 3.0
 # Temporary value to enable data pre-load "kickstart"
@@ -726,7 +726,7 @@ cache_db = 0
 
 # MERINO_PROVIDERS__POLYGON__ENABLED_BY_DEFAULT
 # Whether this provider is enabled by default.
-enabled_by_default = false
+enabled_by_default = true
 
 # MERINO_PROVIDERS__POLYGON__SCORE
 # The ranking score for this provider as a floating point number.
@@ -866,7 +866,7 @@ cache = "none"
 
 # MERINO_PROVIDERS__FLIGHTAWARE__ENABLED_BY_DEFAULT
 # Whether this provider is enabled by default.
-enabled_by_default = false
+enabled_by_default = true
 
 # MERINO_PROVIDERS__FLIGHTAWARE__SCORE
 # The ranking score for this provider as a floating point number.


### PR DESCRIPTION
## References

JIRA: [DISCO-3933](https://mozilla-hub.atlassian.net/browse/DISCO-3933)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3933]: https://mozilla-hub.atlassian.net/browse/DISCO-3933?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2064)
