### PR TITLE
AIMOD-1116 Add timing metrics for query norm pipeline

### DIFF
--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -260,7 +260,11 @@ async def suggest(
     use_normalization = (
         pipeline is not None and NORMALIZATION_CLIENT_VARIANT in client_variants_list
     )
-    q_normalized = pipeline.normalize(q) if use_normalization and pipeline else q
+    if use_normalization and pipeline:
+        with metrics_client.timeit("normalization.experiment.timing"):
+            q_normalized = pipeline.normalize(q)
+    else:
+        q_normalized = q
 
     for p in search_from:
         q_for_provider = (

--- a/metrics.yaml
+++ b/metrics.yaml
@@ -427,6 +427,17 @@ suggest/normalization:
       The "api/v1/suggest" API endpoint, treatment branch only.
     alert_policy: []
 
+  normalization_experiment_timing:
+    description: |
+      Time taken by the normalization pipeline to process a query, in
+      milliseconds. Only emitted for treatment users when the pipeline
+      is active.
+    type: timer
+    labels: []
+    scope: |
+      The "api/v1/suggest" API endpoint, treatment branch only.
+    alert_policy: []
+
 providers/manifest:
   manifest.lookup:
     description: |

--- a/metrics.yaml
+++ b/metrics.yaml
@@ -432,7 +432,7 @@ suggest/normalization:
       Time taken by the normalization pipeline to process a query, in
       milliseconds. Only emitted for treatment users when the pipeline
       is active.
-    type: timer
+    type: timing
     labels: []
     scope: |
       The "api/v1/suggest" API endpoint, treatment branch only.

--- a/tests/unit/query_normalization/test_metrics.py
+++ b/tests/unit/query_normalization/test_metrics.py
@@ -1,0 +1,71 @@
+"""Unit tests for normalization experiment metrics."""
+
+from unittest.mock import MagicMock
+
+from merino.providers.suggest.base import BaseSuggestion, BaseProvider
+from merino.utils.api.metrics import emit_normalization_metrics
+
+
+def _mock_suggestion(provider: str) -> BaseSuggestion:
+    """Create a mock suggestion with a given provider name."""
+    s = MagicMock(spec=BaseSuggestion)
+    s.provider = provider
+    return s
+
+
+def _mock_provider(name: str) -> BaseProvider:
+    """Create a mock provider with a given name."""
+    p = MagicMock(spec=BaseProvider)
+    p.name = name
+    return p
+
+
+def test_emit_normalization_metrics_matched() -> None:
+    """Emit metrics when provider matched."""
+    client = MagicMock()
+    suggestions = [_mock_suggestion("polygon")]
+    providers = [_mock_provider("polygon"), _mock_provider("sports")]
+    norm_providers = frozenset({"polygon", "sports"})
+
+    emit_normalization_metrics(client, suggestions, providers, norm_providers, query_changed=True)
+
+    assert client.increment.call_count == 2
+    client.increment.assert_any_call(
+        "normalization.experiment.provider_match",
+        tags={"provider": "polygon", "matched": "True", "query_changed": "True"},
+    )
+    client.increment.assert_any_call(
+        "normalization.experiment.provider_match",
+        tags={"provider": "sports", "matched": "False", "query_changed": "True"},
+    )
+
+
+def test_emit_normalization_metrics_no_match() -> None:
+    """Emit metrics when no provider matched."""
+    client = MagicMock()
+    suggestions: list[BaseSuggestion] = []
+    providers = [_mock_provider("polygon")]
+    norm_providers = frozenset({"polygon"})
+
+    emit_normalization_metrics(client, suggestions, providers, norm_providers, query_changed=False)
+
+    client.increment.assert_called_once_with(
+        "normalization.experiment.provider_match",
+        tags={"provider": "polygon", "matched": "False", "query_changed": "False"},
+    )
+
+
+def test_emit_normalization_metrics_skips_non_norm_providers() -> None:
+    """Non-normalization providers should not emit metrics."""
+    client = MagicMock()
+    suggestions = [_mock_suggestion("adm")]
+    providers = [_mock_provider("adm"), _mock_provider("polygon")]
+    norm_providers = frozenset({"polygon"})
+
+    emit_normalization_metrics(client, suggestions, providers, norm_providers, query_changed=True)
+
+    assert client.increment.call_count == 1
+    client.increment.assert_called_once_with(
+        "normalization.experiment.provider_match",
+        tags={"provider": "polygon", "matched": "False", "query_changed": "True"},
+    )


### PR DESCRIPTION
## References

JIRA: [AIMOD-1116](https://mozilla-hub.atlassian.net/browse/AIMOD-1116)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->
Adds timing metrics for the query normalization pipeline whenever it's triggered


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2238)


[AIMOD-1116]: https://mozilla-hub.atlassian.net/browse/AIMOD-1116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ