### PR TITLE
[DISCO-4069] Upload historical keyword level engagement data for AMP

### DIFF
--- a/merino/jobs/engagement_model/__init__.py
+++ b/merino/jobs/engagement_model/__init__.py
@@ -37,30 +37,50 @@ def upload_engagement_data() -> None:  # pragma: no cover
         amp_data_downloader = AMPDownloader(gcs_bq_project)
         wiki_data_downloader = WikiDownloader(gcs_bq_project)
 
-        amp_data: list[dict[str, Any]] = amp_data_downloader.download_data()
+        amp_by_advertiser: list[dict[str, Any]] = amp_data_downloader.download_by_advertiser()
+        amp_by_keyword: list[dict[str, Any]] = amp_data_downloader.download_by_keyword()
         wiki_data: dict[str, int] = wiki_data_downloader.download_data()
 
-        transformed_amp_data = {row["advertiser"]: row for row in amp_data}
+        transformed_amp_by_advertiser = amp_data_downloader.transform_by_advertiser(
+            amp_by_advertiser
+        )
+        transformed_amp_by_keyword = amp_data_downloader.transform_by_keyword(amp_by_keyword)
 
-        amp_aggregated = {
-            "impressions": sum(int(row["impressions"]) for row in amp_data),
-            "clicks": sum(int(row["clicks"]) for row in amp_data),
-        }
+        amp_aggregated_by_advertiser = amp_data_downloader.aggregate_by_advertiser(
+            amp_by_advertiser
+        )
+        amp_aggregated_by_keyword = amp_data_downloader.aggregate_by_keyword(
+            transformed_amp_by_keyword
+        )
 
-        payload = {
-            "amp": transformed_amp_data,
+        advertiser_payload = {
+            "amp": transformed_amp_by_advertiser,
             "wiki_aggregated": {
                 "impressions": int(wiki_data["impressions"]),
                 "clicks": int(wiki_data["clicks"]),
             },
-            "amp_aggregated": amp_aggregated,
+            "amp_aggregated": amp_aggregated_by_advertiser,
         }
 
-        content = json.dumps(payload, indent=2)
+        advertiser_content = json.dumps(advertiser_payload, indent=2)
+
+        keyword_payload = {
+            "amp": transformed_amp_by_keyword,
+            "wiki_aggregated": {
+                "impressions": int(wiki_data["impressions"]),
+                "clicks": int(wiki_data["clicks"]),
+            },
+            "amp_aggregated": amp_aggregated_by_keyword,
+        }
+
+        keyword_content = json.dumps(keyword_payload, indent=2)
 
         timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
-        destination_name = f"suggest-merino-exports/engagement/{timestamp}.json"
-        latest_name = "suggest-merino-exports/engagement/latest.json"
+        destination_name_advertiser = f"suggest-merino-exports/engagement/{timestamp}.json"
+        destination_name_keyword = f"suggest-merino-exports/engagement/keyword/{timestamp}.json"
+
+        latest_name_advertiser = "suggest-merino-exports/engagement/latest.json"
+        latest_name_keyword = "suggest-merino-exports/engagement/keyword/latest.json"
 
         uploader = GcsUploader(
             destination_gcp_project=gcs_storage_project,
@@ -69,20 +89,36 @@ def upload_engagement_data() -> None:  # pragma: no cover
         )
 
         uploader.upload_content(
-            content=content,
-            destination_name=destination_name,
+            content=advertiser_content,
+            destination_name=destination_name_advertiser,
             content_type="application/json",
             forced_upload=True,
         )
 
         uploader.upload_content(
-            content=content,
-            destination_name=latest_name,
+            content=advertiser_content,
+            destination_name=latest_name_advertiser,
             content_type="application/json",
             forced_upload=True,
         )
 
-        logger.info("Uploaded engagement data")
+        logger.info("Uploaded advertiser engagement data")
+
+        uploader.upload_content(
+            content=keyword_content,
+            destination_name=destination_name_keyword,
+            content_type="application/json",
+            forced_upload=True,
+        )
+
+        uploader.upload_content(
+            content=keyword_content,
+            destination_name=latest_name_keyword,
+            content_type="application/json",
+            forced_upload=True,
+        )
+
+        logger.info("Uploaded keyword engagement data")
 
     except Exception as ex:
         logger.error(

--- a/merino/jobs/engagement_model/amp_data_downloader.py
+++ b/merino/jobs/engagement_model/amp_data_downloader.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 class EngagementDataDownloader:
     """Download engagement data for AMP"""
 
-    QUERY = """
+    ADVERTISER_QUERY = """
 SELECT
   metrics.string.quick_suggest_advertiser AS advertiser,
   COUNT(*) AS impressions,
@@ -27,13 +27,28 @@ GROUP BY 1
 ORDER BY 1, 3 DESC, 2 DESC
 """
 
+    KEYWORD_QUERY = """
+SELECT
+ LOWER(advertiser),
+ LOWER(query),
+ COUNTIF(is_clicked) AS clicks,
+ COUNT(*) AS impressions
+FROM `moz-fx-data-shared-prod.search_terms_derived.suggest_impression_sanitized_v3`
+WHERE
+ submission_timestamp BETWEEN TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 7 DAY) AND CURRENT_TIMESTAMP()
+AND query is not NULL
+GROUP BY 1, 2
+HAVING impressions > 500
+ORDER BY 1, 4 DESC
+"""
+
     client: Client
 
     def __init__(self, source_gcp_project: str) -> None:
         self.client = Client(source_gcp_project)
 
-    def download_data(self) -> list[dict[str, Any]]:
-        """Execute the AMP engagement query and return aggregated engagement data.
+    def download_by_advertiser(self) -> list[dict[str, Any]]:
+        """Execute the advertiser-level AMP engagement query.
 
         Returns:
             list[dict[str, Any]]: A list of engagement records containing
@@ -43,15 +58,17 @@ ORDER BY 1, 3 DESC, 2 DESC
             RuntimeError: If the BigQuery query fails.
         """
         try:
-            query_job = self.client.query(self.QUERY)
+            query_job = self.client.query(self.ADVERTISER_QUERY)
             results = query_job.result()
 
         except GoogleAPIError as e:
             logger.error(
-                "BigQuery query failed while downloading AMP engagement data",
+                "BigQuery query failed while downloading advertiser-level AMP engagement data",
                 exc_info=True,
             )
-            raise RuntimeError("Failed to fetch AMP engagement data from BigQuery") from e
+            raise RuntimeError(
+                "Failed to fetch advertiser-level AMP engagement data from BigQuery"
+            ) from e
 
         engagement_data: list[dict[str, Any]] = []
 
@@ -69,6 +86,84 @@ ORDER BY 1, 3 DESC, 2 DESC
                 continue
 
         if not engagement_data:
-            logger.warning("AMP engagement query returned no rows")
+            logger.warning("Advertiser-level AMP engagement query returned no rows")
 
         return engagement_data
+
+    def download_by_keyword(self) -> list[dict[str, Any]]:
+        """Execute the keyword-level AMP engagement query.
+
+        Returns:
+            list[dict[str, Any]]: A list of engagement records containing
+            advertiser, query, impressions, and clicks.
+
+        Raises:
+            RuntimeError: If the BigQuery query fails.
+        """
+        try:
+            query_job = self.client.query(self.KEYWORD_QUERY)
+            results = query_job.result()
+
+        except GoogleAPIError as e:
+            logger.error(
+                "BigQuery query failed while downloading keyword-level AMP engagement data",
+                exc_info=True,
+            )
+            raise RuntimeError(
+                "Failed to fetch keyword-level AMP engagement data from BigQuery"
+            ) from e
+
+        engagement_data: list[dict[str, Any]] = []
+
+        for row in results:
+            try:
+                engagement_data.append(
+                    {
+                        "advertiser": row["advertiser"],
+                        "query": row["query"],
+                        "impressions": int(row["impressions"]),
+                        "clicks": int(row["clicks"]),
+                    }
+                )
+            except KeyError:
+                logger.warning("Unexpected row format in BigQuery results: %s", row)
+                continue
+
+        if not engagement_data:
+            logger.warning("Keyword-level AMP engagement query returned no rows")
+
+        return engagement_data
+
+    @staticmethod
+    def transform_by_advertiser(data: list[dict[str, Any]]) -> dict[str, Any]:
+        """Transform advertiser-level AMP data into an advertiser-keyed dict."""
+        return {row["advertiser"]: row for row in data}
+
+    @staticmethod
+    def aggregate_by_advertiser(data: list[dict[str, Any]]) -> dict[str, int]:
+        """Aggregate impressions and clicks across all advertiser-level AMP rows."""
+        return {
+            "impressions": sum(int(row["impressions"]) for row in data),
+            "clicks": sum(int(row["clicks"]) for row in data),
+        }
+
+    @staticmethod
+    def transform_by_keyword(data: list[dict[str, Any]]) -> dict[str, Any]:
+        """Transform keyword-level AMP data into an advertiser/query-keyed dict with historical metrics."""
+        return {
+            f"{row['advertiser']}/{row['query']}": {
+                "historical": {
+                    "impressions": row["impressions"],
+                    "clicks": row["clicks"],
+                }
+            }
+            for row in data
+        }
+
+    @staticmethod
+    def aggregate_by_keyword(transformed: dict[str, Any]) -> dict[str, int]:
+        """Aggregate impressions and clicks from keyword-level transformed AMP data."""
+        return {
+            "impressions": sum(int(v["historical"]["impressions"]) for v in transformed.values()),
+            "clicks": sum(int(v["historical"]["clicks"]) for v in transformed.values()),
+        }

--- a/tests/unit/jobs/engagement_model/test_amp_data_downloader.py
+++ b/tests/unit/jobs/engagement_model/test_amp_data_downloader.py
@@ -8,8 +8,8 @@ from google.api_core.exceptions import GoogleAPIError
 from merino.jobs.engagement_model.amp_data_downloader import EngagementDataDownloader
 
 
-def test_download_amp_data():
-    """Test downloading AMP engagement data."""
+def test_download_by_advertiser():
+    """Test downloading advertiser-level AMP engagement data."""
     rows = [
         {
             "advertiser": "mozilla",
@@ -33,12 +33,12 @@ def test_download_amp_data():
         return_value=mock_client,
     ):
         downloader = EngagementDataDownloader(source_gcp_project="merino-test")
-        data = downloader.download_data()
+        data = downloader.download_by_advertiser()
         assert data == rows
         mock_client.query.assert_called_once()
 
 
-def test_download_amp_data_raises_runtime_error_on_bigquery_failure():
+def test_download_by_advertiser_raises_runtime_error_on_bigquery_failure():
     """Test that a BigQuery failure is wrapped in RuntimeError."""
     mock_client = MagicMock()
     mock_client.query.side_effect = GoogleAPIError("BigQuery failed")
@@ -51,14 +51,14 @@ def test_download_amp_data_raises_runtime_error_on_bigquery_failure():
 
         with pytest.raises(
             RuntimeError,
-            match="Failed to fetch AMP engagement data from BigQuery",
+            match="Failed to fetch advertiser-level AMP engagement data from BigQuery",
         ):
-            downloader.download_data()
+            downloader.download_by_advertiser()
 
         mock_client.query.assert_called_once()
 
 
-def test_download_amp_data_skips_malformed_rows():
+def test_download_by_advertiser_skips_malformed_rows():
     """Test that malformed rows are skipped."""
     rows = [
         {
@@ -83,7 +83,7 @@ def test_download_amp_data_skips_malformed_rows():
         return_value=mock_client,
     ):
         downloader = EngagementDataDownloader(source_gcp_project="merino-test")
-        data = downloader.download_data()
+        data = downloader.download_by_advertiser()
 
         assert data == [
             {
@@ -94,7 +94,7 @@ def test_download_amp_data_skips_malformed_rows():
         ]
 
 
-def test_download_amp_data_returns_empty_list_when_no_rows():
+def test_download_by_advertiser_returns_empty_list_when_no_rows():
     """Test that an empty result set returns an empty list."""
     mock_client = MagicMock()
     mock_query = MagicMock()
@@ -106,6 +106,186 @@ def test_download_amp_data_returns_empty_list_when_no_rows():
         return_value=mock_client,
     ):
         downloader = EngagementDataDownloader(source_gcp_project="merino-test")
-        data = downloader.download_data()
+        data = downloader.download_by_advertiser()
 
         assert data == []
+
+
+def test_download_by_keyword():
+    """Test downloading keyword-level AMP engagement data."""
+    rows = [
+        {
+            "advertiser": "mozilla",
+            "query": "firefox",
+            "impressions": 1000,
+            "clicks": 22,
+        },
+        {
+            "advertiser": "firefox",
+            "query": "browser",
+            "impressions": 5666,
+            "clicks": 0,
+        },
+    ]
+
+    mock_client = MagicMock()
+    mock_query = MagicMock()
+    mock_query.result.return_value = rows
+    mock_client.query.return_value = mock_query
+
+    with patch(
+        "merino.jobs.engagement_model.amp_data_downloader.Client",
+        return_value=mock_client,
+    ):
+        downloader = EngagementDataDownloader(source_gcp_project="merino-test")
+        data = downloader.download_by_keyword()
+        assert data == rows
+        mock_client.query.assert_called_once()
+
+
+def test_download_by_keyword_raises_runtime_error_on_bigquery_failure():
+    """Test that a BigQuery failure is wrapped in RuntimeError."""
+    mock_client = MagicMock()
+    mock_client.query.side_effect = GoogleAPIError("BigQuery failed")
+
+    with patch(
+        "merino.jobs.engagement_model.amp_data_downloader.Client",
+        return_value=mock_client,
+    ):
+        downloader = EngagementDataDownloader(source_gcp_project="merino-test")
+
+        with pytest.raises(
+            RuntimeError,
+            match="Failed to fetch keyword-level AMP engagement data from BigQuery",
+        ):
+            downloader.download_by_keyword()
+
+        mock_client.query.assert_called_once()
+
+
+def test_download_by_keyword_skips_malformed_rows():
+    """Test that malformed rows are skipped."""
+    rows = [
+        {
+            "advertiser": "mozilla",
+            "query": "firefox",
+            "impressions": 1000,
+            "clicks": 22,
+        },
+        {
+            "advertiser": "firefox",
+            "query": "browser",
+            "impressions": 5666,
+            # missing clicks
+        },
+    ]
+
+    mock_client = MagicMock()
+    mock_query = MagicMock()
+    mock_query.result.return_value = rows
+    mock_client.query.return_value = mock_query
+
+    with patch(
+        "merino.jobs.engagement_model.amp_data_downloader.Client",
+        return_value=mock_client,
+    ):
+        downloader = EngagementDataDownloader(source_gcp_project="merino-test")
+        data = downloader.download_by_keyword()
+
+        assert data == [
+            {
+                "advertiser": "mozilla",
+                "query": "firefox",
+                "impressions": 1000,
+                "clicks": 22,
+            }
+        ]
+
+
+def test_download_by_keyword_returns_empty_list_when_no_rows():
+    """Test that an empty result set returns an empty list."""
+    mock_client = MagicMock()
+    mock_query = MagicMock()
+    mock_query.result.return_value = []
+    mock_client.query.return_value = mock_query
+
+    with patch(
+        "merino.jobs.engagement_model.amp_data_downloader.Client",
+        return_value=mock_client,
+    ):
+        downloader = EngagementDataDownloader(source_gcp_project="merino-test")
+        data = downloader.download_by_keyword()
+
+        assert data == []
+
+
+def test_transform_by_advertiser_returns_advertiser_keyed_dict():
+    """Test that advertiser rows are keyed by advertiser name."""
+    data = [
+        {"advertiser": "mozilla", "impressions": 1000, "clicks": 22},
+        {"advertiser": "firefox", "impressions": 5666, "clicks": 0},
+    ]
+    result = EngagementDataDownloader.transform_by_advertiser(data)
+    assert result == {
+        "mozilla": {"advertiser": "mozilla", "impressions": 1000, "clicks": 22},
+        "firefox": {"advertiser": "firefox", "impressions": 5666, "clicks": 0},
+    }
+
+
+def test_transform_by_advertiser_returns_empty_dict_for_empty_input():
+    """Test that an empty input returns an empty dict."""
+    assert EngagementDataDownloader.transform_by_advertiser([]) == {}
+
+
+def test_aggregate_by_advertiser_sums_impressions_and_clicks():
+    """Test that impressions and clicks are summed across all rows."""
+    data = [
+        {"advertiser": "mozilla", "impressions": 1000, "clicks": 22},
+        {"advertiser": "firefox", "impressions": 5666, "clicks": 0},
+    ]
+    result = EngagementDataDownloader.aggregate_by_advertiser(data)
+    assert result == {"impressions": 6666, "clicks": 22}
+
+
+def test_aggregate_by_advertiser_returns_zeros_for_empty_input():
+    """Test that an empty input returns zero totals."""
+    assert EngagementDataDownloader.aggregate_by_advertiser([]) == {
+        "impressions": 0,
+        "clicks": 0,
+    }
+
+
+def test_transform_by_keyword_returns_advertiser_query_keyed_dict():
+    """Test that keyword rows are keyed by advertiser/query with historical wrapper."""
+    data = [
+        {"advertiser": "mozilla", "query": "firefox", "impressions": 1000, "clicks": 22},
+        {"advertiser": "firefox", "query": "browser", "impressions": 5666, "clicks": 0},
+    ]
+    result = EngagementDataDownloader.transform_by_keyword(data)
+    assert result == {
+        "mozilla/firefox": {"historical": {"impressions": 1000, "clicks": 22}},
+        "firefox/browser": {"historical": {"impressions": 5666, "clicks": 0}},
+    }
+
+
+def test_transform_by_keyword_returns_empty_dict_for_empty_input():
+    """Test that an empty input returns an empty dict."""
+    assert EngagementDataDownloader.transform_by_keyword([]) == {}
+
+
+def test_aggregate_by_keyword_sums_impressions_and_clicks():
+    """Test that impressions and clicks are summed from the historical data."""
+    transformed = {
+        "mozilla/firefox": {"historical": {"impressions": 1000, "clicks": 22}},
+        "firefox/browser": {"historical": {"impressions": 5666, "clicks": 0}},
+    }
+    result = EngagementDataDownloader.aggregate_by_keyword(transformed)
+    assert result == {"impressions": 6666, "clicks": 22}
+
+
+def test_aggregate_by_keyword_returns_zeros_for_empty_input():
+    """Test that an empty input returns zero totals."""
+    assert EngagementDataDownloader.aggregate_by_keyword({}) == {
+        "impressions": 0,
+        "clicks": 0,
+    }

--- a/tests/unit/jobs/engagement_model/test_init.py
+++ b/tests/unit/jobs/engagement_model/test_init.py
@@ -8,25 +8,34 @@ from merino.jobs.engagement_model import upload_engagement_data
 
 def test_upload_engagement_data_success() -> None:
     """Test engagement data is fetched, transformed, and uploaded to GCS."""
-    amp_data = [
-        {
-            "advertiser": "mozilla",
-            "impressions": 100,
-            "clicks": 5,
-        },
-        {
-            "advertiser": "firefox",
-            "impressions": 200,
-            "clicks": 10,
-        },
+    amp_by_advertiser = [
+        {"advertiser": "mozilla", "impressions": 100, "clicks": 5},
+        {"advertiser": "firefox", "impressions": 200, "clicks": 10},
     ]
-    wiki_data = {
-        "impressions": 300,
-        "clicks": 20,
+    amp_by_keyword = [
+        {"advertiser": "mozilla", "query": "firefox", "impressions": 100, "clicks": 5},
+        {"advertiser": "firefox", "query": "browser", "impressions": 200, "clicks": 10},
+    ]
+    wiki_data = {"impressions": 300, "clicks": 20}
+
+    transformed_by_advertiser = {
+        "mozilla": {"advertiser": "mozilla", "impressions": 100, "clicks": 5},
+        "firefox": {"advertiser": "firefox", "impressions": 200, "clicks": 10},
     }
+    transformed_by_keyword = {
+        "mozilla/firefox": {"historical": {"impressions": 100, "clicks": 5}},
+        "firefox/browser": {"historical": {"impressions": 200, "clicks": 10}},
+    }
+    aggregated_by_advertiser = {"impressions": 300, "clicks": 15}
+    aggregated_by_keyword = {"impressions": 300, "clicks": 15}
 
     mock_amp_downloader = MagicMock()
-    mock_amp_downloader.download_data.return_value = amp_data
+    mock_amp_downloader.download_by_advertiser.return_value = amp_by_advertiser
+    mock_amp_downloader.download_by_keyword.return_value = amp_by_keyword
+    mock_amp_downloader.transform_by_advertiser.return_value = transformed_by_advertiser
+    mock_amp_downloader.transform_by_keyword.return_value = transformed_by_keyword
+    mock_amp_downloader.aggregate_by_advertiser.return_value = aggregated_by_advertiser
+    mock_amp_downloader.aggregate_by_keyword.return_value = aggregated_by_keyword
 
     mock_wiki_downloader = MagicMock()
     mock_wiki_downloader.download_data.return_value = wiki_data
@@ -67,54 +76,98 @@ def test_upload_engagement_data_success() -> None:
         destination_cdn_hostname="",
     )
 
-    expected_payload = {
-        "amp": {
-            "mozilla": {
-                "advertiser": "mozilla",
-                "impressions": 100,
-                "clicks": 5,
-            },
-            "firefox": {
-                "advertiser": "firefox",
-                "impressions": 200,
-                "clicks": 10,
-            },
-        },
-        "wiki_aggregated": {
-            "impressions": 300,
-            "clicks": 20,
-        },
-        "amp_aggregated": {
-            "impressions": 300,
-            "clicks": 15,
-        },
-    }
-    expected_content = json.dumps(expected_payload, indent=2)
+    mock_amp_downloader.download_by_advertiser.assert_called_once()
+    mock_amp_downloader.download_by_keyword.assert_called_once()
+    mock_amp_downloader.transform_by_advertiser.assert_called_once_with(amp_by_advertiser)
+    mock_amp_downloader.transform_by_keyword.assert_called_once_with(amp_by_keyword)
+    mock_amp_downloader.aggregate_by_advertiser.assert_called_once_with(amp_by_advertiser)
+    mock_amp_downloader.aggregate_by_keyword.assert_called_once_with(transformed_by_keyword)
+    mock_wiki_downloader.download_data.assert_called_once()
 
-    assert mock_uploader.upload_content.call_count == 2
+    expected_advertiser_payload = {
+        "amp": transformed_by_advertiser,
+        "wiki_aggregated": {"impressions": 300, "clicks": 20},
+        "amp_aggregated": aggregated_by_advertiser,
+    }
+    expected_keyword_payload = {
+        "amp": transformed_by_keyword,
+        "wiki_aggregated": {"impressions": 300, "clicks": 20},
+        "amp_aggregated": aggregated_by_keyword,
+    }
+    expected_advertiser_content = json.dumps(expected_advertiser_payload, indent=2)
+    expected_keyword_content = json.dumps(expected_keyword_payload, indent=2)
+
+    assert mock_uploader.upload_content.call_count == 4
     mock_uploader.upload_content.assert_any_call(
-        content=expected_content,
+        content=expected_advertiser_content,
         destination_name="suggest-merino-exports/engagement/20260316120000.json",
         content_type="application/json",
         forced_upload=True,
     )
     mock_uploader.upload_content.assert_any_call(
-        content=expected_content,
+        content=expected_advertiser_content,
         destination_name="suggest-merino-exports/engagement/latest.json",
+        content_type="application/json",
+        forced_upload=True,
+    )
+    mock_uploader.upload_content.assert_any_call(
+        content=expected_keyword_content,
+        destination_name="suggest-merino-exports/engagement/keyword/20260316120000.json",
+        content_type="application/json",
+        forced_upload=True,
+    )
+    mock_uploader.upload_content.assert_any_call(
+        content=expected_keyword_content,
+        destination_name="suggest-merino-exports/engagement/keyword/latest.json",
         content_type="application/json",
         forced_upload=True,
     )
 
 
-def test_upload_engagement_data_logs_error_on_failure() -> None:
-    """Test engagement pipeline errors are logged."""
+def test_upload_engagement_data_logs_error_on_advertiser_download_failure() -> None:
+    """Test engagement pipeline errors are logged when advertiser download fails."""
     mock_settings = MagicMock()
     mock_settings.engagement.gcs_bq_project = "test-bq-project"
     mock_settings.engagement.gcs_storage_bucket = "test-bucket"
     mock_settings.engagement.gcs_storage_project = "test-storage-project"
 
     mock_amp_downloader = MagicMock()
-    mock_amp_downloader.download_data.side_effect = RuntimeError("BigQuery failed")
+    mock_amp_downloader.download_by_advertiser.side_effect = RuntimeError("BigQuery failed")
+
+    mock_wiki_downloader = MagicMock()
+
+    with (
+        patch("merino.jobs.engagement_model.settings", mock_settings),
+        patch(
+            "merino.jobs.engagement_model.AMPDownloader",
+            return_value=mock_amp_downloader,
+        ),
+        patch(
+            "merino.jobs.engagement_model.WikiDownloader",
+            return_value=mock_wiki_downloader,
+        ),
+        patch("merino.jobs.engagement_model.logger") as mock_logger,
+    ):
+        upload_engagement_data()
+
+    mock_logger.error.assert_called_once()
+    args, kwargs = mock_logger.error.call_args
+
+    assert args[0] == "Engagement data pipeline failed: %s: %s"
+    assert args[1] == RuntimeError.__name__
+    assert "BigQuery failed" in args[2]
+    assert kwargs["exc_info"] is True
+
+
+def test_upload_engagement_data_logs_error_on_keyword_download_failure() -> None:
+    """Test engagement pipeline errors are logged when keyword download fails."""
+    mock_settings = MagicMock()
+    mock_settings.engagement.gcs_bq_project = "test-bq-project"
+    mock_settings.engagement.gcs_storage_bucket = "test-bucket"
+    mock_settings.engagement.gcs_storage_project = "test-storage-project"
+
+    mock_amp_downloader = MagicMock()
+    mock_amp_downloader.download_by_keyword.side_effect = RuntimeError("BigQuery failed")
 
     mock_wiki_downloader = MagicMock()
 


### PR DESCRIPTION

## References

JIRA: [DISCO-4069](https://mozilla-hub.atlassian.net/browse/DISCO-4069)

## Description
This PR ingests and uploaded historical keyword level engagement data to GCS for AMP provider

### Changes:
- Added a second BigQuery query (`KEYWORD_QUERY`) to `EngagementDataDownloader` that fetches keyword-level AMP engagement data from `suggest_impression_sanitized_v3` grouped by advertiser and query term.
- Renamed the existing query/download method from `download_data` → `download_by_advertiser` and the query constant from `QUERY` → `ADVERTISER_QUERY` for clarity (temporary as we would be moving completely to keyword level).
- Moved data transformation and aggregation logic from `__init__.py` into `EngagementDataDownloader` as static methods.
- The pipeline now produces two separate GCS payloads: an advertiser-level file at `suggest-merino-exports/engagement/latest.json` (unchanged path, backward-compatible) and a new keyword-level file at `suggest-merino-exports/engagement/keyword/latest.json`



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2227)


[DISCO-4069]: https://mozilla-hub.atlassian.net/browse/DISCO-4069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ