### PR TITLE
chore: Rename references from mozilla-it/deploy-actions to mozilla/deploy-actions

### DIFF
--- a/.github/workflows/publish-gar-image-locust.yaml
+++ b/.github/workflows/publish-gar-image-locust.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Tag image as latest
         run: docker tag ${{ secrets.DOCKER_IMAGE_PATH }}/merino-locust:${{ inputs.image_tag }} ${{ secrets.DOCKER_IMAGE_PATH }}/merino-locust:latest
       - name: Push Locust image to GAR
-        uses: mozilla-it/deploy-actions/docker-push@v3.11.1
+        uses: mozilla/deploy-actions/docker-push@v3.11.1
         with:
           local_image: ${{ secrets.DOCKER_IMAGE_PATH }}/merino-locust:latest
           image_repo_path: ${{ secrets.DOCKER_IMAGE_PATH }}/merino-locust

--- a/.github/workflows/publish-gar-image.yaml
+++ b/.github/workflows/publish-gar-image.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Tag image with GAR path
         run: docker tag app:build ${{ secrets.DOCKER_IMAGE_PATH }}/merino:${{ inputs.image_tag }}
       - name: Push image to GAR
-        uses: mozilla-it/deploy-actions/docker-push@v3.11.1
+        uses: mozilla/deploy-actions/docker-push@v3.11.1
         with:
           local_image: app:build
           image_repo_path: ${{ secrets.DOCKER_IMAGE_PATH }}/merino


### PR DESCRIPTION
## References

JIRA: MZCLD-2266

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->

This PR renames references from mozilla-it/deploy-actions to mozilla/deploy-actions

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2228)
