### PR TITLE
DISCO-4027 Add metrics for amp storage

### DIFF
--- a/merino/providers/suggest/adm/backends/mars.py
+++ b/merino/providers/suggest/adm/backends/mars.py
@@ -84,6 +84,13 @@ class MarsBackend:
         self.etags = {}
         self.last_new_data_at = 0.0
 
+    def _emit_index_metrics(self, idx_id: str) -> None:
+        """Emit gauge metrics for the amp index after a successful build."""
+        stats = self.suggestion_content.index_manager.stats(idx_id)
+        tags = {"index": idx_id}
+        for key, value in stats.items():
+            self.metrics_client.gauge(f"amp.index.{key}", value=value, tags=tags)
+
     def get_segment(self, form_factor_str: str) -> SegmentType:
         """Compose segment from a form factor string.
 
@@ -133,6 +140,7 @@ class MarsBackend:
                     icons_in_use = icons_in_use.union(
                         self.suggestion_content.index_manager.list_icons(idx_id)
                     )
+                    self._emit_index_metrics(idx_id)
                 except Exception as e:
                     logger.warning(
                         f"Unable to build index or get icons for {idx_id}",

--- a/metrics.yaml
+++ b/metrics.yaml
@@ -279,6 +279,66 @@ suggest/mars:
       The ADM provider MARS backend data sync.
     alert_policy: []
 
+  amp.index.keyword_index_size:
+    description: |
+      A gauge tracking the number of keywords in the AMP index after a successful build.
+    type: gauge
+    labels:
+      - name: index
+        description: |
+          The index identifier (country/form-factor segment)
+    scope: |
+      The ADM provider MARS backend data sync.
+    alert_policy: []
+
+  amp.index.suggestions_count:
+    description: |
+      A gauge tracking the number of suggestions in the AMP index after a successful build.
+    type: gauge
+    labels:
+      - name: index
+        description: |
+          The index identifier (country/form-factor segment)
+    scope: |
+      The ADM provider MARS backend data sync.
+    alert_policy: []
+
+  amp.index.icons_count:
+    description: |
+      A gauge tracking the number of icons in the AMP index after a successful build.
+    type: gauge
+    labels:
+      - name: index
+        description: |
+          The index identifier (country/form-factor segment)
+    scope: |
+      The ADM provider MARS backend data sync.
+    alert_policy: []
+
+  amp.index.advertisers_count:
+    description: |
+      A gauge tracking the number of advertisers in the AMP index after a successful build.
+    type: gauge
+    labels:
+      - name: index
+        description: |
+          The index identifier (country/form-factor segment)
+    scope: |
+      The ADM provider MARS backend data sync.
+    alert_policy: []
+
+  amp.index.url_templates_count:
+    description: |
+      A gauge tracking the number of URL templates in the AMP index after a successful build.
+    type: gauge
+    labels:
+      - name: index
+        description: |
+          The index identifier (country/form-factor segment)
+    scope: |
+      The ADM provider MARS backend data sync.
+    alert_policy: []
+
 suggest/flightaware:
   flightaware_request_summary_get:
     description: |

--- a/tests/unit/providers/suggest/adm/backends/test_mars.py
+++ b/tests/unit/providers/suggest/adm/backends/test_mars.py
@@ -625,3 +625,29 @@ async def test_last_new_data_at_set_on_success(
     await mars_backend.fetch()
 
     assert mars_backend.last_new_data_at > 0
+
+
+@pytest.mark.asyncio
+async def test_index_metrics_emitted_after_build(
+    mocker: MockerFixture,
+    mars_backend: MarsBackend,
+    suggestion_response: httpx.Response,
+) -> None:
+    """Test that amp.index.* gauges are emitted after a successful index build."""
+    mocker.patch.object(
+        httpx.AsyncClient,
+        "get",
+        return_value=suggestion_response,
+    )
+
+    await mars_backend.fetch()
+
+    gauge_calls = mars_backend.metrics_client.gauge.call_args_list  # type: ignore[attr-defined]
+    index_calls = {c[0][0]: c[1] for c in gauge_calls if c[0][0].startswith("amp.index.")}
+
+    assert "amp.index.suggestions_count" in index_calls
+    assert index_calls["amp.index.suggestions_count"]["value"] == 1
+    assert index_calls["amp.index.suggestions_count"]["tags"] == {"index": DEFAULT_IDX_ID}
+
+    assert "amp.index.keyword_index_size" in index_calls
+    assert index_calls["amp.index.keyword_index_size"]["value"] == 5


### PR DESCRIPTION
## References

JIRA: [DISCO-4027](https://mozilla-hub.atlassian.net/browse/DISCO-4027)

## Description
Add gauge metrics for AMP index builds in the MARS backend. After each successful index build, amp.index.* gauges are emitted with stats from the Rust `AmpIndexManager` (e.g. suggestion count, keyword index size), tagged by index ID.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2191)


[DISCO-4027]: https://mozilla-hub.atlassian.net/browse/DISCO-4027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ