### PR TITLE
chore: improve test coverage for particle game provider

### DIFF
--- a/merino/providers/games/__init__.py
+++ b/merino/providers/games/__init__.py
@@ -9,7 +9,7 @@ from merino.utils.gcs.gcs_uploader import GcsUploader
 from merino.utils.http_client import create_http_client
 from merino.utils.metrics import get_metrics_client
 
-_particle_provider: Provider
+_particle_provider: Provider | None = None
 
 # Module-level variables as looking up from settings each time is expensive.
 _connect_timeout = settings.games_providers.particle.connect_timeout_sec
@@ -51,5 +51,7 @@ async def init_providers() -> None:
 
 def get_particle_provider() -> Provider:
     """Return the provider for the Particle game"""
-    global _particle_provider
+    if _particle_provider is None:
+        raise ValueError("Particle provider has not been initialized.")
+
     return _particle_provider

--- a/merino/providers/games/particle/backends/utils.py
+++ b/merino/providers/games/particle/backends/utils.py
@@ -17,6 +17,9 @@ def validate_manifest_schema_version(manifest_json: Json) -> None:
     try:
         schema_version = manifest_json["schemaVersion"]
     except KeyError:
+        logger.error("JSON key error retrieving 'schemaVersion' from manifest JSON.")
+        schema_version = None
+    except Exception:
         logger.error("JSON error retrieving 'schemaVersion' from manifest JSON.")
         schema_version = None
 
@@ -37,7 +40,3 @@ def validate_manifest_against_schema(manifest_json: Json, manifest_schema: Json)
     except exceptions.ValidationError as ex:
         logger.error(f"Schema validation failed for manifest JSON: {ex}")
         raise ex
-    # in case the above validation fails in an unexpected way
-    except Exception as ex:
-        logger.error(f"Unexpected error when validation manifest JSON schema: {ex}")
-        raise Exception(f"Unexpected error when validation manifest JSON schema: {ex}")

--- a/tests/unit/providers/games/particle/backends/test_utils.py
+++ b/tests/unit/providers/games/particle/backends/test_utils.py
@@ -92,6 +92,27 @@ def test_validate_manifest_schema_version_raises_with_invalid_schema_version(
     assert "Schema version mismatch when validating manifest JSON" in error_records[0].message
 
 
+def test_validate_manifest_schema_version_raises_with_no_schema_version_in_json(
+    caplog: LogCaptureFixture, filter_caplog: Any
+):
+    """Verify missing schema version raises an exception."""
+    with pytest.raises(Exception):
+        validate_manifest_schema_version(json.loads('{"cremaVersion": 1}'))
+
+    # get error records
+    error_records = filter_caplog(
+        caplog.records,
+        "merino.providers.games.particle.backends.utils",
+    )
+
+    # verify expected errors were logged
+    assert len(error_records) == 2
+    assert (
+        "JSON key error retrieving 'schemaVersion' from manifest JSON." == error_records[0].message
+    )
+    assert "Schema version mismatch when validating manifest JSON" in error_records[1].message
+
+
 # END validate_manifest_schema_version TESTS
 
 

--- a/tests/unit/providers/games/test_init.py
+++ b/tests/unit/providers/games/test_init.py
@@ -1,0 +1,82 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Unit tests for the __init__ manifest provider module."""
+
+from unittest.mock import Mock, patch
+import pytest
+
+from merino.providers.games import (
+    get_particle_provider,
+    init_providers,
+)
+
+from merino.providers.games.particle.provider import Provider as ParticleProvider
+
+
+@pytest.mark.asyncio
+async def test_init_providers() -> None:
+    """Test for the `init_providers` method of the games provider"""
+    with (
+        patch("merino.providers.games._connect_timeout", "mock_connect_timeout"),
+        patch("merino.providers.games._gcs_project", "mock_gcs_project"),
+        patch("merino.providers.games._gcs_bucket", "mock_gcs_bucket"),
+        patch("merino.providers.games._gcs_cdn_hostname", "mock_cdn_hostname"),
+        patch("merino.providers.games._url_root", "mock_url_root"),
+        patch("merino.providers.games._url_path_manifest", "mock_url_path_manifest"),
+        patch("merino.providers.games.GcsUploader") as mock_gcs_uploader,
+        patch("merino.providers.games.create_http_client") as mock_create_http_client,
+        patch("merino.providers.games.get_metrics_client") as mock_get_metrics_client,
+        patch("merino.providers.games.ParticleBackend") as mock_particle_backend,
+    ):
+        mock_gcs_uploader_instance = Mock(name="mock_gcs_uploader")
+        mock_gcs_uploader.return_value = mock_gcs_uploader_instance
+
+        mock_http_client_instance = Mock(name="mock_http_client")
+        mock_create_http_client.return_value = mock_http_client_instance
+
+        mock_metrics_client_instance = Mock(name="mock_metrics_client")
+        mock_get_metrics_client.return_value = mock_metrics_client_instance
+
+        mock_particle_backend_instance = Mock(name="mock_particle_backend")
+        mock_particle_backend.return_value = mock_particle_backend_instance
+
+        await init_providers()
+
+        from merino.providers.games import _particle_provider
+
+        assert _particle_provider is not None
+        assert isinstance(_particle_provider, ParticleProvider)
+        assert _particle_provider.name == "Particle Provider"
+        assert _particle_provider.backend == mock_particle_backend_instance
+        assert _particle_provider.metrics_client == mock_metrics_client_instance
+
+        mock_gcs_uploader.assert_called_once_with(
+            "mock_gcs_project", "mock_gcs_bucket", "mock_cdn_hostname"
+        )
+        mock_create_http_client.assert_called_once_with(connect_timeout="mock_connect_timeout")
+        mock_get_metrics_client.assert_called_once()
+
+        mock_particle_backend.assert_called_once_with(
+            gcs_uploader=mock_gcs_uploader_instance,
+            http_client=mock_http_client_instance,
+            metrics_client=mock_metrics_client_instance,
+            particle_url_root="mock_url_root",
+            particle_url_path_manifest="mock_url_path_manifest",
+        )
+
+
+@pytest.mark.asyncio
+async def test_get_particle_provider_initialized() -> None:
+    """Verify get_particle_provider returns class instance after init_providers call."""
+    await init_providers()
+
+    assert isinstance(get_particle_provider(), ParticleProvider)
+
+
+def test_get_particle_provider_not_initialized() -> None:
+    """Verify that get_particle_provider raises ValueError when _particle_provider is not initialized."""
+    with patch("merino.providers.games._particle_provider", None):
+        with pytest.raises(ValueError, match="Particle provider has not been initialized."):
+            get_particle_provider()


### PR DESCRIPTION


## References

JIRA: [HNT-2508](https://mozilla-hub.atlassian.net/browse/HNT-2508) Improve Particle test coverage

## Description

improve particle game test coverage.

- remove superfluous exception checking when validating json schema
- add None check when retrieving particle provider
- add tests for initializing games providers
- add utils tests


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2243)


[HNT-2508]: https://mozilla-hub.atlassian.net/browse/HNT-2508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ