### PR TITLE
[HNT-2154] Add skeleton for wikimedia potd rss provider

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -1025,6 +1025,20 @@ ident_url_path = "flights/{ident}?ident_type=designator&start={start}&end={end}&
 # The url to the live FlightAware landing page.
 landing_page_url = "https://www.flightaware.com/live/flight/{ident}"
 
+[default.rss_providers.wikimedia_potd]
+# MERINO_RSS_PROVIDERS__WIKIMEDIA_POTD__TYPE
+# The type of this provider, should be `wikimedia_potd`.
+type = "wikimedia_potd"
+
+# MERINO_RSS_PROVIDERS__WIKIMEDIA_POTD__ENABLED_BY_DEFAULT
+# Whether or not this provider is enabled by default.
+enabled_by_default = false
+
+# MERINO_RSS_PROVIDERS__WIKIMEDIA_POTD__QUERY_TIMEOUT_SEC
+# A float (in seconds) indicating the maximum waiting period when querying for POTD data.
+query_timeout_sec = 1.0
+
+
 [default.curated_recommendations.gcs]
 # MERINO__CURATED_RECOMMENDATIONS__GCS__BUCKET_NAME
 # GCS bucket that contains Airflow data for Merino

--- a/merino/main.py
+++ b/merino/main.py
@@ -12,6 +12,7 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 
 from merino import curated_recommendations, governance
+from merino.providers import rss
 from merino.configs.app_configs.config_logging import configure_logging
 from merino.configs.app_configs.config_sentry import configure_sentry
 from merino.providers import suggest, manifest
@@ -45,11 +46,13 @@ async def lifespan(app: FastAPI):
     await configure_metrics()
     await suggest.init_providers()
     await manifest.init_provider()
+    await rss.init_providers()
     curated_recommendations.init_provider()
     governance.start()
     yield
     governance.shutdown()
     # Shut down providers and clean up.
+    await rss.shutdown_providers()
     await suggest.shutdown_providers()
     await get_metrics_client().close()
 

--- a/merino/providers/rss/__init__.py
+++ b/merino/providers/rss/__init__.py
@@ -1,0 +1,36 @@
+"""Initialize all RSS providers."""
+
+import logging
+
+from merino.providers.rss.base import BaseRssProvider
+from merino.providers.rss.manager import load_providers
+
+logger = logging.getLogger(__name__)
+
+providers: dict[str, BaseRssProvider] = {}
+
+
+async def init_providers() -> None:
+    """Initialize all RSS providers.
+
+    This should only be called once at the startup of the application.
+    """
+    providers.update(load_providers())
+    for name, provider in providers.items():
+        await provider.initialize()
+        logger.info("RSS provider initialized", extra={"provider": name})
+
+
+async def shutdown_providers() -> None:
+    """Shut down all RSS providers.
+
+    This should only be called once at the shutdown of the application.
+    """
+    for name, provider in providers.items():
+        await provider.shutdown()
+        logger.info("RSS provider shut down", extra={"provider": name})
+
+
+def get_wikimedia_potd_provider() -> BaseRssProvider:
+    """Return the Wikimedia Picture of the Day provider."""
+    return providers["wikimedia_potd"]

--- a/merino/providers/rss/__init__.py
+++ b/merino/providers/rss/__init__.py
@@ -3,6 +3,7 @@
 import logging
 
 from merino.providers.rss.base import BaseRssProvider
+from merino.providers.rss.wikimedia_potd.provider import WikimediaPotdProvider
 from merino.providers.rss.manager import load_providers
 
 logger = logging.getLogger(__name__)
@@ -15,6 +16,7 @@ async def init_providers() -> None:
 
     This should only be called once at the startup of the application.
     """
+    # load_providers() pulls all the rss providers from the config file.
     providers.update(load_providers())
     for name, provider in providers.items():
         await provider.initialize()
@@ -28,9 +30,13 @@ async def shutdown_providers() -> None:
     """
     for name, provider in providers.items():
         await provider.shutdown()
+        # remove provider from
+        providers.pop(name)
         logger.info("RSS provider shut down", extra={"provider": name})
 
 
-def get_wikimedia_potd_provider() -> BaseRssProvider:
+def get_wikimedia_potd_provider() -> WikimediaPotdProvider:
     """Return the Wikimedia Picture of the Day provider."""
-    return providers["wikimedia_potd"]
+    provider = providers["wikimedia_potd"]
+    assert isinstance(provider, WikimediaPotdProvider)
+    return provider

--- a/merino/providers/rss/base.py
+++ b/merino/providers/rss/base.py
@@ -10,6 +10,11 @@ class BaseRssProvider(ABC):
     _enabled_by_default: bool
     _query_timeout_sec: float
 
+    def __init__(self, name: str, enabled_by_default: bool, query_timeout_sec: float) -> None:
+        self._name = name
+        self._enabled_by_default = enabled_by_default
+        self._query_timeout_sec = query_timeout_sec
+
     @abstractmethod
     async def initialize(self) -> None:  # pragma: no cover
         """Initialize the provider."""

--- a/merino/providers/rss/base.py
+++ b/merino/providers/rss/base.py
@@ -1,0 +1,35 @@
+"""Abstract base class for RSS providers."""
+
+from abc import ABC, abstractmethod
+
+
+class BaseRssProvider(ABC):
+    """Abstract base class for RSS providers."""
+
+    _name: str
+    _enabled_by_default: bool
+    _query_timeout_sec: float
+
+    @abstractmethod
+    async def initialize(self) -> None:  # pragma: no cover
+        """Initialize the provider."""
+        ...
+
+    async def shutdown(self) -> None:  # pragma: no cover
+        """Shut down the provider. Default implementation is no-op."""
+        return
+
+    @property
+    def name(self) -> str:
+        """Return the name of this provider."""
+        return self._name
+
+    @property
+    def enabled_by_default(self) -> bool:
+        """Return whether this provider is enabled by default."""
+        return self._enabled_by_default
+
+    @property
+    def query_timeout_sec(self) -> float:
+        """Return the query timeout for this provider."""
+        return self._query_timeout_sec

--- a/merino/providers/rss/manager.py
+++ b/merino/providers/rss/manager.py
@@ -1,0 +1,44 @@
+"""RSS provider manager."""
+
+from enum import Enum, unique
+
+from dynaconf.base import Settings
+
+from merino.configs import settings
+from merino.providers.rss.base import BaseRssProvider
+from merino.providers.rss.wikimedia_potd.provider import WikimediaPotdProvider
+from merino.utils.metrics import get_metrics_client
+
+
+@unique
+class RssProviderType(str, Enum):
+    """Enum for RSS provider type."""
+
+    WIKIMEDIA_POTD = "wikimedia_potd"
+
+
+def _create_provider(provider_id: str, setting: Settings) -> BaseRssProvider:
+    """Create an RSS provider for a given type and settings.
+
+    Exceptions:
+      - `ValueError` if the provider type is unknown.
+    """
+    match setting.type:
+        case RssProviderType.WIKIMEDIA_POTD:
+            return WikimediaPotdProvider(
+                backend=None,
+                metrics_client=get_metrics_client(),
+                name=provider_id,
+                query_timeout_sec=setting.query_timeout_sec,
+                enabled_by_default=setting.enabled_by_default,
+            )
+        case _:
+            raise ValueError(f"Unknown RSS provider type: {setting.type}")
+
+
+def load_providers() -> dict[str, BaseRssProvider]:
+    """Load RSS providers from configuration."""
+    providers: dict[str, BaseRssProvider] = {}
+    for provider_id, setting in settings.rss_providers.items():
+        providers[provider_id] = _create_provider(provider_id, setting)
+    return providers

--- a/merino/providers/rss/wikimedia_potd/__init__.py
+++ b/merino/providers/rss/wikimedia_potd/__init__.py
@@ -1,0 +1,1 @@
+"""Wikimedia Picture of the Day provider."""

--- a/merino/providers/rss/wikimedia_potd/provider.py
+++ b/merino/providers/rss/wikimedia_potd/provider.py
@@ -1,0 +1,54 @@
+"""Wikimedia Picture of the Day provider."""
+
+import logging
+import aiodogstatsd
+
+from pydantic import BaseModel, Field, HttpUrl
+
+from merino.providers.rss.base import BaseRssProvider
+
+logger = logging.getLogger(__name__)
+
+
+class Potd(BaseModel):
+    """Model for the Wikimedia Picture of the Day."""
+
+    title: str = Field(description="Title of the picture of the day.")
+    image_url: str = Field(description="URL of the picture of the day image.")
+
+
+class WikimediaPotdProvider(BaseRssProvider):
+    """Provider for the Wikimedia Picture of the Day feed."""
+
+    backend: None
+    metrics_client: aiodogstatsd.Client
+    url: HttpUrl
+    manifest_data: None
+
+    def __init__(
+        self,
+        backend: None,
+        metrics_client: aiodogstatsd.Client,
+        name: str,
+        query_timeout_sec: float,
+        enabled_by_default: bool = False,
+    ) -> None:
+        self.backend = None
+        self.metrics_client = metrics_client
+        self._name = name
+        self._query_timeout_sec = query_timeout_sec
+        self._enabled_by_default = enabled_by_default
+        self.url = HttpUrl("https://merino.services.mozilla.com/")
+        self.manifest_data = None
+
+        super().__init__()
+
+    async def initialize(self) -> None:
+        """Initialize the provider."""
+
+    async def get_picture_of_the_day(self) -> Potd:
+        """Return the current Wikimedia Picture of the Day."""
+        return Potd(title="", image_url="")
+
+    async def shutdown(self) -> None:
+        """Shut down the provider."""

--- a/merino/providers/rss/wikimedia_potd/provider.py
+++ b/merino/providers/rss/wikimedia_potd/provider.py
@@ -33,15 +33,13 @@ class WikimediaPotdProvider(BaseRssProvider):
         query_timeout_sec: float,
         enabled_by_default: bool = False,
     ) -> None:
+        super().__init__(
+            name=name, enabled_by_default=enabled_by_default, query_timeout_sec=query_timeout_sec
+        )
         self.backend = None
         self.metrics_client = metrics_client
-        self._name = name
-        self._query_timeout_sec = query_timeout_sec
-        self._enabled_by_default = enabled_by_default
         self.url = HttpUrl("https://merino.services.mozilla.com/")
         self.manifest_data = None
-
-        super().__init__()
 
     async def initialize(self) -> None:
         """Initialize the provider."""

--- a/tests/unit/providers/rss/__init__.py
+++ b/tests/unit/providers/rss/__init__.py
@@ -1,0 +1,5 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Unit tests for RSS providers."""

--- a/tests/unit/providers/rss/wikimedia_potd/__init__.py
+++ b/tests/unit/providers/rss/wikimedia_potd/__init__.py
@@ -1,0 +1,5 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Unit tests for the Wikimedia Picture of the Day provider."""

--- a/tests/unit/providers/rss/wikimedia_potd/test_provider.py
+++ b/tests/unit/providers/rss/wikimedia_potd/test_provider.py
@@ -1,0 +1,58 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Unit tests for the Wikimedia Picture of the Day provider."""
+
+import pytest
+
+from merino.providers.rss.wikimedia_potd.provider import Potd, WikimediaPotdProvider
+
+
+@pytest.fixture(name="provider")
+def fixture_provider(statsd_mock) -> WikimediaPotdProvider:
+    """Return a WikimediaPotdProvider instance for testing."""
+    return WikimediaPotdProvider(
+        backend=None,
+        metrics_client=statsd_mock,
+        name="wikimedia_potd",
+        query_timeout_sec=1.0,
+        enabled_by_default=False,
+    )
+
+
+def test_provider_name(provider: WikimediaPotdProvider) -> None:
+    """Test that the provider name is set correctly."""
+    assert provider.name == "wikimedia_potd"
+
+
+def test_provider_enabled_by_default(provider: WikimediaPotdProvider) -> None:
+    """Test that enabled_by_default is set correctly."""
+    assert provider.enabled_by_default is False
+
+
+def test_provider_query_timeout_sec(provider: WikimediaPotdProvider) -> None:
+    """Test that query_timeout_sec is set correctly."""
+    assert provider.query_timeout_sec == 1.0
+
+
+@pytest.mark.asyncio
+async def test_initialize(provider: WikimediaPotdProvider) -> None:
+    """Test that initialize completes without error."""
+    await provider.initialize()
+
+
+@pytest.mark.asyncio
+async def test_shutdown(provider: WikimediaPotdProvider) -> None:
+    """Test that shutdown completes without error."""
+    await provider.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_get_picture_of_the_day(provider: WikimediaPotdProvider) -> None:
+    """Test that get_picture_of_the_day returns a Potd with empty fields."""
+    potd = await provider.get_picture_of_the_day()
+
+    assert isinstance(potd, Potd)
+    assert potd.title == ""
+    assert potd.image_url == ""


### PR DESCRIPTION
## References

JIRA: [DISCO-2154](https://mozilla-hub.atlassian.net/browse/DISCO-2154)

## Description
Adding a new RSS provider for Wikimedia POTD (picture of the day). This requires a separation from the `Suggest` providers. The new pattern is very similar to how we initialize the existing `Suggest` providers.

- Adding a new directory `providers/rss/`.
- Adding a new `base.py` module for a new `BaseProvider` class for all RSS providers.
- Adding a separate `manager.py` module for all RSS providers.
- Adding a separate `__init__.py` module for all RSS providers.
- Updating the existing `main.py` to initialize the new RSS providers.

## PR Review Checklist
- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2177)


[DISCO-2154]: https://mozilla-hub.atlassian.net/browse/DISCO-2154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ