### PR TITLE
[DISCO 4055] feat: Record subject ID for TS metrics

### DIFF
--- a/merino/providers/suggest/adm/provider.py
+++ b/merino/providers/suggest/adm/provider.py
@@ -261,23 +261,29 @@ class Provider(BaseProvider):
                 for i, suggestion in enumerate(suggestions)
             ]
 
+            tags = {}
+            if suggestions:
+                # FIXME(nanj): this uses the first element as the subject as `suggestions`
+                # should always be a singleton list. Update it if that's false in the future.
+                tags["subject"] = suggestions[0].advertiser.lower()
+
             # If it's the only candidate with an attempted count less than the threshold, skip sampling.
             if len(candidates) == 1 and candidates[0].metrics.attempted < self.min_attempted_count:
                 self.metrics_client.increment(
-                    "providers.adm.thompson.select", tags={"outcome": "skipped"}
+                    "providers.adm.thompson.select", tags={"outcome": "skipped", **tags}
                 )
                 return suggestions[0]
 
             winner = cast(ThompsonSampler, self.thompson).sample(candidates)
             if winner:
                 self.metrics_client.increment(
-                    "providers.adm.thompson.select", tags={"outcome": "selected"}
+                    "providers.adm.thompson.select", tags={"outcome": "selected", **tags}
                 )
                 winner_idx: int = winner.id
                 return suggestions[winner_idx]
             else:
                 self.metrics_client.increment(
-                    "providers.adm.thompson.select", tags={"outcome": "suppressed"}
+                    "providers.adm.thompson.select", tags={"outcome": "suppressed", **tags}
                 )
                 return None
 

--- a/metrics.yaml
+++ b/metrics.yaml
@@ -245,6 +245,9 @@ suggest/adm:
       - name: outcome
         description: |
           The sampling outcome (selected, suppressed, skipped)
+      - name: subject
+        description: |
+          The identifier of the subject that has gone through Thompson sampling
     scope: |
       The "api/v1/suggest" API endpoint.
     alert_policy: []

--- a/tests/unit/providers/suggest/adm/test_provider_thompson.py
+++ b/tests/unit/providers/suggest/adm/test_provider_thompson.py
@@ -65,7 +65,7 @@ async def test_query_with_thompson_returns_suggestion(
         )
     ]
     statsd_mock.increment.assert_called_once_with(
-        "providers.adm.thompson.select", tags={"outcome": "selected"}
+        "providers.adm.thompson.select", tags={"outcome": "selected", "subject": "example.org"}
     )
 
 
@@ -87,7 +87,7 @@ async def test_query_with_thompson_dummy_suppresses_suggestion(
 
     assert res == []
     statsd_mock.increment.assert_called_once_with(
-        "providers.adm.thompson.select", tags={"outcome": "suppressed"}
+        "providers.adm.thompson.select", tags={"outcome": "suppressed", "subject": "example.org"}
     )
 
 
@@ -219,7 +219,7 @@ async def test_query_with_thompson_single_candidate_below_threshold_returns_sugg
         )
     ]
     statsd_mock.increment.assert_called_once_with(
-        "providers.adm.thompson.select", tags={"outcome": "skipped"}
+        "providers.adm.thompson.select", tags={"outcome": "skipped", "subject": "example.org"}
     )
 
 
@@ -287,7 +287,7 @@ async def test_query_with_thompson_returns_fallback_when_fallback_enabled(
         )
     ]
     statsd_mock.increment.assert_called_once_with(
-        "providers.adm.thompson.select", tags={"outcome": "selected"}
+        "providers.adm.thompson.select", tags={"outcome": "selected", "subject": "example.org"}
     )
 
 
@@ -326,5 +326,5 @@ async def test_query_with_thompson_dummy_return_suggestion_when_fallback_enabled
         )
     ]
     statsd_mock.increment.assert_called_once_with(
-        "providers.adm.thompson.select", tags={"outcome": "suppressed"}
+        "providers.adm.thompson.select", tags={"outcome": "suppressed", "subject": "example.org"}
     )


### PR DESCRIPTION
## References

JIRA: [DISCO-4055](https://mozilla-hub.atlassian.net/browse/DISCO-4055)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2193)


[DISCO-4055]: https://mozilla-hub.atlassian.net/browse/DISCO-4055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ