### PR TITLE
[HNT-2406] Add Particle game endpoint

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -313,6 +313,24 @@ cdn_hostname = ""
 # Set to `true` in production and `false` in staging or development.
 gcs_enabled = true
 
+[default.games_particle_gcs]
+# MERINO_GAMES_PARTICLE_GCS__GCS_PROJECT
+# GCS project name that contains domain data
+gcs_project = ""
+
+# MERINO_GAMES_PARTICLE__GCS_BUCKET
+# GCS bucket that contains domain data files
+gcs_bucket = ""
+
+# MERINO_GAMES_PARTICLE__CDN_HOSTNAME
+# CDN hostname used for public URL
+cdn_hostname = ""
+
+# MERINO_GAMES_PARTICLE_GCS__ENABLED
+# Whether to enable fetching from GCS.
+# Set to `true` in production and `false` in staging or development.
+gcs_enabled = true
+
 [default.engagement]
 # MERINO_ENGAGEMENT__GCS_STORAGE_BUCKET
 gcs_storage_bucket = ""
@@ -1067,6 +1085,23 @@ query_timeout_sec = 1.0
 # MERINO_RSS_PROVIDERS__WIKIMEDIA_POTD__FEED_URL
 # URL for the Wikimedia Picture of the Day RSS feed.
 feed_url = "https://commons.wikimedia.org/w/api.php?action=featuredfeed&feed=potd&feedformat=rss"
+
+[default.games_providers.particle]
+# MERINO_GAMES_PROVIDERS__PARTICLE__TYPE
+# The type of this provider, should be `particle`.
+type = "particle"
+
+# MERINO_GAMES_PROVIDERS__PARTICLE__ENABLED_BY_DEFAULT
+# Whether or not this provider is enabled by default.
+enabled_by_default = false
+
+# MERINO_GAMES_PROVIDERS__PARTICLE__CACHE_TTL
+# The amount of time in seconds for the max-age Cache-control header.
+cache_ttl = 86400 # one day
+
+# MERINO_GAMES_PROVIDERS__PARTICLE__GAME_URL
+# The URL pointing to the game hosted in GCP (GCS)
+game_url = "https://prod-games-particle.merino.prod.webservices.mozgcp.net/index.html"
 
 
 [default.curated_recommendations.gcs]

--- a/merino/configs/production.toml
+++ b/merino/configs/production.toml
@@ -39,6 +39,19 @@ gcs_bucket = "merino-images-prodpy"
 # CDN hostname used for public URLs of stored images
 cdn_hostname = "merino-images.services.mozilla.com"
 
+[production.games_particle_gcs]
+# MERINO_GAMES_PARTICLE__GCS_PROJECT
+# GCS project name that contains domain data (GCP V2)
+gcs_project = "moz-fx-merino-prod-5de4"
+
+# MERINO_GAMES_PARTICLE__GCS_BUCKET
+# GCS bucket that contains domain data files (GCP V2)
+gcs_bucket = "merino-games-particle-prod"
+
+# MERINO_GAMES_PARTICLE__CDN_HOSTNAME
+# CDN hostname used for public URL (GCP V2)
+cdn_hostname = "prod-games-particle.merino.prod.webservices.mozgcp.net"
+
 
 [production.engagement]
 # MERINO_ENGAGEMENT__GCS_STORAGE_BUCKET

--- a/merino/configs/stage.toml
+++ b/merino/configs/stage.toml
@@ -32,13 +32,21 @@ gcs_bucket = "merino-images-stagepy"
 # Set to `true` in production and `false` in staging or development.
 gcs_enabled = false
 
-
 [stage.image_gcs_v2]
 # MERINO_IMAGE_GCS_V2__GCS_PROJECT
 gcs_project = "moz-fx-merino-nonprod-ee93"
 
 # MERINO_IMAGE_GCS_V2__GCS_BUCKET
 gcs_bucket = "merino-images-stagepy"
+
+[stage.games_particle.gcs]
+# MERINO_GAMES_PARTICLE_GCS__GCS_PROJECT (GCP V2)
+gcs_project = "moz-fx-merino-nonprod-db57"
+
+# MERINO_GAMES_PARTICLE_GCS__ENABLED
+# Whether to enable fetching from GCS.
+# Set to `true` in production and `false` in staging or development.
+gcs_enabled = false
 
 [stage.providers.top_picks]
 # MERINO_PROVIDERS__TOP_PICKS__DOMAIN_DATA_SOURCE

--- a/merino/main.py
+++ b/merino/main.py
@@ -15,7 +15,7 @@ from merino import curated_recommendations, governance
 from merino.providers import rss
 from merino.configs.app_configs.config_logging import configure_logging
 from merino.configs.app_configs.config_sentry import configure_sentry
-from merino.providers import suggest, manifest
+from merino.providers import games, manifest, suggest
 from merino.utils.metrics import configure_metrics, get_metrics_client
 from merino.middleware import featureflags, geolocation, logging as mw_logging, metrics, user_agent
 from merino.web import api_v1, dockerflow
@@ -48,6 +48,7 @@ async def lifespan(app: FastAPI):
     await manifest.init_provider()
     await rss.init_providers()
     curated_recommendations.init_provider()
+    await games.init_providers()
     governance.start()
     yield
     governance.shutdown()

--- a/merino/providers/games/__init__.py
+++ b/merino/providers/games/__init__.py
@@ -1,0 +1,42 @@
+"""Initialize game providers."""
+
+from merino.configs import settings
+
+from merino.providers.games.particle.backends.particle import ParticleBackend
+from merino.providers.games.particle.provider import Provider
+
+from merino.utils.gcs.gcs_uploader import GcsUploader
+from merino.utils.metrics import get_metrics_client
+
+_particle_provider: Provider
+
+# Module-level variables as looking up from settings each time is expensive.
+_gcs_project = settings.games_particle_gcs.gcs_project
+_gcs_bucket = settings.games_particle_gcs.gcs_bucket
+_gcs_cdn_hostname = settings.games_particle_gcs.cdn_hostname
+
+
+async def init_providers() -> None:
+    """Initialize games providers - currently only Particle"""
+    global _particle_provider
+
+    gcs_uploader = GcsUploader(
+        _gcs_project,
+        _gcs_bucket,
+        _gcs_cdn_hostname,
+    )
+    metrics_client = get_metrics_client()
+
+    particle_backend = ParticleBackend(gcs_uploader=gcs_uploader, metrics_client=metrics_client)
+
+    _particle_provider = Provider(
+        backend=particle_backend, metrics_client=metrics_client, name="Particle Provider"
+    )
+
+    await _particle_provider.initialize()
+
+
+def get_particle_provider() -> Provider:
+    """Return the provider for the Particle game"""
+    global _particle_provider
+    return _particle_provider

--- a/merino/providers/games/particle/__init__.py
+++ b/merino/providers/games/particle/__init__.py
@@ -1,0 +1,1 @@
+"""Particle game provider"""

--- a/merino/providers/games/particle/backends/__init__.py
+++ b/merino/providers/games/particle/backends/__init__.py
@@ -1,0 +1,1 @@
+"""Backends for the Particle game provider."""

--- a/merino/providers/games/particle/backends/particle.py
+++ b/merino/providers/games/particle/backends/particle.py
@@ -1,0 +1,33 @@
+"""Particle game backend."""
+
+import logging
+import aiodogstatsd
+
+from merino.configs import settings
+from merino.providers.games.particle.backends.protocol import Particle
+from merino.utils.gcs.gcs_uploader import GcsUploader
+
+logger = logging.getLogger(__name__)
+
+# Module-level variable as retrieving from settings each time is expensive.
+_game_url = settings.games_providers.particle.game_url
+
+
+class ParticleBackend:
+    """Backend for managing and returning Particle game data."""
+
+    gcs_uploader: GcsUploader
+    metrics_client: aiodogstatsd.Client
+
+    def __init__(
+        self,
+        gcs_uploader: GcsUploader,
+        metrics_client: aiodogstatsd.Client,
+    ) -> None:
+        """Initialize the Polygon backend."""
+        self.gcs_uploader = gcs_uploader
+        self.metrics_client = metrics_client
+
+    async def get_game_url(self) -> Particle | None:
+        """Return the public URL for the Particle game"""
+        return Particle(url=_game_url)

--- a/merino/providers/games/particle/backends/protocol.py
+++ b/merino/providers/games/particle/backends/protocol.py
@@ -1,0 +1,28 @@
+"""Protocol for Particle provider backend."""
+
+from pydantic import BaseModel, Field
+
+from typing import Protocol
+
+
+class Particle(BaseModel):
+    """Model for Particle game data"""
+
+    url: str = Field(description="Public URL for the game")
+
+
+class ParticleBackend(Protocol):
+    """Protocol for a weather backend that this provider depends on.
+
+    Note: This only defines the methods used by the provider. The actual backend
+    might define additional methods and attributes which this provider doesn't
+    directly depend on.
+    """
+
+    async def get_game_url(self) -> Particle | None:
+        """Fetch the Particle game data.
+
+        Returns:
+            A Particle instance if data is available/valid, otherwise None.
+        """
+        ...

--- a/merino/providers/games/particle/provider.py
+++ b/merino/providers/games/particle/provider.py
@@ -1,0 +1,38 @@
+"""Particle integration."""
+
+import logging
+from typing import Any
+
+import aiodogstatsd
+
+from merino.providers.games.particle.backends.protocol import Particle, ParticleBackend
+
+logger = logging.getLogger(__name__)
+
+
+class Provider:
+    """Particle provider for games."""
+
+    backend: ParticleBackend
+    metrics_client: aiodogstatsd.Client
+
+    def __init__(
+        self,
+        backend: ParticleBackend,
+        metrics_client: aiodogstatsd.Client,
+        name: str,
+        enabled_by_default: bool = False,
+        **kwargs: Any,
+    ) -> None:
+        self.backend = backend
+        self.metrics_client = metrics_client
+        self.name = name
+        self._enabled_by_default = enabled_by_default
+        super().__init__(**kwargs)
+
+    async def initialize(self) -> None:
+        """Initialize the provider."""
+
+    async def get_game_url(self) -> Particle | None:
+        """Proxy get_game_url from Particle backend"""
+        return await self.backend.get_game_url()

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -66,6 +66,10 @@ from merino.web.models_v1 import ProviderResponse, SuggestResponse
 from merino.providers.manifest.provider import Provider as ManifestProvider
 from merino.providers.suggest.weather.provider import Provider as WeatherProvider
 
+from merino.providers.games import get_particle_provider
+from merino.providers.games.particle.backends.protocol import Particle
+from merino.providers.games.particle.provider import Provider as ParticleProvider
+
 logger = logging.getLogger(__name__)
 router = APIRouter()
 
@@ -577,4 +581,32 @@ async def get_picture_of_the_day(
     return ORJSONResponse(
         content=jsonable_encoder(potd),
         headers={"Cache-Control": "private, max-age=86400"},
+    )
+
+
+# Module-level variable as retrieving from settings on each
+# call is expensive
+_games_particle_ttl = settings.games_providers.particle.cache_ttl
+
+
+@router.get(
+    "/games/particle",
+    tags=["Games"],
+    summary="Particle game for New Tab",
+    response_model=Particle,
+)
+async def get_game_particle(
+    request: Request, provider: ParticleProvider = Depends(get_particle_provider)
+) -> ORJSONResponse:
+    """Return a JSON object containing the public URL for the Particle game."""
+    particle_data = None
+
+    try:
+        particle_data = await provider.get_game_url()
+    except Exception as ex:
+        logger.info(f"Error when fetching Particle game data: {ex.__class__.__name__}")
+
+    return ORJSONResponse(
+        content=jsonable_encoder(particle_data),
+        headers={"Cache-Control": (f"private, max-age={_games_particle_ttl}")},
     )

--- a/tests/unit/providers/games/__init__.py
+++ b/tests/unit/providers/games/__init__.py
@@ -1,0 +1,5 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Unit tests for Games providers."""

--- a/tests/unit/providers/games/particle/__init__.py
+++ b/tests/unit/providers/games/particle/__init__.py
@@ -1,0 +1,5 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Unit tests for the Particle games provider."""

--- a/tests/unit/providers/games/particle/backends/__init__.py
+++ b/tests/unit/providers/games/particle/backends/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Particle backends."""

--- a/tests/unit/providers/games/particle/backends/test_particle_backend.py
+++ b/tests/unit/providers/games/particle/backends/test_particle_backend.py
@@ -1,0 +1,41 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Unit tests for the Particle backend."""
+
+import pytest
+from unittest.mock import MagicMock
+
+from merino.configs import settings
+from merino.utils.gcs.gcs_uploader import GcsUploader
+from merino.providers.games.particle.backends.particle import ParticleBackend
+
+_game_url = settings.games_providers.particle.game_url
+
+
+@pytest.fixture(name="gcs_uploader_mock")
+def fixture_gcs_uploader_mock() -> GcsUploader:
+    """Return a mock GcsUploader."""
+    return MagicMock(spec=GcsUploader)
+
+
+@pytest.fixture(name="backend")
+def fixture_backend(
+    statsd_mock,
+    gcs_uploader_mock: GcsUploader,
+) -> ParticleBackend:
+    """Return a WikimediaPotdBackend instance for testing."""
+    return ParticleBackend(
+        metrics_client=statsd_mock,
+        gcs_uploader=gcs_uploader_mock,
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_pitcture_of_the_day_returns_correct_potd(backend: ParticleBackend) -> None:
+    """Test that get_game_url."""
+    result = await backend.get_game_url()
+
+    assert result is not None
+    assert result.url == _game_url

--- a/tests/unit/providers/games/particle/test_provider.py
+++ b/tests/unit/providers/games/particle/test_provider.py
@@ -69,7 +69,7 @@ async def test_get_game_url_returns_none_when_backend_returns_none(
 
 
 @pytest.mark.asyncio
-async def test_get_game_url_returns_correct_potd(
+async def test_get_game_url_returns_correct_particle(
     provider: Provider, backend_mock, test_particle
 ) -> None:
     """Test that get_game_url returns a correct Particle instance."""

--- a/tests/unit/providers/games/particle/test_provider.py
+++ b/tests/unit/providers/games/particle/test_provider.py
@@ -1,0 +1,81 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Unit tests for the Particle games provider."""
+
+import pytest
+from pytest_mock import MockerFixture
+
+from merino.providers.games.particle.backends.protocol import (
+    Particle,
+    ParticleBackend,
+)
+from merino.providers.games.particle.provider import Provider
+
+
+test_game_url = "https://test.test"
+
+
+@pytest.fixture(name="backend_mock")
+def fixture_backend_mock(mocker: MockerFixture):
+    """Return a mock ParticleBackend."""
+    return mocker.AsyncMock(spec=ParticleBackend)
+
+
+@pytest.fixture(name="provider")
+def fixture_provider(statsd_mock, backend_mock: ParticleBackend) -> Provider:
+    """Return a Provider instance for testing."""
+    return Provider(
+        backend=backend_mock,
+        metrics_client=statsd_mock,
+        name="particle",
+        enabled_by_default=False,
+    )
+
+
+@pytest.fixture(name="test_particle")
+def fixture_test_particle() -> Particle:
+    """Return a test Particle instance."""
+    return Particle(url=test_game_url)
+
+
+def test_provider_name(provider: Provider) -> None:
+    """Test that the provider name is set correctly."""
+    assert provider.name == "particle"
+
+
+def test_provider_enabled_by_default(provider: Provider) -> None:
+    """Test that enabled_by_default is set correctly."""
+    assert provider._enabled_by_default is False
+
+
+@pytest.mark.asyncio
+async def test_initialize(provider: Provider) -> None:
+    """Test that initialize completes without error."""
+    await provider.initialize()
+
+
+@pytest.mark.asyncio
+async def test_get_game_url_returns_none_when_backend_returns_none(
+    provider: Provider, backend_mock
+) -> None:
+    """Test that get_game_url returns an empty Particle when backend returns None."""
+    backend_mock.get_game_url.return_value = None
+
+    particle = await provider.get_game_url()
+
+    assert particle is None
+
+
+@pytest.mark.asyncio
+async def test_get_game_url_returns_correct_potd(
+    provider: Provider, backend_mock, test_particle
+) -> None:
+    """Test that get_game_url returns a correct Particle instance."""
+    backend_mock.get_game_url.return_value = test_particle
+
+    particle = await provider.get_game_url()
+
+    assert particle is not None
+    assert particle.url == test_game_url


### PR DESCRIPTION
## References

JIRA: [HNT-2406](https://mozilla-hub.atlassian.net/browse/HNT-2406) Create new merino endpoint for FE to hit for the game page

## Description

Adds an endpoint for the Particle game, currently returning only the CDN URL (which will be used as the `src` of an `iframe` on New Tab). This is currently skeleton-ish - more logic will be added to the new backend to poll Particle for updated game files and upload them to the GCS bucket.

This PR is primarily in service of unblocking the front-end for end-to-end testing.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2194)


[HNT-2406]: https://mozilla-hub.atlassian.net/browse/HNT-2406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ