### PR TITLE
AIMOD-1046 artifact size fix for time zone experiment

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -1132,7 +1132,7 @@ bucket_name = ""
 
 # MERINO__ML_RECOMMENDATIONS__GCS__PRIOR__MAX_SIZE
 # The maximum size in bytes of the contextual ranking scores file. If exceeded, an error will be logged.
-max_size = 2_000_000
+max_size = 3_000_000
 
 # MERINO__ML_RECOMMENDATIONS__GCS__PRIOR__BLOB_PREFIX
 # GCS path of the priors JSON file.

--- a/merino/curated_recommendations/ml_backends/static_local_model.py
+++ b/merino/curated_recommendations/ml_backends/static_local_model.py
@@ -42,7 +42,7 @@ CTR_SECTION_MODEL_ID = "ctr_model_section_1"
 SUPPORTED_LIVE_MODELS = {SERVER_V3_MODEL_ID}
 
 DEFAULT_PRODUCTION_MODEL_ID = SERVER_V3_MODEL_ID
-EXPERIMENT_PRODUCTION_MODEL_ID = SERVER_V3_MODEL_ID + "_exp"
+EXPERIMENT_PRODUCTION_MODEL_ID = SERVER_V3_MODEL_ID  # Because we just have a few features zeroed out, we can use the same model id
 
 # These cause interest vector to have no randomization and should only be used
 # when thresholds force a constant ouput


### PR DESCRIPTION
## References
JIRA: https://mozilla-hub.atlassian.net/browse/AIMOD-1046

## Description
Ran through local testing and found that occasionally the Contexual artifact can exceed 2MB triggering alerts.

Updated experiment ID so that experiment based model vector can be used interchangeably with non-experiment based model. The data is similar enough that it should work ok.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2205)
