### PR TITLE
[DISCO-4087] Fix runtime error when shutting down rss providers

### DIFF
--- a/merino/providers/rss/__init__.py
+++ b/merino/providers/rss/__init__.py
@@ -30,9 +30,9 @@ async def shutdown_providers() -> None:
     """
     for name, provider in providers.items():
         await provider.shutdown()
-        # remove provider from
-        providers.pop(name)
         logger.info("RSS provider shut down", extra={"provider": name})
+    # remove all providers from the module level providers dict.
+    providers.clear()
 
 
 def get_wikimedia_potd_provider() -> WikimediaPictureOfTheDayProvider:


### PR DESCRIPTION
## References

JIRA: [DISCO-4087](https://mozilla-hub.atlassian.net/browse/DISCO-4087)

## Description
We were mutating the provider list while iterating over it during shut down. Clearing the list of RSS providers outside the loop now after all of them have been shut down.



## PR Review Checklist

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2225)


[DISCO-4087]: https://mozilla-hub.atlassian.net/browse/DISCO-4087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ