### PR TITLE
[DISCO-4107] Add AMP live dataset access probe job

### DIFF
--- a/merino/jobs/cli.py
+++ b/merino/jobs/cli.py
@@ -14,6 +14,7 @@ from merino.jobs.polygon import cli as polygon_ingestion_cmd
 from merino.jobs.flightaware import cli as flightaware_fetch_schedules_cmd
 from merino.jobs.sportsdata_jobs import cli as sportsdata_cmd
 from merino.jobs.engagement_model import cli as engagement_data_cmd
+from merino.jobs.engagement_model.amp_live_probe import cli as amp_live_probe_cmd
 
 # Include your new jobs module here.
 
@@ -49,6 +50,9 @@ cli.add_typer(sportsdata_cmd, no_args_is_help=True)
 
 # Add the engagement data fetch subcommand
 cli.add_typer(engagement_data_cmd, no_args_is_help=True)
+
+# Add the AMP live dataset access probe subcommand
+cli.add_typer(amp_live_probe_cmd, no_args_is_help=True)
 
 
 @cli.callback()

--- a/merino/jobs/engagement_model/amp_live_probe/__init__.py
+++ b/merino/jobs/engagement_model/amp_live_probe/__init__.py
@@ -1,0 +1,58 @@
+"""Probe job to verify Airflow has access to the live AMP keyword engagement dataset."""
+
+import logging
+import sys
+
+import typer
+from google.api_core.exceptions import GoogleAPIError
+from google.cloud.bigquery import Client, QueryJobConfig
+
+from merino.configs import settings
+
+logger = logging.getLogger(__name__)
+
+QUERY = """
+WITH base AS (
+ SELECT
+   LOWER(a.jsonPayload.fields.query) as query,
+   LOWER(b.metrics.string.quick_suggest_advertiser) as advertiser,
+   b.metrics.boolean.quick_suggest_is_clicked as is_clicked
+ FROM `suggest-searches-prod-a30f.logs.stdout` a
+ JOIN `moz-fx-data-shared-prod.firefox_desktop_live.quick_suggest_v1` b
+ ON a.jsonPayload.fields.rid = b.metrics.string.quick_suggest_request_id
+ WHERE a.timestamp BETWEEN TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 DAY) AND CURRENT_TIMESTAMP()
+ AND b.submission_timestamp BETWEEN TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 DAY) AND CURRENT_TIMESTAMP()
+)
+SELECT
+ advertiser,
+ query,
+ COUNT(*) as impressions,
+ COUNTIF(is_clicked) as clicks
+FROM base
+GROUP BY 1, 2
+HAVING impressions > 200
+ORDER BY 3 DESC
+"""
+
+cli = typer.Typer(
+    name="probe_amp_live_access",
+    help="Probe BigQuery access to the live AMP keyword engagement dataset",
+)
+
+
+@cli.command()
+def probe_amp_live_access() -> None:  # pragma: no cover
+    """Dry-run the live AMP keyword query to verify dataset access without executing it."""
+    logger.info("Probing access to live AMP keyword engagement dataset...")
+
+    try:
+        client = Client(settings.engagement.gcs_bq_project)
+        job_config = QueryJobConfig(dry_run=True, use_query_cache=False)
+        job = client.query(QUERY, job_config=job_config)
+        logger.info(
+            "Access confirmed. Estimated bytes to be processed: %d",
+            job.total_bytes_processed,
+        )
+    except GoogleAPIError as e:
+        logger.error("Access check failed: %s", str(e))
+        sys.exit(1)


### PR DESCRIPTION
## References

JIRA: [DISCO-4107](https://mozilla-hub.atlassian.net/browse/DISCO-4107)

## Description
This PR adds a new `probe-amp-live-access` CLI command. The probe submits the live keyword engagement query as a BigQuery dry run which validates that the service account has access to `suggest-searches-prod-a30f.logs.stdout` and `quick_suggest_v1` without scanning any data.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2233)


[DISCO-4107]: https://mozilla-hub.atlassian.net/browse/DISCO-4107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ