### PR TITLE
fix: correct sports to use `awayTeamRuns`

### DIFF
--- a/merino/providers/suggest/sports/backends/sportsdata/common/data.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/data.py
@@ -55,7 +55,9 @@ class Team(BaseModel):
     expiry: datetime
 
     @classmethod
-    def from_data(cls, team_data: dict[str, Any], term_filter: list[str], team_ttl: timedelta):
+    def from_data(
+        cls, team_data: dict[str, Any], term_filter: list[str], team_ttl: timedelta
+    ):
         """Convert the rich SportsData.io information set to the reduced info we need."""
         logger = logging.getLogger(__name__)
         # build the list of terms we want to search:
@@ -75,7 +77,9 @@ class Team(BaseModel):
                     lword = word.lower()
                     if word not in term_filter:
                         terms.add(lword)
-        locale = " ".join([team_data.get("City") or "", team_data.get("AreaName") or ""]).strip()
+        locale = " ".join(
+            [team_data.get("City") or "", team_data.get("AreaName") or ""]
+        ).strip()
         name = team_data["Name"]
         fullname = team_data.get("FullName") or f"{locale} {team_data["Name"]}"
         logger.debug(f"{LOGGING_TAG} - Team: {fullname}")
@@ -228,7 +232,9 @@ class Sport:
         self.event_ttl = event_ttl or timedelta(
             weeks=settings.sportsdata.get("event_ttl_weeks", EVENT_TTL_WEEKS)
         )
-        self.team_ttl = team_ttl or timedelta(weeks=settings.get("team_ttl_weeks", TEAM_TTL_WEEKS))
+        self.team_ttl = team_ttl or timedelta(
+            weeks=settings.get("team_ttl_weeks", TEAM_TTL_WEEKS)
+        )
         self.term_filter = term_filter
         self.cache_dir = cache_dir
 
@@ -274,6 +280,7 @@ class Sport:
         data: list[dict[str, Any]],
         event_timezone: ZoneInfo = ZoneInfo("UTC"),
         allow_no_teams: bool = False,  # Allow no team information, useful for `quick updates`
+        no_new: bool = False,  # Prevent new items from being added to events.
     ) -> dict[int, "Event"]:
         """Scan the list of Event scores for any event within the 'current' window.
 
@@ -339,12 +346,14 @@ class Sport:
                     or event_description.get("HomeTeamRuns")
                 )
             else:
-                home_id = event_description.get("GlobalHomeTeamID") or event_description.get(
-                    "GlobalHomeTeamId"
-                )
-                away_id = event_description.get("GlobalAwayTeamID") or event_description.get(
-                    "GlobalAwayTeamId"
-                )
+                if no_new:
+                    continue
+                home_id = event_description.get(
+                    "GlobalHomeTeamID"
+                ) or event_description.get("GlobalHomeTeamId")
+                away_id = event_description.get(
+                    "GlobalAwayTeamID"
+                ) or event_description.get("GlobalAwayTeamId")
                 home_name = event_description.get("HomeTeam") or event_description.get(
                     "HomeTeamKey", "UNDEFINED_HOME"
                 )
@@ -365,13 +374,13 @@ class Sport:
                     continue
                 try:
                     if "DateTimeUTC" in event_description:
-                        date = datetime.fromisoformat(event_description["DateTimeUTC"]).replace(
-                            tzinfo=timezone.utc
-                        )
+                        date = datetime.fromisoformat(
+                            event_description["DateTimeUTC"]
+                        ).replace(tzinfo=timezone.utc)
                     else:
-                        date = datetime.fromisoformat(event_description["DateTime"]).replace(
-                            tzinfo=event_timezone
-                        )
+                        date = datetime.fromisoformat(
+                            event_description["DateTime"]
+                        ).replace(tzinfo=event_timezone)
                 # There have been incidents where an event returns "None" as a date value.
                 # We should ignore that event, and allow processing to continue, but note
                 # the error in case we need to escalate the problem.
@@ -388,9 +397,9 @@ class Sport:
                 updated = None
                 # All "Updated" fields are always in ET.
                 if event_description.get("Updated"):
-                    updated = datetime.fromisoformat(event_description["Updated"]).replace(
-                        tzinfo=event_timezone
-                    )
+                    updated = datetime.fromisoformat(
+                        event_description["Updated"]
+                    ).replace(tzinfo=event_timezone)
                 event = Event(
                     sport=self.name,
                     id=id,
@@ -459,14 +468,16 @@ class Sport:
         end_window = datetime.now(tz=timezone.utc) + self.event_ttl
         for event_description in data:
             # US sports use "(Away|Home)Team", Soccer uses "(Away|Home)TeamKey"
-            home_id = event_description.get("GlobalHomeTeamID") or event_description.get(
-                "GlobalHomeTeamId"
-            )
-            away_id = event_description.get("GlobalAwayTeamID") or event_description.get(
-                "GlobalAwayTeamId"
-            )
+            home_id = event_description.get(
+                "GlobalHomeTeamID"
+            ) or event_description.get("GlobalHomeTeamId")
+            away_id = event_description.get(
+                "GlobalAwayTeamID"
+            ) or event_description.get("GlobalAwayTeamId")
             if not home_id or not away_id:
-                logger.warning(f"{LOGGING_TAG} Could not find team for event: {event_description}")
+                logger.warning(
+                    f"{LOGGING_TAG} Could not find team for event: {event_description}"
+                )
                 continue
             home_team = self.teams.get(home_id)
             away_team = self.teams.get(away_id)
@@ -484,17 +495,19 @@ class Sport:
                 continue
             try:
                 if "DateTimeUTC" in event_description:
-                    date = datetime.fromisoformat(event_description["DateTimeUTC"]).replace(
-                        tzinfo=timezone.utc
-                    )
+                    date = datetime.fromisoformat(
+                        event_description["DateTimeUTC"]
+                    ).replace(tzinfo=timezone.utc)
                 else:
-                    date = datetime.fromisoformat(event_description["DateTime"]).replace(
-                        tzinfo=event_timezone
-                    )
+                    date = datetime.fromisoformat(
+                        event_description["DateTime"]
+                    ).replace(tzinfo=event_timezone)
             except TypeError as ex:
                 # It's possible to salvage this game by examining the other fields like "Day" or "Updated",
                 # but if there's an error, it's probably wise to ignore this.
-                logger.info(f"""{LOGGING_TAG}📈 sports.error.no_date ["sport" = "{self.name}"]""")
+                logger.info(
+                    f"""{LOGGING_TAG}📈 sports.error.no_date ["sport" = "{self.name}"]"""
+                )
                 logger.debug(
                     f"{LOGGING_TAG} {self.name} Event {game_id} between {home_team.key} and {away_team.key} has no time, skipping [{ex}]"
                 )

--- a/merino/providers/suggest/sports/backends/sportsdata/common/data.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/data.py
@@ -55,9 +55,7 @@ class Team(BaseModel):
     expiry: datetime
 
     @classmethod
-    def from_data(
-        cls, team_data: dict[str, Any], term_filter: list[str], team_ttl: timedelta
-    ):
+    def from_data(cls, team_data: dict[str, Any], term_filter: list[str], team_ttl: timedelta):
         """Convert the rich SportsData.io information set to the reduced info we need."""
         logger = logging.getLogger(__name__)
         # build the list of terms we want to search:
@@ -77,9 +75,7 @@ class Team(BaseModel):
                     lword = word.lower()
                     if word not in term_filter:
                         terms.add(lword)
-        locale = " ".join(
-            [team_data.get("City") or "", team_data.get("AreaName") or ""]
-        ).strip()
+        locale = " ".join([team_data.get("City") or "", team_data.get("AreaName") or ""]).strip()
         name = team_data["Name"]
         fullname = team_data.get("FullName") or f"{locale} {team_data["Name"]}"
         logger.debug(f"{LOGGING_TAG} - Team: {fullname}")
@@ -232,9 +228,7 @@ class Sport:
         self.event_ttl = event_ttl or timedelta(
             weeks=settings.sportsdata.get("event_ttl_weeks", EVENT_TTL_WEEKS)
         )
-        self.team_ttl = team_ttl or timedelta(
-            weeks=settings.get("team_ttl_weeks", TEAM_TTL_WEEKS)
-        )
+        self.team_ttl = team_ttl or timedelta(weeks=settings.get("team_ttl_weeks", TEAM_TTL_WEEKS))
         self.term_filter = term_filter
         self.cache_dir = cache_dir
 
@@ -348,12 +342,12 @@ class Sport:
             else:
                 if no_new:
                     continue
-                home_id = event_description.get(
-                    "GlobalHomeTeamID"
-                ) or event_description.get("GlobalHomeTeamId")
-                away_id = event_description.get(
-                    "GlobalAwayTeamID"
-                ) or event_description.get("GlobalAwayTeamId")
+                home_id = event_description.get("GlobalHomeTeamID") or event_description.get(
+                    "GlobalHomeTeamId"
+                )
+                away_id = event_description.get("GlobalAwayTeamID") or event_description.get(
+                    "GlobalAwayTeamId"
+                )
                 home_name = event_description.get("HomeTeam") or event_description.get(
                     "HomeTeamKey", "UNDEFINED_HOME"
                 )
@@ -374,13 +368,13 @@ class Sport:
                     continue
                 try:
                     if "DateTimeUTC" in event_description:
-                        date = datetime.fromisoformat(
-                            event_description["DateTimeUTC"]
-                        ).replace(tzinfo=timezone.utc)
+                        date = datetime.fromisoformat(event_description["DateTimeUTC"]).replace(
+                            tzinfo=timezone.utc
+                        )
                     else:
-                        date = datetime.fromisoformat(
-                            event_description["DateTime"]
-                        ).replace(tzinfo=event_timezone)
+                        date = datetime.fromisoformat(event_description["DateTime"]).replace(
+                            tzinfo=event_timezone
+                        )
                 # There have been incidents where an event returns "None" as a date value.
                 # We should ignore that event, and allow processing to continue, but note
                 # the error in case we need to escalate the problem.
@@ -397,9 +391,9 @@ class Sport:
                 updated = None
                 # All "Updated" fields are always in ET.
                 if event_description.get("Updated"):
-                    updated = datetime.fromisoformat(
-                        event_description["Updated"]
-                    ).replace(tzinfo=event_timezone)
+                    updated = datetime.fromisoformat(event_description["Updated"]).replace(
+                        tzinfo=event_timezone
+                    )
                 event = Event(
                     sport=self.name,
                     id=id,
@@ -468,16 +462,14 @@ class Sport:
         end_window = datetime.now(tz=timezone.utc) + self.event_ttl
         for event_description in data:
             # US sports use "(Away|Home)Team", Soccer uses "(Away|Home)TeamKey"
-            home_id = event_description.get(
-                "GlobalHomeTeamID"
-            ) or event_description.get("GlobalHomeTeamId")
-            away_id = event_description.get(
-                "GlobalAwayTeamID"
-            ) or event_description.get("GlobalAwayTeamId")
+            home_id = event_description.get("GlobalHomeTeamID") or event_description.get(
+                "GlobalHomeTeamId"
+            )
+            away_id = event_description.get("GlobalAwayTeamID") or event_description.get(
+                "GlobalAwayTeamId"
+            )
             if not home_id or not away_id:
-                logger.warning(
-                    f"{LOGGING_TAG} Could not find team for event: {event_description}"
-                )
+                logger.warning(f"{LOGGING_TAG} Could not find team for event: {event_description}")
                 continue
             home_team = self.teams.get(home_id)
             away_team = self.teams.get(away_id)
@@ -495,19 +487,17 @@ class Sport:
                 continue
             try:
                 if "DateTimeUTC" in event_description:
-                    date = datetime.fromisoformat(
-                        event_description["DateTimeUTC"]
-                    ).replace(tzinfo=timezone.utc)
+                    date = datetime.fromisoformat(event_description["DateTimeUTC"]).replace(
+                        tzinfo=timezone.utc
+                    )
                 else:
-                    date = datetime.fromisoformat(
-                        event_description["DateTime"]
-                    ).replace(tzinfo=event_timezone)
+                    date = datetime.fromisoformat(event_description["DateTime"]).replace(
+                        tzinfo=event_timezone
+                    )
             except TypeError as ex:
                 # It's possible to salvage this game by examining the other fields like "Day" or "Updated",
                 # but if there's an error, it's probably wise to ignore this.
-                logger.info(
-                    f"""{LOGGING_TAG}📈 sports.error.no_date ["sport" = "{self.name}"]"""
-                )
+                logger.info(f"""{LOGGING_TAG}📈 sports.error.no_date ["sport" = "{self.name}"]""")
                 logger.debug(
                     f"{LOGGING_TAG} {self.name} Event {game_id} between {home_team.key} and {away_team.key} has no time, skipping [{ex}]"
                 )

--- a/merino/providers/suggest/sports/backends/sportsdata/common/data.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/data.py
@@ -55,7 +55,9 @@ class Team(BaseModel):
     expiry: datetime
 
     @classmethod
-    def from_data(cls, team_data: dict[str, Any], term_filter: list[str], team_ttl: timedelta):
+    def from_data(
+        cls, team_data: dict[str, Any], term_filter: list[str], team_ttl: timedelta
+    ):
         """Convert the rich SportsData.io information set to the reduced info we need."""
         logger = logging.getLogger(__name__)
         # build the list of terms we want to search:
@@ -75,7 +77,9 @@ class Team(BaseModel):
                     lword = word.lower()
                     if word not in term_filter:
                         terms.add(lword)
-        locale = " ".join([team_data.get("City") or "", team_data.get("AreaName") or ""]).strip()
+        locale = " ".join(
+            [team_data.get("City") or "", team_data.get("AreaName") or ""]
+        ).strip()
         name = team_data["Name"]
         fullname = team_data.get("FullName") or f"{locale} {team_data["Name"]}"
         logger.debug(f"{LOGGING_TAG} - Team: {fullname}")
@@ -228,7 +232,9 @@ class Sport:
         self.event_ttl = event_ttl or timedelta(
             weeks=settings.sportsdata.get("event_ttl_weeks", EVENT_TTL_WEEKS)
         )
-        self.team_ttl = team_ttl or timedelta(weeks=settings.get("team_ttl_weeks", TEAM_TTL_WEEKS))
+        self.team_ttl = team_ttl or timedelta(
+            weeks=settings.get("team_ttl_weeks", TEAM_TTL_WEEKS)
+        )
         self.term_filter = term_filter
         self.cache_dir = cache_dir
 
@@ -336,18 +342,18 @@ class Sport:
                 )
                 event.away_score = (
                     event_description.get("AwayTeamScore")
-                    or event_description.get("HomeScore")
-                    or event_description.get("HomeTeamRuns")
+                    or event_description.get("AwayScore")
+                    or event_description.get("AwayTeamRuns")
                 )
             else:
                 if no_new:
                     continue
-                home_id = event_description.get("GlobalHomeTeamID") or event_description.get(
-                    "GlobalHomeTeamId"
-                )
-                away_id = event_description.get("GlobalAwayTeamID") or event_description.get(
-                    "GlobalAwayTeamId"
-                )
+                home_id = event_description.get(
+                    "GlobalHomeTeamID"
+                ) or event_description.get("GlobalHomeTeamId")
+                away_id = event_description.get(
+                    "GlobalAwayTeamID"
+                ) or event_description.get("GlobalAwayTeamId")
                 home_name = event_description.get("HomeTeam") or event_description.get(
                     "HomeTeamKey", "UNDEFINED_HOME"
                 )
@@ -368,13 +374,13 @@ class Sport:
                     continue
                 try:
                     if "DateTimeUTC" in event_description:
-                        date = datetime.fromisoformat(event_description["DateTimeUTC"]).replace(
-                            tzinfo=timezone.utc
-                        )
+                        date = datetime.fromisoformat(
+                            event_description["DateTimeUTC"]
+                        ).replace(tzinfo=timezone.utc)
                     else:
-                        date = datetime.fromisoformat(event_description["DateTime"]).replace(
-                            tzinfo=event_timezone
-                        )
+                        date = datetime.fromisoformat(
+                            event_description["DateTime"]
+                        ).replace(tzinfo=event_timezone)
                 # There have been incidents where an event returns "None" as a date value.
                 # We should ignore that event, and allow processing to continue, but note
                 # the error in case we need to escalate the problem.
@@ -391,9 +397,9 @@ class Sport:
                 updated = None
                 # All "Updated" fields are always in ET.
                 if event_description.get("Updated"):
-                    updated = datetime.fromisoformat(event_description["Updated"]).replace(
-                        tzinfo=event_timezone
-                    )
+                    updated = datetime.fromisoformat(
+                        event_description["Updated"]
+                    ).replace(tzinfo=event_timezone)
                 event = Event(
                     sport=self.name,
                     id=id,
@@ -462,14 +468,16 @@ class Sport:
         end_window = datetime.now(tz=timezone.utc) + self.event_ttl
         for event_description in data:
             # US sports use "(Away|Home)Team", Soccer uses "(Away|Home)TeamKey"
-            home_id = event_description.get("GlobalHomeTeamID") or event_description.get(
-                "GlobalHomeTeamId"
-            )
-            away_id = event_description.get("GlobalAwayTeamID") or event_description.get(
-                "GlobalAwayTeamId"
-            )
+            home_id = event_description.get(
+                "GlobalHomeTeamID"
+            ) or event_description.get("GlobalHomeTeamId")
+            away_id = event_description.get(
+                "GlobalAwayTeamID"
+            ) or event_description.get("GlobalAwayTeamId")
             if not home_id or not away_id:
-                logger.warning(f"{LOGGING_TAG} Could not find team for event: {event_description}")
+                logger.warning(
+                    f"{LOGGING_TAG} Could not find team for event: {event_description}"
+                )
                 continue
             home_team = self.teams.get(home_id)
             away_team = self.teams.get(away_id)
@@ -487,17 +495,19 @@ class Sport:
                 continue
             try:
                 if "DateTimeUTC" in event_description:
-                    date = datetime.fromisoformat(event_description["DateTimeUTC"]).replace(
-                        tzinfo=timezone.utc
-                    )
+                    date = datetime.fromisoformat(
+                        event_description["DateTimeUTC"]
+                    ).replace(tzinfo=timezone.utc)
                 else:
-                    date = datetime.fromisoformat(event_description["DateTime"]).replace(
-                        tzinfo=event_timezone
-                    )
+                    date = datetime.fromisoformat(
+                        event_description["DateTime"]
+                    ).replace(tzinfo=event_timezone)
             except TypeError as ex:
                 # It's possible to salvage this game by examining the other fields like "Day" or "Updated",
                 # but if there's an error, it's probably wise to ignore this.
-                logger.info(f"""{LOGGING_TAG}📈 sports.error.no_date ["sport" = "{self.name}"]""")
+                logger.info(
+                    f"""{LOGGING_TAG}📈 sports.error.no_date ["sport" = "{self.name}"]"""
+                )
                 logger.debug(
                     f"{LOGGING_TAG} {self.name} Event {game_id} between {home_team.key} and {away_team.key} has no time, skipping [{ex}]"
                 )

--- a/merino/providers/suggest/sports/backends/sportsdata/common/sports.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/sports.py
@@ -165,7 +165,6 @@ class NFL(Sport):
                 response,
                 event_timezone=local_timezone,
                 allow_no_teams=allow_no_teams,
-                no_new=True,
             )
         return self
 

--- a/merino/providers/suggest/sports/backends/sportsdata/common/sports.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/sports.py
@@ -162,7 +162,10 @@ class NFL(Sport):
             )
 
             self.load_scores_from_source(
-                response, event_timezone=local_timezone, allow_no_teams=allow_no_teams
+                response,
+                event_timezone=local_timezone,
+                allow_no_teams=allow_no_teams,
+                no_new=True,
             )
         return self
 
@@ -274,6 +277,7 @@ class NHL(Sport):
                     response,
                     event_timezone=local_timezone,
                     allow_no_teams=allow_no_teams,
+                    no_new=True,
                 )
             date_list.append(day)
         return self
@@ -381,6 +385,7 @@ class NBA(Sport):
                     response,
                     event_timezone=local_timezone,
                     allow_no_teams=allow_no_teams,
+                    no_new=True,
                 )
                 date_list.append(day)
 
@@ -498,6 +503,7 @@ class UCL(Sport):
                     response,
                     event_timezone=local_timezone,
                     allow_no_teams=allow_no_teams,
+                    no_new=True,
                 )
                 date_list.append(day)
 


### PR DESCRIPTION
## References

JIRA: [DISCO-TODO](https://mozilla-hub.atlassian.net/browse/DISCO-TODO)

## Description
Previous patch incorrectly was using `homeTeamRuns` instead of `awayTeamRuns` for Away team scores. This would produce a lot of tie games.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2209)
