### PR TITLE
[HNT-2155] Skeleton for rss wikimedia potd backend module

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -1042,6 +1042,10 @@ type = "wikimedia_potd"
 # Whether or not this provider is enabled by default.
 enabled_by_default = false
 
+# MERINO_RSS_PROVIDERS__WIKIMEDIA_POTD__CONNECT_TIMEOUT_SEC
+# Timeout in seconds for establishing a connection to Wikimedia RSS endpoint.
+connect_timeout_sec = 3.0
+
 # MERINO_RSS_PROVIDERS__WIKIMEDIA_POTD__QUERY_TIMEOUT_SEC
 # A float (in seconds) indicating the maximum waiting period when querying for POTD data.
 query_timeout_sec = 1.0

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -1046,6 +1046,10 @@ enabled_by_default = false
 # A float (in seconds) indicating the maximum waiting period when querying for POTD data.
 query_timeout_sec = 1.0
 
+# MERINO_RSS_PROVIDERS__WIKIMEDIA_POTD__FEED_URL
+# URL for the Wikimedia Picture of the Day RSS feed.
+feed_url = "https://commons.wikimedia.org/w/api.php?action=featuredfeed&feed=potd&feedformat=rss"
+
 
 [default.curated_recommendations.gcs]
 # MERINO__CURATED_RECOMMENDATIONS__GCS__BUCKET_NAME

--- a/merino/providers/rss/manager.py
+++ b/merino/providers/rss/manager.py
@@ -6,6 +6,9 @@ from dynaconf.base import Settings
 
 from merino.configs import settings
 from merino.providers.rss.base import BaseRssProvider
+from merino.providers.rss.wikimedia_potd.backends.wikimedia_potd import (
+    WikimediaPotdBackend,
+)
 from merino.providers.rss.wikimedia_potd.provider import WikimediaPotdProvider
 from merino.utils.metrics import get_metrics_client
 
@@ -26,7 +29,7 @@ def _create_provider(provider_id: str, setting: Settings) -> BaseRssProvider:
     match setting.type:
         case RssProviderType.WIKIMEDIA_POTD:
             return WikimediaPotdProvider(
-                backend=None,
+                backend=WikimediaPotdBackend(feed_url=setting.feed_url),
                 metrics_client=get_metrics_client(),
                 name=provider_id,
                 query_timeout_sec=setting.query_timeout_sec,

--- a/merino/providers/rss/manager.py
+++ b/merino/providers/rss/manager.py
@@ -5,6 +5,8 @@ from enum import Enum, unique
 from dynaconf.base import Settings
 
 from merino.configs import settings
+from merino.utils.http_client import create_http_client
+from merino.utils.gcs.gcs_uploader import GcsUploader
 from merino.providers.rss.base import BaseRssProvider
 from merino.providers.rss.wikimedia_potd.backends.wikimedia_potd import (
     WikimediaPotdBackend,
@@ -28,8 +30,22 @@ def _create_provider(provider_id: str, setting: Settings) -> BaseRssProvider:
     """
     match setting.type:
         case RssProviderType.WIKIMEDIA_POTD:
+            http_client = create_http_client(
+                base_url=settings.accuweather.url_base,
+                connect_timeout=settings.providers.accuweather.connect_timeout_sec,
+            )
+
             return WikimediaPotdProvider(
-                backend=WikimediaPotdBackend(feed_url=setting.feed_url),
+                backend=WikimediaPotdBackend(
+                    feed_url=setting.feed_url,
+                    gcs_uploader=GcsUploader(
+                        settings.image_gcs.gcs_project,
+                        settings.image_gcs.gcs_bucket,
+                        settings.image_gcs.cdn_hostname,
+                    ),
+                    http_client=http_client,
+                    metrics_client=get_metrics_client(),
+                ),
                 metrics_client=get_metrics_client(),
                 name=provider_id,
                 query_timeout_sec=setting.query_timeout_sec,

--- a/merino/providers/rss/manager.py
+++ b/merino/providers/rss/manager.py
@@ -31,8 +31,8 @@ def _create_provider(provider_id: str, setting: Settings) -> BaseRssProvider:
     match setting.type:
         case RssProviderType.WIKIMEDIA_POTD:
             http_client = create_http_client(
-                base_url=settings.accuweather.url_base,
-                connect_timeout=settings.providers.accuweather.connect_timeout_sec,
+                base_url=settings.rss_providers.wikimedia_potd.fed_url,
+                connect_timeout=settings.rss_providers.wikimedia_potd.connect_timeout_sec,
             )
 
             return WikimediaPotdProvider(

--- a/merino/providers/rss/manager.py
+++ b/merino/providers/rss/manager.py
@@ -31,7 +31,7 @@ def _create_provider(provider_id: str, setting: Settings) -> BaseRssProvider:
     match setting.type:
         case RssProviderType.WIKIMEDIA_POTD:
             http_client = create_http_client(
-                base_url=settings.rss_providers.wikimedia_potd.fed_url,
+                base_url=settings.rss_providers.wikimedia_potd.feed_url,
                 connect_timeout=settings.rss_providers.wikimedia_potd.connect_timeout_sec,
             )
 

--- a/merino/providers/rss/wikimedia_potd/backends/__init__.py
+++ b/merino/providers/rss/wikimedia_potd/backends/__init__.py
@@ -1,0 +1,1 @@
+"""Backends for the Wikimedia Picture of the Day provider."""

--- a/merino/providers/rss/wikimedia_potd/backends/protocol.py
+++ b/merino/providers/rss/wikimedia_potd/backends/protocol.py
@@ -1,0 +1,24 @@
+"""Protocol for Wikimedia Picture of the Day provider backends."""
+
+from typing import Protocol
+
+from pydantic import BaseModel, Field
+
+
+class Potd(BaseModel):
+    """Model for the Wikimedia Picture of the Day."""
+
+    title: str = Field(description="Title of the picture of the day.")
+    image_url: str = Field(description="URL of the picture of the day image.")
+
+
+class WikimediaPotdBackend(Protocol):
+    """Protocol for a Wikimedia POTD backend that this provider depends on."""
+
+    async def fetch(self) -> Potd | None:  # pragma: no cover
+        """Fetch the current Wikimedia Picture of the Day.
+
+        Returns:
+            A Potd instance if data is available, otherwise None.
+        """
+        ...

--- a/merino/providers/rss/wikimedia_potd/backends/protocol.py
+++ b/merino/providers/rss/wikimedia_potd/backends/protocol.py
@@ -15,7 +15,7 @@ class Potd(BaseModel):
 class WikimediaPotdBackend(Protocol):
     """Protocol for a Wikimedia POTD backend that this provider depends on."""
 
-    async def fetch(self) -> Potd | None:  # pragma: no cover
+    async def get_picture_of_the_day(self) -> Potd | None:  # pragma: no cover
         """Fetch the current Wikimedia Picture of the Day.
 
         Returns:

--- a/merino/providers/rss/wikimedia_potd/backends/wikimedia_potd.py
+++ b/merino/providers/rss/wikimedia_potd/backends/wikimedia_potd.py
@@ -1,0 +1,36 @@
+"""Wikimedia Picture of the Day backend."""
+
+import aiodogstatsd
+from httpx import AsyncClient
+
+from merino.providers.rss.wikimedia_potd.backends.protocol import Potd
+from merino.utils.gcs.gcs_uploader import GcsUploader
+
+
+class WikimediaPotdBackend:
+    """Backend for fetching the Wikimedia Picture of the Day RSS feed."""
+
+    metrics_client: aiodogstatsd.Client
+    http_client: AsyncClient
+    gcs_uploader: GcsUploader
+
+    def __init__(
+        self,
+        metrics_client: aiodogstatsd.Client,
+        http_client: AsyncClient,
+        gcs_uploader: GcsUploader,
+        feed_url: str,
+    ) -> None:
+        """Initialize the backend with the RSS feed URL."""
+        self.feed_url = feed_url
+        self.metrics_client = metrics_client
+        self.http_client = http_client
+        self.gcs_uploader = gcs_uploader
+
+    async def fetch(self) -> Potd | None:
+        """Fetch the current Wikimedia Picture of the Day.
+
+        Returns:
+            A Potd instance if data is available, otherwise None.
+        """
+        return None

--- a/merino/providers/rss/wikimedia_potd/backends/wikimedia_potd.py
+++ b/merino/providers/rss/wikimedia_potd/backends/wikimedia_potd.py
@@ -27,7 +27,7 @@ class WikimediaPotdBackend:
         self.http_client = http_client
         self.gcs_uploader = gcs_uploader
 
-    async def fetch(self) -> Potd | None:
+    async def get_picture_of_the_day(self) -> Potd | None:
         """Fetch the current Wikimedia Picture of the Day.
 
         Returns:

--- a/merino/providers/rss/wikimedia_potd/provider.py
+++ b/merino/providers/rss/wikimedia_potd/provider.py
@@ -2,32 +2,28 @@
 
 import logging
 import aiodogstatsd
-
-from pydantic import BaseModel, Field, HttpUrl
+from pydantic import HttpUrl
 
 from merino.providers.rss.base import BaseRssProvider
+from merino.providers.rss.wikimedia_potd.backends.protocol import (
+    Potd,
+    WikimediaPotdBackend,
+)
 
 logger = logging.getLogger(__name__)
-
-
-class Potd(BaseModel):
-    """Model for the Wikimedia Picture of the Day."""
-
-    title: str = Field(description="Title of the picture of the day.")
-    image_url: str = Field(description="URL of the picture of the day image.")
 
 
 class WikimediaPotdProvider(BaseRssProvider):
     """Provider for the Wikimedia Picture of the Day feed."""
 
-    backend: None
+    backend: WikimediaPotdBackend
     metrics_client: aiodogstatsd.Client
     url: HttpUrl
     manifest_data: None
 
     def __init__(
         self,
-        backend: None,
+        backend: WikimediaPotdBackend,
         metrics_client: aiodogstatsd.Client,
         name: str,
         query_timeout_sec: float,
@@ -46,7 +42,8 @@ class WikimediaPotdProvider(BaseRssProvider):
 
     async def get_picture_of_the_day(self) -> Potd:
         """Return the current Wikimedia Picture of the Day."""
-        return Potd(title="", image_url="")
+        potd = await self.backend.fetch()
+        return potd if potd is not None else Potd(title="", image_url="")
 
     async def shutdown(self) -> None:
         """Shut down the provider."""

--- a/merino/providers/rss/wikimedia_potd/provider.py
+++ b/merino/providers/rss/wikimedia_potd/provider.py
@@ -32,7 +32,7 @@ class WikimediaPotdProvider(BaseRssProvider):
         super().__init__(
             name=name, enabled_by_default=enabled_by_default, query_timeout_sec=query_timeout_sec
         )
-        self.backend = None
+        self.backend = backend
         self.metrics_client = metrics_client
         self.url = HttpUrl("https://merino.services.mozilla.com/")
         self.manifest_data = None
@@ -42,7 +42,7 @@ class WikimediaPotdProvider(BaseRssProvider):
 
     async def get_picture_of_the_day(self) -> Potd:
         """Return the current Wikimedia Picture of the Day."""
-        potd = await self.backend.fetch()
+        potd = await self.backend.get_picture_of_the_day()
         return potd if potd is not None else Potd(title="", image_url="")
 
     async def shutdown(self) -> None:

--- a/tests/unit/providers/rss/wikimedia_potd/backends/__init__.py
+++ b/tests/unit/providers/rss/wikimedia_potd/backends/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Wikimedia Picture of the Day backends."""

--- a/tests/unit/providers/rss/wikimedia_potd/backends/test_wikimedia_potd_backend.py
+++ b/tests/unit/providers/rss/wikimedia_potd/backends/test_wikimedia_potd_backend.py
@@ -1,0 +1,51 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Unit tests for the Wikimedia Picture of the Day backend."""
+
+import pytest
+from unittest.mock import MagicMock
+from httpx import AsyncClient
+
+from merino.utils.gcs.gcs_uploader import GcsUploader
+from merino.providers.rss.wikimedia_potd.backends.wikimedia_potd import (
+    WikimediaPotdBackend,
+)
+
+FEED_URL = "https://example.com/feed"
+
+
+@pytest.fixture(name="http_client_mock")
+def fixture_http_client_mock() -> AsyncClient:
+    """Return a mock AsyncClient."""
+    return MagicMock(spec=AsyncClient)
+
+
+@pytest.fixture(name="gcs_uploader_mock")
+def fixture_gcs_uploader_mock() -> GcsUploader:
+    """Return a mock GcsUploader."""
+    return MagicMock(spec=GcsUploader)
+
+
+@pytest.fixture(name="backend")
+def fixture_backend(
+    statsd_mock,
+    http_client_mock: AsyncClient,
+    gcs_uploader_mock: GcsUploader,
+) -> WikimediaPotdBackend:
+    """Return a WikimediaPotdBackend instance for testing."""
+    return WikimediaPotdBackend(
+        metrics_client=statsd_mock,
+        http_client=http_client_mock,
+        gcs_uploader=gcs_uploader_mock,
+        feed_url=FEED_URL,
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_returns_none(backend: WikimediaPotdBackend) -> None:
+    """Test that fetch returns None in the skeleton implementation."""
+    result = await backend.fetch()
+
+    assert result is None

--- a/tests/unit/providers/rss/wikimedia_potd/backends/test_wikimedia_potd_backend.py
+++ b/tests/unit/providers/rss/wikimedia_potd/backends/test_wikimedia_potd_backend.py
@@ -46,6 +46,6 @@ def fixture_backend(
 @pytest.mark.asyncio
 async def test_fetch_returns_none(backend: WikimediaPotdBackend) -> None:
     """Test that fetch returns None in the skeleton implementation."""
-    result = await backend.fetch()
+    result = await backend.get_picture_of_the_day()
 
     assert result is None

--- a/tests/unit/providers/rss/wikimedia_potd/test_provider.py
+++ b/tests/unit/providers/rss/wikimedia_potd/test_provider.py
@@ -64,7 +64,7 @@ async def test_get_picture_of_the_day_returns_default_when_backend_returns_none(
     provider: WikimediaPotdProvider, backend_mock
 ) -> None:
     """Test that get_picture_of_the_day returns an empty Potd when backend returns None."""
-    backend_mock.fetch.return_value = None
+    backend_mock.get_picture_of_the_day.return_value = None
 
     potd = await provider.get_picture_of_the_day()
 

--- a/tests/unit/providers/rss/wikimedia_potd/test_provider.py
+++ b/tests/unit/providers/rss/wikimedia_potd/test_provider.py
@@ -5,15 +5,26 @@
 """Unit tests for the Wikimedia Picture of the Day provider."""
 
 import pytest
+from pytest_mock import MockerFixture
 
-from merino.providers.rss.wikimedia_potd.provider import Potd, WikimediaPotdProvider
+from merino.providers.rss.wikimedia_potd.backends.protocol import (
+    Potd,
+    WikimediaPotdBackend,
+)
+from merino.providers.rss.wikimedia_potd.provider import WikimediaPotdProvider
+
+
+@pytest.fixture(name="backend_mock")
+def fixture_backend_mock(mocker: MockerFixture):
+    """Return a mock WikimediaPotdBackend."""
+    return mocker.AsyncMock(spec=WikimediaPotdBackend)
 
 
 @pytest.fixture(name="provider")
-def fixture_provider(statsd_mock) -> WikimediaPotdProvider:
+def fixture_provider(statsd_mock, backend_mock: WikimediaPotdBackend) -> WikimediaPotdProvider:
     """Return a WikimediaPotdProvider instance for testing."""
     return WikimediaPotdProvider(
-        backend=None,
+        backend=backend_mock,
         metrics_client=statsd_mock,
         name="wikimedia_potd",
         query_timeout_sec=1.0,
@@ -49,8 +60,12 @@ async def test_shutdown(provider: WikimediaPotdProvider) -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_picture_of_the_day(provider: WikimediaPotdProvider) -> None:
-    """Test that get_picture_of_the_day returns a Potd with empty fields."""
+async def test_get_picture_of_the_day_returns_default_when_backend_returns_none(
+    provider: WikimediaPotdProvider, backend_mock
+) -> None:
+    """Test that get_picture_of_the_day returns an empty Potd when backend returns None."""
+    backend_mock.fetch.return_value = None
+
     potd = await provider.get_picture_of_the_day()
 
     assert isinstance(potd, Potd)


### PR DESCRIPTION
## References

JIRA: [HNT-2155](https://mozilla-hub.atlassian.net/browse/HNT-2155)

## Description
Adding skeleton work for the wikimedia picture of the day rss provider.

## PR Review Checklist
- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2178)


[HNT-2155]: https://mozilla-hub.atlassian.net/browse/HNT-2155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ