### PR TITLE
DISCO-4060 Use naming for proper index labelling

### DIFF
--- a/merino/providers/suggest/adm/backends/mars.py
+++ b/merino/providers/suggest/adm/backends/mars.py
@@ -84,10 +84,10 @@ class MarsBackend:
         self.etags = {}
         self.last_new_data_at = 0.0
 
-    def _emit_index_metrics(self, idx_id: str) -> None:
+    def _emit_index_metrics(self, idx_id: str, index_label: str) -> None:
         """Emit gauge metrics for the amp index after a successful build."""
         stats = self.suggestion_content.index_manager.stats(idx_id)
-        tags = {"index": idx_id}
+        tags = {"index": index_label}
         for key, value in stats.items():
             self.metrics_client.gauge(f"amp.index.{key}", value=value, tags=tags)
 
@@ -117,11 +117,13 @@ class MarsBackend:
 
         # Build the list of segments.
         segments: list[tuple[str, SegmentType, str, str]] = []
+        segment_labels: dict[SegmentType, str] = {}
         for country in countries:
             for form_factor in form_factors:
                 segment = self.get_segment(form_factor)
                 idx_id = f"{country}/{segment}"
                 segments.append((country, segment, form_factor, idx_id))
+                segment_labels[segment] = form_factor
 
         # Fetch suggestion data for all segments concurrently.
         mars_suggestions: defaultdict[str, dict[SegmentType, str]] = await self.get_suggestions(
@@ -140,7 +142,8 @@ class MarsBackend:
                     icons_in_use = icons_in_use.union(
                         self.suggestion_content.index_manager.list_icons(idx_id)
                     )
-                    self._emit_index_metrics(idx_id)
+                    index_label = f"{country}/{segment_labels.get(segment, str(segment))}"
+                    self._emit_index_metrics(idx_id, index_label)
                 except Exception as e:
                     logger.warning(
                         f"Unable to build index or get icons for {idx_id}",

--- a/tests/unit/providers/suggest/adm/backends/test_mars.py
+++ b/tests/unit/providers/suggest/adm/backends/test_mars.py
@@ -647,7 +647,7 @@ async def test_index_metrics_emitted_after_build(
 
     assert "amp.index.suggestions_count" in index_calls
     assert index_calls["amp.index.suggestions_count"]["value"] == 1
-    assert index_calls["amp.index.suggestions_count"]["tags"] == {"index": DEFAULT_IDX_ID}
+    assert index_calls["amp.index.suggestions_count"]["tags"] == {"index": "US/desktop"}
 
     assert "amp.index.keyword_index_size" in index_calls
     assert index_calls["amp.index.keyword_index_size"]["value"] == 5


### PR DESCRIPTION
## References

JIRA: [DISCO-4060](https://mozilla-hub.atlassian.net/browse/DISCO-4060)

## Description
The index labeling is currently printing out the index number instead of the name. This PR aims to fix that.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2198)


[DISCO-4060]: https://mozilla-hub.atlassian.net/browse/DISCO-4060?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ