### PR TITLE
HNT-1000: Add support for newtab source in finance provider, serving default ETFs on empty query

### DIFF
--- a/merino/providers/suggest/finance/backends/polygon/etf_ticker_company_mapping.py
+++ b/merino/providers/suggest/finance/backends/polygon/etf_ticker_company_mapping.py
@@ -412,6 +412,9 @@ NI225_POPULAR_3_ETF = ["EWJ", "FLJP", "DXJ"]
 # NOTE: This index only has 2 ETF tickers listed on the US market and supported by Polygon.
 HSI_POPULAR_2_ETF = ["EWH", "KTEC"]
 
+# Default ETFs shown in the Firefox New Tab stocks widget, representing the four major US indices:
+# S&P 500, Nasdaq Composite, Dow Jones Industrial Average, Russell 2000
+STOCKS_WIDGET_DEFAULT_ETFS: list[str] = ["SPY", "ONEQ", "DIA", "IWM"]
 
 # ETF Tickers prone to eager matches (company name-like or typos for common words); used to avoid
 # aggressive matches on partial queries.

--- a/merino/providers/suggest/finance/provider.py
+++ b/merino/providers/suggest/finance/provider.py
@@ -21,6 +21,9 @@ from merino.providers.suggest.finance.backends.protocol import (
     GetManifestResultCode,
     TickerSummary,
 )
+from merino.providers.suggest.finance.backends.polygon.etf_ticker_company_mapping import (
+    STOCKS_WIDGET_DEFAULT_ETFS,
+)
 from merino.providers.suggest.finance.backends.polygon.utils import (
     get_tickers_for_query,
 )
@@ -128,7 +131,9 @@ class Provider(BaseProvider):
 
     def validate(self, srequest: SuggestionRequest) -> None:
         """Validate the suggestion request."""
-        if not srequest.query:
+        # newtab requests don't require a query string; an empty query returns the default ETF set.
+        # A non-empty query is used to look up individual stocks regardless of source.
+        if srequest.source != "newtab" and not srequest.query:
             raise HTTPException(
                 status_code=400,
                 detail="Invalid query parameters: `q` is missing",
@@ -140,8 +145,15 @@ class Provider(BaseProvider):
 
     async def query(self, srequest: SuggestionRequest) -> list[BaseSuggestion]:
         """Provide finance suggestions."""
-        # Get the list of tickers (0 to 3) for the query string.
-        tickers = get_tickers_for_query(srequest.query)
+        tickers: list[str] | None
+        if srequest.source == "newtab" and not srequest.query:
+            tickers = STOCKS_WIDGET_DEFAULT_ETFS
+            self.metrics_client.increment(
+                "polygon.provider.query.new_tab", tags={"source": "newtab"}
+            )
+        else:
+            # Get the list of tickers (0 to 3) for the query string.
+            tickers = get_tickers_for_query(srequest.query)
 
         try:
             if not tickers:

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -79,7 +79,7 @@ QUERY_CHARACTER_MAX = settings.web.api.v1.query_character_max
 CLIENT_VARIANT_CHARACTER_MAX = settings.web.api.v1.client_variant_character_max
 HEADER_CHARACTER_MAX = settings.web.api.v1.header_character_max
 WEATHER_PROVIDER = settings.providers.accuweather.backend
-WEATHER_SOURCE_TYPE = Literal["urlbar", "newtab", "unknown"]
+SOURCE_TYPE = Literal["urlbar", "newtab", "unknown"]
 
 
 @router.get(
@@ -94,7 +94,7 @@ async def suggest(
     country: Annotated[str | None, Query(max_length=2, min_length=2)] = None,
     region: Annotated[str | None, Query(max_length=QUERY_CHARACTER_MAX)] = None,
     city: Annotated[str | None, Query(max_length=QUERY_CHARACTER_MAX)] = None,
-    source: Annotated[WEATHER_SOURCE_TYPE, Query(max_length=QUERY_CHARACTER_MAX)] = "unknown",
+    source: Annotated[SOURCE_TYPE, Query(max_length=QUERY_CHARACTER_MAX)] = "unknown",
     accept_language: Annotated[str | None, Header(max_length=HEADER_CHARACTER_MAX)] = None,
     providers: str | None = None,
     client_variants: str | None = Query(default=None, max_length=CLIENT_VARIANT_CHARACTER_MAX),

--- a/metrics.yaml
+++ b/metrics.yaml
@@ -89,6 +89,18 @@ suggest/polygon:
       The "api/v1/suggest" API endpoint.
     alert_policy: []
 
+  polygon_provider_query_new_tab:
+    description: |
+      A counter for stocks widget requests via the newtab source
+    type: counter
+    labels:
+      - name: source
+        description: |
+          Origin of the stock info request
+    scope: |
+      The "api/v1/suggest" API endpoint.
+    alert_policy: []
+
 suggest/yelp:
   yelp_request_business_search_get:
     description: |

--- a/tests/integration/api/v1/suggest/test_suggest_finance.py
+++ b/tests/integration/api/v1/suggest/test_suggest_finance.py
@@ -14,6 +14,9 @@ from merino.providers.suggest.finance.backends.protocol import (
     TickerSnapshot,
     TickerSummary,
 )
+from merino.providers.suggest.finance.backends.polygon.etf_ticker_company_mapping import (
+    STOCKS_WIDGET_DEFAULT_ETFS,
+)
 from merino.providers.suggest.finance.provider import Provider as FinanceProvider
 from merino.providers.suggest.finance.backends import FinanceBackend
 
@@ -123,6 +126,54 @@ def test_suggest_for_finance_suggestion_returns_no_suggestion_for_invalid_ticker
     body = response.json()
 
     assert len(body["suggestions"]) == 0
+
+
+def test_suggest_finance_returns_default_etfs_for_newtab_source(
+    client: TestClient,
+    backend_mock,
+) -> None:
+    """Test that the suggest endpoint returns the 4 default ETF suggestions when source=newtab and q is empty."""
+    backend_mock.fetch_manifest_data.return_value = (1, None)
+
+    etf_snapshots = [
+        TickerSnapshot(ticker=ticker, last_trade_price="100", todays_change_percent="1.0")
+        for ticker in STOCKS_WIDGET_DEFAULT_ETFS
+    ]
+    etf_summaries = [
+        TickerSummary(
+            ticker=ticker,
+            name=f"{ticker} ETF",
+            last_price="$100 USD",
+            todays_change_perc="+1.0",
+            query=f"{ticker} stock",
+            image_url=None,
+            exchange="NYSE",
+        )
+        for ticker in STOCKS_WIDGET_DEFAULT_ETFS
+    ]
+    backend_mock.get_snapshots.return_value = etf_snapshots
+    backend_mock.get_ticker_summary.side_effect = etf_summaries
+
+    response = client.get("/api/v1/suggest?q=&providers=polygon&source=newtab")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["suggestions"]) == 1
+    values = body["suggestions"][0]["custom_details"]["polygon"]["values"]
+    assert len(values) == len(STOCKS_WIDGET_DEFAULT_ETFS)
+    assert [v["ticker"] for v in values] == STOCKS_WIDGET_DEFAULT_ETFS
+
+
+def test_suggest_finance_returns_400_for_empty_query_without_newtab_source(
+    client: TestClient,
+    backend_mock,
+) -> None:
+    """Test that the suggest endpoint returns 400 when q is empty and source is not newtab."""
+    backend_mock.fetch_manifest_data.return_value = (1, None)
+
+    response = client.get("/api/v1/suggest?q=&providers=polygon")
+
+    assert response.status_code == 400
 
 
 def test_suggest_for_finance_suggestion_returns_no_suggestion_for_eager_match_blocked_ticker(

--- a/tests/unit/providers/suggest/finance/test_provider.py
+++ b/tests/unit/providers/suggest/finance/test_provider.py
@@ -23,6 +23,9 @@ from merino.providers.suggest.finance.backends.protocol import (
     TickerSnapshot,
     TickerSummary,
 )
+from merino.providers.suggest.finance.backends.polygon.etf_ticker_company_mapping import (
+    STOCKS_WIDGET_DEFAULT_ETFS,
+)
 from merino.providers.suggest.finance.provider import (
     Provider,
     BaseSuggestion,
@@ -152,7 +155,7 @@ def test_validate_fails_on_missing_query_param(
     provider: Provider,
     geolocation: Location,
 ) -> None:
-    """Test that the validate method raises HTTP 400 execption."""
+    """Test that validate raises HTTP 400 when query is empty and source is not newtab."""
     with pytest.raises(HTTPException):
         provider.validate(SuggestionRequest(query="", geolocation=geolocation))
 
@@ -266,6 +269,77 @@ async def test_query_ticker_summary_for_etf_keyword_not_returned(
     )
 
     assert suggestions == []
+
+
+def test_validate_passes_for_newtab_with_empty_query(
+    provider: Provider,
+    geolocation: Location,
+) -> None:
+    """Test that validate does not raise when source is newtab and query is empty."""
+    provider.validate(SuggestionRequest(query="", geolocation=geolocation, source="newtab"))
+
+
+@pytest.mark.asyncio
+async def test_query_returns_default_etfs_for_newtab_source_with_empty_query(
+    backend_mock: Any,
+    provider: Provider,
+    statsd_mock: Any,
+    geolocation: Location,
+) -> None:
+    """Test that query returns summaries for STOCKS_WIDGET_DEFAULT_ETFS when source is newtab and query is empty."""
+    etf_snapshots = [
+        TickerSnapshot(ticker=ticker, last_trade_price="100", todays_change_percent="+1.0")
+        for ticker in STOCKS_WIDGET_DEFAULT_ETFS
+    ]
+    etf_summaries = [
+        TickerSummary(
+            ticker=ticker,
+            name=f"{ticker} ETF",
+            last_price="$100 USD",
+            todays_change_perc="+1.0",
+            query=f"{ticker} stock",
+            image_url=None,
+            exchange="NYSE",
+        )
+        for ticker in STOCKS_WIDGET_DEFAULT_ETFS
+    ]
+    backend_mock.get_snapshots.return_value = etf_snapshots
+    backend_mock.get_ticker_summary.side_effect = etf_summaries
+
+    suggestions: list[BaseSuggestion] = await provider.query(
+        SuggestionRequest(query="", geolocation=geolocation, source="newtab")
+    )
+
+    backend_mock.get_snapshots.assert_awaited_once_with(STOCKS_WIDGET_DEFAULT_ETFS)
+    assert len(suggestions) == 1
+    assert suggestions[0].custom_details is not None
+    assert suggestions[0].custom_details.polygon is not None
+    values = suggestions[0].custom_details.polygon.values
+    assert [s.ticker for s in values] == STOCKS_WIDGET_DEFAULT_ETFS
+
+    statsd_mock.increment.assert_called_once_with(
+        "polygon.provider.query.new_tab", tags={"source": "newtab"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_query_uses_ticker_lookup_for_newtab_source_with_non_empty_query(
+    backend_mock: Any,
+    provider: Provider,
+    ticker_summary: TickerSummary,
+    ticker_snapshot: TickerSnapshot,
+    geolocation: Location,
+) -> None:
+    """Test that query uses get_tickers_for_query when source is newtab but query is non-empty."""
+    backend_mock.get_snapshots.return_value = [ticker_snapshot]
+    backend_mock.get_ticker_summary.return_value = ticker_summary
+
+    suggestions: list[BaseSuggestion] = await provider.query(
+        SuggestionRequest(query="ddog", geolocation=geolocation, source="newtab")
+    )
+
+    backend_mock.get_snapshots.assert_awaited_once_with(["DDOG"])
+    assert len(suggestions) == 1
 
 
 # TODO add test for when backend.get_snapshots returns []


### PR DESCRIPTION
## References

JIRA: [HNT-1000](https://mozilla-hub.atlassian.net/browse/HNT-1000)

## Description

Adds `source=newtab` support to the Polygon finance provider, enabling the New Tab stocks widget to fetch a set of default ETFs and also query individual stocks. This approach uses a light touch - the `q` parameter is still required, as making it optional affects absolutely everything and it was not a change I was comfortable making without fully understanding the impact. 

**Usage:**
```bash
# Default ETFs
curl 'localhost:8000/api/v1/suggest?q=&providers=polygon&source=newtab'

# Individual stock lookup, with source attribution to New Tab
curl 'localhost:8000/api/v1/suggest?q=$AAPL&providers=polygon&source=newtab'
```

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[HNT-1000]: https://mozilla-hub.atlassian.net/browse/HNT-1000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2084)
