### PR TITLE
[DISCO-4033] add AMP thompson dry run toggle

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -632,9 +632,9 @@ dummy_attempted_count = 1000
 # Whether to check `client_variants` for Thompson sampling
 check_client_variants = true
 
-# MERINO_PROVIDERS__ADM__THOMPSON__FALLBACK_TO_BASE_SUGGESTION
+# MERINO_PROVIDERS__ADM__THOMPSON__DRY_RUN
 # Toggle to determine whether to return fallback suggestion or thompson selected suggestion
-fallback_to_base_suggestion = true
+dry_run = true
 
 [default.amo.dynamic]
 # MERINO_AMO__DYNAMIC__API_URL

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -632,6 +632,10 @@ dummy_attempted_count = 1000
 # Whether to check `client_variants` for Thompson sampling
 check_client_variants = true
 
+# MERINO_PROVIDERS__ADM__THOMPSON__FALLBACK_TO_BASE_SUGGESTION
+# Toggle to determine whether to return fallback suggestion or thompson selected suggestion
+fallback_to_base_suggestion = true
+
 [default.amo.dynamic]
 # MERINO_AMO__DYNAMIC__API_URL
 # This is the URL for the Addons API to get more information for particular addons.

--- a/merino/configs/testing.toml
+++ b/merino/configs/testing.toml
@@ -111,6 +111,7 @@ backend = "test"
 # MERINO_PROVIDERS__ADM__THOMPSON__ENABLED
 # Toggle Thompson sampling
 enabled = true
+fallback_to_base_suggestion = false
 
 [testing.providers.top_picks]
 # Whether or not this provider is enabled by default.

--- a/merino/configs/testing.toml
+++ b/merino/configs/testing.toml
@@ -111,7 +111,7 @@ backend = "test"
 # MERINO_PROVIDERS__ADM__THOMPSON__ENABLED
 # Toggle Thompson sampling
 enabled = true
-fallback_to_base_suggestion = false
+dry_run = false
 
 [testing.providers.top_picks]
 # Whether or not this provider is enabled by default.

--- a/merino/providers/suggest/adm/provider.py
+++ b/merino/providers/suggest/adm/provider.py
@@ -51,7 +51,7 @@ FORM_FACTORS_FALLBACK_MAPPING = {
 FALLBACK_FORM_FACTOR: str = "other"
 FALLBACK_COUNTRY_CODE: str = "US"
 CLIENT_VARIANTS_ALLOW_LIST = frozenset(settings.web.api.v1.client_variant_allow_list)
-FALLBACK_TO_BASE_SUGGESTION: bool = settings.providers.adm.thompson.fallback_to_base_suggestion
+TS_DRY_RUN: bool = settings.providers.adm.thompson.dry_run
 
 
 class SponsoredSuggestion(BaseSuggestion):
@@ -231,16 +231,8 @@ class Provider(BaseProvider):
     def _select(
         self, suggestions: list[PyAmpResult], client_variants: list[str]
     ) -> PyAmpResult | None:
-        """Select a suggestion from the candidate collection.
-
-        Params:
-          - `suggestions`: A list of candidates `PyAmpResult`
-        Returns:
-            Either a winner `PyAmpResult` or None if the optimizer (e.g. Thompson sampler)
-            determines so. Return the first candidate when the optimizer is disabled.
-        """
-        base_suggestion = suggestions[0] if suggestions else None
-        if self._is_thompson_eligible(client_variants):
+        def _sampling() -> PyAmpResult | None:
+            """Thompson sampling helper function."""
             candidates = [
                 ThompsonCandidate(id=i, metrics=self._fetch_engagement_metrics(suggestion))
                 for i, suggestion in enumerate(suggestions)
@@ -259,16 +251,17 @@ class Provider(BaseProvider):
                     "providers.adm.thompson.select", tags={"outcome": "selected"}
                 )
                 winner_idx: int = winner.id
-                if FALLBACK_TO_BASE_SUGGESTION:
-                    return base_suggestion
                 return suggestions[winner_idx]
             else:
                 self.metrics_client.increment(
                     "providers.adm.thompson.select", tags={"outcome": "suppressed"}
                 )
-                if FALLBACK_TO_BASE_SUGGESTION:
-                    return base_suggestion
                 return None
+
+        if self._is_thompson_eligible(client_variants):
+            winner = _sampling()
+            if not TS_DRY_RUN:
+                return winner
 
         return suggestions[0] if suggestions else None
 

--- a/merino/providers/suggest/adm/provider.py
+++ b/merino/providers/suggest/adm/provider.py
@@ -51,6 +51,7 @@ FORM_FACTORS_FALLBACK_MAPPING = {
 FALLBACK_FORM_FACTOR: str = "other"
 FALLBACK_COUNTRY_CODE: str = "US"
 CLIENT_VARIANTS_ALLOW_LIST = frozenset(settings.web.api.v1.client_variant_allow_list)
+FALLBACK_TO_BASE_SUGGESTION: bool = settings.providers.adm.thompson.fallback_to_base_suggestion
 
 
 class SponsoredSuggestion(BaseSuggestion):
@@ -238,6 +239,7 @@ class Provider(BaseProvider):
             Either a winner `PyAmpResult` or None if the optimizer (e.g. Thompson sampler)
             determines so. Return the first candidate when the optimizer is disabled.
         """
+        base_suggestion = suggestions[0] if suggestions else None
         if self._is_thompson_eligible(client_variants):
             candidates = [
                 ThompsonCandidate(id=i, metrics=self._fetch_engagement_metrics(suggestion))
@@ -257,11 +259,15 @@ class Provider(BaseProvider):
                     "providers.adm.thompson.select", tags={"outcome": "selected"}
                 )
                 winner_idx: int = winner.id
+                if FALLBACK_TO_BASE_SUGGESTION:
+                    return base_suggestion
                 return suggestions[winner_idx]
             else:
                 self.metrics_client.increment(
                     "providers.adm.thompson.select", tags={"outcome": "suppressed"}
                 )
+                if FALLBACK_TO_BASE_SUGGESTION:
+                    return base_suggestion
                 return None
 
         return suggestions[0] if suggestions else None

--- a/tests/unit/providers/suggest/adm/test_provider_thompson.py
+++ b/tests/unit/providers/suggest/adm/test_provider_thompson.py
@@ -5,6 +5,7 @@
 """Unit tests for the Thompson sampling code path of the AdM provider."""
 
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 from pydantic import HttpUrl
@@ -253,3 +254,77 @@ async def test_query_with_thompson_without_engagement_data_skips_sampling(
         )
     ]
     statsd_mock.increment.assert_not_called()
+
+
+@patch("merino.providers.suggest.adm.provider.FALLBACK_TO_BASE_SUGGESTION", True)
+@pytest.mark.asyncio
+async def test_query_with_thompson_returns_fallback_when_fallback_enabled(
+    srequest: SuggestionRequestFixture,
+    adm_with_thompson: Provider,
+    adm_parameters: dict[str, Any],
+    statsd_mock: Any,
+) -> None:
+    """Thompson-enabled provider should return a suggestion when the sampler picks a winner."""
+    await adm_with_thompson.initialize()
+    res = await adm_with_thompson.query(
+        srequest("firefox", GEOLOCATION, USER_AGENT, CLIENT_VARIANTS)
+    )
+
+    assert res == [
+        NonsponsoredSuggestion(
+            block_id=2,
+            full_keyword="firefox accounts",
+            title="Mozilla Firefox Accounts",
+            url=HttpUrl("https://example.org/target/mozfirefoxaccounts"),
+            categories=[],
+            impression_url=HttpUrl("https://example.org/impression/mozilla"),
+            click_url=HttpUrl("https://example.org/click/mozilla"),
+            provider="adm",
+            advertiser="Example.org",
+            is_sponsored=False,
+            icon="attachment-host/main-workspace/quicksuggest/icon-01",
+            score=adm_parameters["score"],
+        )
+    ]
+    statsd_mock.increment.assert_called_once_with(
+        "providers.adm.thompson.select", tags={"outcome": "selected"}
+    )
+
+
+@patch("merino.providers.suggest.adm.provider.FALLBACK_TO_BASE_SUGGESTION", True)
+@pytest.mark.asyncio
+async def test_query_with_thompson_dummy_return_suggestion_when_fallback_enabled(
+    srequest: SuggestionRequestFixture,
+    adm_with_thompson_dummy: Provider,
+    adm_parameters: dict[str, Any],
+    statsd_mock: Any,
+) -> None:
+    """Provider with a dominant dummy should suppress the suggestion (return empty list)."""
+    await adm_with_thompson_dummy.initialize()
+    adm_with_thompson_dummy.engagement_data = EngagementData(
+        amp={"something": {}}, amp_aggregated={}
+    )
+
+    res = await adm_with_thompson_dummy.query(
+        srequest("firefox", GEOLOCATION, USER_AGENT, CLIENT_VARIANTS)
+    )
+
+    assert res == [
+        NonsponsoredSuggestion(
+            block_id=2,
+            full_keyword="firefox accounts",
+            title="Mozilla Firefox Accounts",
+            url=HttpUrl("https://example.org/target/mozfirefoxaccounts"),
+            categories=[],
+            impression_url=HttpUrl("https://example.org/impression/mozilla"),
+            click_url=HttpUrl("https://example.org/click/mozilla"),
+            provider="adm",
+            advertiser="Example.org",
+            is_sponsored=False,
+            icon="attachment-host/main-workspace/quicksuggest/icon-01",
+            score=adm_parameters["score"],
+        )
+    ]
+    statsd_mock.increment.assert_called_once_with(
+        "providers.adm.thompson.select", tags={"outcome": "suppressed"}
+    )

--- a/tests/unit/providers/suggest/adm/test_provider_thompson.py
+++ b/tests/unit/providers/suggest/adm/test_provider_thompson.py
@@ -256,7 +256,7 @@ async def test_query_with_thompson_without_engagement_data_skips_sampling(
     statsd_mock.increment.assert_not_called()
 
 
-@patch("merino.providers.suggest.adm.provider.FALLBACK_TO_BASE_SUGGESTION", True)
+@patch("merino.providers.suggest.adm.provider.TS_DRY_RUN", True)
 @pytest.mark.asyncio
 async def test_query_with_thompson_returns_fallback_when_fallback_enabled(
     srequest: SuggestionRequestFixture,
@@ -264,7 +264,7 @@ async def test_query_with_thompson_returns_fallback_when_fallback_enabled(
     adm_parameters: dict[str, Any],
     statsd_mock: Any,
 ) -> None:
-    """Thompson-enabled provider should return a suggestion when the sampler picks a winner."""
+    """Thompson-enabled provider should return fallback when TS_DRY_RUN is enabled."""
     await adm_with_thompson.initialize()
     res = await adm_with_thompson.query(
         srequest("firefox", GEOLOCATION, USER_AGENT, CLIENT_VARIANTS)
@@ -291,7 +291,7 @@ async def test_query_with_thompson_returns_fallback_when_fallback_enabled(
     )
 
 
-@patch("merino.providers.suggest.adm.provider.FALLBACK_TO_BASE_SUGGESTION", True)
+@patch("merino.providers.suggest.adm.provider.TS_DRY_RUN", True)
 @pytest.mark.asyncio
 async def test_query_with_thompson_dummy_return_suggestion_when_fallback_enabled(
     srequest: SuggestionRequestFixture,
@@ -299,7 +299,7 @@ async def test_query_with_thompson_dummy_return_suggestion_when_fallback_enabled
     adm_parameters: dict[str, Any],
     statsd_mock: Any,
 ) -> None:
-    """Provider with a dominant dummy should suppress the suggestion (return empty list)."""
+    """Provider with a dominant dummy should return fallback suggestion when TS_DRY_RUN is enabled."""
     await adm_with_thompson_dummy.initialize()
     adm_with_thompson_dummy.engagement_data = EngagementData(
         amp={"something": {}}, amp_aggregated={}


### PR DESCRIPTION
## References

JIRA: [DISCO-4033](https://mozilla-hub.atlassian.net/browse/DISCO-4033)

## Description
We want to be able to do a dry run.
So a dry run bool `fallback_to_base_suggestion` is introduced to allow us to:

run through the Thompson Sampling logic
collect relevant TS metrics
but return the baseline (non TS) suggestion



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2187)


[DISCO-4033]: https://mozilla-hub.atlassian.net/browse/DISCO-4033?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ