### PR TITLE
[DISCO-4086] feat(es): remove query retries and introduce es error metrics

### DIFF
--- a/merino/jobs/sportsdata_jobs/__init__.py
+++ b/merino/jobs/sportsdata_jobs/__init__.py
@@ -51,6 +51,7 @@ from merino.providers.suggest.sports.backends.sportsdata.common.sports import (
     # EPL,
 )
 from merino.utils.http_client import create_http_client
+from merino.utils.metrics import get_metrics_client
 
 
 class Options:
@@ -242,6 +243,7 @@ if elastic_credentials.validate():
             platform=platform,
             languages=[lang for lang in sports_settings.get("languages", ["en"])],
             index_map={"event": event_map},
+            metrics_client=get_metrics_client(),
         )
         provider = SportDataUpdater(
             settings=sports_settings,

--- a/merino/providers/suggest/manager.py
+++ b/merino/providers/suggest/manager.py
@@ -235,6 +235,7 @@ def _create_provider(provider_id: str, setting: Settings) -> BaseProvider:
                         ElasticBackend(
                             api_key=setting.es_api_key,
                             url=setting.es_url,
+                            metrics_client=get_metrics_client(),
                         )
                     )
                     if setting.backend == "elasticsearch"
@@ -379,6 +380,7 @@ def _create_provider(provider_id: str, setting: Settings) -> BaseProvider:
                 platform=platform,
                 languages=[lang for lang in setting.get("languages", ["en"])],
                 index_map={"event": event_map},
+                metrics_client=get_metrics_client(),
             )
             return SportsDataProvider(
                 backend=SportsDataBackend(

--- a/merino/providers/suggest/sports/__main__.py
+++ b/merino/providers/suggest/sports/__main__.py
@@ -59,6 +59,7 @@ async def main_loader(
         platform=platform,
         languages=[lang for lang in settings.get("languages", ["en"])],
         index_map={"event": event_map},
+        metrics_client=get_metrics_client(),
     )
     await store.startup()
     await store.prune()
@@ -113,6 +114,7 @@ async def main_query(
         platform=platform,
         languages=[lang for lang in settings.get("languages", ["en"])],
         index_map={"event": event_map},
+        metrics_client=get_metrics_client(),
     )
     backend = SportsDataBackend(store=store, settings=settings)
     provider = SportsDataProvider(

--- a/merino/providers/suggest/sports/backends/sportsdata/common/elastic.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/elastic.py
@@ -5,8 +5,10 @@ import logging
 
 # import sys
 from abc import abstractmethod, ABC
+from aiodogstatsd import Client as StatsDClient
 from datetime import datetime, timezone
 from typing import Any, Final
+
 
 from dynaconf import LazySettings
 from elasticsearch import (
@@ -15,6 +17,7 @@ from elasticsearch import (
     NotFoundError,
     ConflictError,
     helpers,
+    ApiError,
 )
 
 from merino.configs import settings
@@ -29,6 +32,8 @@ from merino.providers.suggest.sports.backends.sportsdata.common.data import (
 from merino.providers.suggest.sports.backends.sportsdata.common.error import (
     SportsDataError,
 )
+from merino.utils.metrics import ES_SEARCH_METRIC_NAME
+
 
 # from merino.jobs.wikipedia_indexer.settings.v1 import EN_INDEX_SETTINGS
 
@@ -357,6 +362,7 @@ class SportsDataStore(ElasticDataStore):
         platform: str,
         index_map: dict[str, str],
         meta_map: str = META_INDEX,
+        metrics_client: StatsDClient,
         **kwargs,
     ) -> None:
         """Initialize a connection to ElasticSearch"""
@@ -367,6 +373,7 @@ class SportsDataStore(ElasticDataStore):
         self.index_map = index_map
         self.meta_map = meta_map
         self.index_settings = {lang: EN_INDEX_SETTINGS for lang in languages}
+        self._metrics_client = metrics_client
         logging.getLogger(__name__).info(
             f"{LOGGING_TAG} Initialized Elastic search at {credentials.dsn}"
         )
@@ -390,7 +397,13 @@ class SportsDataStore(ElasticDataStore):
         if not self.client:
             return None
         try:
-            res = await self.client.search(
+            # Do not retry due to strict latency requirements,
+            # and to avoid overloading cluster (suggest triggers search
+            # on every keystroke with matching intent word)
+            self._metrics_client.increment(
+                f"{ES_SEARCH_METRIC_NAME}.count", tags={"index": self.meta_map}
+            )
+            res = await self.client.options(max_retries=0).search(
                 index=self.meta_map,
                 query={"term": {"_id": key.lower()}},
                 # query={"term": {"key": key.lower()}},
@@ -402,8 +415,19 @@ class SportsDataStore(ElasticDataStore):
             if not len(hits):
                 return None
             return hits[0]["_source"].get("meta_value") or None
+        except ApiError as ex:
+            logging.getLogger(__name__).error(f"{LOGGING_TAG} meta query failed: {ex}")
+            self._metrics_client.increment(
+                f"{ES_SEARCH_METRIC_NAME}.error",
+                tags={"index": self.meta_map, "status": ex.meta.status},
+            )
+            return None
         except Exception as ex:
             logging.getLogger(__name__).error(f"{LOGGING_TAG} meta query failed: {ex}")
+            self._metrics_client.increment(
+                f"{ES_SEARCH_METRIC_NAME}.error",
+                tags={"index": self.meta_map, "status": "unknown"},
+            )
             return None
 
     async def store_meta(self, key: str, value: str):
@@ -598,15 +622,32 @@ class SportsDataStore(ElasticDataStore):
             }
 
             logger.debug(f"{LOGGING_TAG} Searching {index_id} for `{q}`")
-
-            res = await self.client.options(request_timeout=REQUEST_TIMEOUT_SEC).search(
+            self._metrics_client.increment(
+                f"{ES_SEARCH_METRIC_NAME}.count", tags={"index": index_id}
+            )
+            # Do not retry due to strict latency requirements, and to avoid overloading
+            # cluster (searched via suggest on every keystroke when query contains
+            # matching intent word)
+            res = await self.client.options(
+                request_timeout=REQUEST_TIMEOUT_SEC, max_retries=0
+            ).search(
                 index=index_id,
                 query=query,
                 sort=[{"date": "desc"}, {"updated": "desc"}],
                 # The list of fields to return from Elasticsearch
                 source_includes=["event", "touched"],
             )
+        except ApiError as e:
+            self._metrics_client.increment(
+                f"{ES_SEARCH_METRIC_NAME}.error", tags={"index": index_id, "status": e.meta.status}
+            )
+            raise BackendError(
+                f"Failed to search from Elasticsearch for {language_code}: {e}"
+            ) from e
         except Exception as ex:
+            self._metrics_client.increment(
+                f"{ES_SEARCH_METRIC_NAME}.error", tags={"index": index_id, "status": "unknown"}
+            )
             raise BackendError(f"Elasticsearch error for {index_id}") from ex
         logger.debug(f"{LOGGING_TAG} found {res} for `{q}`")
         if res.get("hits", {}).get("total", {}).get("value", 0) > 0:

--- a/merino/providers/suggest/wikipedia/backends/elastic.py
+++ b/merino/providers/suggest/wikipedia/backends/elastic.py
@@ -86,7 +86,9 @@ class ElasticBackend:
             }
         }
 
-        self._metrics_client.increment(f"{ES_SEARCH_METRIC_NAME}.count", tags={"index": index_id})
+        # Add this if wikipedia gets more than one index; for now it's covered by the provider
+        # search count
+        # self._metrics_client.increment(f"{ES_SEARCH_METRIC_NAME}.count", tags={"index": index_id})
         try:
             res = await self.elasticsearch.search(
                 index=index_id,

--- a/merino/providers/suggest/wikipedia/backends/elastic.py
+++ b/merino/providers/suggest/wikipedia/backends/elastic.py
@@ -4,10 +4,14 @@ import logging
 import string
 from typing import Any, Final
 from urllib.parse import quote
+from aiodogstatsd import Client as StatsDClient
+from elasticsearch import ApiError
 
 from merino.configs import settings
 from merino.exceptions import BackendError
 from merino.search.async_elastic import AsyncElasticSearchAdapter
+from merino.utils.metrics import ES_SEARCH_METRIC_NAME
+
 
 SUGGEST_ID: Final[str] = "suggest-on-title"
 REQUEST_TIMEOUT_SEC: Final[float] = settings.providers.wikipedia.es_request_timeout_sec
@@ -51,11 +55,17 @@ class ElasticBackend:
 
     elasticsearch: AsyncElasticSearchAdapter
 
-    def __init__(self, *, api_key: str, url: str) -> None:
+    def __init__(self, *, api_key: str, url: str, metrics_client: StatsDClient) -> None:
         """Initialize the ElasticBackend.
         Raises a ValueError if URL is incorrectly formatted.
+
+        The client is configured to not retry failures. This is due in part to
+        Merino's low latency requirements, and also to avoid undue load
+        (e.g. retrying on 429), since searching via suggest is performed
+        on each keystroke.
         """
-        self.elasticsearch = AsyncElasticSearchAdapter(url=url, api_key=api_key)
+        self.elasticsearch = AsyncElasticSearchAdapter(url=url, api_key=api_key, max_retries=0)
+        self._metrics_client = metrics_client
         logging.info("Initialized Elasticsearch with URL")
 
     async def shutdown(self) -> None:
@@ -76,6 +86,7 @@ class ElasticBackend:
             }
         }
 
+        self._metrics_client.increment(f"{ES_SEARCH_METRIC_NAME}.count", tags={"index": index_id})
         try:
             res = await self.elasticsearch.search(
                 index=index_id,
@@ -83,7 +94,17 @@ class ElasticBackend:
                 timeout=REQUEST_TIMEOUT_SEC,
                 source_includes=["title"],
             )
+        except ApiError as e:
+            self._metrics_client.increment(
+                f"{ES_SEARCH_METRIC_NAME}.error", tags={"index": index_id, "status": e.meta.status}
+            )
+            raise BackendError(
+                f"Failed to search from Elasticsearch for {language_code}: {e}"
+            ) from e
         except Exception as e:
+            self._metrics_client.increment(
+                f"{ES_SEARCH_METRIC_NAME}.error", tags={"index": index_id, "status": "unknown"}
+            )
             raise BackendError(
                 f"Failed to search from Elasticsearch for {language_code}: {e}"
             ) from e

--- a/merino/search/async_elastic.py
+++ b/merino/search/async_elastic.py
@@ -3,6 +3,7 @@
 from typing import Any, Optional, cast
 
 from elasticsearch import AsyncElasticsearch
+from elastic_transport.client_utils import DEFAULT, DefaultType
 
 
 class AsyncElasticSearchAdapter:
@@ -13,18 +14,18 @@ class AsyncElasticSearchAdapter:
     """
 
     def __init__(
-        self,
-        *,
-        url: str,
-        api_key: str,
+        self, *, url: str, api_key: str, max_retries: int | DefaultType = DEFAULT
     ) -> None:
         self._url = url
         self._api_key = api_key
         self._client: Optional[AsyncElasticsearch] = None
+        self._max_retries = max_retries
 
     def create_client(self) -> AsyncElasticsearch:
         """Create an AsyncElasticsearch client."""
-        self._client = AsyncElasticsearch(self._url, api_key=self._api_key)
+        self._client = AsyncElasticsearch(
+            self._url, api_key=self._api_key, max_retries=self._max_retries
+        )
         return self._client
 
     def get_client(self) -> AsyncElasticsearch:

--- a/merino/utils/metrics.py
+++ b/merino/utils/metrics.py
@@ -14,6 +14,8 @@ logger = logging.getLogger(__name__)
 MetricTags = Mapping[str, float | int | str]
 
 INTENT_WORD_COUNT_METRIC_NAME = "intent_word_count"
+# Metric for elasticsearch searches (counts, errors)
+ES_SEARCH_METRIC_NAME = "es.search"
 
 
 @cache

--- a/metrics.yaml
+++ b/metrics.yaml
@@ -518,6 +518,36 @@ utils/synced_gcs_blob_v2:
       Any component using SyncedGcsBlobV2.
     alert_policy: []
 
+search/elasticsearch:
+  es.search.count:
+    description: |
+      A counter for all Elasticsearch search attempts, incremented before the
+      request is issued. Use alongside es.search.error to derive a success rate.
+    type: counter
+    labels:
+      - name: index
+        description: |
+          The Elasticsearch index that was searched.
+    scope: |
+      Any provider backed by Elasticsearch (Wikipedia, Sports).
+    alert_policy: []
+
+  es.search.error:
+    description: |
+      A counter for failed Elasticsearch search requests.
+    type: counter
+    labels:
+      - name: index
+        description: |
+          The Elasticsearch index that was searched.
+      - name: status
+        description: |
+          The HTTP status code returned by Elasticsearch, or "unknown" for
+          non-HTTP errors (e.g. connection errors, timeouts).
+    scope: |
+      Any provider backed by Elasticsearch (Wikipedia, Sports).
+    alert_policy: []
+
 weather/hourly_forecasts:
   weather_hourly_forecasts_request_timing:
     description: |

--- a/tests/integration/providers/suggest/sports/backends/test_sportsdata.py
+++ b/tests/integration/providers/suggest/sports/backends/test_sportsdata.py
@@ -44,7 +44,7 @@ def fixture_sportsdata_parameters(
 
 
 @pytest.fixture(name="sport_data_store_parameters")
-def fixture_sport_data_store_parameters(es_client) -> dict[str, Any]:
+def fixture_sport_data_store_parameters(es_client, statsd_mock: Any) -> dict[str, Any]:
     """SportsDataStore constructor parameters."""
     return {
         "credentials": ElasticCredentials(dsn="", api_key=""),
@@ -53,6 +53,7 @@ def fixture_sport_data_store_parameters(es_client) -> dict[str, Any]:
         "index_map": {
             "event": "sports-{lang}-event",
         },
+        "metrics_client": statsd_mock,
     }
 
 

--- a/tests/unit/jobs/sports/test_sportsdata.py
+++ b/tests/unit/jobs/sports/test_sportsdata.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta, timezone
 from httpx import AsyncClient
 from unittest.mock import MagicMock
 from pytest_mock import MockerFixture
-from typing import cast
+from typing import Any, cast
 
 from merino.configs import settings
 from merino.jobs.sportsdata_jobs import SportDataUpdater
@@ -49,7 +49,7 @@ def fixture_es_client(mocker: MockerFixture) -> MagicMock:
 
 
 @pytest.fixture(name="sport_data_store")
-def fixture_sport_data_store(es_client: MagicMock) -> SportsDataStore:
+def fixture_sport_data_store(es_client: MagicMock, statsd_mock: Any) -> SportsDataStore:
     """Test Sport Data Store instance"""
     creds = ElasticCredentials(dsn="http://es.test:9200", api_key="test-key")
     s = SportsDataStore(
@@ -57,6 +57,7 @@ def fixture_sport_data_store(es_client: MagicMock) -> SportsDataStore:
         languages=["en"],
         platform="test",
         index_map={"event": "sports-en-events-test"},
+        metrics_client=statsd_mock,
     )
     s.client = es_client
     return s

--- a/tests/unit/providers/suggest/sports/backends/common/test_elastic.py
+++ b/tests/unit/providers/suggest/sports/backends/common/test_elastic.py
@@ -3,7 +3,7 @@
 import datetime
 import json
 import logging
-from typing import cast, Any
+from typing import Any, cast
 from unittest import mock
 from unittest.mock import AsyncMock, MagicMock
 
@@ -11,7 +11,7 @@ import freezegun
 import pytest
 
 from dynaconf import LazySettings
-from elasticsearch import BadRequestError, ConflictError
+from elasticsearch import ApiError, BadRequestError, ConflictError
 from elastic_transport import ApiResponseMeta, HttpHeaders, NodeConfig
 from pytest_mock import MockerFixture
 
@@ -51,7 +51,7 @@ def fixture_es_client(mocker: MockerFixture) -> MagicMock:
 
 
 @pytest.fixture(name="sport_data_store")
-def fixture_sport_data_store(es_client: MagicMock) -> SportsDataStore:
+def fixture_sport_data_store(es_client: MagicMock, statsd_mock: Any) -> SportsDataStore:
     """Test Sport Data Store instance."""
     creds = ElasticCredentials(dsn="http://es.test:9200", api_key="test-key")
     s = SportsDataStore(
@@ -59,6 +59,7 @@ def fixture_sport_data_store(es_client: MagicMock) -> SportsDataStore:
         languages=["en"],
         platform="test",
         index_map={"event": "sports-en-events"},
+        metrics_client=statsd_mock,
     )
     s.client = es_client
     return s
@@ -448,6 +449,131 @@ async def test_search_event_raise_exception(
         await sport_data_store.search_events(q="oops", language_code="en", mix_sports=False)
 
 
+@freezegun.freeze_time("2025-09-22T12:00:00Z")
+@pytest.mark.asyncio
+async def test_search_events_count_metric_on_success(
+    sport_data_store: SportsDataStore,
+    es_client: AsyncMock,
+    statsd_mock: Any,
+):
+    """Test that a successful search increments the count metric."""
+    es_client.search.return_value = {"hits": {"total": {"value": 0}, "hits": []}}
+
+    await sport_data_store.search_events(q="game", language_code="en")
+
+    statsd_mock.increment.assert_called_once_with(
+        "es.search.count", tags={"index": "sports-en-events"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_search_events_error_metric_on_api_error(
+    sport_data_store: SportsDataStore,
+    es_client: AsyncMock,
+    statsd_mock: Any,
+):
+    """Test that an ApiError increments both the count and error metrics."""
+    api_error = ApiError(
+        message="service unavailable",
+        meta=ApiResponseMeta(
+            status=503,
+            http_version="",
+            headers=HttpHeaders(),
+            duration=0.0,
+            node=NodeConfig(scheme="", host="", port=0),
+        ),
+        body={},
+    )
+    es_client.search.side_effect = api_error
+
+    with pytest.raises(BackendError):
+        await sport_data_store.search_events(q="game", language_code="en")
+
+    statsd_mock.increment.assert_any_call("es.search.count", tags={"index": "sports-en-events"})
+    statsd_mock.increment.assert_any_call(
+        "es.search.error", tags={"index": "sports-en-events", "status": 503}
+    )
+
+
+@pytest.mark.asyncio
+async def test_search_events_error_metric_on_exception(
+    sport_data_store: SportsDataStore,
+    es_client: AsyncMock,
+    statsd_mock: Any,
+):
+    """Test that a generic exception increments both the count and error metrics."""
+    es_client.search.side_effect = Exception("connection reset")
+
+    with pytest.raises(BackendError):
+        await sport_data_store.search_events(q="game", language_code="en")
+
+    statsd_mock.increment.assert_any_call("es.search.count", tags={"index": "sports-en-events"})
+    statsd_mock.increment.assert_any_call(
+        "es.search.error", tags={"index": "sports-en-events", "status": "unknown"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_query_meta_count_metric_on_success(
+    sport_data_store: SportsDataStore,
+    es_client: AsyncMock,
+    statsd_mock: Any,
+):
+    """Test that a successful query_meta increments the count metric."""
+    es_client.search.return_value = {"hits": {"hits": []}}
+
+    await sport_data_store.query_meta("last_update")
+
+    statsd_mock.increment.assert_any_call("es.search.count", tags={"index": META_INDEX})
+
+
+@pytest.mark.asyncio
+async def test_query_meta_error_metric_on_api_error(
+    sport_data_store: SportsDataStore,
+    es_client: AsyncMock,
+    statsd_mock: Any,
+):
+    """Test that an ApiError in query_meta increments both count and error metrics."""
+    api_error = ApiError(
+        message="service unavailable",
+        meta=ApiResponseMeta(
+            status=503,
+            http_version="",
+            headers=HttpHeaders(),
+            duration=0.0,
+            node=NodeConfig(scheme="", host="", port=0),
+        ),
+        body={},
+    )
+    es_client.search.side_effect = api_error
+
+    result = await sport_data_store.query_meta("last_update")
+
+    assert result is None
+    statsd_mock.increment.assert_any_call("es.search.count", tags={"index": META_INDEX})
+    statsd_mock.increment.assert_any_call(
+        "es.search.error", tags={"index": META_INDEX, "status": 503}
+    )
+
+
+@pytest.mark.asyncio
+async def test_query_meta_error_metric_on_exception(
+    sport_data_store: SportsDataStore,
+    es_client: AsyncMock,
+    statsd_mock: Any,
+):
+    """Test that a generic exception in query_meta increments both count and error metrics."""
+    es_client.search.side_effect = Exception("connection reset")
+
+    result = await sport_data_store.query_meta("last_update")
+
+    assert result is None
+    statsd_mock.increment.assert_any_call("es.search.count", tags={"index": META_INDEX})
+    statsd_mock.increment.assert_any_call(
+        "es.search.error", tags={"index": META_INDEX, "status": "unknown"}
+    )
+
+
 @pytest.mark.asyncio
 async def test_meta_store(sport_data_store: SportsDataStore, es_client: AsyncMock):
     """Test storing data to meta"""
@@ -518,14 +644,26 @@ async def test_startup(sport_data_store: SportsDataStore, es_client: AsyncMock):
 
 
 @pytest.mark.asyncio
-async def test_bad_creds():
+async def test_bad_creds(statsd_mock: Any):
     """Test failure if credentials are not present"""
     creds = ElasticCredentials(dsn="", api_key="")
-    store = SportsDataStore(credentials=creds, languages=["en"], platform="sports", index_map={})
+    store = SportsDataStore(
+        credentials=creds,
+        languages=["en"],
+        platform="sports",
+        index_map={},
+        metrics_client=statsd_mock,
+    )
     with pytest.raises(SportsDataError):
         await store.startup()
     creds = ElasticCredentials(dsn="bogus", api_key="")
-    store = SportsDataStore(credentials=creds, languages=["en"], platform="sports", index_map={})
+    store = SportsDataStore(
+        credentials=creds,
+        languages=["en"],
+        platform="sports",
+        index_map={},
+        metrics_client=statsd_mock,
+    )
     with pytest.raises(SportsDataError):
         await store.startup()
 

--- a/tests/unit/providers/suggest/sports/backends/test_sports_backend.py
+++ b/tests/unit/providers/suggest/sports/backends/test_sports_backend.py
@@ -13,7 +13,7 @@ import httpx
 
 from unittest.mock import MagicMock
 from pytest_mock import MockerFixture
-from typing import cast
+from typing import Any, cast
 
 from merino.configs import settings
 from merino.providers.suggest.sports.backends import get_data
@@ -238,7 +238,7 @@ def fixture_es_client(mocker: MockerFixture) -> MagicMock:
 
 
 @pytest.fixture(name="sport_data_store")
-def fixture_sport_data_store(es_client: MagicMock) -> SportsDataStore:
+def fixture_sport_data_store(es_client: MagicMock, statsd_mock: Any) -> SportsDataStore:
     """Test Sport Data Store instance"""
     creds = ElasticCredentials(
         dsn="http://es.test:9200",
@@ -249,6 +249,7 @@ def fixture_sport_data_store(es_client: MagicMock) -> SportsDataStore:
         languages=["en"],
         platform="test",
         index_map={"event": "sports-en-events-test"},
+        metrics_client=statsd_mock,
     )
     s.client = es_client
     return s

--- a/tests/unit/providers/suggest/wikipedia/backends/test_elastic.py
+++ b/tests/unit/providers/suggest/wikipedia/backends/test_elastic.py
@@ -259,31 +259,12 @@ async def test_es_backend_search_exception_it(
 
 
 @pytest.mark.asyncio
-async def test_es_backend_search_count_metric_on_success(
-    mocker: MockerFixture,
-    es_backend: ElasticBackend,
-    statsd_mock: Any,
-) -> None:
-    """Test that a successful search increments the count metric."""
-    mocker.patch.object(
-        AsyncElasticSearchAdapter,
-        "search",
-        new_callable=AsyncMock,
-        return_value={"suggest": {SUGGEST_ID: [{"options": []}]}},
-    )
-
-    await es_backend.search("foo", "en")
-
-    statsd_mock.increment.assert_called_once_with("es.search.count", tags={"index": INDICES["en"]})
-
-
-@pytest.mark.asyncio
 async def test_es_backend_search_error_metric_on_api_error(
     mocker: MockerFixture,
     es_backend: ElasticBackend,
     statsd_mock: Any,
 ) -> None:
-    """Test that an ApiError increments both the count and error metrics."""
+    """Test that an ApiError increments the error metric with the HTTP status code."""
     api_error = ApiError(
         message="service unavailable",
         meta=ApiResponseMeta(
@@ -300,8 +281,7 @@ async def test_es_backend_search_error_metric_on_api_error(
     with pytest.raises(BackendError):
         await es_backend.search("foo", "en")
 
-    statsd_mock.increment.assert_any_call("es.search.count", tags={"index": INDICES["en"]})
-    statsd_mock.increment.assert_any_call(
+    statsd_mock.increment.assert_called_once_with(
         "es.search.error", tags={"index": INDICES["en"], "status": 503}
     )
 
@@ -312,7 +292,7 @@ async def test_es_backend_search_error_metric_on_exception(
     es_backend: ElasticBackend,
     statsd_mock: Any,
 ) -> None:
-    """Test that a generic exception increments both the count and error metrics."""
+    """Test that a generic exception increments the error metric with status 'unknown'."""
     mocker.patch.object(
         AsyncElasticSearchAdapter, "search", side_effect=Exception("connection reset")
     )
@@ -320,8 +300,7 @@ async def test_es_backend_search_error_metric_on_exception(
     with pytest.raises(BackendError):
         await es_backend.search("foo", "en")
 
-    statsd_mock.increment.assert_any_call("es.search.count", tags={"index": INDICES["en"]})
-    statsd_mock.increment.assert_any_call(
+    statsd_mock.increment.assert_called_once_with(
         "es.search.error", tags={"index": INDICES["en"], "status": "unknown"}
     )
 

--- a/tests/unit/providers/suggest/wikipedia/backends/test_elastic.py
+++ b/tests/unit/providers/suggest/wikipedia/backends/test_elastic.py
@@ -1,14 +1,19 @@
 """Unit tests for the Elastic Backend."""
 
 import string
-from unittest.mock import AsyncMock
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from pytest_mock import MockerFixture
 
+from elastic_transport import ApiResponseMeta, HttpHeaders, NodeConfig
+from elasticsearch import ApiError
+
 from merino.configs import settings
 from merino.exceptions import BackendError
 from merino.providers.suggest.wikipedia.backends.elastic import (
+    INDICES,
     SUGGEST_ID,
     ElasticBackend,
     get_best_keyword,
@@ -17,11 +22,12 @@ from merino.search.async_elastic import AsyncElasticSearchAdapter
 
 
 @pytest.fixture(name="es_backend")
-def fixture_es_backend() -> ElasticBackend:
+def fixture_es_backend(statsd_mock: Any) -> ElasticBackend:
     """Return an ES backend instance."""
     return ElasticBackend(
         url="https://localhost:9200",
         api_key=settings.providers.wikipedia.es_api_key,
+        metrics_client=statsd_mock,
     )
 
 
@@ -30,6 +36,7 @@ def test_es_backend_initialize_with_url():
     backend = ElasticBackend(
         url="https://localhost:9200",
         api_key=settings.providers.wikipedia.es_api_key,
+        metrics_client=MagicMock(),
     )
     assert backend
 
@@ -249,6 +256,74 @@ async def test_es_backend_search_exception_it(
         await es_backend.search("bis", "it")
 
     assert str(excinfo.value) == "Failed to search from Elasticsearch for it: 404 error"
+
+
+@pytest.mark.asyncio
+async def test_es_backend_search_count_metric_on_success(
+    mocker: MockerFixture,
+    es_backend: ElasticBackend,
+    statsd_mock: Any,
+) -> None:
+    """Test that a successful search increments the count metric."""
+    mocker.patch.object(
+        AsyncElasticSearchAdapter,
+        "search",
+        new_callable=AsyncMock,
+        return_value={"suggest": {SUGGEST_ID: [{"options": []}]}},
+    )
+
+    await es_backend.search("foo", "en")
+
+    statsd_mock.increment.assert_called_once_with("es.search.count", tags={"index": INDICES["en"]})
+
+
+@pytest.mark.asyncio
+async def test_es_backend_search_error_metric_on_api_error(
+    mocker: MockerFixture,
+    es_backend: ElasticBackend,
+    statsd_mock: Any,
+) -> None:
+    """Test that an ApiError increments both the count and error metrics."""
+    api_error = ApiError(
+        message="service unavailable",
+        meta=ApiResponseMeta(
+            status=503,
+            http_version="",
+            headers=HttpHeaders(),
+            duration=0.0,
+            node=NodeConfig(scheme="", host="", port=0),
+        ),
+        body={},
+    )
+    mocker.patch.object(AsyncElasticSearchAdapter, "search", side_effect=api_error)
+
+    with pytest.raises(BackendError):
+        await es_backend.search("foo", "en")
+
+    statsd_mock.increment.assert_any_call("es.search.count", tags={"index": INDICES["en"]})
+    statsd_mock.increment.assert_any_call(
+        "es.search.error", tags={"index": INDICES["en"], "status": 503}
+    )
+
+
+@pytest.mark.asyncio
+async def test_es_backend_search_error_metric_on_exception(
+    mocker: MockerFixture,
+    es_backend: ElasticBackend,
+    statsd_mock: Any,
+) -> None:
+    """Test that a generic exception increments both the count and error metrics."""
+    mocker.patch.object(
+        AsyncElasticSearchAdapter, "search", side_effect=Exception("connection reset")
+    )
+
+    with pytest.raises(BackendError):
+        await es_backend.search("foo", "en")
+
+    statsd_mock.increment.assert_any_call("es.search.count", tags={"index": INDICES["en"]})
+    statsd_mock.increment.assert_any_call(
+        "es.search.error", tags={"index": INDICES["en"], "status": "unknown"}
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION


## References

JIRA: [DISCO-4086]

## Description
Troubleshooting performance for wikipedia, I discovered through tracing that 429 responses were being retried by the elasticsearch client, further overloading the cluster. This PR removes retries for reads altogether (due to low latency requirements and frequent querying on keystroke), and introduces additional metrics to understand and alert on elasticsearch performance.

In an ideal world both providers would use the same base and we could implement the metrics only once, but to avoid refactoring for now just add them in both clients on the relevant call paths.

Additional performance optimizations may be forthcoming, but this is a first start.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [x]  `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2223)


[DISCO-4086]: https://mozilla-hub.atlassian.net/browse/DISCO-4086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ