### PR TITLE
[AIMOD-291] Response level section experiments

### DIFF
--- a/merino/curated_recommendations/corpus_backends/protocol.py
+++ b/merino/curated_recommendations/corpus_backends/protocol.py
@@ -1,5 +1,7 @@
 """Protocol for the Corpus provider backend."""
 
+from __future__ import annotations
+
 from enum import Enum, unique
 from typing import Protocol
 
@@ -95,6 +97,16 @@ class CorpusSection(BaseModel):
     iab: IABMetadata | None = None
     externalId: str
     createSource: CreateSource
+    experimentVariant: int = Field(
+        default=0,
+        exclude=True,
+        description="Internal experiment variant for the section. 0 means the canonical section.",
+    )
+    alternateSection: CorpusSection | None = Field(
+        default=None,
+        exclude=True,
+        description="Internal link to an alternate slate for the canonical section.",
+    )
     followable: bool = Field(default=True, description="Whether users can follow this section.")
     allowAds: bool = Field(
         default=True, description="Whether ads can be displayed in this section."

--- a/merino/curated_recommendations/corpus_backends/sections_backend.py
+++ b/merino/curated_recommendations/corpus_backends/sections_backend.py
@@ -35,6 +35,24 @@ from merino.providers.manifest import Provider as ManifestProvider
 logger = logging.getLogger(__name__)
 
 
+def parse_section_external_id(raw_external_id: str) -> tuple[str, int]:
+    """Normalize a raw section ID into its canonical ID and experiment variant."""
+    # Strip any locale suffix (e.g., "__lEN_GB", "__lEN_CA") from externalId if present.
+    external_id = raw_external_id.split("__l", 1)[0]
+
+    marker = "__exp"
+    idx = external_id.rfind(marker)
+    if idx <= 0:
+        return external_id.split("__", 1)[0], 0
+
+    base_id = external_id[:idx]
+    variant_id = external_id[idx + len(marker) :]
+    if variant_id.isdigit():
+        return base_id, int(variant_id)
+
+    return external_id.split("__", 1)[0], 0
+
+
 class SectionsBackend(SectionsProtocol):
     """Backend for fetching corpus sections using the getSections query."""
 
@@ -126,15 +144,13 @@ class SectionsBackend(SectionsProtocol):
             raise CorpusGraphQLError(f"Sections API returned GraphQL errors {data['errors']}")
 
         utm_source = get_utm_source(surface_id)
-        sections_list = []
+        parsed_sections = []
         for section in data["data"]["getSections"]:
             if not section.get("active") or section.get("externalId", "").endswith("_crawl"):
                 logger.info(f"Skipping inactive section {section['externalId']} for {surface_id}")
                 continue
 
-            # Strip any locale suffix (e.g., "__lEN_GB", "__lEN_CA") from externalId if present.
-            # Keep non-locale suffixes such as "__exp5050" intact for downstream processing.
-            external_id = section["externalId"].split("__l", 1)[0]
+            external_id, experiment_variant = parse_section_external_id(section["externalId"])
 
             section_obj = CorpusSection(
                 externalId=external_id,
@@ -144,6 +160,7 @@ class SectionsBackend(SectionsProtocol):
                 heroSubtitle=section.get("heroDescription"),
                 iab=section["iab"],
                 createSource=section["createSource"],
+                experimentVariant=experiment_variant,
                 followable=section["followable"],
                 allowAds=section["allowAds"],
                 sectionItems=[
@@ -153,6 +170,28 @@ class SectionsBackend(SectionsProtocol):
                     for section_item in section["sectionItems"]
                 ],
             )
-            sections_list.append(section_obj)
+            parsed_sections.append(section_obj)
+
+        sections_list = []
+        base_sections_by_id: dict[str, CorpusSection] = {}
+        pending_alternates: dict[str, CorpusSection] = {}
+
+        for section in parsed_sections:
+            if section.experimentVariant == 0:
+                sections_list.append(section)
+                base_sections_by_id[section.externalId] = section
+
+                alternate_section = pending_alternates.pop(section.externalId, None)
+                if alternate_section is not None and section.alternateSection is None:
+                    section.alternateSection = alternate_section
+                continue
+
+            base_section = base_sections_by_id.get(section.externalId)
+            if base_section is not None:
+                if base_section.alternateSection is None:
+                    base_section.alternateSection = section
+                continue
+
+            pending_alternates.setdefault(section.externalId, section)
 
         return sections_list

--- a/merino/curated_recommendations/corpus_backends/sections_backend.py
+++ b/merino/curated_recommendations/corpus_backends/sections_backend.py
@@ -132,9 +132,9 @@ class SectionsBackend(SectionsProtocol):
                 logger.info(f"Skipping inactive section {section['externalId']} for {surface_id}")
                 continue
 
-            # Strip any suffix (e.g., "__lEN_GB", "__lEN_CA") from externalId if present
-            # This handles locale suffixes and any future suffix patterns
-            external_id = section["externalId"].split("__")[0]
+            # Strip any locale suffix (e.g., "__lEN_GB", "__lEN_CA") from externalId if present.
+            # Keep non-locale suffixes such as "__exp5050" intact for downstream processing.
+            external_id = section["externalId"].split("__l", 1)[0]
 
             section_obj = CorpusSection(
                 externalId=external_id,

--- a/merino/curated_recommendations/corpus_backends/sections_backend.py
+++ b/merino/curated_recommendations/corpus_backends/sections_backend.py
@@ -95,7 +95,11 @@ class SectionsBackend(SectionsProtocol):
         before_sleep=before_sleep_log(logger, logging.WARNING),
     )
     async def fetch(self, surface_id: SurfaceId) -> list[CorpusSection]:
-        """Fetch section recommendations from the backend."""
+        """Fetch section recommendations from the backend.
+
+        Experimental sections are omitted from the top-level result and linked
+        to their canonical base sections for downstream resolution.
+        """
         query = """
             query GetSections($filters: SectionFilters!) {
               getSections(filters: $filters) {
@@ -172,26 +176,16 @@ class SectionsBackend(SectionsProtocol):
             )
             parsed_sections.append(section_obj)
 
-        sections_list = []
-        base_sections_by_id: dict[str, CorpusSection] = {}
-        pending_alternates: dict[str, CorpusSection] = {}
+        base_sections = [s for s in parsed_sections if s.experimentVariant == 0]
+        experimental_sections = [s for s in parsed_sections if s.experimentVariant != 0]
 
-        for section in parsed_sections:
-            if section.experimentVariant == 0:
-                sections_list.append(section)
-                base_sections_by_id[section.externalId] = section
+        base_sections_by_id: dict[str, CorpusSection] = {s.externalId: s for s in base_sections}
 
-                alternate_section = pending_alternates.pop(section.externalId, None)
-                if alternate_section is not None and section.alternateSection is None:
-                    section.alternateSection = alternate_section
-                continue
+        for section in experimental_sections:
+            base = base_sections_by_id.get(section.externalId)
+            if base and base.alternateSection is None:
+                base.alternateSection = section
 
-            base_section = base_sections_by_id.get(section.externalId)
-            if base_section is not None:
-                if base_section.alternateSection is None:
-                    base_section.alternateSection = section
-                continue
-
-            pending_alternates.setdefault(section.externalId, section)
+        sections_list = base_sections
 
         return sections_list

--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -199,74 +199,26 @@ def _process_corpus_sections(
     return sections
 
 
-def clean_exp_id(section_id: str) -> tuple[str, str] | None:
-    """Parse a raw experimental section ID into its base ID and experiment type.
-
-    Experimental IDs must end with the suffix ``__exp<type>``.
-    Non-experimental or malformed IDs return ``None``.
-    """
-    marker = "__exp"
-    idx = section_id.rfind(marker)
-    if idx <= 0:
-        return None
-
-    base_id = section_id[:idx]
-    exp_type = section_id[idx + len(marker) :]
-
-    if not exp_type or not exp_type.isalnum():
-        return None
-
-    return base_id, exp_type
+def resolve_5050(original_section: CorpusSection, alternate_section: CorpusSection) -> CorpusSection:
+    """Choose between the base and alternate section with 50/50 odds."""
+    return random.sample([original_section, alternate_section], 1)[0]
 
 
-def resolve_5050(original_id: str, exp_id: str) -> str:
-    """Choose between the base and experimental section IDs with 50/50 odds."""
-    return random.sample([original_id, exp_id], 1)[0]
+def resolve_section_experiment(section: CorpusSection) -> CorpusSection:
+    """Resolve a canonical section and its alternate slate to the winning section."""
+    alternate_section = section.alternateSection
+    if alternate_section is None:
+        return section
 
+    if alternate_section.experimentVariant == 5050:
+        return resolve_5050(section, alternate_section)
 
-def resolve_section_experiment(original_id: str, exp_id: str, exp_type: str) -> str:
-    """Resolve a base/experimental section pair to the winning section ID.
-
-    Unsupported experiment types always fall back to the base section.
-    """
-    if exp_type == "5050":
-        return resolve_5050(original_id, exp_id)
-    else:
-        return original_id
+    return section
 
 
 def dedupe_experiment_sections(sections: list[CorpusSection]) -> list[CorpusSection]:
-    """Resolve raw experimental section pairs and keep a single canonical section.
-
-    Experimental sections are identified by the ``__exp<type>`` suffix. When a
-    matching base section exists, the winning section content is copied into the
-    base section slot and emitted under the canonical base ID.
-    """
-    # Pull out experimental sections.
-    exp_ids = [sec.externalId for sec in sections if clean_exp_id(sec.externalId) is not None]
-    # Map IDs to sections.
-    id_to_section = {section.externalId: section for section in sections}
-    # Build the result map, dropping __exp sections until a winner is chosen.
-    id_to_result = {
-        section.externalId: section for section in sections if section.externalId not in exp_ids
-    }
-    # Find experimental pairs.
-    for eid in exp_ids:
-        parsed_eid = clean_exp_id(eid)
-        if parsed_eid is None:
-            continue
-        can_eid, exp_type = parsed_eid
-        # Check if there is a matching non-experimental section.
-        if can_eid in id_to_section:
-            # Pick the winning section ID.
-            kept_id = resolve_section_experiment(can_eid, eid, exp_type)
-            # Replace the value while keeping the canonical ID.
-            id_to_result[can_eid] = deepcopy(id_to_section[kept_id])
-            id_to_result[can_eid].externalId = can_eid
-    # Canonicalize any remaining double-underscore suffixes on surviving sections.
-    for section in id_to_result.values():
-        section.externalId = section.externalId.split("__", 1)[0]
-    return list(id_to_result.values())
+    """Resolve each canonical section to either its original or alternate slate."""
+    return [resolve_section_experiment(section) for section in sections]
 
 
 async def get_corpus_sections(

--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -199,7 +199,7 @@ def _process_corpus_sections(
     return sections
 
 def clean_exp_id(section_id: str) -> tuple[str, str] | None:
-    marker = "_exp"
+    marker = "__exp"
     idx = section_id.rfind(marker)
     if idx <= 0:
         return None
@@ -228,7 +228,7 @@ def dedupe_experiment_sections(sections):
     exp_ids = [sec.externalId for sec in sections if clean_exp_id(sec.externalId) is not None]
     ## map id to section
     id_to_section = {section.externalId:section for section in sections}
-    ## result id_to_section, , notice we are dropping _exp sections
+    ## result id_to_section, , notice we are dropping __exp sections
     id_to_result = {section.externalId:section for section in sections
                     if section.externalId not in exp_ids}
     ## find experimental pairs

--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -199,6 +199,11 @@ def _process_corpus_sections(
     return sections
 
 def clean_exp_id(section_id: str) -> tuple[str, str] | None:
+    """Parse a raw experimental section ID into its base ID and experiment type.
+
+    Experimental IDs must end with the suffix ``__exp<type>``.
+    Non-experimental or malformed IDs return ``None``.
+    """
     marker = "__exp"
     idx = section_id.rfind(marker)
     if idx <= 0:
@@ -213,35 +218,38 @@ def clean_exp_id(section_id: str) -> tuple[str, str] | None:
     return base_id, exp_type
 
 
-def resolve_5050(original_id, exp_id):
-    return random.sample([original_id,exp_id],1)[0]
+def resolve_5050(original_id: str, exp_id: str) -> str:
+    """Choose between the base and experimental section IDs with 50/50 odds."""
+    return random.sample([original_id, exp_id], 1)[0]
 
-def resolve_section_experiment(original_id, exp_id, exp_type):
-    ## case switch on 
-    if exp_type == '5050':
-        return resolve_5050(original_id,exp_id)
+def resolve_section_experiment(original_id: str, exp_id: str, exp_type: str) -> str:
+    """Resolve a base/experimental section pair to the winning section ID.
+
+    Unsupported experiment types always fall back to the base section.
+    """
+    if exp_type == "5050":
+        return resolve_5050(original_id, exp_id)
     else:
         return original_id
 
-def dedupe_experiment_sections(sections):
-    ## pull out experimental sections
+def dedupe_experiment_sections(sections: list[CorpusSection]) -> list[CorpusSection]:
+    """Resolve raw experimental section pairs and keep a single canonical section.
+
+    Experimental sections are identified by the ``__exp<type>`` suffix. When a
+    matching base section exists, the winning section content is copied into the
+    base section slot and emitted under the canonical base ID.
+    """
     exp_ids = [sec.externalId for sec in sections if clean_exp_id(sec.externalId) is not None]
-    ## map id to section
-    id_to_section = {section.externalId:section for section in sections}
-    ## result id_to_section, , notice we are dropping __exp sections
-    id_to_result = {section.externalId:section for section in sections
-                    if section.externalId not in exp_ids}
-    ## find experimental pairs
+    id_to_section = {section.externalId: section for section in sections}
+    id_to_result = {
+        section.externalId: section for section in sections if section.externalId not in exp_ids
+    }
     for eid in exp_ids:
         can_eid, exp_type = clean_exp_id(eid)
-        ## check if there is a matching non-experimental section
         if can_eid in id_to_section:
-            ## pick
-            kept_id = resolve_section_experiment(can_eid,eid,exp_type)
-            ## replace value, keep canonical id
+            kept_id = resolve_section_experiment(can_eid, eid, exp_type)
             id_to_result[can_eid] = deepcopy(id_to_section[kept_id])
-            ## replace id value with canonical
-            id_to_result[can_eid].externalId = can_eid      
+            id_to_result[can_eid].externalId = can_eid
     return list(id_to_result.values())
 
 

--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -198,6 +198,41 @@ def _process_corpus_sections(
 
     return sections
 
+def clean_exp_id(idstr):
+    ## TODO some regex that removes __exp*__ and returns the * part
+    filtstr = 'foo'
+    filttype = 'bar'
+    return filtstr, filttype
+
+def resolve_5050(original_id, exp_id):
+    return random.sample([original_id,exp_id],1)[0]
+
+def resolve_exp(original_id, exp_id, exp_type):
+    ## case switch on 
+    if exp_type == '5050':
+        return resolve_5050(original_id,exp_id)
+    else:
+        return original_id
+
+def dedupe_experiment_sections(sections):
+    ## get all section ids
+    sec_ids = [section.id for section in sections]
+    ## pull out experimental sections
+    exp_ids = [sid for sid in sec_ids if '__exp' in sid]
+    ## find experimental pairs
+    kept_ids = []
+    for eid in exp_ids:
+        can_eid, exp_type = clean_exp_id(eid)
+        ## check if there is a matching non-experimental section
+        if can_eid in sec_ids:
+            ## pick
+            kept_id, filt_id = resolve_exp(can_eid,eid,exp_type)
+            sec_ids.remove(filt_id)
+    ## do filtering
+    sections = [section for section in sections
+                if section.id in sec_ids]
+    return sections
+
 
 async def get_corpus_sections(
     sections_backend: SectionsProtocol,

--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -199,15 +199,13 @@ def _process_corpus_sections(
     return sections
 
 def clean_exp_id(idstr):
-    ## TODO some regex that removes __exp*__ and returns the * part
-    filtstr = 'foo'
-    filttype = 'bar'
-    return filtstr, filttype
+    base_id, exp_type = idstr.split('_exp')
+    return base_id, exp_type
 
 def resolve_5050(original_id, exp_id):
     return random.sample([original_id,exp_id],1)[0]
 
-def resolve_exp(original_id, exp_id, exp_type):
+def resolve_section_experiment(original_id, exp_id, exp_type):
     ## case switch on 
     if exp_type == '5050':
         return resolve_5050(original_id,exp_id)
@@ -215,23 +213,24 @@ def resolve_exp(original_id, exp_id, exp_type):
         return original_id
 
 def dedupe_experiment_sections(sections):
-    ## get all section ids
-    sec_ids = [section.id for section in sections]
     ## pull out experimental sections
-    exp_ids = [sid for sid in sec_ids if '__exp' in sid]
+    exp_ids = set([sec.id for sec in sections if '_exp' in sec.id])
+    ## map id to section
+    id_to_section = {section.id:section for section in sections}
+    ## result id_to_section, , notice we are dropping _exp sections
+    id_to_result = {section.id:section for section in sections
+                    if section.id not in exp_ids}
     ## find experimental pairs
     kept_ids = []
     for eid in exp_ids:
         can_eid, exp_type = clean_exp_id(eid)
         ## check if there is a matching non-experimental section
-        if can_eid in sec_ids:
+        if can_eid in id_to_section:
             ## pick
-            kept_id, filt_id = resolve_exp(can_eid,eid,exp_type)
-            sec_ids.remove(filt_id)
-    ## do filtering
-    sections = [section for section in sections
-                if section.id in sec_ids]
-    return sections
+            kept_id, _ = resolve_section_experiment(can_eid,eid,exp_type)
+            ## replace value, keep canonical id
+            id_to_result[can_eid] = id_to_section[kept_id]        
+    return list(id_to_result.values())
 
 
 async def get_corpus_sections(

--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -263,6 +263,9 @@ def dedupe_experiment_sections(sections: list[CorpusSection]) -> list[CorpusSect
             # Replace the value while keeping the canonical ID.
             id_to_result[can_eid] = deepcopy(id_to_section[kept_id])
             id_to_result[can_eid].externalId = can_eid
+    # Canonicalize any remaining double-underscore suffixes on surviving sections.
+    for section in id_to_result.values():
+        section.externalId = section.externalId.split("__", 1)[0]
     return list(id_to_result.values())
 
 

--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -198,6 +198,7 @@ def _process_corpus_sections(
 
     return sections
 
+
 def clean_exp_id(section_id: str) -> tuple[str, str] | None:
     """Parse a raw experimental section ID into its base ID and experiment type.
 
@@ -210,7 +211,7 @@ def clean_exp_id(section_id: str) -> tuple[str, str] | None:
         return None
 
     base_id = section_id[:idx]
-    exp_type = section_id[idx + len(marker):]
+    exp_type = section_id[idx + len(marker) :]
 
     if not exp_type or not exp_type.isalnum():
         return None
@@ -222,6 +223,7 @@ def resolve_5050(original_id: str, exp_id: str) -> str:
     """Choose between the base and experimental section IDs with 50/50 odds."""
     return random.sample([original_id, exp_id], 1)[0]
 
+
 def resolve_section_experiment(original_id: str, exp_id: str, exp_type: str) -> str:
     """Resolve a base/experimental section pair to the winning section ID.
 
@@ -232,6 +234,7 @@ def resolve_section_experiment(original_id: str, exp_id: str, exp_type: str) -> 
     else:
         return original_id
 
+
 def dedupe_experiment_sections(sections: list[CorpusSection]) -> list[CorpusSection]:
     """Resolve raw experimental section pairs and keep a single canonical section.
 
@@ -239,15 +242,25 @@ def dedupe_experiment_sections(sections: list[CorpusSection]) -> list[CorpusSect
     matching base section exists, the winning section content is copied into the
     base section slot and emitted under the canonical base ID.
     """
+    # Pull out experimental sections.
     exp_ids = [sec.externalId for sec in sections if clean_exp_id(sec.externalId) is not None]
+    # Map IDs to sections.
     id_to_section = {section.externalId: section for section in sections}
+    # Build the result map, dropping __exp sections until a winner is chosen.
     id_to_result = {
         section.externalId: section for section in sections if section.externalId not in exp_ids
     }
+    # Find experimental pairs.
     for eid in exp_ids:
-        can_eid, exp_type = clean_exp_id(eid)
+        parsed_eid = clean_exp_id(eid)
+        if parsed_eid is None:
+            continue
+        can_eid, exp_type = parsed_eid
+        # Check if there is a matching non-experimental section.
         if can_eid in id_to_section:
+            # Pick the winning section ID.
             kept_id = resolve_section_experiment(can_eid, eid, exp_type)
+            # Replace the value while keeping the canonical ID.
             id_to_result[can_eid] = deepcopy(id_to_section[kept_id])
             id_to_result[can_eid].externalId = can_eid
     return list(id_to_result.values())

--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -198,9 +198,20 @@ def _process_corpus_sections(
 
     return sections
 
-def clean_exp_id(idstr):
-    base_id, exp_type = idstr.split('_exp')
+def clean_exp_id(section_id: str) -> tuple[str, str] | None:
+    marker = "_exp"
+    idx = section_id.rfind(marker)
+    if idx <= 0:
+        return None
+
+    base_id = section_id[:idx]
+    exp_type = section_id[idx + len(marker):]
+
+    if not exp_type or not exp_type.isalnum():
+        return None
+
     return base_id, exp_type
+
 
 def resolve_5050(original_id, exp_id):
     return random.sample([original_id,exp_id],1)[0]
@@ -214,22 +225,23 @@ def resolve_section_experiment(original_id, exp_id, exp_type):
 
 def dedupe_experiment_sections(sections):
     ## pull out experimental sections
-    exp_ids = set([sec.id for sec in sections if '_exp' in sec.id])
+    exp_ids = [sec.externalId for sec in sections if clean_exp_id(sec.externalId) is not None]
     ## map id to section
-    id_to_section = {section.id:section for section in sections}
+    id_to_section = {section.externalId:section for section in sections}
     ## result id_to_section, , notice we are dropping _exp sections
-    id_to_result = {section.id:section for section in sections
-                    if section.id not in exp_ids}
+    id_to_result = {section.externalId:section for section in sections
+                    if section.externalId not in exp_ids}
     ## find experimental pairs
-    kept_ids = []
     for eid in exp_ids:
         can_eid, exp_type = clean_exp_id(eid)
         ## check if there is a matching non-experimental section
         if can_eid in id_to_section:
             ## pick
-            kept_id, _ = resolve_section_experiment(can_eid,eid,exp_type)
+            kept_id = resolve_section_experiment(can_eid,eid,exp_type)
             ## replace value, keep canonical id
-            id_to_result[can_eid] = id_to_section[kept_id]        
+            id_to_result[can_eid] = deepcopy(id_to_section[kept_id])
+            ## replace id value with canonical
+            id_to_result[can_eid].externalId = can_eid      
     return list(id_to_result.values())
 
 
@@ -255,6 +267,9 @@ async def get_corpus_sections(
     """
     # Get raw corpus sections
     raw_corpus_sections = await sections_backend.fetch(surface_id)
+
+    # Dedupe on sections by ID
+    raw_corpus_sections = dedupe_experiment_sections(raw_corpus_sections)
 
     # Split daily-briefing section before filtering (experiment-only gate)
     raw_daily_briefing, remaining_raw = split_daily_briefing_section(raw_corpus_sections)

--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -199,7 +199,9 @@ def _process_corpus_sections(
     return sections
 
 
-def resolve_5050(original_section: CorpusSection, alternate_section: CorpusSection) -> CorpusSection:
+def resolve_5050(
+    original_section: CorpusSection, alternate_section: CorpusSection
+) -> CorpusSection:
     """Choose between the base and alternate section with 50/50 odds."""
     return random.sample([original_section, alternate_section], 1)[0]
 

--- a/tests/integration/api/v1/curated_recommendations/corpus_backends/test_sections_backend.py
+++ b/tests/integration/api/v1/curated_recommendations/corpus_backends/test_sections_backend.py
@@ -161,7 +161,9 @@ async def test_fetch_links_experiment_variant_to_base_section(
 
     sections = await backend.fetch(SurfaceId.NEW_TAB_EN_US)
 
-    government_sections = [section for section in sections if section.externalId == "government-test"]
+    government_sections = [
+        section for section in sections if section.externalId == "government-test"
+    ]
     assert len(government_sections) == 1
     assert government_sections[0].experimentVariant == 0
     assert government_sections[0].alternateSection is not None

--- a/tests/integration/api/v1/curated_recommendations/corpus_backends/test_sections_backend.py
+++ b/tests/integration/api/v1/curated_recommendations/corpus_backends/test_sections_backend.py
@@ -81,9 +81,10 @@ async def test_fetch_ie_strips_locale_suffix(sections_ie_backend: SectionsBacken
 async def test_fetch_preserves_experiment_suffix(
     sections_response_data, fixture_request_data, manifest_provider
 ):
-    """Experiment suffixes should survive fetch normalization."""
+    """Experiment suffixes should be parsed into a canonical section with an alternate slate."""
     response_data = copy.deepcopy(sections_response_data)
-    response_data["data"]["getSections"][0]["externalId"] = "government__exp5050"
+    response_data["data"]["getSections"][0]["externalId"] = "government-test"
+    response_data["data"]["getSections"][1]["externalId"] = "government-test__exp5050"
 
     http_client = AsyncMock(spec=AsyncClient)
     http_client.post.return_value = Response(
@@ -100,16 +101,20 @@ async def test_fetch_preserves_experiment_suffix(
 
     sections = await backend.fetch(SurfaceId.NEW_TAB_EN_US)
 
-    assert any(section.externalId == "government__exp5050" for section in sections)
+    government = next(section for section in sections if section.externalId == "government-test")
+    assert government.experimentVariant == 0
+    assert government.alternateSection is not None
+    assert government.alternateSection.experimentVariant == 5050
 
 
 @pytest.mark.asyncio
 async def test_fetch_strips_locale_suffix_after_experiment_suffix(
     sections_response_data, fixture_request_data, manifest_provider
 ):
-    """Locale stripping should preserve the experiment suffix when both are present."""
+    """Locale stripping should preserve experiment metadata when linking the alternate slate."""
     response_data = copy.deepcopy(sections_response_data)
-    response_data["data"]["getSections"][0]["externalId"] = "government__exp5050__lDE_DE"
+    response_data["data"]["getSections"][0]["externalId"] = "government-test"
+    response_data["data"]["getSections"][1]["externalId"] = "government-test__exp5050__lDE_DE"
 
     http_client = AsyncMock(spec=AsyncClient)
     http_client.post.return_value = Response(
@@ -126,4 +131,38 @@ async def test_fetch_strips_locale_suffix_after_experiment_suffix(
 
     sections = await backend.fetch(SurfaceId.NEW_TAB_EN_US)
 
-    assert any(section.externalId == "government__exp5050" for section in sections)
+    government = next(section for section in sections if section.externalId == "government-test")
+    assert government.experimentVariant == 0
+    assert government.alternateSection is not None
+    assert government.alternateSection.experimentVariant == 5050
+
+
+@pytest.mark.asyncio
+async def test_fetch_links_experiment_variant_to_base_section(
+    sections_response_data, fixture_request_data, manifest_provider
+):
+    """A base/variant pair should be returned as one canonical section with an alternate slate."""
+    response_data = copy.deepcopy(sections_response_data)
+    response_data["data"]["getSections"][0]["externalId"] = "government-test"
+    response_data["data"]["getSections"][1]["externalId"] = "government-test__exp5050"
+
+    http_client = AsyncMock(spec=AsyncClient)
+    http_client.post.return_value = Response(
+        status_code=200,
+        json=response_data,
+        request=fixture_request_data,
+    )
+    backend = SectionsBackend(
+        http_client=http_client,
+        graph_config=CorpusApiGraphConfig(),
+        metrics_client=get_metrics_client(),
+        manifest_provider=manifest_provider,
+    )
+
+    sections = await backend.fetch(SurfaceId.NEW_TAB_EN_US)
+
+    government_sections = [section for section in sections if section.externalId == "government-test"]
+    assert len(government_sections) == 1
+    assert government_sections[0].experimentVariant == 0
+    assert government_sections[0].alternateSection is not None
+    assert government_sections[0].alternateSection.experimentVariant == 5050

--- a/tests/integration/api/v1/curated_recommendations/corpus_backends/test_sections_backend.py
+++ b/tests/integration/api/v1/curated_recommendations/corpus_backends/test_sections_backend.py
@@ -1,9 +1,15 @@
 """Tests covering merino/curated_recommendations/corpus_backends/sections_backend.py"""
 
+import copy
+from unittest.mock import AsyncMock
+
 import pytest
+from httpx import AsyncClient, Response
 
 from merino.curated_recommendations import SectionsBackend
 from merino.curated_recommendations.corpus_backends.protocol import CreateSource, SurfaceId
+from merino.curated_recommendations.corpus_backends.utils import CorpusApiGraphConfig
+from merino.utils.metrics import get_metrics_client
 
 
 @pytest.mark.asyncio
@@ -69,3 +75,55 @@ async def test_fetch_ie_strips_locale_suffix(sections_ie_backend: SectionsBacken
         assert (
             "__" not in section.externalId
         ), f"externalId '{section.externalId}' still contains locale suffix"
+
+
+@pytest.mark.asyncio
+async def test_fetch_preserves_experiment_suffix(
+    sections_response_data, fixture_request_data, manifest_provider
+):
+    """Experiment suffixes should survive fetch normalization."""
+    response_data = copy.deepcopy(sections_response_data)
+    response_data["data"]["getSections"][0]["externalId"] = "government__exp5050"
+
+    http_client = AsyncMock(spec=AsyncClient)
+    http_client.post.return_value = Response(
+        status_code=200,
+        json=response_data,
+        request=fixture_request_data,
+    )
+    backend = SectionsBackend(
+        http_client=http_client,
+        graph_config=CorpusApiGraphConfig(),
+        metrics_client=get_metrics_client(),
+        manifest_provider=manifest_provider,
+    )
+
+    sections = await backend.fetch(SurfaceId.NEW_TAB_EN_US)
+
+    assert any(section.externalId == "government__exp5050" for section in sections)
+
+
+@pytest.mark.asyncio
+async def test_fetch_strips_locale_suffix_after_experiment_suffix(
+    sections_response_data, fixture_request_data, manifest_provider
+):
+    """Locale stripping should preserve the experiment suffix when both are present."""
+    response_data = copy.deepcopy(sections_response_data)
+    response_data["data"]["getSections"][0]["externalId"] = "government__exp5050__lDE_DE"
+
+    http_client = AsyncMock(spec=AsyncClient)
+    http_client.post.return_value = Response(
+        status_code=200,
+        json=response_data,
+        request=fixture_request_data,
+    )
+    backend = SectionsBackend(
+        http_client=http_client,
+        graph_config=CorpusApiGraphConfig(),
+        metrics_client=get_metrics_client(),
+        manifest_provider=manifest_provider,
+    )
+
+    sections = await backend.fetch(SurfaceId.NEW_TAB_EN_US)
+
+    assert any(section.externalId == "government__exp5050" for section in sections)

--- a/tests/unit/curated_recommendations/corpus_backends/test_sections_backend.py
+++ b/tests/unit/curated_recommendations/corpus_backends/test_sections_backend.py
@@ -1,0 +1,29 @@
+"""Unit tests for section parsing helpers in sections_backend.py."""
+
+import pytest
+
+from merino.curated_recommendations.corpus_backends.sections_backend import (
+    parse_section_external_id,
+)
+
+
+class TestParseSectionExternalId:
+    """Tests covering raw section ID normalization."""
+
+    @pytest.mark.parametrize(
+        ("raw_external_id", "expected"),
+        [
+            ("government", ("government", 0)),
+            ("government__lDE_DE", ("government", 0)),
+            ("government__other", ("government", 0)),
+            ("government__exp5050", ("government", 5050)),
+            ("government__exp5050__lDE_DE", ("government", 5050)),
+            ("government__exp", ("government", 0)),
+            ("government__expabc", ("government", 0)),
+            ("government__exp5050_variant", ("government", 0)),
+            ("__exp5050__lDE_DE", ("", 0)),
+        ],
+    )
+    def test_parse_section_external_id(self, raw_external_id: str, expected: tuple[str, int]):
+        """Parser should strip locale suffixes and drop malformed experiment variants."""
+        assert parse_section_external_id(raw_external_id) == expected

--- a/tests/unit/curated_recommendations/test_sections.py
+++ b/tests/unit/curated_recommendations/test_sections.py
@@ -340,13 +340,13 @@ class TestRawSectionExperimentResolution:
         assert len(result[0].sectionItems) == 1
 
     def test_dedupe_experiment_sections_keeps_locale_suffixed_section_untouched(self):
-        """Locale suffixes should not be mistaken for experiment IDs."""
+        """Locale-suffixed survivors should be normalized to the canonical base ID."""
         localized = generate_corpus_section("education__lDE_DE", count=1)
         sports = generate_corpus_section("sports", count=1)
 
         result = dedupe_experiment_sections([localized, sports])
 
-        assert [section.externalId for section in result] == ["education__lDE_DE", "sports"]
+        assert [section.externalId for section in result] == ["education", "sports"]
 
 
 class TestMlSectionsExperiment:

--- a/tests/unit/curated_recommendations/test_sections.py
+++ b/tests/unit/curated_recommendations/test_sections.py
@@ -281,8 +281,7 @@ class TestRawSectionExperimentResolution:
     def test_resolve_section_experiment_unsupported_type_returns_base(self):
         """Unsupported experiment types should keep the base section."""
         assert (
-            resolve_section_experiment("government", "government__exp9999", "9999")
-            == "government"
+            resolve_section_experiment("government", "government__exp9999", "9999") == "government"
         )
 
     def test_dedupe_experiment_sections_keeps_base_when_base_selected(self, monkeypatch):
@@ -297,9 +296,7 @@ class TestRawSectionExperimentResolution:
         assert len(result[0].sectionItems) == 1
         assert result[0].externalId == "government"
 
-    def test_dedupe_experiment_sections_keeps_exp_content_under_canonical_id(
-        self, monkeypatch
-    ):
+    def test_dedupe_experiment_sections_keeps_exp_content_under_canonical_id(self, monkeypatch):
         """If the experiment wins, the content should survive under the base section ID."""
         monkeypatch.setattr(random, "sample", lambda seq, _: [seq[1]])
         base = generate_corpus_section("government", count=1)

--- a/tests/unit/curated_recommendations/test_sections.py
+++ b/tests/unit/curated_recommendations/test_sections.py
@@ -253,15 +253,15 @@ class TestRawSectionExperimentResolution:
 
     def test_clean_exp_id_parses_supported_suffix(self):
         """A supported experimental section ID should parse into base ID and experiment type."""
-        assert clean_exp_id("government_exp5050") == ("government", "5050")
+        assert clean_exp_id("government__exp5050") == ("government", "5050")
 
     @pytest.mark.parametrize(
         "section_id",
         [
             "government",
-            "government_exp",
-            "_exp5050",
-            "government_exp5050_variant",
+            "government__exp",
+            "__exp5050",
+            "government__exp5050_variant",
             "education__lDE_DE",
         ],
     )
@@ -274,14 +274,14 @@ class TestRawSectionExperimentResolution:
         monkeypatch.setattr(random, "sample", lambda seq, _: [seq[1]])
 
         assert (
-            resolve_section_experiment("government", "government_exp5050", "5050")
-            == "government_exp5050"
+            resolve_section_experiment("government", "government__exp5050", "5050")
+            == "government__exp5050"
         )
 
     def test_resolve_section_experiment_unsupported_type_returns_base(self):
         """Unsupported experiment types should keep the base section."""
         assert (
-            resolve_section_experiment("government", "government_exp9999", "9999")
+            resolve_section_experiment("government", "government__exp9999", "9999")
             == "government"
         )
 
@@ -289,7 +289,7 @@ class TestRawSectionExperimentResolution:
         """If the base wins, the canonical output should contain only the base content."""
         monkeypatch.setattr(random, "sample", lambda seq, _: [seq[0]])
         base = generate_corpus_section("government", count=1)
-        exp = generate_corpus_section("government_exp5050", count=2)
+        exp = generate_corpus_section("government__exp5050", count=2)
 
         result = dedupe_experiment_sections([base, exp])
 
@@ -303,14 +303,14 @@ class TestRawSectionExperimentResolution:
         """If the experiment wins, the content should survive under the base section ID."""
         monkeypatch.setattr(random, "sample", lambda seq, _: [seq[1]])
         base = generate_corpus_section("government", count=1)
-        exp = generate_corpus_section("government_exp5050", count=2)
+        exp = generate_corpus_section("government__exp5050", count=2)
 
         result = dedupe_experiment_sections([base, exp])
 
         assert [section.externalId for section in result] == ["government"]
         assert len(result[0].sectionItems) == 2
         assert result[0] is not exp
-        assert exp.externalId == "government_exp5050"
+        assert exp.externalId == "government__exp5050"
 
     def test_dedupe_experiment_sections_preserves_base_position(self, monkeypatch):
         """The chosen section should occupy the original base section position."""
@@ -318,7 +318,7 @@ class TestRawSectionExperimentResolution:
         sports = generate_corpus_section("sports")
         base = generate_corpus_section("government")
         tech = generate_corpus_section("tech")
-        exp = generate_corpus_section("government_exp5050")
+        exp = generate_corpus_section("government__exp5050")
 
         result = dedupe_experiment_sections([sports, base, tech, exp])
 
@@ -326,7 +326,7 @@ class TestRawSectionExperimentResolution:
 
     def test_dedupe_experiment_sections_drops_orphan_experimental_section(self):
         """An experimental section without a matching base should be dropped."""
-        exp = generate_corpus_section("government_exp5050")
+        exp = generate_corpus_section("government__exp5050")
 
         result = dedupe_experiment_sections([exp])
 
@@ -335,7 +335,7 @@ class TestRawSectionExperimentResolution:
     def test_dedupe_experiment_sections_unsupported_variant_keeps_base(self):
         """Unsupported experimental variants should be dropped while the base remains."""
         base = generate_corpus_section("government", count=1)
-        exp = generate_corpus_section("government_exp9999", count=2)
+        exp = generate_corpus_section("government__exp9999", count=2)
 
         result = dedupe_experiment_sections([base, exp])
 
@@ -1679,7 +1679,7 @@ class TestGetCorpusSections:
         mock_backend.fetch = AsyncMock(
             return_value=[
                 generate_corpus_section("government", count=1),
-                generate_corpus_section("government_exp5050", count=2),
+                generate_corpus_section("government__exp5050", count=2),
                 generate_corpus_section("sports", count=1),
             ]
         )
@@ -1692,7 +1692,7 @@ class TestGetCorpusSections:
         mock_backend.fetch = AsyncMock(
             return_value=[
                 generate_corpus_section("government", count=1),
-                generate_corpus_section("government_exp5050", count=2),
+                generate_corpus_section("government__exp5050", count=2),
                 generate_corpus_section(DAILY_BRIEFING_SECTION_KEY, count=1),
             ]
         )

--- a/tests/unit/curated_recommendations/test_sections.py
+++ b/tests/unit/curated_recommendations/test_sections.py
@@ -43,6 +43,8 @@ from merino.curated_recommendations.rankers import ThompsonSamplingRanker
 from merino.curated_recommendations.sections import (
     IS_COHORT_FEATURE_DISABLED,
     adjust_ads_in_sections,
+    clean_exp_id,
+    dedupe_experiment_sections,
     exclude_recommendations_from_blocked_sections,
     is_subtopics_experiment,
     is_daily_briefing_experiment,
@@ -61,6 +63,7 @@ from merino.curated_recommendations.sections import (
     get_legacy_topic_ids,
     pick_random_fresh_story,
     put_daily_briefing_first_then_top_stories,
+    resolve_section_experiment,
     split_daily_briefing_section,
     dedupe_recommendations_across_sections,
 )
@@ -83,6 +86,23 @@ def generate_corpus_item(corpus_id: str = "id", sched_id: str = "sched") -> Corp
         isTimeSensitive=False,
         imageUrl=HttpUrl(f"https://example.com/img/{corpus_id}"),
         iconUrl=None,
+    )
+
+
+def generate_corpus_section(
+    section_id: str, count: int = 1, create_source: CreateSource = CreateSource.ML
+) -> CorpusSection:
+    """Create a CorpusSection instance for testing."""
+    return CorpusSection(
+        sectionItems=[
+            generate_corpus_item(f"{section_id}_item{i}", f"{section_id}_sched{i}")
+            for i in range(count)
+        ],
+        title=f"Title_{section_id}",
+        description=f"Description_{section_id}",
+        externalId=section_id,
+        iab=IABMetadata(categories=["324"]),
+        createSource=create_source,
     )
 
 
@@ -226,6 +246,110 @@ class TestAdjustAdsInSections:
 
         # Rank 0 normally allows ads, but allowAds=False should override
         assert not self.ads_in_section(sample_feed["top_stories_section"])
+
+
+class TestRawSectionExperimentResolution:
+    """Tests covering raw section experiment resolution helpers."""
+
+    def test_clean_exp_id_parses_supported_suffix(self):
+        """A supported experimental section ID should parse into base ID and experiment type."""
+        assert clean_exp_id("government_exp5050") == ("government", "5050")
+
+    @pytest.mark.parametrize(
+        "section_id",
+        [
+            "government",
+            "government_exp",
+            "_exp5050",
+            "government_exp5050_variant",
+            "education__lDE_DE",
+        ],
+    )
+    def test_clean_exp_id_rejects_invalid_ids(self, section_id):
+        """Invalid or malformed section IDs should not parse as experiments."""
+        assert clean_exp_id(section_id) is None
+
+    def test_resolve_section_experiment_uses_5050_random_choice(self, monkeypatch):
+        """5050 experiments should resolve through the random chooser."""
+        monkeypatch.setattr(random, "sample", lambda seq, _: [seq[1]])
+
+        assert (
+            resolve_section_experiment("government", "government_exp5050", "5050")
+            == "government_exp5050"
+        )
+
+    def test_resolve_section_experiment_unsupported_type_returns_base(self):
+        """Unsupported experiment types should keep the base section."""
+        assert (
+            resolve_section_experiment("government", "government_exp9999", "9999")
+            == "government"
+        )
+
+    def test_dedupe_experiment_sections_keeps_base_when_base_selected(self, monkeypatch):
+        """If the base wins, the canonical output should contain only the base content."""
+        monkeypatch.setattr(random, "sample", lambda seq, _: [seq[0]])
+        base = generate_corpus_section("government", count=1)
+        exp = generate_corpus_section("government_exp5050", count=2)
+
+        result = dedupe_experiment_sections([base, exp])
+
+        assert [section.externalId for section in result] == ["government"]
+        assert len(result[0].sectionItems) == 1
+        assert result[0].externalId == "government"
+
+    def test_dedupe_experiment_sections_keeps_exp_content_under_canonical_id(
+        self, monkeypatch
+    ):
+        """If the experiment wins, the content should survive under the base section ID."""
+        monkeypatch.setattr(random, "sample", lambda seq, _: [seq[1]])
+        base = generate_corpus_section("government", count=1)
+        exp = generate_corpus_section("government_exp5050", count=2)
+
+        result = dedupe_experiment_sections([base, exp])
+
+        assert [section.externalId for section in result] == ["government"]
+        assert len(result[0].sectionItems) == 2
+        assert result[0] is not exp
+        assert exp.externalId == "government_exp5050"
+
+    def test_dedupe_experiment_sections_preserves_base_position(self, monkeypatch):
+        """The chosen section should occupy the original base section position."""
+        monkeypatch.setattr(random, "sample", lambda seq, _: [seq[1]])
+        sports = generate_corpus_section("sports")
+        base = generate_corpus_section("government")
+        tech = generate_corpus_section("tech")
+        exp = generate_corpus_section("government_exp5050")
+
+        result = dedupe_experiment_sections([sports, base, tech, exp])
+
+        assert [section.externalId for section in result] == ["sports", "government", "tech"]
+
+    def test_dedupe_experiment_sections_drops_orphan_experimental_section(self):
+        """An experimental section without a matching base should be dropped."""
+        exp = generate_corpus_section("government_exp5050")
+
+        result = dedupe_experiment_sections([exp])
+
+        assert result == []
+
+    def test_dedupe_experiment_sections_unsupported_variant_keeps_base(self):
+        """Unsupported experimental variants should be dropped while the base remains."""
+        base = generate_corpus_section("government", count=1)
+        exp = generate_corpus_section("government_exp9999", count=2)
+
+        result = dedupe_experiment_sections([base, exp])
+
+        assert [section.externalId for section in result] == ["government"]
+        assert len(result[0].sectionItems) == 1
+
+    def test_dedupe_experiment_sections_keeps_locale_suffixed_section_untouched(self):
+        """Locale suffixes should not be mistaken for experiment IDs."""
+        localized = generate_corpus_section("education__lDE_DE", count=1)
+        sports = generate_corpus_section("sports", count=1)
+
+        result = dedupe_experiment_sections([localized, sports])
+
+        assert [section.externalId for section in result] == ["education__lDE_DE", "sports"]
 
 
 class TestMlSectionsExperiment:
@@ -1548,6 +1672,32 @@ class TestGetCorpusSections:
         mock_backend.fetch = AsyncMock(return_value=sample_backend_data)
         return mock_backend
 
+    @pytest.fixture
+    def sections_backend_with_5050_pair(self):
+        """Fake SectionsProtocol returning a base/experimental raw section pair."""
+        mock_backend = MagicMock(spec=SectionsProtocol)
+        mock_backend.fetch = AsyncMock(
+            return_value=[
+                generate_corpus_section("government", count=1),
+                generate_corpus_section("government_exp5050", count=2),
+                generate_corpus_section("sports", count=1),
+            ]
+        )
+        return mock_backend
+
+    @pytest.fixture
+    def sections_backend_with_5050_pair_and_daily_briefing(self):
+        """Fake SectionsProtocol returning a 5050 pair plus a daily briefing section."""
+        mock_backend = MagicMock(spec=SectionsProtocol)
+        mock_backend.fetch = AsyncMock(
+            return_value=[
+                generate_corpus_section("government", count=1),
+                generate_corpus_section("government_exp5050", count=2),
+                generate_corpus_section(DAILY_BRIEFING_SECTION_KEY, count=1),
+            ]
+        )
+        return mock_backend
+
     @pytest.mark.asyncio
     async def test_fetch_called_with_correct_args(self, sections_backend):
         """Ensure fetch is called once with given surface_id."""
@@ -1633,3 +1783,39 @@ class TestGetCorpusSections:
 
         # Should include both ML and MANUAL sections
         assert set(sections.keys()) == {"sports", "custom-section-1", "custom-section-2"}
+
+    @pytest.mark.asyncio
+    async def test_resolves_5050_pair_before_mapping(
+        self, sections_backend_with_5050_pair, monkeypatch
+    ):
+        """A winning experimental section should map downstream under the canonical base ID."""
+        monkeypatch.setattr(random, "sample", lambda seq, _: [seq[1]])
+
+        _, sections = await get_corpus_sections(
+            sections_backend=sections_backend_with_5050_pair,
+            surface_id=SurfaceId.NEW_TAB_EN_US,
+            min_feed_rank=0,
+            include_subtopics=False,
+        )
+
+        assert set(sections.keys()) == {"government", "sports"}
+        assert len(sections["government"].recommendations) == 2
+
+    @pytest.mark.asyncio
+    async def test_daily_briefing_unaffected_by_5050_resolution(
+        self, sections_backend_with_5050_pair_and_daily_briefing, monkeypatch
+    ):
+        """Daily briefing extraction should still work after raw experiment resolution."""
+        monkeypatch.setattr(random, "sample", lambda seq, _: [seq[1]])
+
+        raw_briefing, sections = await get_corpus_sections(
+            sections_backend=sections_backend_with_5050_pair_and_daily_briefing,
+            surface_id=SurfaceId.NEW_TAB_EN_US,
+            min_feed_rank=0,
+            include_subtopics=False,
+        )
+
+        assert raw_briefing is not None
+        assert raw_briefing.externalId == DAILY_BRIEFING_SECTION_KEY
+        assert set(sections.keys()) == {"government"}
+        assert len(sections["government"].recommendations) == 2

--- a/tests/unit/curated_recommendations/test_sections.py
+++ b/tests/unit/curated_recommendations/test_sections.py
@@ -43,7 +43,6 @@ from merino.curated_recommendations.rankers import ThompsonSamplingRanker
 from merino.curated_recommendations.sections import (
     IS_COHORT_FEATURE_DISABLED,
     adjust_ads_in_sections,
-    clean_exp_id,
     dedupe_experiment_sections,
     exclude_recommendations_from_blocked_sections,
     is_subtopics_experiment,
@@ -63,6 +62,7 @@ from merino.curated_recommendations.sections import (
     get_legacy_topic_ids,
     pick_random_fresh_story,
     put_daily_briefing_first_then_top_stories,
+    resolve_5050,
     resolve_section_experiment,
     split_daily_briefing_section,
     dedupe_recommendations_across_sections,
@@ -249,48 +249,35 @@ class TestAdjustAdsInSections:
 
 
 class TestRawSectionExperimentResolution:
-    """Tests covering raw section experiment resolution helpers."""
+    """Tests covering linked section experiment resolution helpers."""
 
-    def test_clean_exp_id_parses_supported_suffix(self):
-        """A supported experimental section ID should parse into base ID and experiment type."""
-        assert clean_exp_id("government__exp5050") == ("government", "5050")
-
-    @pytest.mark.parametrize(
-        "section_id",
-        [
-            "government",
-            "government__exp",
-            "__exp5050",
-            "government__exp5050_variant",
-            "education__lDE_DE",
-        ],
-    )
-    def test_clean_exp_id_rejects_invalid_ids(self, section_id):
-        """Invalid or malformed section IDs should not parse as experiments."""
-        assert clean_exp_id(section_id) is None
-
-    def test_resolve_section_experiment_uses_5050_random_choice(self, monkeypatch):
+    def test_resolve_5050_uses_random_choice(self, monkeypatch):
         """5050 experiments should resolve through the random chooser."""
         monkeypatch.setattr(random, "sample", lambda seq, _: [seq[1]])
+        base = generate_corpus_section("government", count=1)
+        alternate = generate_corpus_section("government", count=2)
+        alternate.experimentVariant = 5050
 
-        assert (
-            resolve_section_experiment("government", "government__exp5050", "5050")
-            == "government__exp5050"
-        )
+        assert resolve_5050(base, alternate) is alternate
 
     def test_resolve_section_experiment_unsupported_type_returns_base(self):
         """Unsupported experiment types should keep the base section."""
-        assert (
-            resolve_section_experiment("government", "government__exp9999", "9999") == "government"
-        )
+        base = generate_corpus_section("government", count=1)
+        alternate = generate_corpus_section("government", count=2)
+        alternate.experimentVariant = 9999
+        base.alternateSection = alternate
+
+        assert resolve_section_experiment(base) is base
 
     def test_dedupe_experiment_sections_keeps_base_when_base_selected(self, monkeypatch):
         """If the base wins, the canonical output should contain only the base content."""
         monkeypatch.setattr(random, "sample", lambda seq, _: [seq[0]])
         base = generate_corpus_section("government", count=1)
-        exp = generate_corpus_section("government__exp5050", count=2)
+        exp = generate_corpus_section("government", count=2)
+        exp.experimentVariant = 5050
+        base.alternateSection = exp
 
-        result = dedupe_experiment_sections([base, exp])
+        result = dedupe_experiment_sections([base])
 
         assert [section.externalId for section in result] == ["government"]
         assert len(result[0].sectionItems) == 1
@@ -300,14 +287,16 @@ class TestRawSectionExperimentResolution:
         """If the experiment wins, the content should survive under the base section ID."""
         monkeypatch.setattr(random, "sample", lambda seq, _: [seq[1]])
         base = generate_corpus_section("government", count=1)
-        exp = generate_corpus_section("government__exp5050", count=2)
+        exp = generate_corpus_section("government", count=2)
+        exp.experimentVariant = 5050
+        base.alternateSection = exp
 
-        result = dedupe_experiment_sections([base, exp])
+        result = dedupe_experiment_sections([base])
 
         assert [section.externalId for section in result] == ["government"]
         assert len(result[0].sectionItems) == 2
-        assert result[0] is not exp
-        assert exp.externalId == "government__exp5050"
+        assert result[0] is exp
+        assert exp.externalId == "government"
 
     def test_dedupe_experiment_sections_preserves_base_position(self, monkeypatch):
         """The chosen section should occupy the original base section position."""
@@ -315,33 +304,29 @@ class TestRawSectionExperimentResolution:
         sports = generate_corpus_section("sports")
         base = generate_corpus_section("government")
         tech = generate_corpus_section("tech")
-        exp = generate_corpus_section("government__exp5050")
+        exp = generate_corpus_section("government")
+        exp.experimentVariant = 5050
+        base.alternateSection = exp
 
-        result = dedupe_experiment_sections([sports, base, tech, exp])
+        result = dedupe_experiment_sections([sports, base, tech])
 
         assert [section.externalId for section in result] == ["sports", "government", "tech"]
-
-    def test_dedupe_experiment_sections_drops_orphan_experimental_section(self):
-        """An experimental section without a matching base should be dropped."""
-        exp = generate_corpus_section("government__exp5050")
-
-        result = dedupe_experiment_sections([exp])
-
-        assert result == []
 
     def test_dedupe_experiment_sections_unsupported_variant_keeps_base(self):
         """Unsupported experimental variants should be dropped while the base remains."""
         base = generate_corpus_section("government", count=1)
-        exp = generate_corpus_section("government__exp9999", count=2)
+        exp = generate_corpus_section("government", count=2)
+        exp.experimentVariant = 9999
+        base.alternateSection = exp
 
-        result = dedupe_experiment_sections([base, exp])
+        result = dedupe_experiment_sections([base])
 
         assert [section.externalId for section in result] == ["government"]
         assert len(result[0].sectionItems) == 1
 
     def test_dedupe_experiment_sections_keeps_locale_suffixed_section_untouched(self):
-        """Locale-suffixed survivors should be normalized to the canonical base ID."""
-        localized = generate_corpus_section("education__lDE_DE", count=1)
+        """Canonical sections should pass through unchanged when no alternate exists."""
+        localized = generate_corpus_section("education", count=1)
         sports = generate_corpus_section("sports", count=1)
 
         result = dedupe_experiment_sections([localized, sports])
@@ -1671,12 +1656,15 @@ class TestGetCorpusSections:
 
     @pytest.fixture
     def sections_backend_with_5050_pair(self):
-        """Fake SectionsProtocol returning a base/experimental raw section pair."""
+        """Fake SectionsProtocol returning a parsed canonical section with an alternate slate."""
         mock_backend = MagicMock(spec=SectionsProtocol)
+        government = generate_corpus_section("government", count=1)
+        government_alternate = generate_corpus_section("government", count=2)
+        government_alternate.experimentVariant = 5050
+        government.alternateSection = government_alternate
         mock_backend.fetch = AsyncMock(
             return_value=[
-                generate_corpus_section("government", count=1),
-                generate_corpus_section("government__exp5050", count=2),
+                government,
                 generate_corpus_section("sports", count=1),
             ]
         )
@@ -1684,12 +1672,15 @@ class TestGetCorpusSections:
 
     @pytest.fixture
     def sections_backend_with_5050_pair_and_daily_briefing(self):
-        """Fake SectionsProtocol returning a 5050 pair plus a daily briefing section."""
+        """Fake SectionsProtocol returning a canonical 5050 pair plus a daily briefing section."""
         mock_backend = MagicMock(spec=SectionsProtocol)
+        government = generate_corpus_section("government", count=1)
+        government_alternate = generate_corpus_section("government", count=2)
+        government_alternate.experimentVariant = 5050
+        government.alternateSection = government_alternate
         mock_backend.fetch = AsyncMock(
             return_value=[
-                generate_corpus_section("government", count=1),
-                generate_corpus_section("government__exp5050", count=2),
+                government,
                 generate_corpus_section(DAILY_BRIEFING_SECTION_KEY, count=1),
             ]
         )


### PR DESCRIPTION
## References

JIRA: [AIMOD-291](https://mozilla-hub.atlassian.net/browse/AIMOD-291?atlOrigin=eyJpIjoiZjI4OTBkYTBmNjgzNDQyY2EzZmEyNTBiMjFiNmYwYmUiLCJwIjoiaiJ9)

## Description
Parses sections and looks for A/B pairs where A is the canonical id and B has a '__exp<name>' suffix. One type of section experiment is implemented: 5050. in the 5050 experiment, A or B is served in any given response at random. The canonical id is attached to version B (also already assigned to version A) so that block and follow is respected.

For non-US locales, there is a locale suffix attached to the id. The locale suffix must be a suffix and is last. We are changing section object construction such that instead of all __ suffix being dropped, only the __l locale suffix is dropped. The __exp suffix is dropped later. There is an additional hard drop of __ so that we keep the behavior of no __ surviving. 

Enum of assumptions:
* experimental sections must follow pattern <base>__exp<name>__l<locale>
* malformed experiments id are dropped. <base>__exp<name>__<anything>__l<locale > is dropped
* there can be only A/B versions for a base name. A/B/C is not supported and outcomes will be non-deterministic
* an experiment id without a matching base name is dropped. no solo experiment sections
* we always pass the base name to the user




## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[AIMOD-291]: https://mozilla-hub.atlassian.net/browse/AIMOD-291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ