### PR TITLE
[DISCO-4106] Fix KeyError for historical engagement data

### DIFF
--- a/merino/jobs/engagement_model/amp_data_downloader.py
+++ b/merino/jobs/engagement_model/amp_data_downloader.py
@@ -29,8 +29,8 @@ ORDER BY 1, 3 DESC, 2 DESC
 
     KEYWORD_QUERY = """
 SELECT
- LOWER(advertiser),
- LOWER(query),
+ LOWER(advertiser) AS advertiser,
+ LOWER(query) AS query,
  COUNTIF(is_clicked) AS clicks,
  COUNT(*) AS impressions
 FROM `moz-fx-data-shared-prod.search_terms_derived.suggest_impression_sanitized_v3`


### PR DESCRIPTION
## References

JIRA: [DISCO-4106](https://mozilla-hub.atlassian.net/browse/DISCO-4106)

## Description
- `KEYWORD_QUERY` was selecting `LOWER(advertiser)` and `LOWER(query)` without `AS` aliases, causing BigQuery to return columns with auto-generated names instead of `advertiser` and `query`
- The downloader's row parsing tried `row["advertiser"]` and `row["query"]`, hit `KeyError` on every row, and silently skipped them all, resulting in an empty list and an empty `amp` field in the keyword engagement file.
- Fixed by adding explicit AS advertiser and AS query aliases to the two columns.
-  [Airflow logs](https://workflow.telemetry.mozilla.org/log?dag_id=merino_engagement_data&task_id=upload_engagement_data_prod&execution_date=2026-04-22T14%3A00%3A00%2B00%3A00)



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2231)


[DISCO-4106]: https://mozilla-hub.atlassian.net/browse/DISCO-4106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ