### PR TITLE
DISCO-4032 Adding ETag to /manifest endpoint

### DIFF
--- a/merino/providers/manifest/backends/filemanager.py
+++ b/merino/providers/manifest/backends/filemanager.py
@@ -7,7 +7,11 @@ from json import JSONDecodeError
 from pydantic import ValidationError
 from gcloud.aio.storage import Blob, Bucket, Storage
 
-from merino.providers.manifest.backends.protocol import ManifestData, GetManifestResultCode
+from merino.providers.manifest.backends.protocol import (
+    GetManifestResultCode,
+    ManifestData,
+    ManifestFetchResult,
+)
 from merino.utils.metrics import get_metrics_client
 from merino.utils.storage import get_storage_client
 
@@ -30,8 +34,14 @@ class ManifestRemoteFilemanager:
         self.blob_name = blob_name
         self.bucket = Bucket(storage=self.gcs_storage_client, name=gcs_bucket_path)
 
-    async def get_file(self) -> tuple[GetManifestResultCode, ManifestData | None]:
-        """Fetch the remote manifest file from GCS"""
+    async def get_file(self) -> ManifestFetchResult:
+        """Fetch the remote manifest file from GCS.
+
+        The blob's ``generation`` is surfaced as the ETag so the HTTP layer can
+        answer conditional ``If-None-Match`` requests without re-reading or
+        re-hashing the manifest body. GCS bumps the generation on every upload,
+        so it changes whenever the job republishes.
+        """
         metrics_client = get_metrics_client()
 
         try:
@@ -41,17 +51,23 @@ class ManifestRemoteFilemanager:
             metrics_client.gauge("manifest.size", value=blob.size)
 
             manifest_content = ManifestData.model_validate(orjson.loads(blob_data))
+            generation = getattr(blob, "generation", None)
+            etag = str(generation) if generation is not None else None
 
             metrics_client.gauge("manifest.domains.count", value=len(manifest_content.domains))
         except JSONDecodeError as json_error:
             logger.error("Failed to decode manifest JSON: %s", json_error)
-            return GetManifestResultCode.FAIL, None
+            return ManifestFetchResult(code=GetManifestResultCode.FAIL, data=None)
         except ValidationError as val_err:
             logger.error(f"Invalid manifest content: {val_err}")
-            return GetManifestResultCode.FAIL, None
+            return ManifestFetchResult(code=GetManifestResultCode.FAIL, data=None)
         except Exception as e:
             logger.error(f"Error fetching remote manifest file {self.blob_name}: {e}")
-            return GetManifestResultCode.FAIL, None
+            return ManifestFetchResult(code=GetManifestResultCode.FAIL, data=None)
 
         logger.info("Successfully loaded remote manifest file: %s", self.blob_name)
-        return GetManifestResultCode.SUCCESS, manifest_content
+        return ManifestFetchResult(
+            code=GetManifestResultCode.SUCCESS,
+            data=manifest_content,
+            etag=etag,
+        )

--- a/merino/providers/manifest/backends/manifest.py
+++ b/merino/providers/manifest/backends/manifest.py
@@ -3,11 +3,8 @@
 import logging
 
 from merino.configs import settings
-from merino.providers.manifest.backends.filemanager import (
-    GetManifestResultCode,
-    ManifestRemoteFilemanager,
-)
-from merino.providers.manifest.backends.protocol import ManifestData
+from merino.providers.manifest.backends.filemanager import ManifestRemoteFilemanager
+from merino.providers.manifest.backends.protocol import ManifestFetchResult
 
 logger = logging.getLogger(__name__)
 
@@ -21,17 +18,11 @@ class ManifestBackend:
         """Initialize the Manifest backend."""
         pass
 
-    async def fetch(self) -> tuple[GetManifestResultCode, ManifestData | None]:
-        """Fetch the manifest data from GCS asynchronously.
-        Returns:
-            (SUCCESS, ManifestData): If new data is fetched from GCS.
-            (FAIL, None): If there's an error with fetching or parsing.
-        """
+    async def fetch(self) -> ManifestFetchResult:
+        """Fetch the manifest data from GCS asynchronously."""
         return await self.fetch_manifest_data()
 
-    async def fetch_manifest_data(
-        self,
-    ) -> tuple[GetManifestResultCode, ManifestData | None]:
+    async def fetch_manifest_data(self) -> ManifestFetchResult:
         """Fetch manifest data from GCS through the remote filemanager."""
         remote_filemanager = ManifestRemoteFilemanager(
             gcs_bucket_path=settings.image_gcs.gcs_bucket,

--- a/merino/providers/manifest/backends/protocol.py
+++ b/merino/providers/manifest/backends/protocol.py
@@ -1,7 +1,7 @@
 """Protocol for the Manifest provider backend."""
 
 from enum import Enum
-from typing import Protocol
+from typing import NamedTuple, Protocol
 
 from pydantic import BaseModel, HttpUrl
 from merino.exceptions import BackendError
@@ -39,13 +39,27 @@ class ManifestData(BaseModel):
     partners: list[dict[str, str]]
 
 
+class ManifestFetchResult(NamedTuple):
+    """Result of fetching the manifest from its backing store.
+
+    The ``etag`` field carries the stringified GCS ``blob.generation`` on a
+    successful fetch. It is surfaced to the HTTP layer so the ``/manifest``
+    endpoint can answer conditional ``If-None-Match`` requests with a
+    ``304 Not Modified`` instead of the full body. It is ``None`` on any
+    failure path and for backends that do not provide a validator.
+    """
+
+    code: GetManifestResultCode
+    data: ManifestData | None
+    etag: str | None = None
+
+
 class ManifestBackend(Protocol):
     """Protocol for the Manifest backend that the provider depends on."""
 
-    async def fetch(self) -> tuple[GetManifestResultCode, ManifestData | None]:
-        """Fetch the manifest from storage and return it as a tuple.
-        Returns:
-            A tuple of (GetManifestResultCode, dict or None)
+    async def fetch(self) -> ManifestFetchResult:
+        """Fetch the manifest from storage.
+
         Raises:
             ManifestBackendError: If the manifest is unavailable or there is an error reading it.
         """

--- a/merino/providers/manifest/provider.py
+++ b/merino/providers/manifest/provider.py
@@ -8,11 +8,11 @@ import aiodogstatsd
 import tldextract
 from pydantic import HttpUrl, ValidationError
 
-from merino.providers.manifest.backends.filemanager import GetManifestResultCode
 from merino.utils import cron
 from merino.utils.metrics import get_metrics_client
 
 from merino.providers.manifest.backends.protocol import (
+    GetManifestResultCode,
     ManifestBackend,
     ManifestBackendError,
     ManifestData,
@@ -33,6 +33,7 @@ class Provider:
     last_fetch_at: float
     name: str
     metrics_client: aiodogstatsd.Client
+    _etag: str | None
 
     def __init__(
         self,
@@ -50,6 +51,7 @@ class Provider:
         self.domain_lookup_table = {}
         self.data_fetched_event = asyncio.Event()
         self.metrics_client = get_metrics_client()
+        self._etag = None
 
         super().__init__()
 
@@ -71,14 +73,15 @@ class Provider:
         Does not set manifest_data if non-success code passed with None.
         """
         try:
-            result_code, data = await self.backend.fetch()
+            result = await self.backend.fetch()
 
-            match GetManifestResultCode(result_code):
-                case GetManifestResultCode.SUCCESS if data is not None:
-                    self.manifest_data = data
+            match result.code:
+                case GetManifestResultCode.SUCCESS if result.data is not None:
+                    self.manifest_data = result.data
+                    self._etag = result.etag
                     self.domain_lookup_table = {
                         self._extract_full_domain(str(domain.url)): idx
-                        for idx, domain in enumerate(data.domains)
+                        for idx, domain in enumerate(result.data.domains)
                     }
                     self.last_fetch_at = time.time()
 
@@ -98,6 +101,15 @@ class Provider:
     def get_manifest_data(self) -> ManifestData | None:
         """Return manifest data"""
         return self.manifest_data
+
+    def get_etag(self) -> str | None:
+        """Return the current manifest's HTTP ETag, or None if not loaded.
+
+        The returned value is already quoted so HTTP handlers can emit it as-is
+        in the ``ETag`` response header and compare it verbatim against an
+        ``If-None-Match`` request header.
+        """
+        return f'"{self._etag}"' if self._etag else None
 
     def get_icon_url(self, url: str | HttpUrl) -> HttpUrl | None:
         """Get icon URL for a URL.

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -7,7 +7,7 @@ from itertools import chain
 from typing import Annotated, Literal
 
 from asgi_correlation_id.context import correlation_id
-from fastapi import APIRouter, Depends, Query, Header
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import ORJSONResponse
 from starlette.requests import Request
@@ -482,11 +482,20 @@ async def curated_content_legacy_fx_114(
     "/manifest",
     tags=["manifest"],
     summary="Get latest website favicons manifest",
+    description=(
+        "Returns the full manifest, plus an ``ETag`` derived from the "
+        "underlying GCS generation. Clients that cache the manifest should "
+        "send the ETag back as ``If-None-Match`` on subsequent requests; "
+        "when the manifest has not changed the server replies with "
+        "``304 Not Modified`` and an empty body."
+    ),
     response_model=ManifestData,
 )
 async def get_manifest(
-    request: Request, provider: ManifestProvider = Depends(get_manifest_provider)
-) -> ORJSONResponse:
+    request: Request,
+    provider: ManifestProvider = Depends(get_manifest_provider),
+    if_none_match: Annotated[str | None, Header()] = None,
+) -> Response:
     """Query merino for manifest data."""
     logger.info("Attempting to get manifest")
 
@@ -498,22 +507,34 @@ async def get_manifest(
         manifest_data = provider.get_manifest_data()
 
         if manifest_data and manifest_data.domains:
+            etag = provider.get_etag()
+            cache_control = (
+                f"private, max-age={settings.runtime.default_manifest_response_ttl_sec}"
+            )
+
+            if etag is not None and if_none_match == etag:
+                metrics_client.increment("manifest.request.not_modified")
+                return Response(
+                    status_code=status.HTTP_304_NOT_MODIFIED,
+                    headers={"ETag": etag, "Cache-Control": cache_control},
+                )
+
             metrics_client.increment("manifest.request.success")
+
+            headers = {"Cache-Control": cache_control}
+            if etag is not None:
+                headers["ETag"] = etag
 
             return ORJSONResponse(
                 content=jsonable_encoder(manifest_data),
-                headers={
-                    "Cache-Control": (
-                        f"private, max-age={settings.runtime.default_manifest_response_ttl_sec}"
-                    )
-                },
+                headers=headers,
             )
 
         metrics_client.increment("manifest.request.error")
         logger.error("Manifest file not found")
-        return ORJSONResponse(
-            content=jsonable_encoder(manifest_data),
-            status_code=404,
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Manifest not found",
         )
 
 

--- a/tests/integration/api/conftest.py
+++ b/tests/integration/api/conftest.py
@@ -13,7 +13,11 @@ from aiodogstatsd import Client as AioDogstatsdClient
 
 from merino.providers.manifest import Provider
 from merino.providers.manifest.backends.manifest import ManifestBackend
-from merino.providers.manifest.backends.protocol import GetManifestResultCode, ManifestData
+from merino.providers.manifest.backends.protocol import (
+    GetManifestResultCode,
+    ManifestData,
+    ManifestFetchResult,
+)
 from merino.utils.gcs.gcs_uploader import GcsUploader
 from contextlib import nullcontext
 from merino.main import app
@@ -90,7 +94,11 @@ def mock_manifest_backend(mock_manifest):
     """Mock ManifestBackend that returns our test data."""
     backend = ManifestBackend()
     backend.fetch = AsyncMock(
-        return_value=(GetManifestResultCode.SUCCESS, ManifestData(**mock_manifest))
+        return_value=ManifestFetchResult(
+            code=GetManifestResultCode.SUCCESS,
+            data=ManifestData(**mock_manifest),
+            etag="test-generation",
+        )
     )
     return backend
 

--- a/tests/integration/api/v1/manifest/test_manifest.py
+++ b/tests/integration/api/v1/manifest/test_manifest.py
@@ -27,22 +27,26 @@ def cleanup_tasks_fixture():
     return cleanup_tasks
 
 
-@pytest.mark.asyncio
-async def test_get_manifest_success(client, gcp_uploader, mock_manifest, cleanup):
-    """Uploads a manifest to the gcs bucket and verifies that the endpoint returns the uploaded file."""
-    # initialize provider on startup
-    await init_provider()
+async def _prime_manifest(gcp_uploader, mock_manifest, cleanup) -> Provider:
+    """Upload a manifest to the fake GCS bucket and wait for the provider to load it.
 
-    # set up the endpoint
+    Returns the initialized provider so tests can inspect state if needed.
+    """
+    await init_provider()
     app.include_router(router, prefix="/api/v1")
 
-    # upload a manifest file to GCS test container
     gcp_uploader.upload_content(orjson.dumps(mock_manifest), "top_picks_latest.json")
 
     provider = get_provider()
     await provider.data_fetched_event.wait()
-
     cleanup(provider)
+    return provider
+
+
+@pytest.mark.asyncio
+async def test_get_manifest_success(client, gcp_uploader, mock_manifest, cleanup):
+    """Uploads a manifest to the gcs bucket and verifies that the endpoint returns the uploaded file."""
+    await _prime_manifest(gcp_uploader, mock_manifest, cleanup)
 
     response = client.get("/api/v1/manifest")
     assert response.status_code == 200
@@ -52,11 +56,50 @@ async def test_get_manifest_success(client, gcp_uploader, mock_manifest, cleanup
     assert manifest.domains[0].domain == "spotify"
 
     assert "Cache-Control" in response.headers
+    assert "ETag" in response.headers
+    # Quoted per RFC 7232; the unquoted form is not a legal ETag value.
+    assert response.headers["ETag"].startswith('"')
+    assert response.headers["ETag"].endswith('"')
 
 
 @pytest.mark.asyncio
-async def test_get_manifest_from_gcs_bucket_should_return_empty_manifest_file(client, cleanup):
-    """Does not upload any manifests to the gcs bucket. Should return none and a 404."""
+async def test_get_manifest_returns_304_on_matching_if_none_match(
+    client, gcp_uploader, mock_manifest, cleanup
+):
+    """A conditional request echoing the current ETag should get a bodyless 304."""
+    await _prime_manifest(gcp_uploader, mock_manifest, cleanup)
+
+    first = client.get("/api/v1/manifest")
+    etag = first.headers["ETag"]
+
+    second = client.get("/api/v1/manifest", headers={"If-None-Match": etag})
+
+    assert second.status_code == 304
+    assert second.content == b""
+    assert second.headers["ETag"] == etag
+    assert "Cache-Control" in second.headers
+
+
+@pytest.mark.asyncio
+async def test_get_manifest_returns_200_on_mismatched_if_none_match(
+    client, gcp_uploader, mock_manifest, cleanup
+):
+    """A stale If-None-Match should fall through to a normal 200 with a fresh ETag."""
+    await _prime_manifest(gcp_uploader, mock_manifest, cleanup)
+
+    response = client.get("/api/v1/manifest", headers={"If-None-Match": '"stale-etag"'})
+
+    assert response.status_code == 200
+    manifest = ManifestData(**response.json())
+    assert len(manifest.domains) == 1
+    assert response.headers["ETag"] != '"stale-etag"'
+
+
+@pytest.mark.asyncio
+async def test_get_manifest_returns_404_when_not_loaded(client, cleanup):
+    """With nothing uploaded to GCS, the endpoint should 404 with an error detail rather than
+    a success-shaped empty manifest body.
+    """
     await init_provider()
 
     # set up the endpoint
@@ -69,6 +112,6 @@ async def test_get_manifest_from_gcs_bucket_should_return_empty_manifest_file(cl
 
     response = client.get("/api/v1/manifest")
     assert response.status_code == 404
-
-    assert response.json()["domains"] == []
+    assert response.json() == {"detail": "Manifest not found"}
     assert "Cache-Control" not in response.headers
+    assert "ETag" not in response.headers

--- a/tests/unit/providers/manifest/backends/test_filemanager.py
+++ b/tests/unit/providers/manifest/backends/test_filemanager.py
@@ -17,14 +17,16 @@ from merino.providers.manifest.backends.protocol import GetManifestResultCode, M
 async def test_get_file_async(
     fixture_filemanager, caplog: pytest.LogCaptureFixture, filter_caplog: FilterCaplogFixture
 ):
-    """Test that the async get_file method returns manifest data."""
-    get_file_result_code, result = await fixture_filemanager.get_file()
+    """Test that the async get_file method returns manifest data and ETag."""
+    result = await fixture_filemanager.get_file()
 
-    assert get_file_result_code is GetManifestResultCode.SUCCESS
-    assert isinstance(result, ManifestData)
-    assert result.domains
-    assert len(result.domains) == 5
-    assert result.domains[0].domain == "google"
+    assert result.code is GetManifestResultCode.SUCCESS
+    assert isinstance(result.data, ManifestData)
+    assert result.data.domains
+    assert len(result.data.domains) == 5
+    assert result.data.domains[0].domain == "google"
+    # blob.generation comes from the conftest fixture
+    assert result.etag == "42"
 
     # assert correct success log is emitted
     with caplog.at_level(logging.INFO):
@@ -43,6 +45,7 @@ async def test_get_file_json_decode_error(
     mock_blob = AsyncMock()
     # returns a non json value
     mock_blob.download.return_value = b"invalid json"
+    mock_blob.generation = 1
 
     mock_bucket = AsyncMock()
     mock_bucket.get_blob.return_value = mock_blob
@@ -54,9 +57,10 @@ async def test_get_file_json_decode_error(
     filemanager.gcs_client = mock_storage
     filemanager.bucket = mock_bucket
 
-    get_file_result_code, result = await filemanager.get_file()
-    assert get_file_result_code is GetManifestResultCode.FAIL
-    assert result is None
+    result = await filemanager.get_file()
+    assert result.code is GetManifestResultCode.FAIL
+    assert result.data is None
+    assert result.etag is None
 
     # assert correct error log is emitted
     with caplog.at_level(logging.ERROR):
@@ -75,6 +79,7 @@ async def test_get_file_validation_error(
     mock_blob = AsyncMock()
     # returns invalid field
     mock_blob.download.return_value = orjson.dumps({"invalid_field": "data"})
+    mock_blob.generation = 1
 
     mock_bucket = AsyncMock()
     mock_bucket.get_blob.return_value = mock_blob
@@ -86,10 +91,11 @@ async def test_get_file_validation_error(
     filemanager.gcs_client = mock_storage
     filemanager.bucket = mock_bucket
 
-    get_file_result_code, result = await filemanager.get_file()
+    result = await filemanager.get_file()
 
-    assert get_file_result_code is GetManifestResultCode.FAIL
-    assert result is None
+    assert result.code is GetManifestResultCode.FAIL
+    assert result.data is None
+    assert result.etag is None
 
     # assert correct error log is emitted
     with caplog.at_level(logging.ERROR):
@@ -116,10 +122,11 @@ async def test_get_file_exception(
     filemanager.gcs_client = mock_storage
     filemanager.bucket = mock_bucket
 
-    get_file_result_code, result = await filemanager.get_file()
+    result = await filemanager.get_file()
 
-    assert get_file_result_code is GetManifestResultCode.FAIL
-    assert result is None
+    assert result.code is GetManifestResultCode.FAIL
+    assert result.data is None
+    assert result.etag is None
 
     # assert correct error log is emitted
     with caplog.at_level(logging.ERROR):

--- a/tests/unit/providers/manifest/backends/test_manifest.py
+++ b/tests/unit/providers/manifest/backends/test_manifest.py
@@ -6,7 +6,10 @@
 
 from unittest.mock import patch
 import pytest
-from merino.providers.manifest.backends.protocol import GetManifestResultCode
+from merino.providers.manifest.backends.protocol import (
+    GetManifestResultCode,
+    ManifestFetchResult,
+)
 from merino.providers.manifest.backends.manifest import ManifestBackend
 
 
@@ -20,13 +23,14 @@ async def test_fetch_manifest_data(backend: ManifestBackend, fixture_filemanager
         "merino.providers.manifest.backends.manifest.ManifestRemoteFilemanager",
         return_value=fixture_filemanager,
     ):
-        get_file_result_code, result = await backend.fetch_manifest_data()
+        result = await backend.fetch_manifest_data()
 
-        assert get_file_result_code is GetManifestResultCode.SUCCESS
-        assert result is not None
-        assert result.domains is not None
-        assert len(result.domains) == 5
-        assert result.domains[1].domain == "microsoft"
+        assert result.code is GetManifestResultCode.SUCCESS
+        assert result.data is not None
+        assert result.data.domains is not None
+        assert len(result.data.domains) == 5
+        assert result.data.domains[1].domain == "microsoft"
+        assert result.etag == "42"
 
 
 @pytest.mark.asyncio
@@ -39,12 +43,13 @@ async def test_fetch_manifest_data_fail(backend: ManifestBackend, fixture_filema
         with patch.object(
             fixture_filemanager,
             "get_file",
-            return_value=(GetManifestResultCode.FAIL, None),
+            return_value=ManifestFetchResult(code=GetManifestResultCode.FAIL, data=None),
         ) as mock_get_file:
-            get_file_result_code, result = await backend.fetch_manifest_data()
+            result = await backend.fetch_manifest_data()
 
-            assert get_file_result_code is GetManifestResultCode.FAIL
-            assert result is None
+            assert result.code is GetManifestResultCode.FAIL
+            assert result.data is None
+            assert result.etag is None
 
             mock_get_file.assert_called_once()
 
@@ -56,10 +61,11 @@ async def test_fetch(backend: ManifestBackend, fixture_filemanager) -> None:
         "merino.providers.manifest.backends.manifest.ManifestRemoteFilemanager",
         return_value=fixture_filemanager,
     ):
-        get_file_result_code, result = await backend.fetch()
+        result = await backend.fetch()
 
-        assert get_file_result_code is GetManifestResultCode.SUCCESS
-        assert result is not None
-        assert result.domains is not None
-        assert len(result.domains) == 5
-        assert result.domains[2].domain == "facebook"
+        assert result.code is GetManifestResultCode.SUCCESS
+        assert result.data is not None
+        assert result.data.domains is not None
+        assert len(result.data.domains) == 5
+        assert result.data.domains[2].domain == "facebook"
+        assert result.etag == "42"

--- a/tests/unit/providers/manifest/conftest.py
+++ b/tests/unit/providers/manifest/conftest.py
@@ -41,6 +41,7 @@ async def fixture_filemanager_blob(blob_json):
     blob = AsyncMock()
     blob.download.return_value = blob_json
     blob.size = 1234
+    blob.generation = 42
     return blob
 
 

--- a/tests/unit/providers/manifest/test_get_icon_url.py
+++ b/tests/unit/providers/manifest/test_get_icon_url.py
@@ -4,7 +4,11 @@ import pytest
 from pydantic import HttpUrl
 from unittest.mock import MagicMock
 
-from merino.providers.manifest.backends.protocol import GetManifestResultCode, ManifestData
+from merino.providers.manifest.backends.protocol import (
+    GetManifestResultCode,
+    ManifestData,
+    ManifestFetchResult,
+)
 from merino.providers.manifest.provider import Provider
 from unittest.mock import patch
 
@@ -16,7 +20,9 @@ async def test_domain_lookup_table_initialization(
     """Test that domain_lookup_table is correctly initialized during provider setup."""
     with patch(
         "merino.providers.manifest.backends.manifest.ManifestBackend.fetch",
-        return_value=(GetManifestResultCode.SUCCESS, manifest_data),
+        return_value=ManifestFetchResult(
+            code=GetManifestResultCode.SUCCESS, data=manifest_data, etag="42"
+        ),
     ):
         await manifest_provider.initialize()
         await cleanup(manifest_provider)
@@ -63,7 +69,9 @@ async def test_get_icon_url_domain_variants(
     """Test icon URL retrieval with different domain format variants."""
     with patch(
         "merino.providers.manifest.backends.manifest.ManifestBackend.fetch",
-        return_value=(GetManifestResultCode.SUCCESS, manifest_data),
+        return_value=ManifestFetchResult(
+            code=GetManifestResultCode.SUCCESS, data=manifest_data, etag="42"
+        ),
     ):
         await manifest_provider.initialize()
         await cleanup(manifest_provider)
@@ -78,7 +86,9 @@ async def test_get_icon_url_not_found(
     """Test icon URL retrieval for non-existent domain."""
     with patch(
         "merino.providers.manifest.backends.manifest.ManifestBackend.fetch",
-        return_value=(GetManifestResultCode.SUCCESS, manifest_data),
+        return_value=ManifestFetchResult(
+            code=GetManifestResultCode.SUCCESS, data=manifest_data, etag="42"
+        ),
     ):
         await manifest_provider.initialize()
         await cleanup(manifest_provider)
@@ -93,7 +103,9 @@ async def test_get_icon_url_invalid_url(
     """Test icon URL retrieval with invalid URLs."""
     with patch(
         "merino.providers.manifest.backends.manifest.ManifestBackend.fetch",
-        return_value=(GetManifestResultCode.SUCCESS, manifest_data),
+        return_value=ManifestFetchResult(
+            code=GetManifestResultCode.SUCCESS, data=manifest_data, etag="42"
+        ),
     ):
         await manifest_provider.initialize()
         await cleanup(manifest_provider)
@@ -116,7 +128,9 @@ async def test_get_icon_url_with_pydantic_url(
     """Test icon URL retrieval with Pydantic HttpUrl type."""
     with patch(
         "merino.providers.manifest.backends.manifest.ManifestBackend.fetch",
-        return_value=(GetManifestResultCode.SUCCESS, manifest_data),
+        return_value=ManifestFetchResult(
+            code=GetManifestResultCode.SUCCESS, data=manifest_data, etag="42"
+        ),
     ):
         await manifest_provider.initialize()
         await cleanup(manifest_provider)
@@ -154,7 +168,9 @@ async def test_get_icon_url_invalid_icon_metric(
         patch.object(manifest_provider, "metrics_client", mock_metrics_client),
         patch(
             "merino.providers.manifest.backends.manifest.ManifestBackend.fetch",
-            return_value=(GetManifestResultCode.SUCCESS, manifest_data),
+            return_value=ManifestFetchResult(
+                code=GetManifestResultCode.SUCCESS, data=manifest_data, etag="42"
+            ),
         ),
     ):
         await manifest_provider.initialize()
@@ -199,7 +215,9 @@ async def test_get_icon_url_tld_specific_matching(manifest_provider: Provider, c
 
     with patch(
         "merino.providers.manifest.backends.manifest.ManifestBackend.fetch",
-        return_value=(GetManifestResultCode.SUCCESS, custom_manifest_data),
+        return_value=ManifestFetchResult(
+            code=GetManifestResultCode.SUCCESS, data=custom_manifest_data, etag="42"
+        ),
     ):
         await manifest_provider.initialize()
         await cleanup(manifest_provider)

--- a/tests/unit/providers/manifest/test_provider.py
+++ b/tests/unit/providers/manifest/test_provider.py
@@ -12,6 +12,7 @@ from merino.providers.manifest.backends.protocol import (
     GetManifestResultCode,
     ManifestBackendError,
     ManifestData,
+    ManifestFetchResult,
 )
 from merino.providers.manifest.provider import Provider
 from merino.providers.manifest.backends.manifest import ManifestBackend
@@ -27,16 +28,19 @@ async def test_initialize(
     """Test initialization of manifest provider"""
     with patch(
         "merino.providers.manifest.backends.manifest.ManifestBackend.fetch",
-        return_value=(GetManifestResultCode.SUCCESS, manifest_data),
+        return_value=ManifestFetchResult(
+            code=GetManifestResultCode.SUCCESS, data=manifest_data, etag="42"
+        ),
     ):
         await manifest_provider.initialize()
         await cleanup(manifest_provider)
 
-        result_code, _ = await backend.fetch()
+        result = await backend.fetch()
 
-        assert result_code is GetManifestResultCode.SUCCESS
+        assert result.code is GetManifestResultCode.SUCCESS
         assert manifest_provider.manifest_data == manifest_data
         assert manifest_provider.last_fetch_at > 0
+        assert manifest_provider.get_etag() == '"42"'
 
 
 @pytest.mark.asyncio
@@ -46,7 +50,9 @@ async def test_get_manifest_data(
     """Test get_manifest_data method returns manifest data"""
     with patch(
         "merino.providers.manifest.backends.manifest.ManifestBackend.fetch",
-        return_value=(GetManifestResultCode.SUCCESS, manifest_data),
+        return_value=ManifestFetchResult(
+            code=GetManifestResultCode.SUCCESS, data=manifest_data, etag="42"
+        ),
     ):
         await manifest_provider.initialize()
         await cleanup(manifest_provider)
@@ -64,7 +70,9 @@ async def test_should_fetch_true(
     """Test should_fetch method returns true based on the resync interval"""
     with patch(
         "merino.providers.manifest.backends.manifest.ManifestBackend.fetch",
-        return_value=(GetManifestResultCode.SUCCESS, manifest_data),
+        return_value=ManifestFetchResult(
+            code=GetManifestResultCode.SUCCESS, data=manifest_data, etag="42"
+        ),
     ):
         # difference between last fetch and current time is 100000 (greater than 86400)
         with patch(
@@ -86,7 +94,9 @@ async def test_should_fetch_false(
     """Test should_fetch method returns false based on the resync interval"""
     with patch(
         "merino.providers.manifest.backends.manifest.ManifestBackend.fetch",
-        return_value=(GetManifestResultCode.SUCCESS, manifest_data),
+        return_value=ManifestFetchResult(
+            code=GetManifestResultCode.SUCCESS, data=manifest_data, etag="42"
+        ),
     ):
         with patch(
             "merino.providers.manifest.provider.time.time",
@@ -107,7 +117,9 @@ async def test_fetch_data_success(
     """Test fetch_data method sets manifest data on SUCCESS"""
     with patch(
         "merino.providers.manifest.backends.manifest.ManifestBackend.fetch",
-        return_value=(GetManifestResultCode.SUCCESS, manifest_data),
+        return_value=ManifestFetchResult(
+            code=GetManifestResultCode.SUCCESS, data=manifest_data, etag="42"
+        ),
     ):
         await manifest_provider.initialize()
         await cleanup(manifest_provider)
@@ -123,7 +135,7 @@ async def test_fetch_data_fail(manifest_provider: Provider, cleanup) -> None:
     """Test fetch_data method does not set manifest data when a failure occurs"""
     with patch(
         "merino.providers.manifest.backends.manifest.ManifestBackend.fetch",
-        return_value=(GetManifestResultCode.FAIL, None),
+        return_value=ManifestFetchResult(code=GetManifestResultCode.FAIL, data=None),
     ):
         await manifest_provider.initialize()
         await cleanup(manifest_provider)


### PR DESCRIPTION
## References

JIRA: [DISCO-4032](https://mozilla-hub.atlassian.net/browse/DISCO-4032)

## Description
We want to make the `/manifest` endpoint being able to be called as cheap as possible. The first step is to pass an `ETag` to the endpoint, so we can check if the Manifest file changed or not. This allows clients to store the `ETag` in the response, and send it back in the following requests. If the `ETag` is the same, we know the file hasn't changed. 



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-4032]: https://mozilla-hub.atlassian.net/browse/DISCO-4032?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ