### PR TITLE
[DISCO-4116] Update historical AMP keyword query lookback window

### DIFF
--- a/merino/jobs/engagement_model/amp_data_downloader.py
+++ b/merino/jobs/engagement_model/amp_data_downloader.py
@@ -35,7 +35,7 @@ SELECT
  COUNT(*) AS impressions
 FROM `moz-fx-data-shared-prod.search_terms_derived.suggest_impression_sanitized_v3`
 WHERE
- submission_timestamp BETWEEN TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 7 DAY) AND CURRENT_TIMESTAMP()
+ submission_timestamp BETWEEN TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 9 DAY) AND TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 2 DAY)
 AND query is not NULL
 GROUP BY 1, 2
 HAVING impressions > 500


### PR DESCRIPTION
## References

JIRA: [DISCO-4116](https://mozilla-hub.atlassian.net/browse/DISCO-4116)

## Description
- The original plan was to source "live" keyword engagement data from `suggest-searches-prod-a30f.logs.stdout`, but Airflow cannot be granted access to the unsanitized search term data.
- As a temporary measure until PII-sanitized live data is available, the most recent data from `suggest_impression_sanitized_v3` will be treated as "live" using a 48-hr lookback window (the dataset's 24-hr delay means this effectively returns the previous day's data)
- Since both live and historical queries now target the same table, the historical window has now been updated to avoid overlap: from a 7-day window ending now, to a 7-day window offset by 2 days.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2240)


[DISCO-4116]: https://mozilla-hub.atlassian.net/browse/DISCO-4116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ