### PR TITLE
[AIMOD-1117] Enable Query Normalization in Prod (feature flagged)

### DIFF
--- a/merino/configs/production.toml
+++ b/merino/configs/production.toml
@@ -126,7 +126,7 @@ cache = "redis"
 cache = "redis"
 
 [production.query_normalization]
-enabled = false
+enabled = true
 data_source = "remote"
 gcs_bucket = "merino-ml-data-prod"
 


### PR DESCRIPTION
## References

JIRA: [AIMOD-1117](https://mozilla-hub.atlassian.net/browse/AIMOD-1117)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->

This PR enables the query normalization experiment in prod. It's currently feature flagged with the `client_variants=query_norm_treatment` and can only run when enrolled in the treatment branch of the experiment.

We've done load testing against staging with `client_variants` parameter and the p95 was `240ms` vs baseline `220ms` ([link](https://mozilla-hub.atlassian.net/wiki/spaces/FAAMT/pages/2477523204/Query+Normalization+Impact+Analysis#Merino-Staging-Load-Test-(Locust)))


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2242)


[AIMOD-1117]: https://mozilla-hub.atlassian.net/browse/AIMOD-1117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ