### PR TITLE
[DISCO-4081] fix: Sports return value of scores 0

### DIFF
--- a/merino/providers/suggest/sports/backends/sportsdata/common/data.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/data.py
@@ -329,15 +329,11 @@ class Sport:
             # only update the scores.
             if id in self.events:
                 event = self.events[id]
-                event.home_score = (
-                    event_description.get("HomeTeamScore")
-                    or event_description.get("HomeScore")
-                    or event_description.get("HomeTeamRuns")
+                event.home_score = self.get_score(
+                    event_description, ["HomeTeamScore", "HomeScore", "HomeTeamRuns"]
                 )
-                event.away_score = (
-                    event_description.get("AwayTeamScore")
-                    or event_description.get("AwayScore")
-                    or event_description.get("AwayTeamRuns")
+                event.away_score = self.get_score(
+                    event_description, ["AwayTeamScore", "AwayScore", "AwayTeamRuns"]
                 )
             else:
                 if no_new:
@@ -404,12 +400,12 @@ class Sport:
                     ),
                     home_team=home_team.minimal(),
                     away_team=away_team.minimal(),
-                    home_score=event_description.get("HomeTeamScore")
-                    or event_description.get("HomeScore")
-                    or event_description.get("HomeTeamRuns"),
-                    away_score=event_description.get("AwayTeamScore")
-                    or event_description.get("AwayScore")
-                    or event_description.get("AwayTeamRuns"),
+                    home_score=self.get_score(
+                        event_description, ["HomeTeamScore", "HomeScore", "HomeTeamRuns"]
+                    ),
+                    away_score=self.get_score(
+                        event_description, ["AwayTeamScore", "AwayScore", "AwayTeamRuns"]
+                    ),
                     status=GameStatus.parse(event_description["Status"]),
                     expiry=utc_time_from_now(self.event_ttl),
                     updated=updated,
@@ -524,15 +520,23 @@ class Sport:
                 ),
                 home_team=home_team.minimal(),
                 away_team=away_team.minimal(),
-                home_score=event_description.get("HomeTeamScore")
-                or event_description.get("HomeScore")
-                or event_description.get("HomeTeamRuns"),  # used by MLB
-                away_score=event_description.get("AwayTeamScore")
-                or event_description.get("AwayScore")
-                or event_description.get("AwayTeamRuns"),  # used by MLB
+                home_score=self.get_score(
+                    event_description, ["HomeTeamScore", "HomeScore", "HomeTeamRuns"]
+                ),  # HomeTeamRuns used by MLB
+                away_score=self.get_score(
+                    event_description, ["AwayTeamScore", "AwayScore", "AwayTeamRuns"]
+                ),  # AwayTeamRuns used by MLB
                 status=GameStatus.parse(event_description["Status"]),
                 expiry=utc_time_from_now(self.event_ttl),
                 updated=updated,
             )
             self.events[event.id] = event
         return self.events
+
+    def get_score(self, data: dict[str, Any], score_keys: list[str]):
+        """Get first non None score or return None."""
+        for key in score_keys:
+            score = data.get(key)
+            if score is not None:
+                return score
+        return None

--- a/tests/unit/providers/suggest/sports/backends/common/test_data.py
+++ b/tests/unit/providers/suggest/sports/backends/common/test_data.py
@@ -305,3 +305,26 @@ def test_load_bad_teams_from_source(
     teams_data = sport.load_teams_from_source(teams)
 
     assert set(teams_data.keys()) == {456}
+
+
+@pytest.mark.parametrize("sport_cls", [NFL, NHL, NBA], ids=["NFL", "NHL", "NBA"])
+def test_get_score_returns_zero(sport_cls: type[Sport]):
+    """Ensure get_score returns 0 when a score of 0 is present."""
+    sport = sport_cls(settings=settings.providers.sports, name="", base_url="")
+    data = {"HomeTeamScore": None, "HomeScore": 0, "HomeTeamRuns": None}
+    assert sport.get_score(data, ["HomeTeamScore", "HomeScore", "HomeTeamRuns"]) == 0
+
+
+@pytest.mark.parametrize("sport_cls", [NFL, NHL, NBA], ids=["NFL", "NHL", "NBA"])
+def test_get_score_returns_value(sport_cls: type[Sport]):
+    """Ensure get_score returns a non-none value."""
+    sport = sport_cls(settings=settings.providers.sports, name="", base_url="")
+    data = {"HomeTeamScore": 7, "HomeScore": None, "HomeTeamRuns": None}
+    assert sport.get_score(data, ["HomeTeamScore", "HomeScore", "HomeTeamRuns"]) == 7
+
+
+@pytest.mark.parametrize("sport_cls", [NFL, NHL, NBA], ids=["NFL", "NHL", "NBA"])
+def test_get_score_returns_none_when_no_keys_present(sport_cls: type[Sport]):
+    """Ensure get_score returns None when none of the keys are present."""
+    sport = sport_cls(settings=settings.providers.sports, name="", base_url="")
+    assert sport.get_score({}, ["HomeTeamScore", "HomeScore", "HomeTeamRuns"]) is None


### PR DESCRIPTION
## References

JIRA: [DISCO-4081](https://mozilla-hub.atlassian.net/browse/DISCO-4081)

## Description
0 is falsy so

```
                event.home_score = (
                    event_description.get("HomeTeamScore")
                    or event_description.get("HomeScore")
                    or event_description.get("HomeTeamRuns")
                )
                event.away_score = (
                    event_description.get("AwayTeamScore")
                    or event_description.get("AwayScore")
                    or event_description.get("AwayTeamRuns")
                )
```
returns None, which is not what we want when the current score is 0 for an ongoing game


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2221)


[DISCO-4081]: https://mozilla-hub.atlassian.net/browse/DISCO-4081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ