### PR TITLE
[DISCO-4070] Upload live keyword level engagement data for AMP

### DIFF
--- a/merino/jobs/engagement_model/__init__.py
+++ b/merino/jobs/engagement_model/__init__.py
@@ -38,13 +38,21 @@ def upload_engagement_data() -> None:  # pragma: no cover
         wiki_data_downloader = WikiDownloader(gcs_bq_project)
 
         amp_by_advertiser: list[dict[str, Any]] = amp_data_downloader.download_by_advertiser()
-        amp_by_keyword: list[dict[str, Any]] = amp_data_downloader.download_by_keyword()
+        amp_keyword_historical: list[dict[str, Any]] = (
+            amp_data_downloader.download_historical_data_by_keyword()
+        )
+        amp_keyword_live: list[dict[str, Any]] = (
+            amp_data_downloader.download_live_data_by_keyword()
+        )
         wiki_data: dict[str, int] = wiki_data_downloader.download_data()
 
         transformed_amp_by_advertiser = amp_data_downloader.transform_by_advertiser(
             amp_by_advertiser
         )
-        transformed_amp_by_keyword = amp_data_downloader.transform_by_keyword(amp_by_keyword)
+        transformed_amp_by_keyword = amp_data_downloader.transform_by_keyword(
+            historical=amp_keyword_historical,
+            live=amp_keyword_live,
+        )
 
         amp_aggregated_by_advertiser = amp_data_downloader.aggregate_by_advertiser(
             amp_by_advertiser

--- a/merino/jobs/engagement_model/amp_data_downloader.py
+++ b/merino/jobs/engagement_model/amp_data_downloader.py
@@ -27,7 +27,7 @@ GROUP BY 1
 ORDER BY 1, 3 DESC, 2 DESC
 """
 
-    KEYWORD_QUERY = """
+    KEYWORD_QUERY_HISTORICAL = """
 SELECT
  LOWER(advertiser) AS advertiser,
  LOWER(query) AS query,
@@ -39,6 +39,21 @@ WHERE
 AND query is not NULL
 GROUP BY 1, 2
 HAVING impressions > 500
+ORDER BY 1, 4 DESC
+"""
+
+    KEYWORD_QUERY_LIVE = """
+SELECT
+ LOWER(advertiser) AS advertiser,
+ LOWER(query) AS query,
+ COUNTIF(is_clicked) AS clicks,
+ COUNT(*) AS impressions
+FROM `moz-fx-data-shared-prod.search_terms_derived.suggest_impression_sanitized_v3`
+WHERE
+ submission_timestamp BETWEEN TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 48 HOUR) AND CURRENT_TIMESTAMP()
+AND query is not NULL
+GROUP BY 1, 2
+HAVING impressions > 200
 ORDER BY 1, 4 DESC
 """
 
@@ -90,7 +105,7 @@ ORDER BY 1, 4 DESC
 
         return engagement_data
 
-    def download_by_keyword(self) -> list[dict[str, Any]]:
+    def download_historical_data_by_keyword(self) -> list[dict[str, Any]]:
         """Execute the keyword-level AMP engagement query.
 
         Returns:
@@ -101,16 +116,16 @@ ORDER BY 1, 4 DESC
             RuntimeError: If the BigQuery query fails.
         """
         try:
-            query_job = self.client.query(self.KEYWORD_QUERY)
+            query_job = self.client.query(self.KEYWORD_QUERY_HISTORICAL)
             results = query_job.result()
 
         except GoogleAPIError as e:
             logger.error(
-                "BigQuery query failed while downloading keyword-level AMP engagement data",
+                "BigQuery query failed while downloading historical keyword-level AMP engagement data",
                 exc_info=True,
             )
             raise RuntimeError(
-                "Failed to fetch keyword-level AMP engagement data from BigQuery"
+                "Failed to fetch historical keyword-level AMP engagement data from BigQuery"
             ) from e
 
         engagement_data: list[dict[str, Any]] = []
@@ -126,11 +141,55 @@ ORDER BY 1, 4 DESC
                     }
                 )
             except KeyError:
-                logger.warning("Unexpected row format in BigQuery results: %s", row)
+                logger.warning("Unexpected row format in BigQuery results (historical): %s", row)
                 continue
 
         if not engagement_data:
-            logger.warning("Keyword-level AMP engagement query returned no rows")
+            logger.warning("Historical keyword-level AMP engagement query returned no rows")
+
+        return engagement_data
+
+    def download_live_data_by_keyword(self) -> list[dict[str, Any]]:
+        """Execute the keyword-level AMP engagement query.
+
+        Returns:
+            list[dict[str, Any]]: A list of engagement records containing
+            advertiser, query, impressions, and clicks.
+
+        Raises:
+            RuntimeError: If the BigQuery query fails.
+        """
+        try:
+            query_job = self.client.query(self.KEYWORD_QUERY_LIVE)
+            results = query_job.result()
+
+        except GoogleAPIError as e:
+            logger.error(
+                "BigQuery query failed while downloading live keyword-level AMP engagement data",
+                exc_info=True,
+            )
+            raise RuntimeError(
+                "Failed to fetch live keyword-level AMP engagement data from BigQuery"
+            ) from e
+
+        engagement_data: list[dict[str, Any]] = []
+
+        for row in results:
+            try:
+                engagement_data.append(
+                    {
+                        "advertiser": row["advertiser"],
+                        "query": row["query"],
+                        "impressions": int(row["impressions"]),
+                        "clicks": int(row["clicks"]),
+                    }
+                )
+            except KeyError:
+                logger.warning("Unexpected row format in BigQuery results (live): %s", row)
+                continue
+
+        if not engagement_data:
+            logger.warning("Live keyword-level AMP engagement query returned no rows")
 
         return engagement_data
 
@@ -148,22 +207,39 @@ ORDER BY 1, 4 DESC
         }
 
     @staticmethod
-    def transform_by_keyword(data: list[dict[str, Any]]) -> dict[str, Any]:
-        """Transform keyword-level AMP data into an advertiser/query-keyed dict with historical metrics."""
-        return {
-            f"{row['advertiser']}/{row['query']}": {
-                "historical": {
-                    "impressions": row["impressions"],
-                    "clicks": row["clicks"],
-                }
+    def transform_by_keyword(
+        historical: list[dict[str, Any]],
+        live: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        """Merge historical and live keyword-level AMP data into an advertiser/query-keyed dict.
+
+        Both datasets are optional per advertiser/query pair — a key may have only
+        historical, only live, or both.
+        """
+        result: dict[str, Any] = {}
+
+        for row in historical:
+            key = f"{row['advertiser']}/{row['query']}"
+            if key not in result:
+                result[key] = {}
+            result[key]["historical"] = {
+                "impressions": row["impressions"],
+                "clicks": row["clicks"],
             }
-            for row in data
-        }
+
+        for row in live:
+            key = f"{row['advertiser']}/{row['query']}"
+            if key not in result:
+                result[key] = {}
+            result[key]["live"] = {
+                "impressions": row["impressions"],
+                "clicks": row["clicks"],
+            }
+
+        return result
 
     @staticmethod
-    def aggregate_by_keyword(transformed: dict[str, Any]) -> dict[str, int]:
-        """Aggregate impressions and clicks from keyword-level transformed AMP data."""
-        return {
-            "impressions": sum(int(v["historical"]["impressions"]) for v in transformed.values()),
-            "clicks": sum(int(v["historical"]["clicks"]) for v in transformed.values()),
-        }
+    def aggregate_by_keyword(_transformed: dict[str, Any]) -> dict[str, int]:
+        """Aggregate impressions and clicks from keyword-level AMP data."""
+        # Not currently consumed — returning zeros until a use case is defined.
+        return {"impressions": 0, "clicks": 0}

--- a/merino/jobs/engagement_model/amp_data_downloader.py
+++ b/merino/jobs/engagement_model/amp_data_downloader.py
@@ -105,8 +105,12 @@ ORDER BY 1, 4 DESC
 
         return engagement_data
 
-    def download_historical_data_by_keyword(self) -> list[dict[str, Any]]:
-        """Execute the keyword-level AMP engagement query.
+    def _fetch_keyword_rows(self, query: str, label: str) -> list[dict[str, Any]]:
+        """Execute a keyword-level BigQuery query and return parsed rows.
+
+        Args:
+            query: The SQL query to execute.
+            label: A short label (e.g. "historical", "live") used in log messages.
 
         Returns:
             list[dict[str, Any]]: A list of engagement records containing
@@ -116,16 +120,16 @@ ORDER BY 1, 4 DESC
             RuntimeError: If the BigQuery query fails.
         """
         try:
-            query_job = self.client.query(self.KEYWORD_QUERY_HISTORICAL)
+            query_job = self.client.query(query)
             results = query_job.result()
-
         except GoogleAPIError as e:
             logger.error(
-                "BigQuery query failed while downloading historical keyword-level AMP engagement data",
+                "BigQuery query failed while downloading %s keyword-level AMP engagement data",
+                label,
                 exc_info=True,
             )
             raise RuntimeError(
-                "Failed to fetch historical keyword-level AMP engagement data from BigQuery"
+                f"Failed to fetch {label} keyword-level AMP engagement data from BigQuery"
             ) from e
 
         engagement_data: list[dict[str, Any]] = []
@@ -141,57 +145,21 @@ ORDER BY 1, 4 DESC
                     }
                 )
             except KeyError:
-                logger.warning("Unexpected row format in BigQuery results (historical): %s", row)
+                logger.warning("Unexpected row format in BigQuery results (%s): %s", label, row)
                 continue
 
         if not engagement_data:
-            logger.warning("Historical keyword-level AMP engagement query returned no rows")
+            logger.warning("%s keyword-level AMP engagement query returned no rows", label)
 
         return engagement_data
+
+    def download_historical_data_by_keyword(self) -> list[dict[str, Any]]:
+        """Execute the historical keyword-level AMP engagement query."""
+        return self._fetch_keyword_rows(self.KEYWORD_QUERY_HISTORICAL, "historical")
 
     def download_live_data_by_keyword(self) -> list[dict[str, Any]]:
-        """Execute the keyword-level AMP engagement query.
-
-        Returns:
-            list[dict[str, Any]]: A list of engagement records containing
-            advertiser, query, impressions, and clicks.
-
-        Raises:
-            RuntimeError: If the BigQuery query fails.
-        """
-        try:
-            query_job = self.client.query(self.KEYWORD_QUERY_LIVE)
-            results = query_job.result()
-
-        except GoogleAPIError as e:
-            logger.error(
-                "BigQuery query failed while downloading live keyword-level AMP engagement data",
-                exc_info=True,
-            )
-            raise RuntimeError(
-                "Failed to fetch live keyword-level AMP engagement data from BigQuery"
-            ) from e
-
-        engagement_data: list[dict[str, Any]] = []
-
-        for row in results:
-            try:
-                engagement_data.append(
-                    {
-                        "advertiser": row["advertiser"],
-                        "query": row["query"],
-                        "impressions": int(row["impressions"]),
-                        "clicks": int(row["clicks"]),
-                    }
-                )
-            except KeyError:
-                logger.warning("Unexpected row format in BigQuery results (live): %s", row)
-                continue
-
-        if not engagement_data:
-            logger.warning("Live keyword-level AMP engagement query returned no rows")
-
-        return engagement_data
+        """Execute the live keyword-level AMP engagement query."""
+        return self._fetch_keyword_rows(self.KEYWORD_QUERY_LIVE, "live")
 
     @staticmethod
     def transform_by_advertiser(data: list[dict[str, Any]]) -> dict[str, Any]:

--- a/tests/unit/jobs/engagement_model/test_amp_data_downloader.py
+++ b/tests/unit/jobs/engagement_model/test_amp_data_downloader.py
@@ -111,8 +111,8 @@ def test_download_by_advertiser_returns_empty_list_when_no_rows():
         assert data == []
 
 
-def test_download_by_keyword():
-    """Test downloading keyword-level AMP engagement data."""
+def test_download_historical_data_by_keyword():
+    """Test downloading historical keyword-level AMP engagement data."""
     rows = [
         {
             "advertiser": "mozilla",
@@ -138,12 +138,12 @@ def test_download_by_keyword():
         return_value=mock_client,
     ):
         downloader = EngagementDataDownloader(source_gcp_project="merino-test")
-        data = downloader.download_by_keyword()
+        data = downloader.download_historical_data_by_keyword()
         assert data == rows
         mock_client.query.assert_called_once()
 
 
-def test_download_by_keyword_raises_runtime_error_on_bigquery_failure():
+def test_download_historical_data_by_keyword_raises_runtime_error_on_bigquery_failure():
     """Test that a BigQuery failure is wrapped in RuntimeError."""
     mock_client = MagicMock()
     mock_client.query.side_effect = GoogleAPIError("BigQuery failed")
@@ -156,14 +156,14 @@ def test_download_by_keyword_raises_runtime_error_on_bigquery_failure():
 
         with pytest.raises(
             RuntimeError,
-            match="Failed to fetch keyword-level AMP engagement data from BigQuery",
+            match="Failed to fetch historical keyword-level AMP engagement data from BigQuery",
         ):
-            downloader.download_by_keyword()
+            downloader.download_historical_data_by_keyword()
 
         mock_client.query.assert_called_once()
 
 
-def test_download_by_keyword_skips_malformed_rows():
+def test_download_historical_data_by_keyword_skips_malformed_rows():
     """Test that malformed rows are skipped."""
     rows = [
         {
@@ -190,7 +190,7 @@ def test_download_by_keyword_skips_malformed_rows():
         return_value=mock_client,
     ):
         downloader = EngagementDataDownloader(source_gcp_project="merino-test")
-        data = downloader.download_by_keyword()
+        data = downloader.download_historical_data_by_keyword()
 
         assert data == [
             {
@@ -202,7 +202,7 @@ def test_download_by_keyword_skips_malformed_rows():
         ]
 
 
-def test_download_by_keyword_returns_empty_list_when_no_rows():
+def test_download_historical_data_by_keyword_returns_empty_list_when_no_rows():
     """Test that an empty result set returns an empty list."""
     mock_client = MagicMock()
     mock_query = MagicMock()
@@ -214,7 +214,115 @@ def test_download_by_keyword_returns_empty_list_when_no_rows():
         return_value=mock_client,
     ):
         downloader = EngagementDataDownloader(source_gcp_project="merino-test")
-        data = downloader.download_by_keyword()
+        data = downloader.download_historical_data_by_keyword()
+
+        assert data == []
+
+
+def test_download_live_data_by_keyword():
+    """Test downloading live keyword-level AMP engagement data."""
+    rows = [
+        {
+            "advertiser": "mozilla",
+            "query": "firefox",
+            "impressions": 500,
+            "clicks": 10,
+        },
+        {
+            "advertiser": "firefox",
+            "query": "browser",
+            "impressions": 200,
+            "clicks": 5,
+        },
+    ]
+
+    mock_client = MagicMock()
+    mock_query = MagicMock()
+    mock_query.result.return_value = rows
+    mock_client.query.return_value = mock_query
+
+    with patch(
+        "merino.jobs.engagement_model.amp_data_downloader.Client",
+        return_value=mock_client,
+    ):
+        downloader = EngagementDataDownloader(source_gcp_project="merino-test")
+        data = downloader.download_live_data_by_keyword()
+        assert data == rows
+        mock_client.query.assert_called_once()
+
+
+def test_download_live_data_by_keyword_raises_runtime_error_on_bigquery_failure():
+    """Test that a BigQuery failure is wrapped in RuntimeError."""
+    mock_client = MagicMock()
+    mock_client.query.side_effect = GoogleAPIError("BigQuery failed")
+
+    with patch(
+        "merino.jobs.engagement_model.amp_data_downloader.Client",
+        return_value=mock_client,
+    ):
+        downloader = EngagementDataDownloader(source_gcp_project="merino-test")
+
+        with pytest.raises(
+            RuntimeError,
+            match="Failed to fetch live keyword-level AMP engagement data from BigQuery",
+        ):
+            downloader.download_live_data_by_keyword()
+
+        mock_client.query.assert_called_once()
+
+
+def test_download_live_data_by_keyword_skips_malformed_rows():
+    """Test that malformed rows are skipped."""
+    rows = [
+        {
+            "advertiser": "mozilla",
+            "query": "firefox",
+            "impressions": 500,
+            "clicks": 10,
+        },
+        {
+            "advertiser": "firefox",
+            "query": "browser",
+            "impressions": 200,
+            # missing clicks
+        },
+    ]
+
+    mock_client = MagicMock()
+    mock_query = MagicMock()
+    mock_query.result.return_value = rows
+    mock_client.query.return_value = mock_query
+
+    with patch(
+        "merino.jobs.engagement_model.amp_data_downloader.Client",
+        return_value=mock_client,
+    ):
+        downloader = EngagementDataDownloader(source_gcp_project="merino-test")
+        data = downloader.download_live_data_by_keyword()
+
+        assert data == [
+            {
+                "advertiser": "mozilla",
+                "query": "firefox",
+                "impressions": 500,
+                "clicks": 10,
+            }
+        ]
+
+
+def test_download_live_data_by_keyword_returns_empty_list_when_no_rows():
+    """Test that an empty result set returns an empty list."""
+    mock_client = MagicMock()
+    mock_query = MagicMock()
+    mock_query.result.return_value = []
+    mock_client.query.return_value = mock_query
+
+    with patch(
+        "merino.jobs.engagement_model.amp_data_downloader.Client",
+        return_value=mock_client,
+    ):
+        downloader = EngagementDataDownloader(source_gcp_project="merino-test")
+        data = downloader.download_live_data_by_keyword()
 
         assert data == []
 
@@ -255,36 +363,85 @@ def test_aggregate_by_advertiser_returns_zeros_for_empty_input():
     }
 
 
-def test_transform_by_keyword_returns_advertiser_query_keyed_dict():
-    """Test that keyword rows are keyed by advertiser/query with historical wrapper."""
-    data = [
+def test_transform_by_keyword_with_historical_only():
+    """Test that historical-only rows produce entries with only a historical key."""
+    historical = [
         {"advertiser": "mozilla", "query": "firefox", "impressions": 1000, "clicks": 22},
         {"advertiser": "firefox", "query": "browser", "impressions": 5666, "clicks": 0},
     ]
-    result = EngagementDataDownloader.transform_by_keyword(data)
+    result = EngagementDataDownloader.transform_by_keyword(historical=historical, live=[])
     assert result == {
         "mozilla/firefox": {"historical": {"impressions": 1000, "clicks": 22}},
         "firefox/browser": {"historical": {"impressions": 5666, "clicks": 0}},
     }
 
 
-def test_transform_by_keyword_returns_empty_dict_for_empty_input():
-    """Test that an empty input returns an empty dict."""
-    assert EngagementDataDownloader.transform_by_keyword([]) == {}
-
-
-def test_aggregate_by_keyword_sums_impressions_and_clicks():
-    """Test that impressions and clicks are summed from the historical data."""
-    transformed = {
-        "mozilla/firefox": {"historical": {"impressions": 1000, "clicks": 22}},
-        "firefox/browser": {"historical": {"impressions": 5666, "clicks": 0}},
+def test_transform_by_keyword_with_live_only():
+    """Test that live-only rows produce entries with only a live key."""
+    live = [
+        {"advertiser": "mozilla", "query": "firefox", "impressions": 500, "clicks": 10},
+        {"advertiser": "firefox", "query": "browser", "impressions": 200, "clicks": 5},
+    ]
+    result = EngagementDataDownloader.transform_by_keyword(historical=[], live=live)
+    assert result == {
+        "mozilla/firefox": {"live": {"impressions": 500, "clicks": 10}},
+        "firefox/browser": {"live": {"impressions": 200, "clicks": 5}},
     }
-    result = EngagementDataDownloader.aggregate_by_keyword(transformed)
-    assert result == {"impressions": 6666, "clicks": 22}
+
+
+def test_transform_by_keyword_merges_matching_pairs():
+    """Test that matching advertiser/query pairs from both datasets are merged."""
+    historical = [
+        {"advertiser": "mozilla", "query": "firefox", "impressions": 1000, "clicks": 22},
+    ]
+    live = [
+        {"advertiser": "mozilla", "query": "firefox", "impressions": 500, "clicks": 10},
+    ]
+    result = EngagementDataDownloader.transform_by_keyword(historical=historical, live=live)
+    assert result == {
+        "mozilla/firefox": {
+            "historical": {"impressions": 1000, "clicks": 22},
+            "live": {"impressions": 500, "clicks": 10},
+        }
+    }
+
+
+def test_transform_by_keyword_unions_non_matching_pairs():
+    """Test that non-overlapping pairs appear with only their respective data source."""
+    historical = [
+        {"advertiser": "mozilla", "query": "firefox", "impressions": 1000, "clicks": 22},
+    ]
+    live = [
+        {"advertiser": "firefox", "query": "browser", "impressions": 200, "clicks": 5},
+    ]
+    result = EngagementDataDownloader.transform_by_keyword(historical=historical, live=live)
+    assert result == {
+        "mozilla/firefox": {"historical": {"impressions": 1000, "clicks": 22}},
+        "firefox/browser": {"live": {"impressions": 200, "clicks": 5}},
+    }
+
+
+def test_transform_by_keyword_returns_empty_dict_for_empty_inputs():
+    """Test that empty historical and live inputs return an empty dict."""
+    assert EngagementDataDownloader.transform_by_keyword(historical=[], live=[]) == {}
+
+
+def test_aggregate_by_keyword_returns_zeros():
+    """Test that aggregate_by_keyword returns zeros (not yet consumed)."""
+    transformed = {
+        "mozilla/firefox": {
+            "historical": {"impressions": 1000, "clicks": 22},
+            "live": {"impressions": 500, "clicks": 10},
+        },
+    }
+    assert EngagementDataDownloader.aggregate_by_keyword(transformed) == {
+        "impressions": 0,
+        "clicks": 0,
+    }
 
 
 def test_aggregate_by_keyword_returns_zeros_for_empty_input():
-    """Test that an empty input returns zero totals."""
+    """Test that an empty input also returns zeros."""
     assert EngagementDataDownloader.aggregate_by_keyword({}) == {
         "impressions": 0,
         "clicks": 0,

--- a/tests/unit/jobs/engagement_model/test_amp_data_downloader.py
+++ b/tests/unit/jobs/engagement_model/test_amp_data_downloader.py
@@ -111,21 +111,11 @@ def test_download_by_advertiser_returns_empty_list_when_no_rows():
         assert data == []
 
 
-def test_download_historical_data_by_keyword():
-    """Test downloading historical keyword-level AMP engagement data."""
+def test_fetch_keyword_rows_returns_parsed_rows():
+    """Test that _fetch_keyword_rows parses BigQuery rows correctly."""
     rows = [
-        {
-            "advertiser": "mozilla",
-            "query": "firefox",
-            "impressions": 1000,
-            "clicks": 22,
-        },
-        {
-            "advertiser": "firefox",
-            "query": "browser",
-            "impressions": 5666,
-            "clicks": 0,
-        },
+        {"advertiser": "mozilla", "query": "firefox", "impressions": 1000, "clicks": 22},
+        {"advertiser": "firefox", "query": "browser", "impressions": 5666, "clicks": 0},
     ]
 
     mock_client = MagicMock()
@@ -138,13 +128,13 @@ def test_download_historical_data_by_keyword():
         return_value=mock_client,
     ):
         downloader = EngagementDataDownloader(source_gcp_project="merino-test")
-        data = downloader.download_historical_data_by_keyword()
+        data = downloader._fetch_keyword_rows("SELECT 1", "test")
         assert data == rows
-        mock_client.query.assert_called_once()
+        mock_client.query.assert_called_once_with("SELECT 1")
 
 
-def test_download_historical_data_by_keyword_raises_runtime_error_on_bigquery_failure():
-    """Test that a BigQuery failure is wrapped in RuntimeError."""
+def test_fetch_keyword_rows_raises_runtime_error_on_bigquery_failure():
+    """Test that a BigQuery failure is wrapped in RuntimeError with the given label."""
     mock_client = MagicMock()
     mock_client.query.side_effect = GoogleAPIError("BigQuery failed")
 
@@ -156,28 +146,16 @@ def test_download_historical_data_by_keyword_raises_runtime_error_on_bigquery_fa
 
         with pytest.raises(
             RuntimeError,
-            match="Failed to fetch historical keyword-level AMP engagement data from BigQuery",
+            match="Failed to fetch test keyword-level AMP engagement data from BigQuery",
         ):
-            downloader.download_historical_data_by_keyword()
-
-        mock_client.query.assert_called_once()
+            downloader._fetch_keyword_rows("SELECT 1", "test")
 
 
-def test_download_historical_data_by_keyword_skips_malformed_rows():
-    """Test that malformed rows are skipped."""
+def test_fetch_keyword_rows_skips_malformed_rows():
+    """Test that rows missing expected fields are skipped."""
     rows = [
-        {
-            "advertiser": "mozilla",
-            "query": "firefox",
-            "impressions": 1000,
-            "clicks": 22,
-        },
-        {
-            "advertiser": "firefox",
-            "query": "browser",
-            "impressions": 5666,
-            # missing clicks
-        },
+        {"advertiser": "mozilla", "query": "firefox", "impressions": 1000, "clicks": 22},
+        {"advertiser": "firefox", "query": "browser", "impressions": 5666},  # missing clicks
     ]
 
     mock_client = MagicMock()
@@ -190,19 +168,13 @@ def test_download_historical_data_by_keyword_skips_malformed_rows():
         return_value=mock_client,
     ):
         downloader = EngagementDataDownloader(source_gcp_project="merino-test")
-        data = downloader.download_historical_data_by_keyword()
-
+        data = downloader._fetch_keyword_rows("SELECT 1", "test")
         assert data == [
-            {
-                "advertiser": "mozilla",
-                "query": "firefox",
-                "impressions": 1000,
-                "clicks": 22,
-            }
+            {"advertiser": "mozilla", "query": "firefox", "impressions": 1000, "clicks": 22}
         ]
 
 
-def test_download_historical_data_by_keyword_returns_empty_list_when_no_rows():
+def test_fetch_keyword_rows_returns_empty_list_when_no_rows():
     """Test that an empty result set returns an empty list."""
     mock_client = MagicMock()
     mock_query = MagicMock()
@@ -214,117 +186,33 @@ def test_download_historical_data_by_keyword_returns_empty_list_when_no_rows():
         return_value=mock_client,
     ):
         downloader = EngagementDataDownloader(source_gcp_project="merino-test")
-        data = downloader.download_historical_data_by_keyword()
-
-        assert data == []
+        assert downloader._fetch_keyword_rows("SELECT 1", "test") == []
 
 
-def test_download_live_data_by_keyword():
-    """Test downloading live keyword-level AMP engagement data."""
-    rows = [
-        {
-            "advertiser": "mozilla",
-            "query": "firefox",
-            "impressions": 500,
-            "clicks": 10,
-        },
-        {
-            "advertiser": "firefox",
-            "query": "browser",
-            "impressions": 200,
-            "clicks": 5,
-        },
-    ]
-
-    mock_client = MagicMock()
-    mock_query = MagicMock()
-    mock_query.result.return_value = rows
-    mock_client.query.return_value = mock_query
-
+def test_download_historical_data_by_keyword_delegates_to_helper():
+    """Test that download_historical_data_by_keyword calls _fetch_keyword_rows with the historical query."""
     with patch(
         "merino.jobs.engagement_model.amp_data_downloader.Client",
-        return_value=mock_client,
     ):
         downloader = EngagementDataDownloader(source_gcp_project="merino-test")
-        data = downloader.download_live_data_by_keyword()
-        assert data == rows
-        mock_client.query.assert_called_once()
+        downloader._fetch_keyword_rows = MagicMock(return_value=[])
+        downloader.download_historical_data_by_keyword()
+        downloader._fetch_keyword_rows.assert_called_once_with(
+            EngagementDataDownloader.KEYWORD_QUERY_HISTORICAL, "historical"
+        )
 
 
-def test_download_live_data_by_keyword_raises_runtime_error_on_bigquery_failure():
-    """Test that a BigQuery failure is wrapped in RuntimeError."""
-    mock_client = MagicMock()
-    mock_client.query.side_effect = GoogleAPIError("BigQuery failed")
-
+def test_download_live_data_by_keyword_delegates_to_helper():
+    """Test that download_live_data_by_keyword calls _fetch_keyword_rows with the live query."""
     with patch(
         "merino.jobs.engagement_model.amp_data_downloader.Client",
-        return_value=mock_client,
     ):
         downloader = EngagementDataDownloader(source_gcp_project="merino-test")
-
-        with pytest.raises(
-            RuntimeError,
-            match="Failed to fetch live keyword-level AMP engagement data from BigQuery",
-        ):
-            downloader.download_live_data_by_keyword()
-
-        mock_client.query.assert_called_once()
-
-
-def test_download_live_data_by_keyword_skips_malformed_rows():
-    """Test that malformed rows are skipped."""
-    rows = [
-        {
-            "advertiser": "mozilla",
-            "query": "firefox",
-            "impressions": 500,
-            "clicks": 10,
-        },
-        {
-            "advertiser": "firefox",
-            "query": "browser",
-            "impressions": 200,
-            # missing clicks
-        },
-    ]
-
-    mock_client = MagicMock()
-    mock_query = MagicMock()
-    mock_query.result.return_value = rows
-    mock_client.query.return_value = mock_query
-
-    with patch(
-        "merino.jobs.engagement_model.amp_data_downloader.Client",
-        return_value=mock_client,
-    ):
-        downloader = EngagementDataDownloader(source_gcp_project="merino-test")
-        data = downloader.download_live_data_by_keyword()
-
-        assert data == [
-            {
-                "advertiser": "mozilla",
-                "query": "firefox",
-                "impressions": 500,
-                "clicks": 10,
-            }
-        ]
-
-
-def test_download_live_data_by_keyword_returns_empty_list_when_no_rows():
-    """Test that an empty result set returns an empty list."""
-    mock_client = MagicMock()
-    mock_query = MagicMock()
-    mock_query.result.return_value = []
-    mock_client.query.return_value = mock_query
-
-    with patch(
-        "merino.jobs.engagement_model.amp_data_downloader.Client",
-        return_value=mock_client,
-    ):
-        downloader = EngagementDataDownloader(source_gcp_project="merino-test")
-        data = downloader.download_live_data_by_keyword()
-
-        assert data == []
+        downloader._fetch_keyword_rows = MagicMock(return_value=[])
+        downloader.download_live_data_by_keyword()
+        downloader._fetch_keyword_rows.assert_called_once_with(
+            EngagementDataDownloader.KEYWORD_QUERY_LIVE, "live"
+        )
 
 
 def test_transform_by_advertiser_returns_advertiser_keyed_dict():

--- a/tests/unit/jobs/engagement_model/test_init.py
+++ b/tests/unit/jobs/engagement_model/test_init.py
@@ -12,9 +12,13 @@ def test_upload_engagement_data_success() -> None:
         {"advertiser": "mozilla", "impressions": 100, "clicks": 5},
         {"advertiser": "firefox", "impressions": 200, "clicks": 10},
     ]
-    amp_by_keyword = [
+    amp_keyword_historical = [
         {"advertiser": "mozilla", "query": "firefox", "impressions": 100, "clicks": 5},
         {"advertiser": "firefox", "query": "browser", "impressions": 200, "clicks": 10},
+    ]
+    amp_keyword_live = [
+        {"advertiser": "mozilla", "query": "firefox", "impressions": 50, "clicks": 3},
+        {"advertiser": "chrome", "query": "search", "impressions": 80, "clicks": 2},
     ]
     wiki_data = {"impressions": 300, "clicks": 20}
 
@@ -23,15 +27,20 @@ def test_upload_engagement_data_success() -> None:
         "firefox": {"advertiser": "firefox", "impressions": 200, "clicks": 10},
     }
     transformed_by_keyword = {
-        "mozilla/firefox": {"historical": {"impressions": 100, "clicks": 5}},
+        "mozilla/firefox": {
+            "historical": {"impressions": 100, "clicks": 5},
+            "live": {"impressions": 50, "clicks": 3},
+        },
         "firefox/browser": {"historical": {"impressions": 200, "clicks": 10}},
+        "chrome/search": {"live": {"impressions": 80, "clicks": 2}},
     }
     aggregated_by_advertiser = {"impressions": 300, "clicks": 15}
-    aggregated_by_keyword = {"impressions": 300, "clicks": 15}
+    aggregated_by_keyword = {"impressions": 0, "clicks": 0}
 
     mock_amp_downloader = MagicMock()
     mock_amp_downloader.download_by_advertiser.return_value = amp_by_advertiser
-    mock_amp_downloader.download_by_keyword.return_value = amp_by_keyword
+    mock_amp_downloader.download_historical_data_by_keyword.return_value = amp_keyword_historical
+    mock_amp_downloader.download_live_data_by_keyword.return_value = amp_keyword_live
     mock_amp_downloader.transform_by_advertiser.return_value = transformed_by_advertiser
     mock_amp_downloader.transform_by_keyword.return_value = transformed_by_keyword
     mock_amp_downloader.aggregate_by_advertiser.return_value = aggregated_by_advertiser
@@ -77,9 +86,13 @@ def test_upload_engagement_data_success() -> None:
     )
 
     mock_amp_downloader.download_by_advertiser.assert_called_once()
-    mock_amp_downloader.download_by_keyword.assert_called_once()
+    mock_amp_downloader.download_historical_data_by_keyword.assert_called_once()
+    mock_amp_downloader.download_live_data_by_keyword.assert_called_once()
     mock_amp_downloader.transform_by_advertiser.assert_called_once_with(amp_by_advertiser)
-    mock_amp_downloader.transform_by_keyword.assert_called_once_with(amp_by_keyword)
+    mock_amp_downloader.transform_by_keyword.assert_called_once_with(
+        historical=amp_keyword_historical,
+        live=amp_keyword_live,
+    )
     mock_amp_downloader.aggregate_by_advertiser.assert_called_once_with(amp_by_advertiser)
     mock_amp_downloader.aggregate_by_keyword.assert_called_once_with(transformed_by_keyword)
     mock_wiki_downloader.download_data.assert_called_once()
@@ -167,7 +180,9 @@ def test_upload_engagement_data_logs_error_on_keyword_download_failure() -> None
     mock_settings.engagement.gcs_storage_project = "test-storage-project"
 
     mock_amp_downloader = MagicMock()
-    mock_amp_downloader.download_by_keyword.side_effect = RuntimeError("BigQuery failed")
+    mock_amp_downloader.download_historical_data_by_keyword.side_effect = RuntimeError(
+        "BigQuery failed"
+    )
 
     mock_wiki_downloader = MagicMock()
 


### PR DESCRIPTION
## References

JIRA: [DISCO-4070](https://mozilla-hub.atlassian.net/browse/DISCO-4070)

## Description
This PR ingests and uploads live keyword level engagement data to GCS for AMP provider (we're temporarily pulling from the `moz-fx-data-shared-prod.search_terms_derived.suggest_impression_sanitized_v3` table with a 48hr lookback window to depict "live" data, will be updated once we get access) 



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2241)


[DISCO-4070]: https://mozilla-hub.atlassian.net/browse/DISCO-4070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ