### PR TITLE
feat(gcs): add shared storage client

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -276,6 +276,12 @@ env = "dev"
 # If set to `debug`, the DSN will be set to a testing value recommended by Sentry,
 # and extra output will be included in the logs.
 
+[default.gcs]
+# To enable overriding the GCS endpoint
+# Leave empty to use the default Google Cloud Storage api
+# MERINO_GCS__ENDPOINT_URL
+endpoint_url = ""
+
 [default.image_gcs_v2]
 # MERINO_IMAGE_GCS_V2__GCS_PROJECT
 # GCS project name that contains domain data

--- a/merino/configs/development.toml
+++ b/merino/configs/development.toml
@@ -51,3 +51,9 @@ dsn = "http://localhost:9200"
 # Unused, just needs to be non-empty
 api_key = "local"
 request_timeout_ms = 10000
+
+[development.gcs]
+# To enable overriding the GCS endpoint
+# Leave empty to use the default Google Cloud Storage api
+# MERINO_GCS__ENDPOINT_URL
+endpoint_url = "http://localhost:4443"

--- a/merino/providers/manifest/backends/filemanager.py
+++ b/merino/providers/manifest/backends/filemanager.py
@@ -9,6 +9,8 @@ from gcloud.aio.storage import Blob, Bucket, Storage
 
 from merino.providers.manifest.backends.protocol import ManifestData, GetManifestResultCode
 from merino.utils.metrics import get_metrics_client
+from merino.utils.storage import get_storage_client
+
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +26,7 @@ class ManifestRemoteFilemanager:
         """:param gcs_bucket_path: GCS bucket name to fetch from.
         :param blob_name: Name of the blob in the GCS bucket.
         """
-        self.gcs_storage_client = Storage()
+        self.gcs_storage_client = get_storage_client()
         self.blob_name = blob_name
         self.bucket = Bucket(storage=self.gcs_storage_client, name=gcs_bucket_path)
 

--- a/merino/providers/suggest/finance/backends/polygon/filemanager.py
+++ b/merino/providers/suggest/finance/backends/polygon/filemanager.py
@@ -14,6 +14,7 @@ from merino.providers.suggest.finance.backends.protocol import (
     GetManifestResultCode,
     FinanceManifest,
 )
+from merino.utils.storage import get_storage_client
 
 logger = logging.getLogger(__name__)
 
@@ -34,12 +35,12 @@ class PolygonFilemanager:
         self.blob_name = blob_name
 
     async def get_bucket(self) -> Bucket:
-        """Lazily instantiate the GCS client and return the configured bucket"""
+        """Return the configured bucket using shared storage client."""
         if self.bucket is not None:
             return self.bucket
 
         if self.gcs_client is None:
-            self.gcs_client = Storage()
+            self.gcs_client = get_storage_client()
 
         self.bucket = Bucket(storage=self.gcs_client, name=self.gcs_bucket_path)
         return self.bucket

--- a/merino/providers/suggest/flightaware/backends/filemanager.py
+++ b/merino/providers/suggest/flightaware/backends/filemanager.py
@@ -12,6 +12,8 @@ from gcloud.aio.storage import Blob, Bucket, Storage
 from merino.providers.suggest.flightaware.backends.protocol import (
     GetFlightNumbersResultCode,
 )
+from merino.utils.storage import get_storage_client
+
 
 logger = logging.getLogger(__name__)
 
@@ -32,12 +34,12 @@ class FlightawareFilemanager:
         self.blob_name = blob_name
 
     async def get_bucket(self) -> Bucket:
-        """Lazily instantiate the GCS client and return the configured bucket"""
+        """Return the configured bucket using shared storage client"""
         if self.bucket is not None:
             return self.bucket
 
         if self.gcs_client is None:
-            self.gcs_client = Storage()
+            self.gcs_client = get_storage_client()
 
         self.bucket = Bucket(storage=self.gcs_client, name=self.gcs_bucket_path)
         return self.bucket

--- a/merino/utils/gcs/engagement/filemanager.py
+++ b/merino/utils/gcs/engagement/filemanager.py
@@ -10,6 +10,9 @@ import orjson
 from gcloud.aio.storage import Blob, Bucket, Storage
 from pydantic import BaseModel
 
+from merino.utils.storage import get_storage_client
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -39,12 +42,12 @@ class EngagementFilemanager:
         self.bucket = None
 
     def get_bucket(self) -> Bucket:
-        """Lazily instantiate the GCS client and return the configured bucket."""
+        """Return the configured bucket using shared storage client."""
         if self.bucket is not None:
             return self.bucket
 
         if self.gcs_client is None:
-            self.gcs_client = Storage()
+            self.gcs_client = get_storage_client()
 
         self.bucket = Bucket(storage=self.gcs_client, name=self.gcs_bucket_path)
         return self.bucket

--- a/merino/utils/storage.py
+++ b/merino/utils/storage.py
@@ -1,0 +1,23 @@
+"""Shared GCS Client"""
+
+from typing import Optional
+
+from gcloud.aio.storage import Storage
+
+from merino.configs import settings
+
+
+_shared_storage_client: Optional[Storage] = None
+
+
+def get_storage_client() -> Storage:  # pragma: no cover
+    """Get or create a shared GCS client, reusing the
+    underlying aiohttp connection pool.
+    """
+    global _shared_storage_client
+    url: str = settings.gcs.endpoint_url
+    if _shared_storage_client is not None:
+        return _shared_storage_client
+    # Use locahost override if set, otherwise the default google api
+    _shared_storage_client = Storage(api_root=url) if url else Storage()
+    return _shared_storage_client

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,19 @@ def fixture_filter_caplog() -> FilterCaplogFixture:
     return filter_caplog
 
 
+@pytest.fixture(autouse=True)
+def reset_storage_client() -> None:
+    """Reset the shared GCS storage client singleton between tests.
+
+    The Storage client holds an aiohttp session bound to an event loop.
+    The integration tests specifically create a fresh event loop per test,
+    which leaves the cached session in a broken state, unless reset.
+    """
+    import merino.utils.storage as storage_module
+
+    storage_module._shared_storage_client = None
+
+
 @pytest.fixture(name="statsd_mock")
 def fixture_statsd_mock(mocker: MockerFixture) -> Any:
     """Create a StatsD client mock object for testing."""

--- a/tests/unit/providers/suggest/finance/backends/test_filemanager.py
+++ b/tests/unit/providers/suggest/finance/backends/test_filemanager.py
@@ -85,7 +85,7 @@ async def test_get_file_validation_error(mocker):
 async def test_get_bucket_memoization(mocker):
     """Test that get_bucket returns the same bucket instance on multiple calls (memoized)."""
     mock_storage = mocker.patch(
-        "merino.providers.suggest.finance.backends.polygon.filemanager.Storage"
+        "merino.providers.suggest.finance.backends.polygon.filemanager.get_storage_client"
     )
     mock_bucket_instance = mocker.MagicMock()
     mock_storage.return_value = mocker.MagicMock()
@@ -123,13 +123,13 @@ async def test_get_file_uses_get_bucket(mocker):
 
 @pytest.mark.asyncio
 async def test_get_bucket_initializes_client_and_bucket(mocker):
-    """Test that get_bucket initializes gcs_client and bucket if unset."""
+    """Test that get_bucket initializes bucket if unset."""
     # create mock instances
     mock_storage_instance = mocker.MagicMock(name="MockStorageInstance")
     mock_bucket_instance = mocker.MagicMock(name="MockBucketInstance")
 
     mock_storage_class = mocker.patch(
-        "merino.providers.suggest.finance.backends.polygon.filemanager.Storage",
+        "merino.providers.suggest.finance.backends.polygon.filemanager.get_storage_client",
         return_value=mock_storage_instance,
     )
     mock_bucket_class = mocker.patch(

--- a/tests/unit/utils/gcs/engagement/test_filemanager.py
+++ b/tests/unit/utils/gcs/engagement/test_filemanager.py
@@ -52,8 +52,8 @@ def test_get_bucket_lazily_creates_client_and_bucket(
     filemanager: EngagementFilemanager,
     mock_bucket,
 ) -> None:
-    """Test that get_bucket() creates the GCS client and Bucket on first call."""
-    mock_storage_cls = mocker.patch("merino.utils.gcs.engagement.filemanager.Storage")
+    """Test that get_bucket() creates the Bucket on first call using shared gcs client."""
+    mock_storage_cls = mocker.patch("merino.utils.gcs.engagement.filemanager.get_storage_client")
     mocker.patch("merino.utils.gcs.engagement.filemanager.Bucket", return_value=mock_bucket)
 
     assert filemanager.gcs_client is None


### PR DESCRIPTION
## References

Broken off from https://mozilla-hub.atlassian.net/browse/DISCO-3988

## Description

This creates cached singleton for GCS storage, rather than creating a new storage client on demand. Mostly this is to enable overrides for using the GCS emulator for running locally, but it's also good practice to reuse the underlying http connection.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2201)
