### PR TITLE
DISCO-4057 Track byte size of MARS response

### DIFF
--- a/merino/providers/suggest/adm/backends/mars.py
+++ b/merino/providers/suggest/adm/backends/mars.py
@@ -258,6 +258,12 @@ class MarsBackend:
 
             response.raise_for_status()
 
+            self.metrics_client.gauge(
+                "mars.fetch.response_size_bytes",
+                value=len(response.content),
+                tags=tags,
+            )
+
             etag = response.headers.get("ETag")
             if etag:
                 self.etags[idx_id] = etag

--- a/metrics.yaml
+++ b/metrics.yaml
@@ -272,6 +272,23 @@ suggest/mars:
       The ADM provider MARS backend data sync.
     alert_policy: []
 
+  mars_fetch_response_size_bytes:
+    description: |
+      A gauge tracking the raw HTTP response body size in bytes from the MARS
+      suggest/data endpoint. Useful for monitoring payload growth, especially
+      when testing large responses (e.g. segmented caching validation).
+    type: gauge
+    labels:
+      - name: country
+        description: |
+          The country code for the fetched segment
+      - name: form_factor
+        description: |
+          The form factor for the fetched segment
+    scope: |
+      The ADM provider MARS backend data sync.
+    alert_policy: []
+
   mars_data_staleness_seconds:
     description: |
       A gauge tracking the time in seconds since the last successful data fetch

--- a/tests/unit/providers/suggest/adm/backends/test_mars.py
+++ b/tests/unit/providers/suggest/adm/backends/test_mars.py
@@ -628,6 +628,29 @@ async def test_last_new_data_at_set_on_success(
 
 
 @pytest.mark.asyncio
+async def test_fetch_response_size_metric(
+    mocker: MockerFixture,
+    mars_backend: MarsBackend,
+    suggestion_json: str,
+    suggestion_response: httpx.Response,
+) -> None:
+    """Test that mars.fetch.response_size_bytes gauge is emitted on 200."""
+    mocker.patch.object(
+        httpx.AsyncClient,
+        "get",
+        return_value=suggestion_response,
+    )
+
+    await mars_backend.fetch()
+
+    mars_backend.metrics_client.gauge.assert_any_call(  # type: ignore[attr-defined]
+        "mars.fetch.response_size_bytes",
+        value=len(suggestion_json.encode()),
+        tags={"country": "US", "form_factor": "desktop"},
+    )
+
+
+@pytest.mark.asyncio
 async def test_index_metrics_emitted_after_build(
     mocker: MockerFixture,
     mars_backend: MarsBackend,


### PR DESCRIPTION
## References

JIRA: [DISCO-4057DO](https://mozilla-hub.atlassian.net/browse/DISCO-4057)

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2196)
