### PR TITLE
DISCO-4108 - Add key to missing logo metrics

### DIFF
--- a/merino/utils/logos.py
+++ b/merino/utils/logos.py
@@ -74,8 +74,12 @@ def get_logo_url(category: LogoCategory, key: str) -> Optional[HttpUrl]:
     logo = load_manifest().get(category, key)
     if logo is None:
         logger.warning(f"Logo does not exist for category={category} and key={key}")
+        # Normalize to the manifest's uppercase storage form so "aa" and "AA"
+        # collapse to a single series. Cardinality is bounded by the known key
+        # spaces (IATA codes, sports team keys), so this is safe for Prometheus.
         metrics_client.increment(
-            "manifest.lookup", tags={"name": f"logos.{category}", "result": "miss"}
+            "manifest.lookup",
+            tags={"name": f"logos.{category}", "key": key.upper(), "result": "miss"},
         )
         return None
     return HttpUrl(urljoin(CDN_ROOT_URL, logo.url))

--- a/merino/utils/logos.py
+++ b/merino/utils/logos.py
@@ -9,6 +9,7 @@ import orjson
 from importlib.resources import files
 from urllib.parse import urljoin
 
+import sentry_sdk
 from pydantic import BaseModel, HttpUrl
 
 from merino.utils.metrics import get_metrics_client
@@ -21,6 +22,12 @@ metrics_client = get_metrics_client()
 _cdn_host_name: str = settings.image_gcs_v2.cdn_hostname
 _protocol = "http" if "localhost" in _cdn_host_name else "https"
 CDN_ROOT_URL: str = f"{_protocol}://{_cdn_host_name}"
+
+# Tracks which (category, key) misses have already been reported to Sentry in
+# this process, so sustained miss traffic on the same entry doesn't burn event
+# quota. Cardinality is bounded by the known key spaces (IATA codes, sports
+# team keys), so the set never grows meaningfully large.
+_REPORTED_MISSES: set[tuple[str, str]] = set()
 
 
 class LogoCategory(StrEnum):
@@ -73,13 +80,30 @@ def get_logo_url(category: LogoCategory, key: str) -> Optional[HttpUrl]:
     """
     logo = load_manifest().get(category, key)
     if logo is None:
+        normalized_key = key.upper()
         logger.warning(f"Logo does not exist for category={category} and key={key}")
         # Normalize to the manifest's uppercase storage form so "aa" and "AA"
         # collapse to a single series. Cardinality is bounded by the known key
         # spaces (IATA codes, sports team keys), so this is safe for Prometheus.
         metrics_client.increment(
             "manifest.lookup",
-            tags={"name": f"logos.{category}", "key": key.upper(), "result": "miss"},
+            tags={"name": f"logos.{category}", "key": normalized_key, "result": "miss"},
         )
+        # Report each unique (category, key) miss to Sentry once per process so
+        # the on-call surface stays actionable and doesn't drown in repeats.
+        # Sentry's own fingerprinting would still dedupe the resulting Issue,
+        # but every send counts against event quota and the Grafana panel shows
+        # sustained multi-miss-per-second bursts on known-bad keys.
+        miss_id = (category.value, normalized_key)
+        if miss_id not in _REPORTED_MISSES:
+            _REPORTED_MISSES.add(miss_id)
+            sentry_sdk.capture_message(
+                f"Missing logo: category={category} key={normalized_key}",
+                level="error",
+                scope=lambda scope: scope.set_context(
+                    "missing logo",
+                    {"category": str(category), "key": normalized_key},
+                ),
+            )
         return None
     return HttpUrl(urljoin(CDN_ROOT_URL, logo.url))

--- a/metrics.yaml
+++ b/metrics.yaml
@@ -414,7 +414,14 @@ providers/manifest:
     labels:
       - name: name
         description: |
-          An identifier for the manifest, e.g. "logos"
+          An identifier for the manifest namespace, e.g. "logos.airline",
+          "logos.nba".
+      - name: key
+        description: |
+          The specific key that was looked up, normalized to the manifest's
+          uppercase storage form (e.g. IATA code "AA", sports team key "GSW").
+          Only emitted on miss events so dashboards can show which entries
+          are missing without loading cardinality on the hot path.
       - name: result
         description: |
           The outcome of the lookup (e.g. "miss" when the requested key

--- a/tests/unit/utils/test_logos.py
+++ b/tests/unit/utils/test_logos.py
@@ -48,10 +48,11 @@ def test_get_logo_url_not_found(
     assert "mlb" in records[0].message
     assert "zzzzz" in records[0].message
 
-    # Increments miss metric
+    # Increments miss metric with the normalized key so dashboards can show
+    # which specific logo is missing, not just the category.
     statsd_mock.increment.assert_called_once_with(
         "manifest.lookup",
-        tags={"name": "logos.mlb", "result": "miss"},
+        tags={"name": "logos.mlb", "key": "ZZZZZ", "result": "miss"},
     )
 
 

--- a/tests/unit/utils/test_logos.py
+++ b/tests/unit/utils/test_logos.py
@@ -39,6 +39,9 @@ def test_get_logo_url_not_found(
 ) -> None:
     """Returns None when the manifest has no entry for the given category and key."""
     mocker.patch("merino.utils.logos.metrics_client", statsd_mock)
+    mocker.patch("merino.utils.logos._REPORTED_MISSES", set())
+    sentry_capture = mocker.patch("merino.utils.logos.sentry_sdk.capture_message")
+
     with caplog.at_level(logging.WARNING):
         result = get_logo_url(LogoCategory.MLB, "zzzzz")
 
@@ -54,6 +57,34 @@ def test_get_logo_url_not_found(
         "manifest.lookup",
         tags={"name": "logos.mlb", "key": "ZZZZZ", "result": "miss"},
     )
+
+    # Fires a Sentry event at error level so on-call gets a single triageable
+    # Issue per unique missing logo rather than a line in GCP Logs nobody reads.
+    sentry_capture.assert_called_once()
+    call = sentry_capture.call_args
+    assert call.args[0] == "Missing logo: category=mlb key=ZZZZZ"
+    assert call.kwargs["level"] == "error"
+
+
+def test_get_logo_url_not_found_reports_to_sentry_once_per_process(
+    statsd_mock,
+    mocker,
+) -> None:
+    """Repeated misses for the same (category, key) fire Sentry at most once.
+
+    Prevents chatty misses (e.g. sustained bursts on a known-bad key) from
+    burning event quota. The metric still fires on every miss since Grafana
+    relies on the rate.
+    """
+    mocker.patch("merino.utils.logos.metrics_client", statsd_mock)
+    mocker.patch("merino.utils.logos._REPORTED_MISSES", set())
+    sentry_capture = mocker.patch("merino.utils.logos.sentry_sdk.capture_message")
+
+    for _ in range(5):
+        assert get_logo_url(LogoCategory.MLB, "zzzzz") is None
+
+    sentry_capture.assert_called_once()
+    assert statsd_mock.increment.call_count == 5
 
 
 @pytest.mark.restore_load_manifest


### PR DESCRIPTION
## References

JIRA: [DISCO-4108](https://mozilla-hub.atlassian.net/browse/DISCO-4108)

## Description
In Grafana, we see that we are  missing some logos for different sports. But it would be good to see which teams we are missing to fetch.

<img width="968" height="326" alt="Screenshot 2026-04-22 at 15 03 08" src="https://github.com/user-attachments/assets/6251f3ae-4ee4-46af-bb10-a5f6a2107760" />


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2232)


[DISCO-4108]: https://mozilla-hub.atlassian.net/browse/DISCO-4108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ