### PR TITLE
HNT-1890 (1/4): cache adapter primitives + architecture doc

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -30,6 +30,7 @@
   - [Test Failures in CI](./operations/testfailures.md)
   - [Configs](./operations/configs.md)
   - [Elasticsearch](./operations/elasticsearch.md)
+  - [Curated Recommendations](./operations/curated-recommendations/corpus-cache.md)
   - [Jobs](./operations/jobs.md)
     - [Navigational Suggestions](./operations/jobs/navigational_suggestions.md)
     - [Dynamic Wikipedia Indexer](./operations/jobs/dynamic-wiki-indexer.md)

--- a/docs/data.md
+++ b/docs/data.md
@@ -200,6 +200,9 @@ The following additional metrics are recorded when curated recommendations are r
 - `recommendation.ml.cohort_model.last_updated` -
  A gauge for the staleness (in seconds) of the cohort model data, measured between when the data was
  updated in GCS and the current time. This value could get large as the model may be updated weekly.
+- `cache` (tags: `name`=`corpus`, `result`=`hit`|`stale`|`miss`) -
+ A counter for cache lookups. `hit`: fresh data returned. `stale`: cached entry
+ triggers revalidation. `miss`: no data in cache.
 
 
 

--- a/docs/operations/curated-recommendations/corpus-cache.md
+++ b/docs/operations/curated-recommendations/corpus-cache.md
@@ -1,0 +1,104 @@
+# Corpus Cache (Redis L2)
+
+Shared Redis cache between the per-pod in-memory cache and the Corpus GraphQL API.
+
+## Why
+
+Merino pods each independently fetch from the Corpus API on a short interval. This puts unnecessary load on Apollo/Client-API and creates risk as we expand internationally or scale pod count. Unlike most suggest providers, the number of unique backend requests is small (one per surface per refresh interval), making them highly cacheable — and the curated-corpus-api backend doesn't handle traffic spikes well.
+
+## How it works
+
+```mermaid
+flowchart TB
+    req["Firefox NewTab Request"]
+
+    subgraph L1 ["L1 — Per-Pod In-Memory Cache"]
+        check_l1{{"Check in-memory cache"}}
+        l1_lock{{"asyncio.Lock (per entry)"}}
+    end
+
+    respond["Respond with data"]
+    return_error["BackendError"]
+
+    subgraph bg ["Background Revalidation Task"]
+
+        subgraph L2 ["L2 — Shared Redis"]
+            check_l2{{"Check Redis cache"}}
+            acquire_lock{{"Try distributed lock"}}
+        end
+
+        api["Fetch from Corpus GraphQL API"]
+        write["Write to Redis + release lock"]
+        retry_redis["Wait 500ms, retry Redis"]
+        serve_stale["Serve stale + update L1"]
+        return_data["Return data + update L1"]
+        return_503["503 Service Unavailable"]
+    end
+
+    req --> check_l1
+
+    check_l1 -- "FRESH or STALE" --> respond
+    check_l1 -. "MISS (cold start)" .-> l1_lock
+
+    respond -. "if STALE, spawns task" .-> l1_lock
+    l1_lock -- "acquired" --> check_l2
+    l1_lock -. "waited, value populated" .-> respond
+    l1_lock -. "waited, fetch failed" .-> return_error
+
+    check_l2 -- "FRESH HIT" --> return_data
+    check_l2 -. "STALE or MISS" .-> acquire_lock
+
+    acquire_lock -- "LOCK ACQUIRED" --> api
+    acquire_lock -. "LOCK HELD + stale exists" .-> serve_stale
+    acquire_lock -. "LOCK HELD + no data" .-> retry_redis
+
+    retry_redis -- "HIT" --> return_data
+    retry_redis -. "MISS" .-> return_503
+
+    api --> write --> return_data
+
+    style req fill:#2c3e50,stroke:#1a252f,color:#ecf0f1,stroke-width:2px
+    style check_l1 fill:#2980b9,stroke:#1f6da0,color:#fff,stroke-width:2px
+    style l1_lock fill:#2980b9,stroke:#1f6da0,color:#fff,stroke-width:2px
+    style check_l2 fill:#d35400,stroke:#a04000,color:#fff,stroke-width:2px
+    style acquire_lock fill:#e67e22,stroke:#bf6516,color:#fff,stroke-width:2px
+    style api fill:#1e8449,stroke:#145a32,color:#fff,stroke-width:2px
+    style write fill:#1e8449,stroke:#145a32,color:#fff,stroke-width:2px
+    style respond fill:#27ae60,stroke:#1e8449,color:#fff,stroke-width:2px
+    style serve_stale fill:#f4d03f,stroke:#d4ac0f,color:#333
+    style retry_redis fill:#e67e22,stroke:#bf6516,color:#fff,stroke-width:2px
+    style return_data fill:#27ae60,stroke:#1e8449,color:#fff
+    style return_503 fill:#e74c3c,stroke:#c0392b,color:#fff
+    style return_error fill:#e74c3c,stroke:#c0392b,color:#fff
+    style L1 fill:#eaf2f8,stroke:#2980b9,stroke-width:2px,color:#2c3e50
+    style L2 fill:#fef5e7,stroke:#d35400,stroke-width:2px,color:#2c3e50
+    style bg fill:#f4f6f7,stroke:#95a5a6,stroke-width:2px,stroke-dasharray: 8 4,color:#2c3e50
+```
+
+Two layers of caching sit in front of the Corpus GraphQL API:
+
+- **L1 (in-memory)** — per-pod. Serves requests immediately. On stale, spawns a background task to revalidate. Uses an `asyncio.Lock` per cache entry to coordinate concurrent updates within a single pod.
+- **L2 (Redis)** — shared across all pods. On stale, one pod acquires a distributed lock and revalidates while others continue serving stale data. Uses `SET NX EX` to coordinate across pods.
+
+Both layers use the stale-while-revalidate pattern: serve the cached value immediately and refresh in the background.
+
+### Cold-miss behavior
+
+On cold start (no L1 or L2 data), the L1 `asyncio.Lock` ensures only one coroutine per pod enters L2. Other coroutines in the same pod wait on the lock and receive the result when it completes (or a `BackendError` if it fails).
+
+At the L2 level, one pod acquires the distributed lock and fetches from the API. Pods that lose the lock race wait 500ms and retry Redis once. If still no data, they raise `CorpusCacheUnavailable`, which the API layer translates to **HTTP 503**.
+
+Note: if Redis is timing out (not just down), the lock holder blocks for the duration of each Redis timeout. During this time, all other coroutines in the pod are waiting on the `asyncio.Lock`.
+
+## Design decisions
+
+| Decision | Choice | Why |
+|---|---|---|
+| Cache layer | Redis L2 behind existing in-memory L1 | Keeps per-pod latency low, Redis only consulted on L1 miss or stale |
+| Write pattern | Distributed stale-while-revalidate | One pod revalidates, others serve stale. Avoids thundering herd |
+| L1 lock | `asyncio.Lock` per cache entry | Coordinates concurrent revalidation within a single pod |
+| L2 lock | `SET NX EX` with TTL | Distributed, self-expiring. Worst case on timeout: one extra API call |
+| Cache format | Pydantic model dicts via orjson | Saves CPU across pods vs re-parsing raw GraphQL |
+| Cold miss (lock held) | 503 Service Unavailable | Prevents connection pile-up; Firefox shows cached NewTab content |
+| No circuit breaker | L1 `asyncio.Lock` limits Redis traffic | Only one coroutine per cache entry per pod reaches Redis. In steady state, L1 serves stale data and only the background task hits Redis. No need for a separate circuit breaker |
+| Hard TTL | 1 day (86400s) | Long safety net so data survives extended API outages |

--- a/merino/cache/none.py
+++ b/merino/cache/none.py
@@ -35,3 +35,9 @@ class NoCacheAdapter:  # pragma: no cover
 
     async def scard(self, key: str) -> int:  # noqa: D102
         return 0
+
+    async def set_nx(self, key: str, ttl_sec: int) -> bool:  # noqa: D102
+        return True
+
+    async def delete(self, key: str) -> None:  # noqa: D102
+        pass

--- a/merino/cache/protocol.py
+++ b/merino/cache/protocol.py
@@ -78,3 +78,22 @@ class CacheAdapter(Protocol):
     async def scard(self, key: str) -> int:
         """Get the number of members in a Redis set."""
         ...
+
+    async def set_nx(self, key: str, ttl_sec: int) -> bool:  # pragma: no cover
+        """Set the key only if it does not already exist, with a TTL in seconds.
+
+        Returns:
+            True if the key was set, False if it already existed.
+
+        Raises:
+            - `CacheAdapterError` for cache backend errors.
+        """
+        ...
+
+    async def delete(self, key: str) -> None:  # pragma: no cover
+        """Delete a key from the cache.
+
+        Raises:
+            - `CacheAdapterError` for cache backend errors.
+        """
+        ...

--- a/merino/cache/redis.py
+++ b/merino/cache/redis.py
@@ -127,6 +127,31 @@ class RedisAdapter:
         except RedisError as exc:
             raise CacheAdapterError(f"Failed to SCARD {key} with error: {exc}") from exc
 
+    async def set_nx(self, key: str, ttl_sec: int) -> bool:
+        """Set the key only if it does not exist, with a TTL in seconds.
+
+        Returns:
+            True if the key was set, False if it already existed.
+
+        Raises:
+            - `CacheAdapterError` if Redis returns an error.
+        """
+        try:
+            return bool(await self.primary.set(key, b"1", nx=True, ex=ttl_sec))
+        except RedisError as exc:
+            raise CacheAdapterError(f"Failed to SETNX `{repr(key)}` with error: `{exc}`") from exc
+
+    async def delete(self, key: str) -> None:
+        """Delete a key from Redis.
+
+        Raises:
+            - `CacheAdapterError` if Redis returns an error.
+        """
+        try:
+            await self.primary.delete(key)
+        except RedisError as exc:
+            raise CacheAdapterError(f"Failed to DELETE `{repr(key)}` with error: `{exc}`") from exc
+
     async def close(self) -> None:
         """Close the Redis connection."""
         if self.primary is self.replica:

--- a/tests/unit/utils/test_cache_redis.py
+++ b/tests/unit/utils/test_cache_redis.py
@@ -2,14 +2,16 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-"""Unit tests for the cron.py module."""
+"""Unit tests for the Redis cache adapter."""
 
 import pytest
+from unittest.mock import AsyncMock
+
+from redis.asyncio import Redis, RedisError
 from pytest_mock import MockerFixture
 
-from redis.asyncio import Redis
-
 from merino.cache.redis import create_redis_clients, RedisAdapter
+from merino.exceptions import CacheAdapterError
 
 
 @pytest.mark.asyncio
@@ -32,3 +34,65 @@ async def test_adapter_in_standalone_mode(mocker: MockerFixture) -> None:
     await adapter.close()
 
     spy.assert_called_once()
+
+
+class TestSetNx:
+    """Tests for RedisAdapter.set_nx."""
+
+    @pytest.mark.asyncio
+    async def test_returns_true_when_key_set(self) -> None:
+        """Return True when the key was newly created."""
+        mock_primary = AsyncMock()
+        mock_primary.set.return_value = True
+        adapter = RedisAdapter(mock_primary)
+
+        result = await adapter.set_nx("lock:key", 30)
+
+        assert result is True
+        mock_primary.set.assert_called_once_with("lock:key", b"1", nx=True, ex=30)
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_key_exists(self) -> None:
+        """Return False when the key already exists (Redis returns None)."""
+        mock_primary = AsyncMock()
+        mock_primary.set.return_value = None
+        adapter = RedisAdapter(mock_primary)
+
+        result = await adapter.set_nx("lock:key", 30)
+
+        assert result is False
+        mock_primary.set.assert_called_once_with("lock:key", b"1", nx=True, ex=30)
+
+    @pytest.mark.asyncio
+    async def test_raises_cache_adapter_error_on_redis_error(self) -> None:
+        """Raise CacheAdapterError when Redis returns an error."""
+        mock_primary = AsyncMock()
+        mock_primary.set.side_effect = RedisError("connection lost")
+        adapter = RedisAdapter(mock_primary)
+
+        with pytest.raises(CacheAdapterError, match="SETNX"):
+            await adapter.set_nx("lock:key", 30)
+
+
+class TestDelete:
+    """Tests for RedisAdapter.delete."""
+
+    @pytest.mark.asyncio
+    async def test_deletes_key(self) -> None:
+        """Delete a key from Redis."""
+        mock_primary = AsyncMock()
+        adapter = RedisAdapter(mock_primary)
+
+        await adapter.delete("lock:key")
+
+        mock_primary.delete.assert_called_once_with("lock:key")
+
+    @pytest.mark.asyncio
+    async def test_raises_cache_adapter_error_on_redis_error(self) -> None:
+        """Raise CacheAdapterError when Redis returns an error."""
+        mock_primary = AsyncMock()
+        mock_primary.delete.side_effect = RedisError("connection lost")
+        adapter = RedisAdapter(mock_primary)
+
+        with pytest.raises(CacheAdapterError, match="DELETE"):
+            await adapter.delete("lock:key")


### PR DESCRIPTION
**PR 1/4** to implement shared caching of curated recommendations between pods.

Stack: 1/4 (this) → [2/4](https://github.com/mozilla-services/merino-py/pull/1439) impl → [3/4](https://github.com/mozilla-services/merino-py/pull/1440) integration tests → [4/4](https://github.com/mozilla-services/merino-py/pull/1441) wire-up.

## References

JIRA: [HNT-1890](https://mozilla-hub.atlassian.net/browse/HNT-1890)

## Description

Foundational, behavior-preserving change. Lays the groundwork for a shared L2 corpus cache and is intentionally split into two pieces so the **design can be reviewed before the implementation**.

### What's in this PR

- **Architecture doc** — `docs/operations/curated-recommendations/corpus-cache.md`. Describes the L1 SWR + L2 distributed-lock design, cold-miss behavior (503), cache key layout, TTL choices, and rollout. Indexed via `docs/SUMMARY.md` and `docs/data.md` so it's discoverable as soon as this PR lands.
- **`CacheAdapter` protocol** (`merino/cache/protocol.py`) — adds `set_nx` (set-if-not-exists with TTL) and `delete`. These back the distributed lock in PR 2/4.
- **`RedisAdapter`** (`merino/cache/redis.py`) — implements them via `SET NX EX` / `DEL`.
- **`NoCacheAdapter`** (`merino/cache/none.py`) — no-op implementations.
- **Adapter test coverage** for the new methods (`tests/unit/utils/test_cache_redis.py`).

### Architecture

Requests are always served from the in-memory cache (L1) — either fresh or stale. Stale data is served whenever possible so that the Redis and API calls never block the request. Revalidation happens in a background task: it checks Redis (L2) first, and only the pod that acquires the distributed lock fetches from the API.

```mermaid
flowchart TB
    req["Firefox NewTab Request"]

    subgraph L1 ["L1 — Per-Pod In-Memory Cache"]
        check_l1{{"Check in-memory cache"}}
        l1_lock{{"asyncio.Lock (per entry)"}}
    end

    respond["Respond with data"]
    return_error["BackendError"]

    subgraph bg ["Background Revalidation Task"]

        subgraph L2 ["L2 — Shared Redis"]
            check_l2{{"Check Redis cache"}}
            acquire_lock{{"Try distributed lock"}}
        end

        api["Fetch from Corpus GraphQL API"]
        write["Write to Redis + release lock"]
        retry_redis["Wait 500ms, retry Redis"]
        serve_stale["Serve stale + update L1"]
        return_data["Return data + update L1"]
        return_503["503 Service Unavailable"]
    end

    req --> check_l1

    check_l1 -- "FRESH or STALE" --> respond
    check_l1 -. "MISS (cold start)" .-> l1_lock

    respond -. "if STALE, spawns task" .-> l1_lock
    l1_lock -- "acquired" --> check_l2
    l1_lock -. "waited, value populated" .-> respond
    l1_lock -. "waited, fetch failed" .-> return_error

    check_l2 -- "FRESH HIT" --> return_data
    check_l2 -. "STALE or MISS" .-> acquire_lock

    acquire_lock -- "LOCK ACQUIRED" --> api
    acquire_lock -. "LOCK HELD + stale exists" .-> serve_stale
    acquire_lock -. "LOCK HELD + no data" .-> retry_redis

    retry_redis -- "HIT" --> return_data
    retry_redis -. "MISS" .-> return_503

    api --> write --> return_data
```

### Key design decisions (full rationale in `corpus-cache.md`)

| Decision | Choice | Why |
|---|---|---|
| Cache layer | Redis L2 behind in-memory L1 | Keeps per-pod latency low, Redis only consulted on L1 miss or stale |
| Write pattern | Distributed stale-while-revalidate | One pod revalidates, others serve stale. Avoids thundering herd |
| L2 lock primitive | `SET NX EX` with TTL | Distributed, self-expiring. Worst case on timeout: one extra API call |
| Cold miss (lock held) | 503 Service Unavailable | Prevents connection pile-up; Firefox shows cached NewTab content |
| No circuit breaker | L1 `asyncio.Lock` limits Redis traffic | Only one coroutine per cache entry per pod reaches Redis |
| Redis cluster | Shared with other providers | ~36 keys, ~4MB total. [Confirmed with Nan](https://mozilla.slack.com/archives/C04EG0ZKTC0/p1776104552490389): 5 MB storage, 40 IOPS |

The `set_nx`/`delete` methods are added with no consumer in this PR — the consumer (`RedisCorpusCache`) lands in PR 2/4. This split exists so the architecture and adapter contract can be approved before the SWR cache logic.

## PR Review Checklist

- [x] Conforms to Contribution Guidelines
- [x] PR title starts with JIRA reference
- [ ] `[load test: (abort|skip|warn)]` keywords applied (n/a — no behavior change)
- [x] Documentation updated
- [x] Test coverage expanded


[HNT-1890]: https://mozilla-hub.atlassian.net/browse/HNT-1890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ