### PR TITLE
fix: DISCO-4049 Backfill schedules (if available) with scores for sport events 

### DIFF
--- a/merino/providers/suggest/sports/backends/sportsdata/common/data.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/data.py
@@ -324,76 +324,93 @@ class Sport:
         start_window = datetime.now(tz=timezone.utc) - self.event_ttl
         end_window = datetime.now(tz=timezone.utc) + self.event_ttl
         for event_description in data:
-            home_id = event_description.get("GlobalHomeTeamID") or event_description.get(
-                "GlobalHomeTeamId"
-            )
-            away_id = event_description.get("GlobalAwayTeamID") or event_description.get(
-                "GlobalAwayTeamId"
-            )
-            home_name = event_description.get("HomeTeam") or event_description.get(
-                "HomeTeamKey", "UNDEFINED_HOME"
-            )
-            away_name = event_description.get("AwayTeam") or event_description.get(
-                "AwayTeamKey", "UNDEFINED_AWAY"
-            )
-            if not home_id or not away_id:
-                logger.warning(
-                    f"{LOGGING_TAG} Could not find team id for '{home_name}' vs '{away_name}' for {self.name}: {event_description}"
+            id = event_description["GlobalGameID"]
+            # only update the scores.
+            if id in self.events:
+                event = self.events[id]
+                event.home_score = (
+                    event_description.get("HomeTeamScore")
+                    or event_description.get("HomeScore")
+                    or event_description.get("HomeTeamRuns")
                 )
-                continue
-            home_team = self.teams.get(home_id)
-            away_team = self.teams.get(away_id)
-            if not home_team or not away_team:
-                logger.warning(
-                    f"{LOGGING_TAG} Could not find team info for '{home_name}' vs '{away_name}' for {self.name}: {event_description}"
+                event.away_score = (
+                    event_description.get("AwayTeamScore")
+                    or event_description.get("HomeScore")
+                    or event_description.get("HomeTeamRuns")
                 )
-                continue
-            try:
-                if "DateTimeUTC" in event_description:
-                    date = datetime.fromisoformat(event_description["DateTimeUTC"]).replace(
-                        tzinfo=timezone.utc
+            else:
+                home_id = event_description.get("GlobalHomeTeamID") or event_description.get(
+                    "GlobalHomeTeamId"
+                )
+                away_id = event_description.get("GlobalAwayTeamID") or event_description.get(
+                    "GlobalAwayTeamId"
+                )
+                home_name = event_description.get("HomeTeam") or event_description.get(
+                    "HomeTeamKey", "UNDEFINED_HOME"
+                )
+                away_name = event_description.get("AwayTeam") or event_description.get(
+                    "AwayTeamKey", "UNDEFINED_AWAY"
+                )
+                if not home_id or not away_id:
+                    logger.warning(
+                        f"{LOGGING_TAG} Could not find team id for '{home_name}' vs '{away_name}' for {self.name}: {event_description}"
                     )
-                else:
-                    date = datetime.fromisoformat(event_description["DateTime"]).replace(
+                    continue
+                home_team = self.teams.get(home_id)
+                away_team = self.teams.get(away_id)
+                if not home_team or not away_team:
+                    logger.warning(
+                        f"{LOGGING_TAG} Could not find team info for '{home_name}' vs '{away_name}' for {self.name}: {event_description}"
+                    )
+                    continue
+                try:
+                    if "DateTimeUTC" in event_description:
+                        date = datetime.fromisoformat(event_description["DateTimeUTC"]).replace(
+                            tzinfo=timezone.utc
+                        )
+                    else:
+                        date = datetime.fromisoformat(event_description["DateTime"]).replace(
+                            tzinfo=event_timezone
+                        )
+                # There have been incidents where an event returns "None" as a date value.
+                # We should ignore that event, and allow processing to continue, but note
+                # the error in case we need to escalate the problem.
+                except TypeError:
+                    # It's possible to salvage this game by examining the other fields like "Day" or "Updated",
+                    # but if there's an error, it's probably wise to ignore this.
+                    logger.info(
+                        f"""{LOGGING_TAG}📈 sports.error.no_date ["sport" = "{self.name}"]"""
+                    )
+                    continue
+                # Ignore any events that are outside of the event interest window.
+                if not start_window <= date <= end_window:
+                    continue
+                updated = None
+                # All "Updated" fields are always in ET.
+                if event_description.get("Updated"):
+                    updated = datetime.fromisoformat(event_description["Updated"]).replace(
                         tzinfo=event_timezone
                     )
-            # There have been incidents where an event returns "None" as a date value.
-            # We should ignore that event, and allow processing to continue, but note
-            # the error in case we need to escalate the problem.
-            except TypeError:
-                # It's possible to salvage this game by examining the other fields like "Day" or "Updated",
-                # but if there's an error, it's probably wise to ignore this.
-                logger.info(f"""{LOGGING_TAG}📈 sports.error.no_date ["sport" = "{self.name}"]""")
-                continue
-            # Ignore any events that are outside of the event interest window.
-            if not start_window <= date <= end_window:
-                continue
-            updated = None
-            # All "Updated" fields are always in ET.
-            if event_description.get("Updated"):
-                updated = datetime.fromisoformat(event_description["Updated"]).replace(
-                    tzinfo=event_timezone
+                event = Event(
+                    sport=self.name,
+                    id=id,
+                    terms=f"{home_team.terms} {away_team.terms}",
+                    date=date,
+                    original_date=event_description.get(
+                        "DateTimeUTC", event_description.get("DateTime")
+                    ),
+                    home_team=home_team.minimal(),
+                    away_team=away_team.minimal(),
+                    home_score=event_description.get("HomeTeamScore")
+                    or event_description.get("HomeScore")
+                    or event_description.get("HomeTeamRuns"),
+                    away_score=event_description.get("AwayTeamScore")
+                    or event_description.get("AwayScore")
+                    or event_description.get("AwayTeamRuns"),
+                    status=GameStatus.parse(event_description["Status"]),
+                    expiry=utc_time_from_now(self.event_ttl),
+                    updated=updated,
                 )
-            event = Event(
-                sport=self.name,
-                id=event_description["GlobalGameID"],
-                terms=f"{home_team.terms} {away_team.terms}",
-                date=date,
-                original_date=event_description.get(
-                    "DateTimeUTC", event_description.get("DateTime")
-                ),
-                home_team=home_team.minimal(),
-                away_team=away_team.minimal(),
-                home_score=event_description.get("HomeTeamScore")
-                or event_description.get("HomeScore")
-                or event_description.get("HomeTeamRuns"),
-                away_score=event_description.get("AwayTeamScore")
-                or event_description.get("AwayScore")
-                or event_description.get("AwayTeamRuns"),
-                status=GameStatus.parse(event_description["Status"]),
-                expiry=utc_time_from_now(self.event_ttl),
-                updated=updated,
-            )
             self.events[event.id] = event
         return self.events
 
@@ -458,7 +475,8 @@ class Sport:
                     f"{LOGGING_TAG} Could not find team info for event: {event_description}"
                 )
                 continue
-            game_id = event_description.get("GlobalGameID") or event_description["GameId"]
+            game_id = event_description["GlobalGameID"]
+
             status = GameStatus.parse(event_description["Status"])
             # Ignore cancelled games.
             if status == GameStatus.Canceled:

--- a/merino/providers/suggest/sports/backends/sportsdata/common/sports.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/sports.py
@@ -256,9 +256,26 @@ class NHL(Sport):
             ttl=timedelta(minutes=5),
             cache_dir=self.cache_dir,
         )
-        self.load_scores_from_source(
-            response, event_timezone=local_timezone, allow_no_teams=allow_no_teams
-        )
+        # NHL scores do not have GlobalGameID
+        self.load_schedules_from_source(response, event_timezone=local_timezone)
+        date_list = []
+        for _id, event in self.events.items():
+            day = event.date.strftime("%Y-%b-%d").upper()
+            if not event.status.is_scheduled() and day not in date_list:
+                # Note: NHL `ScoresBasic` does _NOT_ include the GlobalGameID.
+                url = f"{self.base_url}/GamesByDate/{day}?key={self.api_key}"
+                response = await get_data(
+                    client=client,
+                    url=url,
+                    ttl=timedelta(minutes=5),
+                    cache_dir=self.cache_dir,
+                )
+                self.load_scores_from_source(
+                    response,
+                    event_timezone=local_timezone,
+                    allow_no_teams=allow_no_teams,
+                )
+            date_list.append(day)
         return self
 
 
@@ -346,9 +363,27 @@ class NBA(Sport):
             ttl=timedelta(minutes=5),
             cache_dir=self.cache_dir,
         )
-        self.load_scores_from_source(
-            response, event_timezone=local_timezone, allow_no_teams=allow_no_teams
-        )
+        self.load_schedules_from_source(response, event_timezone=local_timezone)
+        date_list = []
+        # update scores based on events:
+        # Events may cross multiple days, so we should update those scores.
+        for _id, event in self.events.items():
+            day = event.date.strftime("%Y-%b-%d").upper()
+            if not event.status.is_scheduled() and day not in date_list:
+                url = f"{self.base_url}/ScoresBasic/{day}?key={self.api_key}"
+                response = await get_data(
+                    client=client,
+                    url=url,
+                    ttl=timedelta(minutes=5),
+                    cache_dir=self.cache_dir,
+                )
+                self.load_scores_from_source(
+                    response,
+                    event_timezone=local_timezone,
+                    allow_no_teams=allow_no_teams,
+                )
+                date_list.append(day)
+
         return self
 
 
@@ -445,9 +480,27 @@ class UCL(Sport):
             ttl=timedelta(minutes=5),
             cache_dir=self.cache_dir,
         )
-        self.load_scores_from_source(
-            response, event_timezone=local_timezone, allow_no_teams=allow_no_teams
-        )
+        self.load_schedules_from_source(response, event_timezone=local_timezone)
+        date_list = []
+        # update scores based on events:
+        # Events may cross multiple days, so we should update those scores.
+        for _id, event in self.events.items():
+            day = event.date.strftime("%Y-%b-%d").upper()
+            if not event.status.is_scheduled() and day not in date_list:
+                url = f"{self.base_url}/ScoresBasic/{day}?key={self.api_key}"
+                response = await get_data(
+                    client=client,
+                    url=url,
+                    ttl=timedelta(minutes=5),
+                    cache_dir=self.cache_dir,
+                )
+                self.load_scores_from_source(
+                    response,
+                    event_timezone=local_timezone,
+                    allow_no_teams=allow_no_teams,
+                )
+                date_list.append(day)
+
         return self
 
 
@@ -527,6 +580,9 @@ class MLB(Sport):
         """Fetch the list of events for the sport. (5 min interval)"""
         local_timezone = ZoneInfo("America/New_York")
         date = datetime.now(tz=local_timezone).strftime("%Y-%b-%d").upper()
+        # MLB `SchedulesBasic` only uses local GameID and TeamID values. This breaks our
+        # foreign key system, so we'll skip that for the game date directly. (Fortunately, there are
+        # A LOT of baseball games.)
         url = f"{self.base_url}/ScoresBasic/{date}?key={self.api_key}"
         """
         [

--- a/tests/unit/providers/suggest/sports/backends/common/test_sports.py
+++ b/tests/unit/providers/suggest/sports/backends/common/test_sports.py
@@ -609,7 +609,12 @@ async def test_nhl_update_events(
     assert ev.status == GameStatus.Final
     assert ev.home_team["key"] == "TOR"
     assert ev.away_team["key"] == "VAN"
-    get_data.assert_called_once()
+    assert 2 == get_data.call_count
+    for call in get_data.call_args_list:
+        assert call.kwargs["url"] in [
+            "https://api.sportsdata.io/v3/nhl/scores/json/SchedulesBasic/2026PRE?key=",
+            "https://api.sportsdata.io/v3/nhl/scores/json/GamesByDate/2025-SEP-22?key=",
+        ]
 
 
 @freezegun.freeze_time("2025-09-22T00:00:00", tz_offset=0)
@@ -634,7 +639,12 @@ async def test_nba_update_events(
     await nba.update_events(client=mock_client)
     assert 30023869 in nba.events and 0 not in nba.events
     assert nba.events[30023869].status == GameStatus.Final
-    get_data.assert_called_once()
+    assert 2 == get_data.call_count
+    for call in get_data.call_args_list:
+        assert call.kwargs["url"] in [
+            "https://api.sportsdata.io/v3/nba/scores/json/SchedulesBasic/2026PRE?key=",
+            "https://api.sportsdata.io/v3/nba/scores/json/ScoresBasic/2025-SEP-22?key=",
+        ]
 
 
 @freezegun.freeze_time("2025-09-22T00:00:00", tz_offset=0)


### PR DESCRIPTION
## References

JIRA: [DISCO-4049](https://mozilla-hub.atlassian.net/browse/DISCO-4049)

## Description
Some sports do not publish the scores to their schedules.
Some sports do not have schedules at all.
Some sports require a different score API to be called.

Closes DISCO-4049



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2200)


[DISCO-4049]: https://mozilla-hub.atlassian.net/browse/DISCO-4049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ