### PR TITLE
feat(gcs): add SyncedGcsBlobV2

### DIFF
--- a/merino/utils/synced_gcs_blob.py
+++ b/merino/utils/synced_gcs_blob.py
@@ -9,6 +9,7 @@ import logging
 import time
 from datetime import datetime, timezone
 from typing import Callable
+from warnings import deprecated
 
 from google.cloud.storage import Client
 from aiodogstatsd import Client as StatsdClient
@@ -22,6 +23,9 @@ logger = logging.getLogger(__name__)
 LAST_UPDATED_INITIAL_VALUE = datetime.min.replace(tzinfo=timezone.utc)
 
 
+@deprecated(
+    "Prefer SyncedGcsBlobV2 which uses async storage client and reduces metrics cardinality"
+)
 class SyncedGcsBlob:
     """Class to manage a synchronized Google Cloud Storage blob.
 

--- a/merino/utils/synced_gcs_blob_v2.py
+++ b/merino/utils/synced_gcs_blob_v2.py
@@ -1,0 +1,216 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Module providing a class to manage synchronized blobs from Google Cloud Storage."""
+
+import asyncio
+import logging
+import time
+from datetime import datetime, timezone
+from json import JSONDecodeError
+from typing import Callable, Generic, Optional, TypeVar
+
+import aiohttp
+import orjson
+from aiodogstatsd import Client as StatsdClient
+from aiodogstatsd.typedefs import MTags
+from gcloud.aio.storage import Blob, Bucket, Storage
+from pydantic import BaseModel, ValidationError
+
+from merino.utils import cron
+
+
+logger = logging.getLogger(__name__)
+
+
+LAST_UPDATED_INITIAL_VALUE = datetime.min.replace(tzinfo=timezone.utc)
+
+T = TypeVar("T", bound=BaseModel)
+
+
+class SyncedGcsBlobV2(Generic[T]):
+    """Class to manage a synchronized Google Cloud Storage blob.
+
+    This class periodically fetches data from a GCS blob in the background.
+    """
+
+    cron_task: asyncio.Task
+    last_updated: datetime
+    metrics_namespace = "gcs.sync"
+    _data: Optional[T]
+
+    def __init__(
+        self,
+        storage_client: Storage,
+        metrics_client: StatsdClient,
+        bucket_name: str,
+        blob_name: str,
+        max_size: int,
+        cron_interval_seconds: float,
+        cron_job_name: str,
+        fetch_callback: Callable[[bytes], T],
+    ) -> None:
+        """Initialize the SyncedGcsBlob instance.
+
+        Args:
+            storage_client: Async GCS client (gcloud.aio.storage.Storage).
+            metrics_client: aiodogstatsd client for recording metrics.
+            bucket_name: GCS bucket name.
+            blob_name: Full path to the GCS blob.
+            max_size: Maximum size in bytes of the GCS blob. If exceeded, an error will be logged.
+            cron_interval_seconds: Interval at which to check GCS for updates in seconds.
+            cron_job_name: Name for the cron job
+            fetch_callback: callback invoked upon fetched data.
+        """
+        self.storage_client = storage_client
+        self.metrics_client = metrics_client
+        self.bucket_name = bucket_name
+        self.blob_name = blob_name
+        self.max_size = max_size
+        self.cron_interval_seconds = cron_interval_seconds
+        self.cron_job_name = cron_job_name
+        self.fetch_callback = fetch_callback
+        self.last_updated = LAST_UPDATED_INITIAL_VALUE
+        self._update_count = 0
+        self._bucket = Bucket(storage=storage_client, name=bucket_name)
+        self._default_tags: MTags = {"bucket": self.bucket_name, "blob": self.blob_name}
+        self._data = None
+
+    def initialize(self) -> None:
+        """Start the background cron job to get new data."""
+        cron_job = cron.Job(
+            name=self.cron_job_name,
+            interval=self.cron_interval_seconds,
+            condition=lambda: True,
+            task=self._update_task_async,
+        )
+        # Store the created task on the instance variable. Otherwise, it will get
+        # garbage collected because asyncio's runtime only holds a weak reference to it.
+        self.cron_task = asyncio.create_task(cron_job())
+
+    @property
+    def update_count(self) -> int:
+        """Return the number of times the data has been updated."""
+        return self._update_count
+
+    @property
+    def data(self) -> Optional[T]:
+        """Returns the synced data processed with fetch_callback,
+        or None if it is not yet available (or failed to fetch).
+        """
+        if self._data is None:
+            logger.error("Synced data accessed before it is available")
+            self.metrics_client.increment(
+                f"{SyncedGcsBlobV2.metrics_namespace}.unavailable", tags=self._default_tags
+            )
+        return self._data
+
+    async def _update_task_async(self) -> None:
+        """Fetch the latest data from GCS and invoke the appropriate callback."""
+        with self.metrics_client.timeit(
+            f"{self.metrics_namespace}.update.timing", tags=self._default_tags
+        ):
+            await self._update_task()
+
+    def _gauge_validity(self, value: int):
+        self.metrics_client.gauge(
+            f"{SyncedGcsBlobV2.metrics_namespace}.valid", value=value, tags=self._default_tags
+        )
+
+    def _increment_fetch_status(self, status_code: int):
+        self.metrics_client.increment(
+            f"{self.metrics_namespace}.fetch.response",
+            tags={**self._default_tags, "status": status_code},
+        )
+
+    async def _update_task(self) -> None:
+        """Task to update the data with the latest data from GCS."""
+        try:
+            blob: Blob = await self._bucket.get_blob(self.blob_name)
+        except aiohttp.ClientResponseError as e:
+            if e.status == 404:
+                logger.error(f"Blob '{self.blob_name}' not found.")
+                self._increment_fetch_status(e.status)
+            else:
+                logger.error(f"Error fetching blob metadata for '{self.blob_name}': {e}")
+                self._increment_fetch_status(e.status)
+            return
+
+        self._increment_fetch_status(200)
+
+        blob_size = int(blob.size)
+        blob_updated = datetime.fromisoformat(blob.updated)
+
+        self.metrics_client.gauge(
+            f"{self.metrics_namespace}.size", value=blob_size, tags=self._default_tags
+        )
+        if blob_size > self.max_size:
+            logger.error(f"Blob '{self.blob_name}' size {blob_size} exceeds {self.max_size}")
+            self._gauge_validity(0)
+        elif blob_updated <= self.last_updated:
+            logger.info(f"{self.blob_name} unchanged since {self.last_updated}.")
+            # Set last_updated as this data is not stale, just unchanged
+            self.last_updated = blob_updated
+        else:
+            raw: bytes = await blob.download()
+            try:
+                result = self.fetch_callback(raw)
+                self._data = result
+                self._update_count += 1
+                self.last_updated = blob_updated
+                self._gauge_validity(1)
+            except JSONDecodeError as json_error:
+                self._gauge_validity(0)
+                logger.error(f"Failed to decode blob JSON: {json_error}")
+            except ValidationError as val_err:
+                self._gauge_validity(0)
+                logger.error(f"Invalid blob content: {val_err}")
+            except Exception as generic_err:
+                self._gauge_validity(0)
+                logger.error(f"Blob fetch failure: {generic_err}")
+
+        # Report the staleness of the data in seconds.
+        if self.last_updated != LAST_UPDATED_INITIAL_VALUE:
+            self.metrics_client.gauge(
+                f"{self.metrics_namespace}.last_updated",
+                value=time.time() - self.last_updated.timestamp(),
+                tags=self._default_tags,
+            )
+
+
+def typed_gcs_json_blob_factory(
+    model: type[T],
+    storage_client: Storage,
+    metrics_client: StatsdClient,
+    bucket_name: str,
+    blob_name: str,
+    max_size: int,
+    cron_interval_seconds: float,
+    cron_job_name: str,
+) -> SyncedGcsBlobV2[T]:
+    """Generate a SyncedGcsBlobV2 object
+    which pulls and validates a JSON file according to the
+    provided pydantic model.
+    Raises errors if JSON is invalid or model validation fails,
+    to be handled by the caller.
+    """
+
+    def fetch_callback(data: bytes) -> T:
+        default_tags: MTags = {"bucket": bucket_name, "blob": blob_name}
+        parsed = model.model_validate(orjson.loads(data))
+        metrics_client.gauge(
+            f"{SyncedGcsBlobV2.metrics_namespace}.valid", value=1, tags=default_tags
+        )
+        return parsed
+
+    return SyncedGcsBlobV2(
+        storage_client,
+        metrics_client,
+        bucket_name,
+        blob_name,
+        max_size,
+        cron_interval_seconds,
+        cron_job_name,
+        fetch_callback,
+    )

--- a/merino/utils/synced_gcs_blob_v2.py
+++ b/merino/utils/synced_gcs_blob_v2.py
@@ -140,7 +140,8 @@ class SyncedGcsBlobV2(Generic[T]):
         self._increment_fetch_status(200)
 
         blob_size = int(blob.size)
-        blob_updated = datetime.fromisoformat(blob.updated)
+        # Populated at runtime
+        blob_updated = datetime.fromisoformat(blob.updated)  # type: ignore[attr-defined]
 
         self.metrics_client.gauge(
             f"{self.metrics_namespace}.size", value=blob_size, tags=self._default_tags

--- a/merino/utils/synced_gcs_blob_v2.py
+++ b/merino/utils/synced_gcs_blob_v2.py
@@ -79,6 +79,8 @@ class SyncedGcsBlobV2(Generic[T]):
 
     def initialize(self) -> None:
         """Start the background cron job to get new data."""
+        if hasattr(self, "cron_task"):
+            return  # already initialized
         cron_job = cron.Job(
             name=self.cron_job_name,
             interval=self.cron_interval_seconds,

--- a/merino/utils/synced_gcs_blob_v2.py
+++ b/merino/utils/synced_gcs_blob_v2.py
@@ -102,7 +102,7 @@ class SyncedGcsBlobV2(Generic[T]):
         if self._data is None:
             logger.error("Synced data accessed before it is available")
             self.metrics_client.increment(
-                f"{SyncedGcsBlobV2.metrics_namespace}.unavailable", tags=self._default_tags
+                f"{SyncedGcsBlobV2.metrics_namespace}.data.not_ready", tags=self._default_tags
             )
         return self._data
 

--- a/metrics.yaml
+++ b/metrics.yaml
@@ -405,6 +405,101 @@ suggest/flightaware:
       The "api/v1/suggest" API endpoint
     alert_policy: []
 
+utils/synced_gcs_blob_v2:
+  gcs.sync.data.not_ready:
+    description: |
+      A counter incremented when synced GCS blob data is accessed before it is available.
+    type: counter
+    labels:
+      - name: bucket
+        description: |
+          The GCS bucket name.
+      - name: blob
+        description: |
+          The full path to the GCS blob.
+    scope: |
+      Any component using SyncedGcsBlobV2.
+    alert_policy: []
+
+  gcs.sync.update.timing:
+    description: |
+      A timer covering the count and latency of GCS blob update task executions.
+    type: timing
+    labels:
+      - name: bucket
+        description: |
+          The GCS bucket name.
+      - name: blob
+        description: |
+          The full path to the GCS blob.
+    scope: |
+      Any component using SyncedGcsBlobV2.
+    alert_policy: []
+
+  gcs.sync.valid:
+    description: |
+      A gauge indicating whether the most recently fetched GCS blob data is valid (1) or invalid (0).
+    type: gauge
+    labels:
+      - name: bucket
+        description: |
+          The GCS bucket name.
+      - name: blob
+        description: |
+          The full path to the GCS blob.
+    scope: |
+      Any component using SyncedGcsBlobV2.
+    alert_policy: []
+
+  gcs.sync.fetch.response:
+    description: |
+      A counter for GCS blob fetch responses, labeled by HTTP status code.
+    type: counter
+    labels:
+      - name: bucket
+        description: |
+          The GCS bucket name.
+      - name: blob
+        description: |
+          The full path to the GCS blob.
+      - name: status
+        description: |
+          The HTTP status code returned by the GCS fetch (e.g., 200, 404).
+    scope: |
+      Any component using SyncedGcsBlobV2.
+    alert_policy: []
+
+  gcs.sync.size:
+    description: |
+      A gauge tracking the size in bytes of the fetched GCS blob.
+    type: gauge
+    labels:
+      - name: bucket
+        description: |
+          The GCS bucket name.
+      - name: blob
+        description: |
+          The full path to the GCS blob.
+    scope: |
+      Any component using SyncedGcsBlobV2.
+    alert_policy: []
+
+  gcs.sync.last_updated:
+    description: |
+      A gauge tracking the time in seconds since the GCS blob was last successfully updated.
+      Can be used to alert if data becomes stale.
+    type: gauge
+    labels:
+      - name: bucket
+        description: |
+          The GCS bucket name.
+      - name: blob
+        description: |
+          The full path to the GCS blob.
+    scope: |
+      Any component using SyncedGcsBlobV2.
+    alert_policy: []
+
 weather/hourly_forecasts:
   weather_hourly_forecasts_request_timing:
     description: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,6 +178,8 @@ filterwarnings = [
   "ignore::pytest.PytestUnraisableExceptionWarning",
   # Ignored as `robobro` still uses an old version of `werkzeug`
   "ignore:'OrderedMultiDict' is deprecated",
+  # Ignored while callers are being migrated to SyncedGcsBlobV2
+  "ignore:Prefer SyncedGcsBlobV2:DeprecationWarning",
 ]
 [tool.hatch.build.targets.sdist]
 include = ["merino"]

--- a/tests/integration/utils/__init__.py
+++ b/tests/integration/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for utils"""

--- a/tests/integration/utils/test_synced_gcs_blob_v2.py
+++ b/tests/integration/utils/test_synced_gcs_blob_v2.py
@@ -1,0 +1,186 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Integration smoke tests for SyncedGcsBlobV2"""
+
+import asyncio
+import logging
+import time
+
+import orjson
+import pytest
+import pytest_asyncio
+from gcloud.aio.storage import Storage
+from pydantic import BaseModel
+
+from merino.utils.synced_gcs_blob_v2 import (
+    LAST_UPDATED_INITIAL_VALUE,
+    SyncedGcsBlobV2,
+    typed_gcs_json_blob_factory,
+)
+
+BUCKET_NAME = "test-synced-gcs-blob-v2"
+BLOB_NAME = "test/data.json"
+MAX_SIZE = 10 * 1024 * 1024  # 10 MB
+CRON_INTERVAL = 0.02  # 20ms
+
+
+class FakeModel(BaseModel):
+    """Minimal Pydantic model used as the blob payload in tests."""
+
+    value: int
+
+
+@pytest.fixture(scope="module")
+def gcs_bucket(gcs_storage_client):
+    """Create and tear down an isolated bucket for this test module."""
+    bucket = gcs_storage_client.create_bucket(BUCKET_NAME)
+    yield bucket
+    bucket.delete(force=True)
+
+
+@pytest_asyncio.fixture
+async def async_storage():
+    """Return an async gcloud.aio Storage client and clean up after testing.
+
+    Note: STORAGE_EMULATOR_HOST is set by the gcs_storage_container fixture, which causes
+    Storage() to skip authentication and route all requests to the local fake-gcs-server.
+    """
+    client = Storage()
+    yield client
+    await client.close()
+
+
+def _upload(gcs_bucket, payload: dict) -> None:
+    """Upload a JSON payload to the test blob using the sync client (test setup)."""
+    blob = gcs_bucket.blob(BLOB_NAME)
+    blob.upload_from_string(orjson.dumps(payload).decode())
+
+
+async def _wait_for_update(synced: SyncedGcsBlobV2, initial_count: int = 0, timeout=1.0) -> None:
+    """Test helper method; poll until update_count advances past initial_count, or timeout."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if synced.update_count > initial_count:
+            return
+        await asyncio.sleep(0.01)
+
+
+@pytest.mark.asyncio
+async def test_fetches_blob_and_parses_model(gcs_bucket, async_storage, metrics_client):
+    """Data uploaded to GCS is fetched, parsed, and accessible via .data."""
+    _upload(gcs_bucket, {"value": 42})
+
+    synced = typed_gcs_json_blob_factory(
+        model=FakeModel,
+        storage_client=async_storage,
+        metrics_client=metrics_client,
+        bucket_name=BUCKET_NAME,
+        blob_name=BLOB_NAME,
+        max_size=MAX_SIZE,
+        cron_interval_seconds=CRON_INTERVAL,
+        cron_job_name="test_fetches_blob",
+    )
+    synced.initialize()
+    await _wait_for_update(synced)
+
+    assert synced.data == FakeModel(value=42)
+    assert synced.update_count == 1
+
+
+@pytest.mark.asyncio
+async def test_data_is_none_before_first_fetch(async_storage, metrics_client):
+    """Data is None when accessed before the first successful fetch."""
+    synced: SyncedGcsBlobV2[FakeModel] = SyncedGcsBlobV2(
+        storage_client=async_storage,
+        metrics_client=metrics_client,
+        bucket_name=BUCKET_NAME,
+        blob_name="nonexistent/blob.json",
+        max_size=MAX_SIZE,
+        cron_interval_seconds=CRON_INTERVAL,
+        cron_job_name="test_data_none",
+        fetch_callback=lambda raw: FakeModel.model_validate(orjson.loads(raw)),
+    )
+    # Do not initialize as that will trigger a cron execution
+    assert synced.data is None
+
+
+@pytest.mark.asyncio
+async def test_missing_blob_logs_error(async_storage, metrics_client, caplog):
+    """A missing blob logs an error and leaves data as None."""
+    synced: SyncedGcsBlobV2[FakeModel] = SyncedGcsBlobV2(
+        storage_client=async_storage,
+        metrics_client=metrics_client,
+        bucket_name=BUCKET_NAME,
+        blob_name="does/not/exist.json",
+        max_size=MAX_SIZE,
+        cron_interval_seconds=CRON_INTERVAL,
+        cron_job_name="test_missing_blob",
+        fetch_callback=lambda raw: FakeModel.model_validate(orjson.loads(raw)),
+    )
+    synced.initialize()
+
+    caplog.set_level(logging.ERROR)
+    deadline = time.monotonic() + 1.0
+    while time.monotonic() < deadline:
+        if "does/not/exist.json" in caplog.text:
+            break
+        await asyncio.sleep(0.01)
+
+    assert "does/not/exist.json" in caplog.text
+    assert synced.data is None
+    assert synced.update_count == 0
+
+
+@pytest.mark.asyncio
+async def test_unchanged_blob_is_not_re_fetched(gcs_bucket, async_storage, metrics_client):
+    """Polling a blob that has not changed does not increment update_count,
+    but does update `last_updated`.
+    """
+    _upload(gcs_bucket, {"value": 7})
+
+    synced = typed_gcs_json_blob_factory(
+        model=FakeModel,
+        storage_client=async_storage,
+        metrics_client=metrics_client,
+        bucket_name=BUCKET_NAME,
+        blob_name=BLOB_NAME,
+        max_size=MAX_SIZE,
+        cron_interval_seconds=CRON_INTERVAL,
+        cron_job_name="test_unchanged_blob",
+    )
+    synced.initialize()
+    await _wait_for_update(synced)
+    assert synced.update_count == 1
+
+    # Let several more cron ticks pass and confirm count stays at 1.
+    await asyncio.sleep(CRON_INTERVAL * 5)
+    assert synced.update_count == 1
+    assert synced.last_updated > LAST_UPDATED_INITIAL_VALUE
+
+
+@pytest.mark.asyncio
+async def test_picks_up_new_version_after_update(gcs_bucket, async_storage, metrics_client):
+    """When a blob is re-uploaded with new content, the next poll fetches it."""
+    _upload(gcs_bucket, {"value": 1})
+
+    synced = typed_gcs_json_blob_factory(
+        model=FakeModel,
+        storage_client=async_storage,
+        metrics_client=metrics_client,
+        bucket_name=BUCKET_NAME,
+        blob_name=BLOB_NAME,
+        max_size=MAX_SIZE,
+        cron_interval_seconds=CRON_INTERVAL,
+        cron_job_name="test_picks_up_new_version",
+    )
+    synced.initialize()
+    await _wait_for_update(synced)
+    assert synced.data == FakeModel(value=1)
+
+    _upload(gcs_bucket, {"value": 99})
+    await _wait_for_update(synced, initial_count=1)
+
+    assert synced.data == FakeModel(value=99)
+    assert synced.update_count == 2

--- a/tests/unit/utils/test_synced_gcs_blob_v2.py
+++ b/tests/unit/utils/test_synced_gcs_blob_v2.py
@@ -1,0 +1,333 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Unit tests for SyncedGcsBlobV2 and typed_gcs_json_blob_factory.
+See also integration tests for coverage of fetch behavior with
+fake GCS bucket.
+"""
+
+import logging
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import aiohttp
+import orjson
+import pytest
+from gcloud.aio.storage import Storage
+from pydantic import BaseModel
+from pytest_mock import MockerFixture
+
+from merino.utils.synced_gcs_blob_v2 import (
+    SyncedGcsBlobV2,
+    typed_gcs_json_blob_factory,
+)
+
+BUCKET_NAME = "test-bucket"
+BLOB_NAME = "test/data.json"
+MAX_SIZE = 1024
+BLOB_UPDATED = "2024-01-15T12:00:00+00:00"
+DEFAULT_TAGS = {"bucket": BUCKET_NAME, "blob": BLOB_NAME}
+
+
+class FakeModel(BaseModel):
+    """Minimal Pydantic model for tests."""
+
+    value: int
+
+
+@pytest.fixture
+def mock_storage(mocker: MockerFixture) -> MagicMock:
+    """Return a mock async Storage client."""
+    return mocker.MagicMock(spec=Storage)
+
+
+@pytest.fixture
+def mock_blob(mocker: MockerFixture) -> MagicMock:
+    """Return a mock async GCS Blob with sensible defaults."""
+    blob = mocker.AsyncMock()
+    blob.size = "100"
+    blob.updated = BLOB_UPDATED
+    blob.download = mocker.AsyncMock(return_value=orjson.dumps({"value": 1}))
+    return blob
+
+
+@pytest.fixture
+def mock_bucket(mocker: MockerFixture, mock_blob: MagicMock) -> MagicMock:
+    """Return a mock async GCS Bucket whose get_blob returns mock_blob."""
+    bucket = mocker.AsyncMock()
+    bucket.get_blob = mocker.AsyncMock(return_value=mock_blob)
+    return bucket
+
+
+@pytest.fixture
+def synced(
+    mock_storage: MagicMock, mock_bucket: MagicMock, statsd_mock: MagicMock
+) -> SyncedGcsBlobV2:
+    """Return a SyncedGcsBlobV2 with its internal bucket replaced by the mock."""
+    instance: SyncedGcsBlobV2[FakeModel] = SyncedGcsBlobV2(
+        storage_client=mock_storage,
+        metrics_client=statsd_mock,
+        bucket_name=BUCKET_NAME,
+        blob_name=BLOB_NAME,
+        max_size=MAX_SIZE,
+        cron_interval_seconds=60,
+        cron_job_name="test_job",
+        fetch_callback=lambda raw: FakeModel.model_validate(orjson.loads(raw)),
+    )
+    instance._bucket = mock_bucket
+    return instance
+
+
+def test_accessing_data_while_none_emits_unavailable_metric(
+    synced: SyncedGcsBlobV2, statsd_mock: MagicMock
+) -> None:
+    """Data returns None and emits unavailable metric before any fetch.
+    Note: in here and other tests, passing in the same mock that was used
+    to initialize the `synced` fixture to avoid type complaints about
+    StatsdClient, rather than accessing directly through synced fixture.
+    """
+    assert synced.data is None
+    statsd_mock.increment.assert_called_once_with("gcs.sync.unavailable", tags=DEFAULT_TAGS)
+
+
+@pytest.mark.asyncio
+async def test_update_task_fetches_and_stores_data(
+    synced: SyncedGcsBlobV2, mock_blob: MagicMock, statsd_mock: MagicMock
+) -> None:
+    """A successful fetch populates data, increments update_count, and emits valid=1."""
+    mock_blob.download.return_value = orjson.dumps({"value": 42})
+
+    await synced._update_task()
+
+    assert synced.data == FakeModel(value=42)
+    assert synced.update_count == 1
+    assert synced.last_updated == datetime.fromisoformat(BLOB_UPDATED)
+    statsd_mock.gauge.assert_any_call("gcs.sync.valid", value=1, tags=DEFAULT_TAGS)
+
+
+@pytest.mark.asyncio
+async def test_update_task_emits_size_metric(
+    synced: SyncedGcsBlobV2, mock_blob: MagicMock, statsd_mock: MagicMock
+) -> None:
+    """A successful fetch emits the blob size as a gauge."""
+    mock_blob.size = "512"
+
+    await synced._update_task()
+
+    statsd_mock.gauge.assert_any_call("gcs.sync.size", value=512, tags=DEFAULT_TAGS)
+
+
+@pytest.mark.asyncio
+async def test_update_task_emits_staleness_metric_after_fetch(
+    synced: SyncedGcsBlobV2, statsd_mock: MagicMock
+) -> None:
+    """After a successful fetch, last_updated staleness gauge is emitted."""
+    await synced._update_task()
+
+    call_keys = [call[0][0] for call in statsd_mock.gauge.call_args_list]
+    assert "gcs.sync.last_updated" in call_keys
+
+
+@pytest.mark.asyncio
+async def test_update_task_logs_error_when_blob_too_large(
+    synced: SyncedGcsBlobV2,
+    mock_blob: MagicMock,
+    statsd_mock: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A blob exceeding max_size logs an error, emits valid=0, and does not download."""
+    mock_blob.size = str(MAX_SIZE + 1)
+
+    with caplog.at_level(logging.ERROR):
+        await synced._update_task()
+
+    assert f"size {MAX_SIZE + 1} exceeds {MAX_SIZE}" in caplog.text
+    mock_blob.download.assert_not_called()
+    assert synced.update_count == 0
+    statsd_mock.gauge.assert_any_call("gcs.sync.valid", value=0, tags=DEFAULT_TAGS)
+
+
+@pytest.fixture
+def http_error(mocker: MockerFixture):
+    """Return an aiohttp.ClientResponseError with a given status."""
+
+    def _http_error(status: int) -> aiohttp.ClientResponseError:
+        return aiohttp.ClientResponseError(request_info=mocker.Mock(), history=(), status=status)
+
+    return _http_error
+
+
+@pytest.mark.asyncio
+async def test_update_task_logs_error_on_404(
+    synced: SyncedGcsBlobV2,
+    mock_bucket: MagicMock,
+    statsd_mock: MagicMock,
+    http_error,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A 404 from get_blob logs a not-found error and increments fetch.response with status=404."""
+    mock_bucket.get_blob.side_effect = http_error(404)
+
+    with caplog.at_level(logging.ERROR):
+        await synced._update_task()
+
+    assert f"Blob '{BLOB_NAME}' not found." in caplog.text
+    assert synced.update_count == 0
+    statsd_mock.increment.assert_any_call(
+        "gcs.sync.fetch.response", tags=DEFAULT_TAGS | {"status": 404}
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_task_logs_error_on_other_http_errors(
+    synced: SyncedGcsBlobV2,
+    mock_bucket: MagicMock,
+    statsd_mock: MagicMock,
+    http_error,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A non-404 HTTP error from get_blob logs a generic error and increments fetch.response with that status."""
+    mock_bucket.get_blob.side_effect = http_error(503)
+
+    with caplog.at_level(logging.ERROR):
+        await synced._update_task()
+
+    assert f"Error fetching blob metadata for '{BLOB_NAME}'" in caplog.text
+    assert synced.update_count == 0
+    statsd_mock.increment.assert_any_call(
+        "gcs.sync.fetch.response", tags=DEFAULT_TAGS | {"status": 503}
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_task_increments_fetch_response_200_on_success(
+    synced: SyncedGcsBlobV2, statsd_mock: MagicMock
+) -> None:
+    """A successful get_blob increments fetch.response with status=200."""
+    await synced._update_task()
+
+    statsd_mock.increment.assert_any_call(
+        "gcs.sync.fetch.response", tags=DEFAULT_TAGS | {"status": 200}
+    )
+
+
+# --- _update_task: fetch_callback errors ---
+
+
+@pytest.mark.asyncio
+async def test_update_task_handles_json_decode_error(
+    synced: SyncedGcsBlobV2,
+    mock_blob: MagicMock,
+    statsd_mock: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A malformed JSON payload logs an error, emits valid=0, and does not advance state."""
+    mock_blob.download.return_value = b"not valid json {"
+
+    with caplog.at_level(logging.ERROR):
+        await synced._update_task()
+
+    assert "Failed to decode blob JSON" in caplog.text
+    assert synced.data is None
+    assert synced.update_count == 0
+    statsd_mock.gauge.assert_any_call("gcs.sync.valid", value=0, tags=DEFAULT_TAGS)
+
+
+@pytest.mark.asyncio
+async def test_update_task_handles_validation_error(
+    synced: SyncedGcsBlobV2,
+    mock_blob: MagicMock,
+    statsd_mock: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A payload that fails Pydantic validation logs an error and emits valid=0."""
+    mock_blob.download.return_value = orjson.dumps({"value": "not-an-int"})
+
+    with caplog.at_level(logging.ERROR):
+        await synced._update_task()
+
+    assert "Invalid blob content" in caplog.text
+    assert synced.update_count == 0
+    statsd_mock.gauge.assert_any_call("gcs.sync.valid", value=0, tags=DEFAULT_TAGS)
+
+
+@pytest.mark.asyncio
+async def test_update_task_handles_generic_exception(
+    synced: SyncedGcsBlobV2,
+    mock_blob: MagicMock,
+    statsd_mock: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An unexpected exception from fetch_callback logs an error and emits valid=0."""
+    mock_blob.download.return_value = orjson.dumps({"value": 1})
+
+    def exploding_callback(raw: bytes) -> FakeModel:
+        raise RuntimeError("unexpected failure")
+
+    synced.fetch_callback = exploding_callback
+
+    with caplog.at_level(logging.ERROR):
+        await synced._update_task()
+
+    assert "Blob fetch failure" in caplog.text
+    assert synced.update_count == 0
+    statsd_mock.gauge.assert_any_call("gcs.sync.valid", value=0, tags=DEFAULT_TAGS)
+
+
+# --- typed_gcs_json_blob_factory ---
+
+
+@pytest.mark.asyncio
+async def test_factory_parses_model_and_emits_valid_metric(
+    mock_storage: MagicMock, mock_bucket: MagicMock, statsd_mock: MagicMock, mock_blob: MagicMock
+) -> None:
+    """typed_gcs_json_blob_factory produces a SyncedGcsBlobV2 that parses the model correctly."""
+    mock_blob.download.return_value = orjson.dumps({"value": 7})
+
+    synced = typed_gcs_json_blob_factory(
+        model=FakeModel,
+        storage_client=mock_storage,
+        metrics_client=statsd_mock,
+        bucket_name=BUCKET_NAME,
+        blob_name=BLOB_NAME,
+        max_size=MAX_SIZE,
+        cron_interval_seconds=60,
+        cron_job_name="factory_test",
+    )
+    synced._bucket = mock_bucket
+
+    await synced._update_task()
+
+    assert synced.data == FakeModel(value=7)
+    statsd_mock.gauge.assert_any_call("gcs.sync.valid", value=1, tags=DEFAULT_TAGS)
+
+
+@pytest.mark.asyncio
+async def test_factory_raises_on_invalid_json(
+    mock_storage: MagicMock,
+    mock_bucket: MagicMock,
+    statsd_mock: MagicMock,
+    mock_blob: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """typed_gcs_json_blob_factory: invalid JSON is caught by _update_task and logged."""
+    mock_blob.download.return_value = b"{"
+
+    synced = typed_gcs_json_blob_factory(
+        model=FakeModel,
+        storage_client=mock_storage,
+        metrics_client=statsd_mock,
+        bucket_name=BUCKET_NAME,
+        blob_name=BLOB_NAME,
+        max_size=MAX_SIZE,
+        cron_interval_seconds=60,
+        cron_job_name="factory_test_invalid",
+    )
+    synced._bucket = mock_bucket
+
+    with caplog.at_level(logging.ERROR):
+        await synced._update_task()
+
+    assert synced.data is None
+    assert "Failed to decode blob JSON" in caplog.text

--- a/tests/unit/utils/test_synced_gcs_blob_v2.py
+++ b/tests/unit/utils/test_synced_gcs_blob_v2.py
@@ -273,6 +273,16 @@ async def test_update_task_handles_generic_exception(
     statsd_mock.gauge.assert_any_call("gcs.sync.valid", value=0, tags=DEFAULT_TAGS)
 
 
+def test_initialize_is_idempotent(synced: SyncedGcsBlobV2, mocker: MockerFixture) -> None:
+    """Calling initialize() twice creates only one cron task."""
+    mock_create_task = mocker.patch("asyncio.create_task", return_value=mocker.MagicMock())
+
+    synced.initialize()
+    synced.initialize()
+
+    mock_create_task.assert_called_once()
+
+
 ## Tests for typed_gcs_json_blob_factory
 
 

--- a/tests/unit/utils/test_synced_gcs_blob_v2.py
+++ b/tests/unit/utils/test_synced_gcs_blob_v2.py
@@ -9,6 +9,7 @@ fake GCS bucket.
 
 import logging
 from datetime import datetime
+from typing import cast
 from unittest.mock import MagicMock
 
 import aiohttp
@@ -39,7 +40,7 @@ class FakeModel(BaseModel):
 @pytest.fixture
 def mock_storage(mocker: MockerFixture) -> MagicMock:
     """Return a mock async Storage client."""
-    return mocker.MagicMock(spec=Storage)
+    return cast(MagicMock, mocker.MagicMock(spec=Storage))
 
 
 @pytest.fixture
@@ -49,7 +50,7 @@ def mock_blob(mocker: MockerFixture) -> MagicMock:
     blob.size = "100"
     blob.updated = BLOB_UPDATED
     blob.download = mocker.AsyncMock(return_value=orjson.dumps({"value": 1}))
-    return blob
+    return cast(MagicMock, blob)
 
 
 @pytest.fixture
@@ -57,7 +58,7 @@ def mock_bucket(mocker: MockerFixture, mock_blob: MagicMock) -> MagicMock:
     """Return a mock async GCS Bucket whose get_blob returns mock_blob."""
     bucket = mocker.AsyncMock()
     bucket.get_blob = mocker.AsyncMock(return_value=mock_blob)
-    return bucket
+    return cast(MagicMock, bucket)
 
 
 @pytest.fixture

--- a/tests/unit/utils/test_synced_gcs_blob_v2.py
+++ b/tests/unit/utils/test_synced_gcs_blob_v2.py
@@ -79,16 +79,16 @@ def synced(
     return instance
 
 
-def test_accessing_data_while_none_emits_unavailable_metric(
+def test_accessing_data_while_none_emits_not_ready_metric(
     synced: SyncedGcsBlobV2, statsd_mock: MagicMock
 ) -> None:
-    """Data returns None and emits unavailable metric before any fetch.
+    """Data returns None and emits data.not_ready metric before any fetch.
     Note: in here and other tests, passing in the same mock that was used
     to initialize the `synced` fixture to avoid type complaints about
     StatsdClient, rather than accessing directly through synced fixture.
     """
     assert synced.data is None
-    statsd_mock.increment.assert_called_once_with("gcs.sync.unavailable", tags=DEFAULT_TAGS)
+    statsd_mock.increment.assert_called_once_with("gcs.sync.data.not_ready", tags=DEFAULT_TAGS)
 
 
 @pytest.mark.asyncio
@@ -212,9 +212,6 @@ async def test_update_task_increments_fetch_response_200_on_success(
     )
 
 
-# --- _update_task: fetch_callback errors ---
-
-
 @pytest.mark.asyncio
 async def test_update_task_handles_json_decode_error(
     synced: SyncedGcsBlobV2,
@@ -275,7 +272,7 @@ async def test_update_task_handles_generic_exception(
     statsd_mock.gauge.assert_any_call("gcs.sync.valid", value=0, tags=DEFAULT_TAGS)
 
 
-# --- typed_gcs_json_blob_factory ---
+## Tests for typed_gcs_json_blob_factory
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## References
Broken off from https://mozilla-hub.atlassian.net/browse/DISCO-3988

## Description
According to ADR the goal is to unify cached blob access with one class. SyncedGcsBlob requires some updates to comply with suggest provider expectations and SRE requirements around metrics:
* use the async `Storage` client
* reduce metrics cardinality by using labels
* add unit and integration tests

The metrics updates are breaking changes so a new version was created instead, which existing code paths can migrate to. The existing metrics from SyncedGcsBlob were preserved but use labels to differentiate namespace instead of the metric name. The rest of the methods were mostly preserved with updates to the following:

Some other small improvements include:
* Requiring a callback function in the class constructor to eliminate potential for developer error (previously it required manually setting the callback after the instance was constructed)
* Implement error handling with additional metrics
* Store the cached data directly on the class, rather than requiring implementation in the callback_fn
* New helper: Adding a factory method for JSON blobs - automatically parse and validate against a model


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2202)
