### PR TITLE
AIMOD-1046 Set up for inferred+time zone experiment

### DIFF
--- a/merino/curated_recommendations/ml_backends/static_local_model.py
+++ b/merino/curated_recommendations/ml_backends/static_local_model.py
@@ -177,7 +177,7 @@ class FakeLocalModelSections(LocalModelBackend):
 
 
 # See calculation https://colab.research.google.com/drive/1GlEr2TScikP8YLKpAL1sGTawnimD1IyV#scrollTo=KawDDJnjBwIM
-# Section March 2026 rollout
+# Section March 2026 rollout. This also rougly applies to experiments with the same p/q but 5 interests
 MODEL_P_VALUE = 0.92
 MODEL_Q_VALUE = 0.0288
 
@@ -239,8 +239,9 @@ class SuperInferredModel(LocalModelBackend):
     # These are the only features supported in a small experiment (in addition to time zone)
     v3_small_experiment_topics = {
         Topic.SPORTS.value,
-        Topic.PARENTING.value,
         Topic.SCIENCE.value,
+        Topic.POLITICS.value,
+        Topic.ARTS.value,
     }
 
     limited_topics_set = set(v3_limited_topics)

--- a/merino/curated_recommendations/protocol.py
+++ b/merino/curated_recommendations/protocol.py
@@ -106,7 +106,7 @@ class ExperimentName(str, Enum):
     CONTEXTUAL_AD_RELEASE_EXPERIMENT = "new-tab-contextual-ad-updates-release"
     CONTEXTUAL_AD_V2_RELEASE_EXPERIMENT = "new-tab-contextual-ad-updates-v2-release"
     NEW_TAB_CUSTOM_SECTIONS_EXPERIMENT = "new-tab-custom-sections"
-    INFERRED_TIME_ZONE_EXPERIMENT = "contextual-time-zone"
+    INFERRED_TIME_ZONE_EXPERIMENT = "new-tab-stories-time-zone-based-ranking"
 
     # Experiment for doing local reranking of popular today via inferred interests
     INFERRED_LOCAL_EXPERIMENT = "new-tab-automated-personalization-local-ranking"

--- a/merino/curated_recommendations/rankers/contextual_ranker.py
+++ b/merino/curated_recommendations/rankers/contextual_ranker.py
@@ -1,6 +1,5 @@
 """Algorithms for ranking curated recommendations."""
 
-from merino.curated_recommendations.corpus_backends.protocol import Topic
 import numpy as np
 
 from merino.curated_recommendations.ml_backends.protocol import (
@@ -44,7 +43,11 @@ logger = logging.getLogger(__name__)
 # These topics are in the current interest vector but not being used to determine the
 # cohort selection.
 CONTEXUAL_INFERRED_PER_TOPIC_WEIGHTING = {
-    Topic.TECHNOLOGY: 1.0,
+    #    Example interst boost:
+    #    Topic.PERSONAL_FINANCE: 1.0,
+    #    Currently our cohort based contextual ranker is handling the boosting so
+    #    we don't currently need manual score boosts.
+    "example_unused_topic": 1.0,
 }
 
 CONTEXUAL_INFERRED_SINGLE_TOPIC_BOOST_WEIGHT = 0.0001

--- a/tests/unit/curated_recommendations/ml_backends/test_static_local_model.py
+++ b/tests/unit/curated_recommendations/ml_backends/test_static_local_model.py
@@ -655,7 +655,7 @@ def test_get_dummy_experiment_name(model_limited):
     assert result.model_data.private_features and len(result.model_data.private_features) > 0
 
     # Some interests have been removed
-    zeroed_interest = result.model_data.interest_vector[Topic.POLITICS.value]
+    zeroed_interest = result.model_data.interest_vector[Topic.TECHNOLOGY.value]
     assert len(zeroed_interest.thresholds) == len(THRESHOLDS_V3_NORMALIZED)
     assert zeroed_interest.thresholds[0] > 10
 

--- a/tests/unit/curated_recommendations/test_rankers.py
+++ b/tests/unit/curated_recommendations/test_rankers.py
@@ -1418,8 +1418,11 @@ class TestContextualRanker:
         ranked = ranker.rank_items(recs, personal_interests=tech_interests)
         assert len(ranked) == 3
         assert ranked[0].ranking_data is not None
+        """ Re-enable if boosting is turned on. Currently boosting is off """
+        """
         assert ranked[0].corpusItemId == "b"
         assert ranked[0].ranking_data.score > A_RANK
+        """
 
         tech_interests = ProcessedInterests(scores={Topic.TECHNOLOGY.value: 0.0})
         ranked = ranker.rank_items(recs, personal_interests=tech_interests)


### PR DESCRIPTION
## References

JIRA: https://mozilla-hub.atlassian.net/browse/AIMOD-1046

## Description
Set up experiment ID for a small time zone experiment.

The experiment is set up here https://experimenter.services.mozilla.com/nimbus/new-tab-stories-time-zone-based-ranking/summary/

As part of this I re-reviewed privacy settings in the colab notebook, and found we support 5 interests at 5%. We can do this because differential private interest vectors are removed from all telemetry via the experiment settings.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2203)
