### PR TITLE
[DISCO-4071]Add ingestion of kw/advertiser engagement data

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -345,6 +345,10 @@ gcs_storage_project = ""
 # Path within the GCS bucket to the engagement data blob.
 blob_name = "suggest-merino-exports/engagement/latest.json"
 
+# MERINO_ENGAGEMENT__KEYWORD_BLOB_NAME
+# Path within the GCS bucket to the keyword-level engagement data blob.
+keyword_blob_name = "suggest-merino-exports/engagement/keyword/latest.json"
+
 [default.icon]
 # Subdirectory within bucket for favicons
 favicons_root = "favicons"

--- a/merino/providers/suggest/adm/backends/protocol.py
+++ b/merino/providers/suggest/adm/backends/protocol.py
@@ -24,6 +24,28 @@ class EngagementData(BaseModel):
     amp_aggregated: dict[str, int]
 
 
+class KeywordMetrics(BaseModel):
+    """Impressions and clicks for a single time window."""
+
+    impressions: int
+    clicks: int
+
+
+class KeywordEntry(BaseModel):
+    """Live and historical engagement metrics for a single advertiser/keyword pair."""
+
+    live: KeywordMetrics
+    historical: KeywordMetrics
+
+
+class KeywordEngagementData(BaseModel):
+    """Model for keyword-level engagement data file content."""
+
+    amp: dict[str, KeywordEntry] = {}
+    amp_aggregated: dict[str, int] = {}
+    wiki_aggregated: dict[str, int] = {}
+
+
 class SuggestionContent(BaseModel):
     """Class that holds the result from a fetch operation."""
 

--- a/merino/providers/suggest/adm/backends/protocol.py
+++ b/merino/providers/suggest/adm/backends/protocol.py
@@ -1,7 +1,7 @@
 """Protocol for the AdM provider backends."""
 
 from enum import Enum
-from typing import Protocol
+from typing import Optional, Protocol
 
 from pydantic import BaseModel, ConfigDict
 from moz_merino_ext.amp import AmpIndexManager
@@ -34,8 +34,8 @@ class KeywordMetrics(BaseModel):
 class KeywordEntry(BaseModel):
     """Live and historical engagement metrics for a single advertiser/keyword pair."""
 
-    live: KeywordMetrics
-    historical: KeywordMetrics
+    live: Optional[KeywordMetrics]
+    historical: Optional[KeywordMetrics]
 
 
 class KeywordEngagementData(BaseModel):

--- a/merino/providers/suggest/adm/backends/protocol.py
+++ b/merino/providers/suggest/adm/backends/protocol.py
@@ -3,7 +3,7 @@
 from enum import Enum
 from typing import Optional, Protocol
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, model_validator
 from moz_merino_ext.amp import AmpIndexManager
 
 SegmentType = tuple[int]
@@ -34,8 +34,15 @@ class KeywordMetrics(BaseModel):
 class KeywordEntry(BaseModel):
     """Live and historical engagement metrics for a single advertiser/keyword pair."""
 
-    live: Optional[KeywordMetrics]
-    historical: Optional[KeywordMetrics]
+    live: Optional[KeywordMetrics] = None
+    historical: Optional[KeywordMetrics] = None
+
+    @model_validator(mode="after")
+    def at_least_one_present(self) -> "KeywordEntry":
+        """Check that there is at least one type of metrics set."""
+        if self.live is None and self.historical is None:
+            raise ValueError("at least one of live or historical must be set")
+        return self
 
 
 class KeywordEngagementData(BaseModel):
@@ -43,7 +50,6 @@ class KeywordEngagementData(BaseModel):
 
     amp: dict[str, KeywordEntry] = {}
     amp_aggregated: dict[str, int] = {}
-    wiki_aggregated: dict[str, int] = {}
 
 
 class SuggestionContent(BaseModel):

--- a/merino/providers/suggest/adm/provider.py
+++ b/merino/providers/suggest/adm/provider.py
@@ -14,8 +14,15 @@ from pydantic import HttpUrl
 from merino.configs import settings
 from merino.optimizers.models import EngagementMetrics, ThompsonCandidate
 from merino.optimizers.thompson import ThompsonSampler
-from merino.providers.suggest.adm.backends.protocol import EngagementData, FormFactor
-from merino.utils.gcs.engagement.filemanager import EngagementFilemanager
+from merino.providers.suggest.adm.backends.protocol import (
+    EngagementData,
+    FormFactor,
+    KeywordEngagementData,
+)
+from merino.utils.gcs.engagement.filemanager import (
+    EngagementFilemanager,
+    KeywordEngagementFilemanager,
+)
 from merino.utils import cron
 from merino.providers.suggest.adm.backends.protocol import AdmBackend, SuggestionContent
 from merino.providers.suggest.base import (
@@ -97,6 +104,10 @@ class Provider(BaseProvider):
     engagement_resync_interval_sec: float
     last_engagement_fetch_at: float
     engagement_cron_task: asyncio.Task
+    keyword_engagement_data: KeywordEngagementData
+    keyword_filemanager: KeywordEngagementFilemanager
+    last_keyword_engagement_fetch_at: float
+    keyword_engagement_cron_task: asyncio.Task
     staleness_cron_task: asyncio.Task
 
     def __init__(
@@ -110,6 +121,7 @@ class Provider(BaseProvider):
         engagement_gcs_bucket: str,
         engagement_blob_name: str,
         engagement_resync_interval_sec: float,
+        keyword_engagement_blob_name: str,
         enabled_by_default: bool = True,
         min_attempted_count: int = 0,
         thompson: ThompsonSampler | None = None,
@@ -133,6 +145,12 @@ class Provider(BaseProvider):
         self.filemanager = EngagementFilemanager(
             gcs_bucket_path=engagement_gcs_bucket,
             blob_name=engagement_blob_name,
+        )
+        self.keyword_engagement_data = KeywordEngagementData(amp={}, amp_aggregated={})
+        self.last_keyword_engagement_fetch_at = 0
+        self.keyword_filemanager = KeywordEngagementFilemanager(
+            gcs_bucket_path=engagement_gcs_bucket,
+            blob_name=keyword_engagement_blob_name,
         )
         self.should_check_client_variants = should_check_client_variants
         super().__init__(**kwargs)
@@ -171,6 +189,15 @@ class Provider(BaseProvider):
         )
         self.engagement_cron_task = asyncio.create_task(engagement_cron_job())
 
+        await self._fetch_keyword_engagement_data()
+        keyword_engagement_cron_job = cron.Job(
+            name="resync_keyword_engagement_data",
+            interval=self.cron_interval_sec,
+            condition=self._should_fetch_keyword_engagement,
+            task=self._fetch_keyword_engagement_data,
+        )
+        self.keyword_engagement_cron_task = asyncio.create_task(keyword_engagement_cron_job())
+
         staleness_cron_job = cron.Job(
             name="mars_staleness_metric",
             interval=self.cron_interval_sec,
@@ -201,6 +228,12 @@ class Provider(BaseProvider):
         """Check if it should fetch engagement data from GCS."""
         return (time.time() - self.last_engagement_fetch_at) >= self.engagement_resync_interval_sec
 
+    def _should_fetch_keyword_engagement(self) -> bool:
+        """Check if it should fetch keyword engagement data from GCS."""
+        return (
+            time.time() - self.last_keyword_engagement_fetch_at
+        ) >= self.engagement_resync_interval_sec
+
     async def _fetch(self) -> None:
         """Fetch suggestions, keywords, and icons from Remote Settings."""
         self.suggestion_content = await self.backend.fetch()
@@ -222,6 +255,27 @@ class Provider(BaseProvider):
         except Exception as e:
             logger.warning(
                 "Failed to fetch engagement data from GCS",
+                extra={"error": str(e)},
+            )
+
+    async def _fetch_keyword_engagement_data(self) -> None:
+        """Fetch keyword engagement data from GCS and store it in memory.
+
+        If the fetch returns no data, `last_keyword_engagement_fetch_at` is not updated
+        so the cron job retries on the next tick.
+        """
+        try:
+            data = await self.keyword_filemanager.get_file()
+            if data is None:
+                logger.warning(
+                    "Keyword engagement data fetch returned None, will retry on next tick"
+                )
+                return
+            self.keyword_engagement_data = KeywordEngagementData.model_validate(data.model_dump())
+            self.last_keyword_engagement_fetch_at = time.time()
+        except Exception as e:
+            logger.warning(
+                "Failed to fetch keyword engagement data from GCS",
                 extra={"error": str(e)},
             )
 

--- a/merino/providers/suggest/manager.py
+++ b/merino/providers/suggest/manager.py
@@ -209,6 +209,7 @@ def _create_provider(provider_id: str, setting: Settings) -> BaseProvider:
                 engagement_gcs_bucket=settings.engagement.gcs_storage_bucket,
                 engagement_blob_name=settings.engagement.blob_name,
                 engagement_resync_interval_sec=setting.engagement_resync_interval_sec,
+                keyword_engagement_blob_name=settings.engagement.keyword_blob_name,
                 should_check_client_variants=settings.providers.adm.thompson.check_client_variants,
             )
         case ProviderType.GEOLOCATION:

--- a/merino/utils/gcs/engagement/filemanager.py
+++ b/merino/utils/gcs/engagement/filemanager.py
@@ -10,6 +10,7 @@ import orjson
 from gcloud.aio.storage import Blob, Bucket, Storage
 from pydantic import BaseModel
 
+from merino.providers.suggest.adm.backends.protocol import KeywordEntry
 from merino.utils.storage import get_storage_client
 
 
@@ -22,20 +23,6 @@ class EngagementData(BaseModel):
     amp: dict[str, dict[str, str | int]] = {}
     amp_aggregated: dict[str, int] = {}
     wiki_aggregated: dict[str, int] = {}
-
-
-class KeywordMetrics(BaseModel):
-    """Impressions and clicks for a given window."""
-
-    impressions: int
-    clicks: int
-
-
-class KeywordEntry(BaseModel):
-    """Live and historical engagement metrics for a single advertiser/keyword pair."""
-
-    live: KeywordMetrics
-    historical: KeywordMetrics
 
 
 class KeywordEngagementData(BaseModel):

--- a/merino/utils/gcs/engagement/filemanager.py
+++ b/merino/utils/gcs/engagement/filemanager.py
@@ -24,6 +24,28 @@ class EngagementData(BaseModel):
     wiki_aggregated: dict[str, int] = {}
 
 
+class KeywordMetrics(BaseModel):
+    """Impressions and clicks for a given window."""
+
+    impressions: int
+    clicks: int
+
+
+class KeywordEntry(BaseModel):
+    """Live and historical engagement metrics for a single advertiser/keyword pair."""
+
+    live: KeywordMetrics
+    historical: KeywordMetrics
+
+
+class KeywordEngagementData(BaseModel):
+    """Model for the keyword-level engagement data file stored in GCS."""
+
+    amp: dict[str, KeywordEntry] = {}
+    amp_aggregated: dict[str, int] = {}
+    wiki_aggregated: dict[str, int] = {}
+
+
 class EngagementFilemanager:
     """Filemanager for fetching engagement data from GCS asynchronously."""
 
@@ -63,4 +85,46 @@ class EngagementFilemanager:
             logger.error(f"Failed to decode engagement data JSON: {e}")
         except Exception as e:
             logger.error(f"Error fetching engagement data file {self.blob_name}: {e}")
+        return None
+
+
+class KeywordEngagementFilemanager:
+    """Filemanager for fetching keyword-level engagement data from GCS asynchronously."""
+
+    gcs_bucket_path: str
+    blob_name: str
+    gcs_client: Storage | None
+    bucket: Bucket | None
+
+    def __init__(self, gcs_bucket_path: str, blob_name: str) -> None:
+        """:param gcs_bucket_path: GCS bucket name to fetch from.
+        :param blob_name: Name of the blob in the GCS bucket.
+        """
+        self.gcs_bucket_path = gcs_bucket_path
+        self.blob_name = blob_name
+        self.gcs_client = None
+        self.bucket = None
+
+    def get_bucket(self) -> Bucket:
+        """Return the configured bucket using shared storage client."""
+        if self.bucket is not None:
+            return self.bucket
+
+        if self.gcs_client is None:
+            self.gcs_client = get_storage_client()
+
+        self.bucket = Bucket(storage=self.gcs_client, name=self.gcs_bucket_path)
+        return self.bucket
+
+    async def get_file(self) -> KeywordEngagementData | None:
+        """Fetch the keyword engagement data file from GCS and return a validated model instance."""
+        try:
+            bucket = self.get_bucket()
+            blob: Blob = await bucket.get_blob(self.blob_name)
+            blob_data = await blob.download()
+            return KeywordEngagementData.model_validate(orjson.loads(blob_data))
+        except (JSONDecodeError, ValueError) as e:
+            logger.error(f"Failed to decode keyword engagement data JSON: {e}")
+        except Exception as e:
+            logger.error(f"Error fetching keyword engagement data file {self.blob_name}: {e}")
         return None

--- a/tests/unit/providers/suggest/adm/conftest.py
+++ b/tests/unit/providers/suggest/adm/conftest.py
@@ -33,6 +33,7 @@ def fixture_adm_parameters() -> dict[str, Any]:
         "engagement_gcs_bucket": "test-engagement-bucket",
         "engagement_blob_name": "suggest-merino-exports/engagement/latest.json",
         "engagement_resync_interval_sec": 3600,
+        "keyword_engagement_blob_name": "suggest-merino-exports/engagement/keyword/latest.json",
     }
 
 

--- a/tests/unit/providers/suggest/adm/test_provider.py
+++ b/tests/unit/providers/suggest/adm/test_provider.py
@@ -13,7 +13,13 @@ from pytest_mock import MockerFixture
 
 from merino.middleware.geolocation import Location
 from merino.middleware.user_agent import UserAgent
-from merino.providers.suggest.adm.backends.protocol import EngagementData, FormFactor
+from merino.providers.suggest.adm.backends.protocol import (
+    EngagementData,
+    FormFactor,
+    KeywordEngagementData,
+    KeywordEntry,
+    KeywordMetrics,
+)
 from merino.providers.suggest.adm.provider import NonsponsoredSuggestion, Provider
 
 from tests.types import FilterCaplogFixture
@@ -97,6 +103,9 @@ async def test_initialize_remote_settings_failure(
     """
     error_message: str = "The remote server was unreachable"
     error_message_engagement: str = "Engagement data fetch returned None, will retry on next tick"
+    error_message_kw_engagement: str = (
+        "Keyword engagement data fetch returned None, will retry on next tick"
+    )
     # override default mocked behavior for fetch
     backend_mock.fetch.side_effect = Exception(error_message)
 
@@ -107,13 +116,15 @@ async def test_initialize_remote_settings_failure(
         # since the cron jobs have kicked in as the initial fetch fails.
         adm.cron_task.cancel()
         adm.engagement_cron_task.cancel()
+        adm.keyword_engagement_cron_task.cancel()
         adm.staleness_cron_task.cancel()
 
     records = filter_caplog(caplog.records, "merino.providers.suggest.adm.provider")
-    assert len(records) == 2
+    assert len(records) == 3
     assert records[0].__dict__["error message"] == error_message
     assert adm.last_fetch_at == 0
     assert records[1].message == error_message_engagement
+    assert records[2].message == error_message_kw_engagement
     # SuggestionContent should be empty as initialize was unsuccessful.
     assert adm.suggestion_content.index_manager.list() == []
     assert adm.suggestion_content.icons == {}
@@ -191,6 +202,17 @@ SAMPLE_ENGAGEMENT_DATA = EngagementData(
     amp_aggregated={"impressions": 463225, "clicks": 5878},
 )
 
+SAMPLE_KEYWORD_ENGAGEMENT_DATA = KeywordEngagementData(
+    amp={
+        "mozilla/firefox": KeywordEntry(
+            live=KeywordMetrics(impressions=3333, clicks=88),
+            historical=KeywordMetrics(impressions=6666, clicks=333),
+        ),
+    },
+    amp_aggregated={"impressions": 463225, "clicks": 5878},
+    wiki_aggregated={"impressions": 2935973, "clicks": 2325},
+)
+
 
 @pytest.mark.asyncio
 async def test_fetch_engagement_data_success(
@@ -247,6 +269,67 @@ async def test_fetch_engagement_data_exception(
     assert records[0].__dict__["error"] == "GCS unavailable"
     assert adm.engagement_data == original_data
     assert adm.last_engagement_fetch_at == 0
+
+
+@pytest.mark.asyncio
+async def test_fetch_keyword_engagement_data_success(
+    mocker: MockerFixture,
+    adm: Provider,
+) -> None:
+    """Test that _fetch_keyword_engagement_data stores data and updates the timestamp on success."""
+    mocker.patch.object(
+        adm.keyword_filemanager, "get_file", return_value=SAMPLE_KEYWORD_ENGAGEMENT_DATA
+    )
+
+    assert adm.last_keyword_engagement_fetch_at == 0
+    await adm._fetch_keyword_engagement_data()
+
+    assert adm.keyword_engagement_data == SAMPLE_KEYWORD_ENGAGEMENT_DATA
+    assert adm.last_keyword_engagement_fetch_at > 0
+
+
+@pytest.mark.asyncio
+async def test_fetch_keyword_engagement_data_returns_none(
+    caplog: LogCaptureFixture,
+    filter_caplog: FilterCaplogFixture,
+    mocker: MockerFixture,
+    adm: Provider,
+) -> None:
+    """Test that a None return from get_file logs a warning and does not update the timestamp,
+    so the cron retries on the next tick.
+    """
+    mocker.patch.object(adm.keyword_filemanager, "get_file", return_value=None)
+    original_data = adm.keyword_engagement_data
+
+    await adm._fetch_keyword_engagement_data()
+
+    records = filter_caplog(caplog.records, "merino.providers.suggest.adm.provider")
+    assert len(records) == 1
+    assert "None" in records[0].message
+    assert adm.keyword_engagement_data == original_data
+    assert adm.last_keyword_engagement_fetch_at == 0
+
+
+@pytest.mark.asyncio
+async def test_fetch_keyword_engagement_data_exception(
+    caplog: LogCaptureFixture,
+    filter_caplog: FilterCaplogFixture,
+    mocker: MockerFixture,
+    adm: Provider,
+) -> None:
+    """Test that an exception from get_file logs a warning and does not update the timestamp."""
+    mocker.patch.object(
+        adm.keyword_filemanager, "get_file", side_effect=Exception("GCS unavailable")
+    )
+    original_data = adm.keyword_engagement_data
+
+    await adm._fetch_keyword_engagement_data()
+
+    records = filter_caplog(caplog.records, "merino.providers.suggest.adm.provider")
+    assert len(records) == 1
+    assert records[0].__dict__["error"] == "GCS unavailable"
+    assert adm.keyword_engagement_data == original_data
+    assert adm.last_keyword_engagement_fetch_at == 0
 
 
 @pytest.mark.asyncio

--- a/tests/unit/utils/gcs/engagement/test_filemanager.py
+++ b/tests/unit/utils/gcs/engagement/test_filemanager.py
@@ -10,13 +10,12 @@ import pytest
 from pydantic import ValidationError
 from pytest_mock import MockerFixture
 
+from merino.providers.suggest.adm.backends.protocol import KeywordEntry, KeywordMetrics
 from merino.utils.gcs.engagement.filemanager import (
     EngagementData,
     EngagementFilemanager,
     KeywordEngagementData,
     KeywordEngagementFilemanager,
-    KeywordEntry,
-    KeywordMetrics,
 )
 
 GCS_BUCKET = "test-bucket"

--- a/tests/unit/utils/gcs/engagement/test_filemanager.py
+++ b/tests/unit/utils/gcs/engagement/test_filemanager.py
@@ -7,6 +7,7 @@
 import json
 
 import pytest
+from pydantic import ValidationError
 from pytest_mock import MockerFixture
 
 from merino.utils.gcs.engagement.filemanager import (
@@ -240,8 +241,10 @@ async def test_keyword_get_file_success(
     assert isinstance(result, KeywordEngagementData)
     assert isinstance(result.amp["mozilla/firefox"], KeywordEntry)
     assert isinstance(result.amp["mozilla/firefox"].live, KeywordMetrics)
+    assert result.amp["mozilla/firefox"].live is not None
     assert result.amp["mozilla/firefox"].live.impressions == 3333
     assert result.amp["mozilla/firefox"].live.clicks == 88
+    assert result.amp["mozilla/firefox"].historical is not None
     assert result.amp["mozilla/firefox"].historical.impressions == 6666
     assert result.amp["mozilla/firefox"].historical.clicks == 333
     assert result.amp_aggregated["impressions"] == 463225
@@ -289,3 +292,9 @@ async def test_keyword_get_file_gcs_exception(
 
     assert result is None
     assert any("GCS timeout" in r.message for r in caplog.records)
+
+
+def test_keyword_entry_requires_at_least_one_metrics_window() -> None:
+    """Test that KeywordEntry raises if both live and historical are absent."""
+    with pytest.raises(ValidationError):
+        KeywordEntry()

--- a/tests/unit/utils/gcs/engagement/test_filemanager.py
+++ b/tests/unit/utils/gcs/engagement/test_filemanager.py
@@ -9,15 +9,36 @@ import json
 import pytest
 from pytest_mock import MockerFixture
 
-from merino.utils.gcs.engagement.filemanager import EngagementData, EngagementFilemanager
+from merino.utils.gcs.engagement.filemanager import (
+    EngagementData,
+    EngagementFilemanager,
+    KeywordEngagementData,
+    KeywordEngagementFilemanager,
+    KeywordEntry,
+    KeywordMetrics,
+)
 
 GCS_BUCKET = "test-bucket"
 BLOB_NAME = "suggest-merino-exports/engagement/latest.json"
+KEYWORD_BLOB_NAME = "suggest-merino-exports/engagement/keyword/latest.json"
 
 SAMPLE_ENGAGEMENT_JSON = json.dumps(
     {
         "amp": {
             "amazon": {"advertiser": "amazon", "impressions": 202640, "clicks": 2568},
+        },
+        "wiki_aggregated": {"impressions": 2935973, "clicks": 2325},
+        "amp_aggregated": {"impressions": 463225, "clicks": 5878},
+    }
+)
+
+SAMPLE_KEYWORD_ENGAGEMENT_JSON = json.dumps(
+    {
+        "amp": {
+            "mozilla/firefox": {
+                "live": {"impressions": 3333, "clicks": 88},
+                "historical": {"impressions": 6666, "clicks": 333},
+            },
         },
         "wiki_aggregated": {"impressions": 2935973, "clicks": 2325},
         "amp_aggregated": {"impressions": 463225, "clicks": 5878},
@@ -135,6 +156,136 @@ async def test_get_file_gcs_exception(
     mocker.patch("merino.utils.gcs.engagement.filemanager.Bucket", return_value=mock_bucket)
 
     result = await filemanager.get_file()
+
+    assert result is None
+    assert any("GCS timeout" in r.message for r in caplog.records)
+
+
+@pytest.fixture(name="keyword_filemanager")
+def fixture_keyword_filemanager() -> KeywordEngagementFilemanager:
+    """Return a fresh KeywordEngagementFilemanager instance for test."""
+    return KeywordEngagementFilemanager(gcs_bucket_path=GCS_BUCKET, blob_name=KEYWORD_BLOB_NAME)
+
+
+@pytest.fixture(name="mock_keyword_blob")
+def fixture_mock_keyword_blob(mocker: MockerFixture):
+    """Return a mock gcloud.aio.storage Blob with keyword engagement data."""
+    blob = mocker.AsyncMock()
+    blob.download = mocker.AsyncMock(return_value=SAMPLE_KEYWORD_ENGAGEMENT_JSON.encode())
+    return blob
+
+
+@pytest.fixture(name="mock_keyword_bucket")
+def fixture_mock_keyword_bucket(mocker: MockerFixture, mock_keyword_blob):
+    """Return a mock gcloud.aio.storage Bucket for keyword engagement data."""
+    bucket = mocker.AsyncMock()
+    bucket.get_blob = mocker.AsyncMock(return_value=mock_keyword_blob)
+    return bucket
+
+
+def test_keyword_get_bucket_lazily_creates_client_and_bucket(
+    mocker: MockerFixture,
+    keyword_filemanager: KeywordEngagementFilemanager,
+    mock_keyword_bucket,
+) -> None:
+    """Test that get_bucket() creates the GCS client and Bucket on first call."""
+    mock_storage_cls = mocker.patch("merino.utils.gcs.engagement.filemanager.get_storage_client")
+    mocker.patch(
+        "merino.utils.gcs.engagement.filemanager.Bucket", return_value=mock_keyword_bucket
+    )
+
+    assert keyword_filemanager.gcs_client is None
+    assert keyword_filemanager.bucket is None
+
+    bucket = keyword_filemanager.get_bucket()
+
+    mock_storage_cls.assert_called_once()
+    assert bucket is mock_keyword_bucket
+    assert keyword_filemanager.bucket is mock_keyword_bucket
+
+
+def test_keyword_get_bucket_returns_cached_bucket(
+    mocker: MockerFixture,
+    keyword_filemanager: KeywordEngagementFilemanager,
+    mock_keyword_bucket,
+) -> None:
+    """Test that get_bucket() returns the cached Bucket without recreating the client."""
+    keyword_filemanager.bucket = mock_keyword_bucket
+    mock_storage_cls = mocker.patch("merino.utils.gcs.engagement.filemanager.Storage")
+
+    bucket = keyword_filemanager.get_bucket()
+
+    mock_storage_cls.assert_not_called()
+    assert bucket is mock_keyword_bucket
+
+
+@pytest.mark.asyncio
+async def test_keyword_get_file_success(
+    mocker: MockerFixture,
+    keyword_filemanager: KeywordEngagementFilemanager,
+    mock_keyword_bucket,
+    mock_keyword_blob,
+) -> None:
+    """Test that get_file() downloads the blob and returns a full KeywordEngagementData instance."""
+    mocker.patch("merino.utils.gcs.engagement.filemanager.Storage")
+    mocker.patch(
+        "merino.utils.gcs.engagement.filemanager.Bucket", return_value=mock_keyword_bucket
+    )
+
+    result = await keyword_filemanager.get_file()
+
+    mock_keyword_bucket.get_blob.assert_called_once_with(KEYWORD_BLOB_NAME)
+    mock_keyword_blob.download.assert_called_once()
+    assert result is not None
+    assert isinstance(result, KeywordEngagementData)
+    assert isinstance(result.amp["mozilla/firefox"], KeywordEntry)
+    assert isinstance(result.amp["mozilla/firefox"].live, KeywordMetrics)
+    assert result.amp["mozilla/firefox"].live.impressions == 3333
+    assert result.amp["mozilla/firefox"].live.clicks == 88
+    assert result.amp["mozilla/firefox"].historical.impressions == 6666
+    assert result.amp["mozilla/firefox"].historical.clicks == 333
+    assert result.amp_aggregated["impressions"] == 463225
+    assert result.wiki_aggregated["clicks"] == 2325
+
+
+@pytest.mark.asyncio
+async def test_keyword_get_file_json_decode_error(
+    caplog: pytest.LogCaptureFixture,
+    mocker: MockerFixture,
+    keyword_filemanager: KeywordEngagementFilemanager,
+    mock_keyword_bucket,
+    mock_keyword_blob,
+) -> None:
+    """Test that get_file() returns None and logs an error on invalid JSON."""
+    mock_keyword_blob.download.return_value = b"not valid json {"
+    mocker.patch("merino.utils.gcs.engagement.filemanager.Storage")
+    mocker.patch(
+        "merino.utils.gcs.engagement.filemanager.Bucket", return_value=mock_keyword_bucket
+    )
+
+    result = await keyword_filemanager.get_file()
+
+    assert result is None
+    assert any(
+        "Failed to decode keyword engagement data JSON" in r.message for r in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_keyword_get_file_gcs_exception(
+    caplog: pytest.LogCaptureFixture,
+    mocker: MockerFixture,
+    keyword_filemanager: KeywordEngagementFilemanager,
+    mock_keyword_bucket,
+) -> None:
+    """Test that get_file() returns None and logs an error when GCS raises an exception."""
+    mock_keyword_bucket.get_blob.side_effect = Exception("GCS timeout")
+    mocker.patch("merino.utils.gcs.engagement.filemanager.Storage")
+    mocker.patch(
+        "merino.utils.gcs.engagement.filemanager.Bucket", return_value=mock_keyword_bucket
+    )
+
+    result = await keyword_filemanager.get_file()
 
     assert result is None
     assert any("GCS timeout" in r.message for r in caplog.records)


### PR DESCRIPTION
## References

JIRA: [DISCO-4071](https://mozilla-hub.atlassian.net/browse/DISCO-4071)

## Description
Ingestion of the keyword/advertiser engagement data. There a lot of duplication with the engagement advertiser level stuff, but it would probs be removed in [4072](https://mozilla-hub.atlassian.net/browse/DISCO-4072)



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-4071]: https://mozilla-hub.atlassian.net/browse/DISCO-4071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ