### PR TITLE
[DISCO 4058] chore: Enable Thompson sampling in dryrun mode

### DIFF
--- a/merino/configs/production.toml
+++ b/merino/configs/production.toml
@@ -63,6 +63,28 @@ gcs_bucket = "merino-images-prod"
 # CDN hostname used for public URLs of stored images
 cdn_hostname = "prod-images.merino.prod.webservices.mozgcp.net"
 
+[production.providers.adm.thompson]
+# MERINO_PROVIDERS__ADM__THOMPSON__ENABLED
+enabled = true
+
+# MERINO_PROVIDERS__ADM__THOMPSON__DUMMY_ENABLED
+dummy_enabled = true
+
+# MERINO_PROVIDERS__ADM__THOMPSON__MIN_ATTEMPTED_COUNT
+min_attempted_count = 500
+
+# MERINO_PROVIDERS__ADM__THOMPSON__DUMMY_ENGAGED_COUNT
+dummy_engaged_count = 1
+
+# MERINO_PROVIDERS__ADM__THOMPSON__DUMMY_ATTEMPTED_COUNT
+dummy_attempted_count = 1000
+
+# MERINO_PROVIDERS__ADM__THOMPSON__CHECK_CLIENT_VARIANTS
+check_client_variants = false
+
+# MERINO_PROVIDERS__ADM__THOMPSON__DRY_RUN
+dry_run = true
+
 [production.providers.top_picks]
 # MERINO_PROVIDERS__TOP_PICKS__DOMAIN_DATA_SOURCE
 # Enum of either `remote` or `local` that defines whether domain data


### PR DESCRIPTION
## References

JIRA: [DISCO-4058](https://mozilla-hub.atlassian.net/browse/DISCO-4058)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->

Enable Thompson sampling for AMP in dryrun mode.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2197)


[DISCO-4058]: https://mozilla-hub.atlassian.net/browse/DISCO-4058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ