### PR TITLE
[HNT-2147] Set up wikimedia potd rss endpoint

### DIFF
--- a/merino/providers/rss/__init__.py
+++ b/merino/providers/rss/__init__.py
@@ -3,7 +3,7 @@
 import logging
 
 from merino.providers.rss.base import BaseRssProvider
-from merino.providers.rss.wikimedia_potd.provider import WikimediaPotdProvider
+from merino.providers.rss.wikimedia_potd.provider import WikimediaPictureOfTheDayProvider
 from merino.providers.rss.manager import load_providers
 
 logger = logging.getLogger(__name__)
@@ -35,8 +35,8 @@ async def shutdown_providers() -> None:
         logger.info("RSS provider shut down", extra={"provider": name})
 
 
-def get_wikimedia_potd_provider() -> WikimediaPotdProvider:
+def get_wikimedia_potd_provider() -> WikimediaPictureOfTheDayProvider:
     """Return the Wikimedia Picture of the Day provider."""
     provider = providers["wikimedia_potd"]
-    assert isinstance(provider, WikimediaPotdProvider)
+    assert isinstance(provider, WikimediaPictureOfTheDayProvider)
     return provider

--- a/merino/providers/rss/manager.py
+++ b/merino/providers/rss/manager.py
@@ -11,7 +11,7 @@ from merino.providers.rss.base import BaseRssProvider
 from merino.providers.rss.wikimedia_potd.backends.wikimedia_potd import (
     WikimediaPotdBackend,
 )
-from merino.providers.rss.wikimedia_potd.provider import WikimediaPotdProvider
+from merino.providers.rss.wikimedia_potd.provider import WikimediaPictureOfTheDayProvider
 from merino.utils.metrics import get_metrics_client
 
 
@@ -35,7 +35,7 @@ def _create_provider(provider_id: str, setting: Settings) -> BaseRssProvider:
                 connect_timeout=settings.rss_providers.wikimedia_potd.connect_timeout_sec,
             )
 
-            return WikimediaPotdProvider(
+            return WikimediaPictureOfTheDayProvider(
                 backend=WikimediaPotdBackend(
                     feed_url=setting.feed_url,
                     gcs_uploader=GcsUploader(

--- a/merino/providers/rss/wikimedia_potd/backends/protocol.py
+++ b/merino/providers/rss/wikimedia_potd/backends/protocol.py
@@ -1,21 +1,24 @@
 """Protocol for Wikimedia Picture of the Day provider backends."""
 
 from typing import Protocol
-
 from pydantic import BaseModel, Field
 
 
-class Potd(BaseModel):
+class PictureOfTheDay(BaseModel):
     """Model for the Wikimedia Picture of the Day."""
 
     title: str = Field(description="Title of the picture of the day.")
-    image_url: str = Field(description="URL of the picture of the day image.")
+    thumbnail_image_url: str = Field(description="Thumbnail URL of the picture of the day image.")
+    high_res_image_url: str = Field(
+        description="High resolution URL of the picture of the day image."
+    )
+    published_date: str = Field(description="Date when the image was published.")
 
 
-class WikimediaPotdBackend(Protocol):
+class WikimediaPictureOfTheDayBackend(Protocol):
     """Protocol for a Wikimedia POTD backend that this provider depends on."""
 
-    async def get_picture_of_the_day(self) -> Potd | None:  # pragma: no cover
+    async def get_picture_of_the_day(self) -> PictureOfTheDay | None:  # pragma: no cover
         """Fetch the current Wikimedia Picture of the Day.
 
         Returns:

--- a/merino/providers/rss/wikimedia_potd/backends/protocol.py
+++ b/merino/providers/rss/wikimedia_potd/backends/protocol.py
@@ -1,15 +1,17 @@
 """Protocol for Wikimedia Picture of the Day provider backends."""
 
 from typing import Protocol
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, HttpUrl
 
 
 class PictureOfTheDay(BaseModel):
     """Model for the Wikimedia Picture of the Day."""
 
     title: str = Field(description="Title of the picture of the day.")
-    thumbnail_image_url: str = Field(description="Thumbnail URL of the picture of the day image.")
-    high_res_image_url: str = Field(
+    thumbnail_image_url: HttpUrl = Field(
+        description="Thumbnail URL of the picture of the day image."
+    )
+    high_res_image_url: HttpUrl = Field(
         description="High resolution URL of the picture of the day image."
     )
     published_date: str = Field(description="Date when the image was published.")

--- a/merino/providers/rss/wikimedia_potd/backends/wikimedia_potd.py
+++ b/merino/providers/rss/wikimedia_potd/backends/wikimedia_potd.py
@@ -3,7 +3,7 @@
 import aiodogstatsd
 from httpx import AsyncClient
 
-from merino.providers.rss.wikimedia_potd.backends.protocol import Potd
+from merino.providers.rss.wikimedia_potd.backends.protocol import PictureOfTheDay
 from merino.utils.gcs.gcs_uploader import GcsUploader
 
 
@@ -27,10 +27,16 @@ class WikimediaPotdBackend:
         self.http_client = http_client
         self.gcs_uploader = gcs_uploader
 
-    async def get_picture_of_the_day(self) -> Potd | None:
+    async def get_picture_of_the_day(self) -> PictureOfTheDay | None:
         """Fetch the current Wikimedia Picture of the Day.
 
         Returns:
             A Potd instance if data is available, otherwise None.
         """
-        return None
+        # NOTE: These are hardcoded for now as a test. The urls are public.
+        return PictureOfTheDay(
+            title="Sample Picture Title",
+            thumbnail_image_url="https://storage.googleapis.com/merino-images-prod/rss/wikimedia_potd/POTD_2026_04_13.jpg",
+            high_res_image_url="https://storage.googleapis.com/merino-images-prod/rss/wikimedia_potd/POTD_hi_res_2026_4_13.jpg",
+            published_date="Mon, 13 Apr 2026 00:00:00 GMT",
+        )

--- a/merino/providers/rss/wikimedia_potd/backends/wikimedia_potd.py
+++ b/merino/providers/rss/wikimedia_potd/backends/wikimedia_potd.py
@@ -2,6 +2,7 @@
 
 import aiodogstatsd
 from httpx import AsyncClient
+from pydantic import HttpUrl
 
 from merino.providers.rss.wikimedia_potd.backends.protocol import PictureOfTheDay
 from merino.utils.gcs.gcs_uploader import GcsUploader
@@ -37,7 +38,11 @@ class WikimediaPotdBackend:
         # dynamic logic will be added in follow up work.
         return PictureOfTheDay(
             title="Wikimedia Commons picture of the day",
-            thumbnail_image_url="https://storage.googleapis.com/merino-images-prod/rss/wikimedia_potd/POTD_2026_04_13.jpg",
-            high_res_image_url="https://storage.googleapis.com/merino-images-prod/rss/wikimedia_potd/POTD_hi_res_2026_4_13.jpg",
+            thumbnail_image_url=HttpUrl(
+                "https://storage.googleapis.com/merino-images-prod/rss/wikimedia_potd/POTD_2026_04_13.jpg"
+            ),
+            high_res_image_url=HttpUrl(
+                "https://storage.googleapis.com/merino-images-prod/rss/wikimedia_potd/POTD_hi_res_2026_4_13.jpg"
+            ),
             published_date="Mon, 13 Apr 2026 00:00:00 GMT",
         )

--- a/merino/providers/rss/wikimedia_potd/backends/wikimedia_potd.py
+++ b/merino/providers/rss/wikimedia_potd/backends/wikimedia_potd.py
@@ -31,11 +31,12 @@ class WikimediaPotdBackend:
         """Fetch the current Wikimedia Picture of the Day.
 
         Returns:
-            A Potd instance if data is available, otherwise None.
+            A PictureOfTheDay instance if data is available, otherwise None.
         """
-        # NOTE: These are hardcoded for now as a test. The urls are public.
+        # NOTE: These are hardcoded for now to unblock FE testing. The urls are public.
+        # dynamic logic will be added in follow up work.
         return PictureOfTheDay(
-            title="Sample Picture Title",
+            title="Wikimedia Commons picture of the day",
             thumbnail_image_url="https://storage.googleapis.com/merino-images-prod/rss/wikimedia_potd/POTD_2026_04_13.jpg",
             high_res_image_url="https://storage.googleapis.com/merino-images-prod/rss/wikimedia_potd/POTD_hi_res_2026_4_13.jpg",
             published_date="Mon, 13 Apr 2026 00:00:00 GMT",

--- a/merino/providers/rss/wikimedia_potd/provider.py
+++ b/merino/providers/rss/wikimedia_potd/provider.py
@@ -12,10 +12,6 @@ from merino.providers.rss.wikimedia_potd.backends.protocol import (
 
 logger = logging.getLogger(__name__)
 
-FALLBACK_POTD = PictureOfTheDay(
-    title="", thumbnail_image_url="", high_res_image_url="", published_date=""
-)
-
 
 class WikimediaPictureOfTheDayProvider(BaseRssProvider):
     """Provider for the Wikimedia Picture of the Day feed."""
@@ -44,10 +40,10 @@ class WikimediaPictureOfTheDayProvider(BaseRssProvider):
     async def initialize(self) -> None:
         """Initialize the provider."""
 
-    async def get_picture_of_the_day(self) -> PictureOfTheDay:
+    async def get_picture_of_the_day(self) -> PictureOfTheDay | None:
         """Return the current Wikimedia Picture of the Day."""
         potd = await self.backend.get_picture_of_the_day()
-        return potd if potd is not None else FALLBACK_POTD
+        return potd if potd else None
 
     async def shutdown(self) -> None:
         """Shut down the provider."""

--- a/merino/providers/rss/wikimedia_potd/provider.py
+++ b/merino/providers/rss/wikimedia_potd/provider.py
@@ -6,24 +6,28 @@ from pydantic import HttpUrl
 
 from merino.providers.rss.base import BaseRssProvider
 from merino.providers.rss.wikimedia_potd.backends.protocol import (
-    Potd,
-    WikimediaPotdBackend,
+    PictureOfTheDay,
+    WikimediaPictureOfTheDayBackend,
 )
 
 logger = logging.getLogger(__name__)
 
+FALLBACK_POTD = PictureOfTheDay(
+    title="", thumbnail_image_url="", high_res_image_url="", published_date=""
+)
 
-class WikimediaPotdProvider(BaseRssProvider):
+
+class WikimediaPictureOfTheDayProvider(BaseRssProvider):
     """Provider for the Wikimedia Picture of the Day feed."""
 
-    backend: WikimediaPotdBackend
+    backend: WikimediaPictureOfTheDayBackend
     metrics_client: aiodogstatsd.Client
     url: HttpUrl
     manifest_data: None
 
     def __init__(
         self,
-        backend: WikimediaPotdBackend,
+        backend: WikimediaPictureOfTheDayBackend,
         metrics_client: aiodogstatsd.Client,
         name: str,
         query_timeout_sec: float,
@@ -40,10 +44,10 @@ class WikimediaPotdProvider(BaseRssProvider):
     async def initialize(self) -> None:
         """Initialize the provider."""
 
-    async def get_picture_of_the_day(self) -> Potd:
+    async def get_picture_of_the_day(self) -> PictureOfTheDay:
         """Return the current Wikimedia Picture of the Day."""
         potd = await self.backend.get_picture_of_the_day()
-        return potd if potd is not None else Potd(title="", image_url="")
+        return potd if potd is not None else FALLBACK_POTD
 
     async def shutdown(self) -> None:
         """Shut down the provider."""

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -38,7 +38,8 @@ from merino.curated_recommendations.legacy.protocol import (
 from merino.middleware import ScopeKey
 from merino.middleware.user_agent import UserAgent
 from merino.providers.rss import get_wikimedia_potd_provider
-from merino.providers.rss.wikimedia_potd.provider import Potd, WikimediaPotdProvider
+from merino.providers.rss.wikimedia_potd.backends.protocol import PictureOfTheDay
+from merino.providers.rss.wikimedia_potd.provider import WikimediaPictureOfTheDayProvider
 from merino.providers.suggest import get_providers as get_suggest_providers
 from merino.providers.suggest import get_weather_provider
 from merino.providers.manifest import get_provider as get_manifest_provider
@@ -553,21 +554,26 @@ async def get_hourly_forecasts(
             headers={"Cache-Control": (f"private, max-age={ttl}")},
         )
 
+
 @router.get(
-    "/rss/potd",
+    "/rss/picture-of-the-day",
     tags=["rss"],
     summary="Get picture of the day",
-    response_model=Potd
+    response_model=PictureOfTheDay,
 )
-async def get_potd(request: Request, provider: WikimediaPotdProvider = Depends(get_wikimedia_potd_provider)) -> ORJSONResponse:
-    """Get picture of the day"""
-    # TODO undo when needed
-    # metrics_client: Client = request.scope[ScopeKey.METRICS_CLIENT]
+async def get_picture_of_the_day(
+    request: Request,
+    provider: WikimediaPictureOfTheDayProvider = Depends(get_wikimedia_potd_provider),
+) -> ORJSONResponse:
+    """Get the picture of the day."""
+    potd = None
     try:
-        if(potd := await provider.get_picture_of_the_day() is not None):
-            return ORJSONResponse(
-                content=jsonable_encoder(potd),
-                #headers={"Cache-Control": (f"private, max-age={ttl}")},
-            )
-    except Exception:
-        return ORJSONResponse(content={})
+        potd = await provider.get_picture_of_the_day()
+    except Exception as ex:
+        logger.info(f"Something went wrong when fetching potd: {ex.__class__.__name__}")
+
+    # TODO figure out ttl
+    return ORJSONResponse(
+        content=jsonable_encoder(potd),
+        # headers={"Cache-Control": (f"private, max-age={ttl}")},
+    )

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -572,7 +572,7 @@ async def get_picture_of_the_day(
     except Exception as ex:
         logger.info(f"Something went wrong when fetching potd: {ex.__class__.__name__}")
 
-    # TTL is temporarily hardcoded for 24h.
+    # TTL is temporarily hardcoded as 24h.
     # Will be dynamically calculated in follow up work.
     return ORJSONResponse(
         content=jsonable_encoder(potd),

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -572,8 +572,9 @@ async def get_picture_of_the_day(
     except Exception as ex:
         logger.info(f"Something went wrong when fetching potd: {ex.__class__.__name__}")
 
-    # TODO figure out ttl
+    # TTL is temporarily hardcoded for 24h.
+    # Will be dynamically calculated in follow up work.
     return ORJSONResponse(
         content=jsonable_encoder(potd),
-        # headers={"Cache-Control": (f"private, max-age={ttl}")},
+        headers={"Cache-Control": "private, max-age=86400"},
     )

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -37,6 +37,8 @@ from merino.curated_recommendations.legacy.protocol import (
 )
 from merino.middleware import ScopeKey
 from merino.middleware.user_agent import UserAgent
+from merino.providers.rss import get_wikimedia_potd_provider
+from merino.providers.rss.wikimedia_potd.provider import Potd, WikimediaPotdProvider
 from merino.providers.suggest import get_providers as get_suggest_providers
 from merino.providers.suggest import get_weather_provider
 from merino.providers.manifest import get_provider as get_manifest_provider
@@ -550,3 +552,22 @@ async def get_hourly_forecasts(
             content=jsonable_encoder(hourly_forecasts),
             headers={"Cache-Control": (f"private, max-age={ttl}")},
         )
+
+@router.get(
+    "/rss/potd",
+    tags=["rss"],
+    summary="Get picture of the day",
+    response_model=Potd
+)
+async def get_potd(request: Request, provider: WikimediaPotdProvider = Depends(get_wikimedia_potd_provider)) -> ORJSONResponse:
+    """Get picture of the day"""
+    # TODO undo when needed
+    # metrics_client: Client = request.scope[ScopeKey.METRICS_CLIENT]
+    try:
+        if(potd := await provider.get_picture_of_the_day() is not None):
+            return ORJSONResponse(
+                content=jsonable_encoder(potd),
+                #headers={"Cache-Control": (f"private, max-age={ttl}")},
+            )
+    except Exception:
+        return ORJSONResponse(content={})

--- a/tests/unit/providers/rss/wikimedia_potd/backends/test_wikimedia_potd_backend.py
+++ b/tests/unit/providers/rss/wikimedia_potd/backends/test_wikimedia_potd_backend.py
@@ -7,6 +7,7 @@
 import pytest
 from unittest.mock import MagicMock
 from httpx import AsyncClient
+from pydantic import HttpUrl
 
 from merino.utils.gcs.gcs_uploader import GcsUploader
 from merino.providers.rss.wikimedia_potd.backends.wikimedia_potd import (
@@ -44,8 +45,12 @@ def fixture_backend(
 
 
 @pytest.mark.asyncio
-async def test_fetch_returns_none(backend: WikimediaPotdBackend) -> None:
-    """Test that fetch returns None in the skeleton implementation."""
+async def test_get_pitcture_of_the_day_returns_correct_potd(backend: WikimediaPotdBackend) -> None:
+    """Test that get_picture_of_the_day method returns the correct potd instance."""
     result = await backend.get_picture_of_the_day()
 
     assert result is not None
+    assert result.title == "Wikimedia Commons picture of the day"
+    assert result.published_date == "Mon, 13 Apr 2026 00:00:00 GMT"
+    assert isinstance(result.thumbnail_image_url, HttpUrl)
+    assert isinstance(result.high_res_image_url, HttpUrl)

--- a/tests/unit/providers/rss/wikimedia_potd/backends/test_wikimedia_potd_backend.py
+++ b/tests/unit/providers/rss/wikimedia_potd/backends/test_wikimedia_potd_backend.py
@@ -48,4 +48,4 @@ async def test_fetch_returns_none(backend: WikimediaPotdBackend) -> None:
     """Test that fetch returns None in the skeleton implementation."""
     result = await backend.get_picture_of_the_day()
 
-    assert result is None
+    assert result is not None

--- a/tests/unit/providers/rss/wikimedia_potd/test_provider.py
+++ b/tests/unit/providers/rss/wikimedia_potd/test_provider.py
@@ -4,6 +4,7 @@
 
 """Unit tests for the Wikimedia Picture of the Day provider."""
 
+from pydantic.networks import HttpUrl
 import pytest
 from pytest_mock import MockerFixture
 
@@ -31,6 +32,17 @@ def fixture_provider(
         name="wikimedia_potd",
         query_timeout_sec=1.0,
         enabled_by_default=False,
+    )
+
+
+@pytest.fixture(name="test_potd")
+def fixture_test_potd() -> PictureOfTheDay:
+    """Return a test picture of the day instance."""
+    return PictureOfTheDay(
+        title="Wikimedia Commons picture of the day",
+        thumbnail_image_url="https://test-thumbnail.jpg",
+        high_res_image_url="https://test-high-res.jpg",
+        published_date="Mon, 13 Apr 2026 00:00:00 GMT",
     )
 
 
@@ -62,7 +74,7 @@ async def test_shutdown(provider: WikimediaPictureOfTheDayProvider) -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_picture_of_the_day_returns_default_when_backend_returns_none(
+async def test_get_picture_of_the_day_returns_none_when_backend_returns_none(
     provider: WikimediaPictureOfTheDayProvider, backend_mock
 ) -> None:
     """Test that get_picture_of_the_day returns an empty Potd when backend returns None."""
@@ -70,8 +82,20 @@ async def test_get_picture_of_the_day_returns_default_when_backend_returns_none(
 
     potd = await provider.get_picture_of_the_day()
 
-    assert isinstance(potd, PictureOfTheDay)
-    assert potd.title == ""
-    assert potd.thumbnail_image_url == ""
-    assert potd.high_res_image_url == ""
-    assert potd.published_date == ""
+    assert potd is None
+
+
+@pytest.mark.asyncio
+async def test_get_picture_of_the_day_returns_correct_potd(
+    provider: WikimediaPictureOfTheDayProvider, backend_mock, test_potd
+) -> None:
+    """Test that get_picture_of_the_day returns a correct potd instance."""
+    backend_mock.get_picture_of_the_day.return_value = test_potd
+
+    potd = await provider.get_picture_of_the_day()
+
+    assert potd is not None
+    assert potd.title == "Wikimedia Commons picture of the day"
+    assert potd.thumbnail_image_url == HttpUrl("https://test-thumbnail.jpg")
+    assert potd.high_res_image_url == HttpUrl("https://test-high-res.jpg")
+    assert potd.published_date == "Mon, 13 Apr 2026 00:00:00 GMT"

--- a/tests/unit/providers/rss/wikimedia_potd/test_provider.py
+++ b/tests/unit/providers/rss/wikimedia_potd/test_provider.py
@@ -8,22 +8,24 @@ import pytest
 from pytest_mock import MockerFixture
 
 from merino.providers.rss.wikimedia_potd.backends.protocol import (
-    Potd,
-    WikimediaPotdBackend,
+    PictureOfTheDay,
+    WikimediaPictureOfTheDayBackend,
 )
-from merino.providers.rss.wikimedia_potd.provider import WikimediaPotdProvider
+from merino.providers.rss.wikimedia_potd.provider import WikimediaPictureOfTheDayProvider
 
 
 @pytest.fixture(name="backend_mock")
 def fixture_backend_mock(mocker: MockerFixture):
     """Return a mock WikimediaPotdBackend."""
-    return mocker.AsyncMock(spec=WikimediaPotdBackend)
+    return mocker.AsyncMock(spec=WikimediaPictureOfTheDayBackend)
 
 
 @pytest.fixture(name="provider")
-def fixture_provider(statsd_mock, backend_mock: WikimediaPotdBackend) -> WikimediaPotdProvider:
+def fixture_provider(
+    statsd_mock, backend_mock: WikimediaPictureOfTheDayBackend
+) -> WikimediaPictureOfTheDayProvider:
     """Return a WikimediaPotdProvider instance for testing."""
-    return WikimediaPotdProvider(
+    return WikimediaPictureOfTheDayProvider(
         backend=backend_mock,
         metrics_client=statsd_mock,
         name="wikimedia_potd",
@@ -32,42 +34,44 @@ def fixture_provider(statsd_mock, backend_mock: WikimediaPotdBackend) -> Wikimed
     )
 
 
-def test_provider_name(provider: WikimediaPotdProvider) -> None:
+def test_provider_name(provider: WikimediaPictureOfTheDayProvider) -> None:
     """Test that the provider name is set correctly."""
     assert provider.name == "wikimedia_potd"
 
 
-def test_provider_enabled_by_default(provider: WikimediaPotdProvider) -> None:
+def test_provider_enabled_by_default(provider: WikimediaPictureOfTheDayProvider) -> None:
     """Test that enabled_by_default is set correctly."""
     assert provider.enabled_by_default is False
 
 
-def test_provider_query_timeout_sec(provider: WikimediaPotdProvider) -> None:
+def test_provider_query_timeout_sec(provider: WikimediaPictureOfTheDayProvider) -> None:
     """Test that query_timeout_sec is set correctly."""
     assert provider.query_timeout_sec == 1.0
 
 
 @pytest.mark.asyncio
-async def test_initialize(provider: WikimediaPotdProvider) -> None:
+async def test_initialize(provider: WikimediaPictureOfTheDayProvider) -> None:
     """Test that initialize completes without error."""
     await provider.initialize()
 
 
 @pytest.mark.asyncio
-async def test_shutdown(provider: WikimediaPotdProvider) -> None:
+async def test_shutdown(provider: WikimediaPictureOfTheDayProvider) -> None:
     """Test that shutdown completes without error."""
     await provider.shutdown()
 
 
 @pytest.mark.asyncio
 async def test_get_picture_of_the_day_returns_default_when_backend_returns_none(
-    provider: WikimediaPotdProvider, backend_mock
+    provider: WikimediaPictureOfTheDayProvider, backend_mock
 ) -> None:
     """Test that get_picture_of_the_day returns an empty Potd when backend returns None."""
     backend_mock.get_picture_of_the_day.return_value = None
 
     potd = await provider.get_picture_of_the_day()
 
-    assert isinstance(potd, Potd)
+    assert isinstance(potd, PictureOfTheDay)
     assert potd.title == ""
-    assert potd.image_url == ""
+    assert potd.thumbnail_image_url == ""
+    assert potd.high_res_image_url == ""
+    assert potd.published_date == ""


### PR DESCRIPTION
## References

JIRA: [HNT-2147](https://mozilla-hub.atlassian.net/browse/HNT-2147)

## Description
Setting up the new and first, rss endpoint. This endpoint will serve the Wikimedia commons picture of the day. It is serving a **_hardcoded static response to unblock FE engineers_** to start testing. More backend work will follow.



## PR Review Checklist
- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2199)


[HNT-2147]: https://mozilla-hub.atlassian.net/browse/HNT-2147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ