### PR TITLE
bug: Trap for NFL week being undefined

### DIFF
--- a/merino/providers/suggest/sports/backends/sportsdata/common/elastic.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/elastic.py
@@ -708,6 +708,9 @@ class SportsDataStore(ElasticDataStore):
 
         # Write the fields to Elasticsearch.
         # The `_source` _MUST_ match the previously specified `mapping`
+        if not sport.events:
+            logger.info(f"{LOGGING_TAG} No events")
+            return
         for event in sport.events.values():
             action = {
                 "_index": index,

--- a/merino/providers/suggest/sports/backends/sportsdata/common/sports.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/sports.py
@@ -28,7 +28,7 @@ class NFL(Sport):
     """National Football League"""
 
     season: str | None = None
-    week: int = 0
+    week: int | None = 0
     _lock: asyncio.Lock
 
     def __init__(self, settings: LazySettings, *args, **kwargs):
@@ -100,6 +100,9 @@ class NFL(Sport):
             # The ProBowl interferes with displaying the Superbowl.
             self.season = response[0].get("ApiSeason").replace("STAR", "POST")
             self.week = 4
+        if self.week is None:
+            logger.debug(f"{LOGGING_TAG} No week, no events")
+            return
         start = response[0].get("StartDate")
         end = response[0].get("EndDate")
         logger.debug(f"{LOGGING_TAG} {self.name} {self.season} week {self.week} {start} to {end}")
@@ -126,6 +129,9 @@ class NFL(Sport):
         logger.debug(f"{LOGGING_TAG} Getting Events for {self.name}")
         local_timezone = ZoneInfo("America/New_York")
         # get this week and next week
+        if self.week is None:
+            logger.debug(f"{LOGGING_TAG} No events (No week)")
+            return
         for week in [int(self.week), int(self.week) + 1]:
             url = f"{self.base_url}/ScoresBasic/{self.season}/{week}?key={self.api_key}"
             response = await get_data(


### PR DESCRIPTION
Closes: DISCO-3954

## References

JIRA: [DISCO-3954](https://mozilla-hub.atlassian.net/browse/DISCO-3954)

## Description

NFL (being special) returns `None` as the week during the post season scouting period. This was causing errors.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-3954]: https://mozilla-hub.atlassian.net/browse/DISCO-3954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2075)
