### PR TITLE
HNT-1890 (2/4): RedisCorpusCache + corpus_cache config + unit tests

### DIFF
--- a/merino/configs/__init__.py
+++ b/merino/configs/__init__.py
@@ -203,6 +203,18 @@ _validators = [
         lte=600.0,
         env=["development"],
     ),
+    Validator(
+        "curated_recommendations.corpus_cache.cache",
+        is_in=["none", "redis"],
+    ),
+    Validator(
+        "curated_recommendations.corpus_cache.soft_ttl_sec",
+        "curated_recommendations.corpus_cache.hard_ttl_sec",
+        "curated_recommendations.corpus_cache.lock_ttl_sec",
+        is_type_of=int,
+        gt=0,
+    ),
+    Validator("curated_recommendations.corpus_cache.key_prefix", is_type_of=str),
     Validator("sentry.env", is_in=["prod", "stage", "dev"]),
     Validator("sentry.mode", is_in=["disabled", "release", "debug"]),
     Validator("sentry.traces_sample_rate", gte=0, lte=1),

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -1254,6 +1254,33 @@ blob_name = "contextual_ts/cohort_model_v2.safetensors"
 cron_interval_seconds = 600
 
 
+[default.curated_recommendations.corpus_cache]
+# MERINO__CURATED_RECOMMENDATIONS__CORPUS_CACHE__CACHE
+# Shared corpus cache backend. "redis" enables Redis as an L2 cache
+# between in-memory SWR (L1) and the Corpus GraphQL API. "none" disables it.
+# With "none", every pod (~300 in production) hits the Corpus API independently on each refresh.
+# This was the default until May 2026; reverting may now exceed Apollo's monthly volume or Corpus API capacity.
+cache = "none"
+
+# MERINO__CURATED_RECOMMENDATIONS__CORPUS_CACHE__SOFT_TTL_SEC
+# Soft TTL in seconds. Balances propagating time-sensitive content quickly vs backend load.
+# Average time for new content to reach New Tab is ~half this value (e.g. 60s => ~30s avg propagation).
+soft_ttl_sec = 60
+
+# MERINO__CURATED_RECOMMENDATIONS__CORPUS_CACHE__HARD_TTL_SEC
+# Hard TTL in seconds. Safety net so data survives extended API outages (1 day).
+# During a Corpus API outage, New Tab keeps serving stale data up to this age before requests fail.
+hard_ttl_sec = 86400
+
+# MERINO__CURATED_RECOMMENDATIONS__CORPUS_CACHE__LOCK_TTL_SEC
+# Distributed lock TTL in seconds. Auto-releases if the lock holder crashes.
+lock_ttl_sec = 30
+
+# MERINO__CURATED_RECOMMENDATIONS__CORPUS_CACHE__KEY_PREFIX
+# Prefix for all Redis keys. Bump the version on schema changes.
+key_prefix = "curated:v1"
+
+
 
 [default.curated_recommendations.corpus_api]
 # MERINO__CURATED_RECOMMENDATIONS__CORPUS_API__RETRY_COUNT

--- a/merino/curated_recommendations/corpus_backends/redis_cache.py
+++ b/merino/curated_recommendations/corpus_backends/redis_cache.py
@@ -1,0 +1,322 @@
+"""Redis L2 cache for corpus backends with distributed stale-while-revalidate."""
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Awaitable, Callable, Literal, TypeVar
+
+import aiodogstatsd
+import orjson
+
+from merino.cache.protocol import CacheAdapter
+from merino.curated_recommendations.corpus_backends.protocol import (
+    CorpusItem,
+    CorpusSection,
+    ScheduledSurfaceProtocol,
+    SectionsProtocol,
+    SurfaceId,
+)
+from merino.exceptions import CacheAdapterError
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+_METRICS_NAME = "corpus"
+
+
+class CorpusCacheUnavailable(Exception):
+    """Raised when the corpus cache cannot serve data.
+
+    Triggers include: cold miss with lock held or retry exhausted.
+    The API layer translates this to HTTP 503.
+    """
+
+    pass
+
+
+BackendType = Literal["scheduled", "sections"]
+
+
+@dataclass(frozen=True)
+class CorpusCacheConfig:
+    """Configuration for the Redis corpus cache layer.
+
+    Attributes:
+        soft_ttl_sec: Seconds before a cached entry is considered stale. One pod revalidates
+            while others continue to serve the stale value.
+        hard_ttl_sec: Seconds before Redis evicts the key entirely. Safety net.
+        lock_ttl_sec: Seconds before a distributed revalidation lock auto-expires.
+        key_prefix: Prefix for all Redis keys. Bump the version (e.g. v1 → v2) on
+            breaking schema changes so stale data from the old format is not deserialized.
+    """
+
+    soft_ttl_sec: int
+    hard_ttl_sec: int
+    lock_ttl_sec: int
+    key_prefix: str
+
+
+def _build_data_key(
+    config: CorpusCacheConfig, backend_type: BackendType, surface_id: SurfaceId
+) -> str:
+    """Build the Redis key for cached corpus data."""
+    return ":".join([config.key_prefix, backend_type, surface_id.value])
+
+
+def _build_lock_key(
+    config: CorpusCacheConfig, backend_type: BackendType, surface_id: SurfaceId
+) -> str:
+    """Build the Redis key for the distributed revalidation lock."""
+    return ":".join([config.key_prefix, "lock", backend_type, surface_id.value])
+
+
+def _serialize_envelope(data: list[dict], soft_ttl_sec: int) -> bytes:
+    """Serialize data with an expiration timestamp into a cache envelope."""
+    envelope = {
+        "expires_at": time.time() + soft_ttl_sec,
+        "data": data,
+    }
+    return orjson.dumps(envelope)
+
+
+def _deserialize_envelope(raw: bytes) -> tuple[float, list[dict]]:
+    """Deserialize a cache envelope, returning (expires_at, data)."""
+    envelope = orjson.loads(raw)
+    return envelope["expires_at"], envelope["data"]
+
+
+class _RedisCorpusCache:
+    """Shared Redis cache logic for corpus backends.
+
+    Implements distributed stale-while-revalidate: when the cached value is stale,
+    one pod acquires a lock and revalidates while others serve stale data.
+
+    No circuit breaker: the L1 in-memory cache's asyncio.Lock already limits Redis
+    traffic to one coroutine per cache entry per pod. Redis errors surface as
+    CorpusCacheUnavailable (HTTP 503) only on cold starts; in steady state, L1
+    serves stale data and the background revalidation task absorbs any Redis errors.
+    """
+
+    def __init__(
+        self,
+        cache: CacheAdapter,
+        config: CorpusCacheConfig,
+        metrics_client: aiodogstatsd.Client,
+    ) -> None:
+        self._cache = cache
+        self._config = config
+        self._metrics = metrics_client
+
+    async def get_or_fetch(
+        self,
+        backend_type: BackendType,
+        surface_id: SurfaceId,
+        *,
+        fetch_fn: Callable[[], Awaitable[list[T]]],
+        serialize_fn: Callable[[list[T]], list[dict]],
+        deserialize_fn: Callable[[list[dict]], list[T]],
+    ) -> list[T]:
+        """Check Redis, returning cached data or fetching from the backend.
+
+        Args:
+            backend_type: Type identifier for key namespacing.
+            surface_id: Surface ID enum for the cache key.
+            fetch_fn: Async callable that fetches fresh data from the backend.
+            serialize_fn: Converts typed models to dicts for Redis storage.
+            deserialize_fn: Converts dicts from Redis back to typed models.
+        """
+        data_key = _build_data_key(self._config, backend_type, surface_id)
+        lock_key = _build_lock_key(self._config, backend_type, surface_id)
+        # Try reading from Redis
+        cached = await self._redis_get(data_key)
+        if cached is not None:
+            try:
+                expires_at, items_data = cached
+                is_fresh = time.time() < expires_at
+            except TypeError:
+                # expires_at is not numeric (corrupted envelope)
+                logger.error("Invalid expires_at in corpus cache key %s", data_key, exc_info=True)
+                is_fresh = False
+                items_data = None
+
+            if is_fresh and items_data is not None:
+                try:
+                    result = deserialize_fn(items_data)
+                    self._metrics.increment("cache", tags={"name": _METRICS_NAME, "result": "hit"})
+                    return result
+                except Exception:
+                    logger.error(
+                        "Deserialization failed for corpus cache key %s",
+                        data_key,
+                        exc_info=True,
+                    )
+                    # Fall through to revalidation/fetch below
+            elif items_data is not None:
+                # Stale — try to revalidate
+                self._metrics.increment("cache", tags={"name": _METRICS_NAME, "result": "stale"})
+                if await self._try_acquire_lock(lock_key):
+                    return await self._revalidate(data_key, lock_key, fetch_fn, serialize_fn)
+                try:
+                    return deserialize_fn(items_data)
+                except Exception:
+                    logger.error(
+                        "Deserialization of stale data failed for corpus cache key %s",
+                        data_key,
+                        exc_info=True,
+                    )
+
+        # Cache miss — try to acquire lock and fetch
+        self._metrics.increment("cache", tags={"name": _METRICS_NAME, "result": "miss"})
+        if await self._try_acquire_lock(lock_key):
+            return await self._revalidate(data_key, lock_key, fetch_fn, serialize_fn)
+        # Another pod is populating; wait for it to finish (P95 API latency is ~217ms)
+        await asyncio.sleep(0.5)
+        cached = await self._redis_get(data_key)
+        if cached is not None:
+            _, items_data = cached
+            if items_data is not None:
+                try:
+                    return deserialize_fn(items_data)
+                except Exception:
+                    logger.error(
+                        "Deserialization failed on retry for corpus cache key %s",
+                        data_key,
+                        exc_info=True,
+                    )
+        # No data available and another pod holds the lock. Signal the API layer
+        # to return 503 so connections don't pile up waiting for the lock holder.
+        raise CorpusCacheUnavailable(f"No data available for {data_key}")
+
+    async def _revalidate(
+        self,
+        data_key: str,
+        lock_key: str,
+        fetch_fn: Callable[[], Awaitable[list[T]]],
+        serialize_fn: Callable[[list[T]], list[dict]],
+    ) -> list[T]:
+        """Fetch from the backend, write to Redis, and release the lock.
+
+        Uses try/finally to ensure the lock is released even on cancellation
+        (asyncio.CancelledError is a BaseException, not caught by except Exception).
+        """
+        try:
+            items = await fetch_fn()
+            # Cache write is best-effort: don't lose fetched items on serialize or write failure.
+            try:
+                serialized = serialize_fn(items)
+            except Exception:
+                logger.error(
+                    "Serialization failed for corpus cache key %s", data_key, exc_info=True
+                )
+            else:
+                await self._redis_set(data_key, serialized)
+            return items
+        finally:
+            await self._release_lock(lock_key)
+
+    async def _redis_get(self, key: str) -> tuple[float, list[dict]] | None:
+        """Read and deserialize from Redis. Returns None on any error."""
+        try:
+            raw = await self._cache.get(key)
+            if raw is None:
+                return None
+            return _deserialize_envelope(raw)
+        except CacheAdapterError:
+            logger.error("Redis read error for corpus cache key %s", key, exc_info=True)
+            return None
+        except (orjson.JSONDecodeError, KeyError, TypeError):
+            logger.error(
+                "Redis deserialization error for corpus cache key %s",
+                key,
+                exc_info=True,
+            )
+            return None
+
+    async def _redis_set(self, key: str, data: list[dict]) -> None:
+        """Serialize and write to Redis. Logs on error without raising."""
+        try:
+            value = _serialize_envelope(data, self._config.soft_ttl_sec)
+            await self._cache.set(key, value, ttl=timedelta(seconds=self._config.hard_ttl_sec))
+        except Exception:
+            logger.error("Redis write error for corpus cache key %s", key, exc_info=True)
+
+    async def _try_acquire_lock(self, lock_key: str) -> bool:
+        """Attempt to acquire a distributed lock via SET NX EX."""
+        try:
+            result = await self._cache.set_nx(lock_key, self._config.lock_ttl_sec)
+            return result
+        except CacheAdapterError:
+            logger.error("Redis lock acquire error for %s", lock_key, exc_info=True)
+            return False
+
+    async def _release_lock(self, lock_key: str) -> None:
+        """Release the distributed lock by deleting the key.
+
+        Note: This uses unconditional DELETE rather than owner-aware release
+        (compare-and-delete via Lua script). If revalidation exceeds lock_ttl_sec
+        (30s default), another pod's lock could be deleted. The consequence is at
+        most one extra redundant API call, not a stampede, because the stale-while-revalidate pattern
+        ensures other pods serve stale/cached data regardless of lock state.
+        """
+        try:
+            await self._cache.delete(lock_key)
+        except CacheAdapterError:
+            logger.error("Redis lock release error for %s", lock_key, exc_info=True)
+
+
+class RedisCachedScheduledSurface(ScheduledSurfaceProtocol):
+    """Redis L2 cache wrapper for ScheduledSurfaceBackend.
+
+    Checks Redis before hitting the Corpus API. Uses distributed stale-while-revalidate:
+    one pod acquires a lock and revalidates while others serve stale data.
+    """
+
+    def __init__(
+        self,
+        backend: ScheduledSurfaceProtocol,
+        cache: CacheAdapter,
+        config: CorpusCacheConfig,
+        metrics_client: aiodogstatsd.Client,
+    ) -> None:
+        self._backend = backend
+        self._redis_cache = _RedisCorpusCache(cache, config, metrics_client)
+
+    async def fetch(self, surface_id: SurfaceId, days_offset: int = 0) -> list[CorpusItem]:
+        """Fetch corpus items, checking Redis L2 cache first."""
+        return await self._redis_cache.get_or_fetch(
+            "scheduled",
+            surface_id,
+            fetch_fn=lambda: self._backend.fetch(surface_id, days_offset),
+            serialize_fn=lambda items: [item.model_dump(mode="json") for item in items],
+            deserialize_fn=lambda data: [CorpusItem.model_validate(d) for d in data],
+        )
+
+
+class RedisCachedSections(SectionsProtocol):
+    """Redis L2 cache wrapper for SectionsBackend.
+
+    Same distributed stale-while-revalidate pattern as RedisCachedScheduledSurface.
+    """
+
+    def __init__(
+        self,
+        backend: SectionsProtocol,
+        cache: CacheAdapter,
+        config: CorpusCacheConfig,
+        metrics_client: aiodogstatsd.Client,
+    ) -> None:
+        self._backend = backend
+        self._redis_cache = _RedisCorpusCache(cache, config, metrics_client)
+
+    async def fetch(self, surface_id: SurfaceId) -> list[CorpusSection]:
+        """Fetch corpus sections, checking Redis L2 cache first."""
+        return await self._redis_cache.get_or_fetch(
+            "sections",
+            surface_id,
+            fetch_fn=lambda: self._backend.fetch(surface_id),
+            serialize_fn=lambda sections: [s.model_dump(mode="json") for s in sections],
+            deserialize_fn=lambda data: [CorpusSection.model_validate(d) for d in data],
+        )

--- a/tests/unit/curated_recommendations/corpus_backends/test_redis_cache.py
+++ b/tests/unit/curated_recommendations/corpus_backends/test_redis_cache.py
@@ -1,0 +1,616 @@
+"""Unit tests for the Redis L2 corpus cache layer."""
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import aiodogstatsd
+import orjson
+import pytest
+
+from merino.curated_recommendations.corpus_backends.protocol import (
+    CorpusSection,
+    CreateSource,
+    SurfaceId,
+)
+from merino.curated_recommendations.corpus_backends.redis_cache import (
+    BackendType,
+    CorpusCacheConfig,
+    CorpusCacheUnavailable,
+    RedisCachedScheduledSurface,
+    RedisCachedSections,
+    _RedisCorpusCache,
+    _build_data_key,
+    _build_lock_key,
+    _deserialize_envelope,
+    _serialize_envelope,
+)
+from merino.exceptions import CacheAdapterError
+from tests.unit.curated_recommendations.test_sections import generate_corpus_item
+
+SURFACE_ID = SurfaceId.NEW_TAB_EN_US
+
+CONFIG = CorpusCacheConfig(
+    soft_ttl_sec=60,
+    hard_ttl_sec=600,
+    lock_ttl_sec=30,
+    key_prefix="curated:v1",
+)
+
+
+def _make_corpus_section() -> CorpusSection:
+    """Create a CorpusSection with sensible defaults for testing."""
+    return CorpusSection(
+        sectionItems=[generate_corpus_item()],
+        title="Test Section",
+        externalId="test-section",
+        createSource=CreateSource.ML,
+    )
+
+
+def _make_fresh_envelope(items_data: list[dict], soft_ttl_sec: int = 60) -> bytes:
+    """Create a serialized cache envelope that is still fresh."""
+    return _serialize_envelope(items_data, soft_ttl_sec)
+
+
+def _make_stale_envelope(items_data: list[dict]) -> bytes:
+    """Create a serialized cache envelope that has already expired."""
+    envelope = {
+        "expires_at": time.time() - 10,
+        "data": items_data,
+    }
+    return orjson.dumps(envelope)
+
+
+class TestKeyBuilders:
+    """Tests for Redis key construction functions."""
+
+    @pytest.mark.parametrize(
+        ("backend_type", "expected"),
+        [
+            ("scheduled", "curated:v1:scheduled:NEW_TAB_EN_US"),
+            ("sections", "curated:v1:sections:NEW_TAB_EN_US"),
+        ],
+        ids=["scheduled", "sections"],
+    )
+    def test_build_data_key(self, backend_type: BackendType, expected: str) -> None:
+        """Build a data key for the given backend type."""
+        assert _build_data_key(CONFIG, backend_type, SurfaceId.NEW_TAB_EN_US) == expected
+
+    def test_build_lock_key(self) -> None:
+        """Build a lock key with 'lock' segment inserted."""
+        key = _build_lock_key(CONFIG, "scheduled", SurfaceId.NEW_TAB_EN_US)
+        assert key == "curated:v1:lock:scheduled:NEW_TAB_EN_US"
+
+
+class TestEnvelope:
+    """Tests for envelope serialization and deserialization."""
+
+    def test_roundtrip(self) -> None:
+        """Serialize and deserialize an envelope."""
+        data = [{"corpusItemId": "abc", "title": "Hello"}]
+        raw = _serialize_envelope(data, soft_ttl_sec=60)
+        expires_at, deserialized = _deserialize_envelope(raw)
+        assert deserialized == data
+        assert expires_at > time.time()
+
+    def test_deserialize_invalid_json(self) -> None:
+        """Raise on invalid JSON bytes."""
+        with pytest.raises(orjson.JSONDecodeError):
+            _deserialize_envelope(b"not json")
+
+
+class TestRedisCorpusCache:
+    """Tests for the shared _RedisCorpusCache logic."""
+
+    def setup_method(self) -> None:
+        """Set up mock cache adapter and helper functions."""
+        self.mock_cache = AsyncMock()
+        self.metrics_client = MagicMock(spec=aiodogstatsd.Client)
+        self.redis_cache = _RedisCorpusCache(self.mock_cache, CONFIG, self.metrics_client)
+        self.fetch_fn = AsyncMock(return_value=["item1", "item2"])
+        self.serialize_fn = lambda items: [{"v": i} for i in items]
+        self.deserialize_fn = lambda data: [d["v"] for d in data]
+
+    @pytest.mark.asyncio
+    async def test_fresh_hit_returns_cached_data(self) -> None:
+        """Return deserialized data on a fresh Redis hit without calling fetch_fn."""
+        items_data = [{"v": "item1"}, {"v": "item2"}]
+        self.mock_cache.get.return_value = _make_fresh_envelope(items_data)
+
+        result = await self.redis_cache.get_or_fetch(
+            "scheduled",
+            SURFACE_ID,
+            fetch_fn=self.fetch_fn,
+            serialize_fn=self.serialize_fn,
+            deserialize_fn=self.deserialize_fn,
+        )
+
+        assert result == ["item1", "item2"]
+        self.fetch_fn.assert_not_called()
+        self.mock_cache.set_nx.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_stale_hit_lock_winner_revalidates(self) -> None:
+        """Revalidate when stale and lock is acquired."""
+        items_data = [{"v": "old"}]
+        self.mock_cache.get.return_value = _make_stale_envelope(items_data)
+        self.mock_cache.set_nx.return_value = True
+
+        result = await self.redis_cache.get_or_fetch(
+            "scheduled",
+            SURFACE_ID,
+            fetch_fn=self.fetch_fn,
+            serialize_fn=self.serialize_fn,
+            deserialize_fn=self.deserialize_fn,
+        )
+
+        assert result == ["item1", "item2"]
+        self.fetch_fn.assert_called_once()
+        self.mock_cache.set.assert_called_once()
+        self.mock_cache.delete.assert_called_once_with("curated:v1:lock:scheduled:NEW_TAB_EN_US")
+
+    @pytest.mark.asyncio
+    async def test_stale_hit_lock_loser_returns_stale(self) -> None:
+        """Return stale data when another pod holds the lock."""
+        items_data = [{"v": "stale"}]
+        self.mock_cache.get.return_value = _make_stale_envelope(items_data)
+        self.mock_cache.set_nx.return_value = False
+
+        result = await self.redis_cache.get_or_fetch(
+            "scheduled",
+            SURFACE_ID,
+            fetch_fn=self.fetch_fn,
+            serialize_fn=self.serialize_fn,
+            deserialize_fn=self.deserialize_fn,
+        )
+
+        assert result == ["stale"]
+        self.fetch_fn.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_lock_winner_fetches(self) -> None:
+        """Fetch from backend on cache miss when lock is acquired."""
+        self.mock_cache.get.return_value = None
+        self.mock_cache.set_nx.return_value = True
+
+        result = await self.redis_cache.get_or_fetch(
+            "scheduled",
+            SURFACE_ID,
+            fetch_fn=self.fetch_fn,
+            serialize_fn=self.serialize_fn,
+            deserialize_fn=self.deserialize_fn,
+        )
+
+        assert result == ["item1", "item2"]
+        self.fetch_fn.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_lock_loser_retries_and_succeeds(self) -> None:
+        """Wait and retry Redis when cache misses and lock is held by another pod."""
+        items_data = [{"v": "item1"}, {"v": "item2"}]
+        # First get returns None (miss), second get returns data (written by lock winner)
+        self.mock_cache.get.side_effect = [None, _make_fresh_envelope(items_data)]
+        self.mock_cache.set_nx.return_value = False
+
+        result = await self.redis_cache.get_or_fetch(
+            "scheduled",
+            SURFACE_ID,
+            fetch_fn=self.fetch_fn,
+            serialize_fn=self.serialize_fn,
+            deserialize_fn=self.deserialize_fn,
+        )
+
+        assert result == ["item1", "item2"]
+        self.fetch_fn.assert_not_called()
+        assert self.mock_cache.get.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_lock_loser_retries_then_raises_unavailable(self) -> None:
+        """Raise CorpusCacheUnavailable when retry still finds no data after waiting."""
+        self.mock_cache.get.return_value = None
+        self.mock_cache.set_nx.return_value = False
+
+        with pytest.raises(CorpusCacheUnavailable):
+            await self.redis_cache.get_or_fetch(
+                "scheduled",
+                SURFACE_ID,
+                fetch_fn=self.fetch_fn,
+                serialize_fn=self.serialize_fn,
+                deserialize_fn=self.deserialize_fn,
+            )
+
+        self.fetch_fn.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_lock_loser_retry_deserialize_error_raises_unavailable(
+        self,
+    ) -> None:
+        """Raise CorpusCacheUnavailable when retry data can't be deserialized."""
+        items_data = [{"v": "item1"}]
+        self.mock_cache.get.side_effect = [None, _make_fresh_envelope(items_data)]
+        self.mock_cache.set_nx.return_value = False
+
+        def bad_deserialize(data: list[dict]) -> list:
+            raise ValueError("schema changed")
+
+        with pytest.raises(CorpusCacheUnavailable):
+            await self.redis_cache.get_or_fetch(
+                "scheduled",
+                SURFACE_ID,
+                fetch_fn=self.fetch_fn,
+                serialize_fn=self.serialize_fn,
+                deserialize_fn=bad_deserialize,
+            )
+
+        self.fetch_fn.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_redis_read_error_falls_through(self) -> None:
+        """Fall through to backend when Redis read fails."""
+        self.mock_cache.get.side_effect = CacheAdapterError("connection refused")
+        self.mock_cache.set_nx.return_value = True
+
+        result = await self.redis_cache.get_or_fetch(
+            "scheduled",
+            SURFACE_ID,
+            fetch_fn=self.fetch_fn,
+            serialize_fn=self.serialize_fn,
+            deserialize_fn=self.deserialize_fn,
+        )
+
+        assert result == ["item1", "item2"]
+        self.fetch_fn.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_redis_write_error_does_not_raise(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Continue normally when Redis write fails after fetching."""
+        self.mock_cache.get.return_value = None
+        self.mock_cache.set_nx.return_value = True
+        self.mock_cache.set.side_effect = CacheAdapterError("write failed")
+
+        result = await self.redis_cache.get_or_fetch(
+            "scheduled",
+            SURFACE_ID,
+            fetch_fn=self.fetch_fn,
+            serialize_fn=self.serialize_fn,
+            deserialize_fn=self.deserialize_fn,
+        )
+
+        assert result == ["item1", "item2"]
+        # Cache write was attempted (and failed), but lock should still be released
+        self.mock_cache.set.assert_called_once()
+        self.mock_cache.delete.assert_called_once_with("curated:v1:lock:scheduled:NEW_TAB_EN_US")
+        assert any("write error" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_deserialization_error_falls_through(self) -> None:
+        """Treat corrupted Redis data as a cache miss."""
+        self.mock_cache.get.return_value = b"not valid json"
+        self.mock_cache.set_nx.return_value = True
+
+        result = await self.redis_cache.get_or_fetch(
+            "scheduled",
+            SURFACE_ID,
+            fetch_fn=self.fetch_fn,
+            serialize_fn=self.serialize_fn,
+            deserialize_fn=self.deserialize_fn,
+        )
+
+        assert result == ["item1", "item2"]
+        self.fetch_fn.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_lock_acquire_error_on_miss_raises_unavailable(self) -> None:
+        """Raise CorpusCacheUnavailable when lock acquisition fails on miss."""
+        self.mock_cache.get.return_value = None
+        self.mock_cache.set_nx.side_effect = CacheAdapterError("lock error")
+
+        with pytest.raises(CorpusCacheUnavailable):
+            await self.redis_cache.get_or_fetch(
+                "scheduled",
+                SURFACE_ID,
+                fetch_fn=self.fetch_fn,
+                serialize_fn=self.serialize_fn,
+                deserialize_fn=self.deserialize_fn,
+            )
+
+        self.fetch_fn.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_lock_acquire_error_returns_stale_on_stale_hit(self) -> None:
+        """Return stale data when lock acquisition fails on stale hit."""
+        items_data = [{"v": "stale"}]
+        self.mock_cache.get.return_value = _make_stale_envelope(items_data)
+        self.mock_cache.set_nx.side_effect = CacheAdapterError("lock error")
+
+        result = await self.redis_cache.get_or_fetch(
+            "scheduled",
+            SURFACE_ID,
+            fetch_fn=self.fetch_fn,
+            serialize_fn=self.serialize_fn,
+            deserialize_fn=self.deserialize_fn,
+        )
+
+        assert result == ["stale"]
+        self.fetch_fn.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_backend_error_releases_lock(self) -> None:
+        """Release the lock when the backend raises an error."""
+        self.mock_cache.get.return_value = None
+        self.mock_cache.set_nx.return_value = True
+        self.fetch_fn.side_effect = Exception("API down")
+
+        with pytest.raises(Exception, match="API down"):
+            await self.redis_cache.get_or_fetch(
+                "scheduled",
+                SURFACE_ID,
+                fetch_fn=self.fetch_fn,
+                serialize_fn=self.serialize_fn,
+                deserialize_fn=self.deserialize_fn,
+            )
+
+        self.mock_cache.delete.assert_called_once_with("curated:v1:lock:scheduled:NEW_TAB_EN_US")
+
+    @pytest.mark.asyncio
+    async def test_serialize_error_returns_items_and_releases_lock(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Return fetched items even when serialize_fn fails (best-effort cache write)."""
+        self.mock_cache.get.return_value = None
+        self.mock_cache.set_nx.return_value = True
+
+        def bad_serialize(items: list) -> list[dict]:
+            raise TypeError("cannot serialize")
+
+        result = await self.redis_cache.get_or_fetch(
+            "scheduled",
+            SURFACE_ID,
+            fetch_fn=self.fetch_fn,
+            serialize_fn=bad_serialize,
+            deserialize_fn=self.deserialize_fn,
+        )
+
+        assert result == ["item1", "item2"]
+        self.mock_cache.delete.assert_called_once_with("curated:v1:lock:scheduled:NEW_TAB_EN_US")
+        assert any("Serialization failed" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_deserialize_fn_error_on_fresh_hit_falls_through(self) -> None:
+        """Fall through to backend when deserialize_fn raises on fresh cached data."""
+        items_data = [{"v": "item1"}]
+        self.mock_cache.get.return_value = _make_fresh_envelope(items_data)
+        self.mock_cache.set_nx.return_value = True
+
+        def bad_deserialize(data: list[dict]) -> list:
+            raise ValueError("validation error")
+
+        result = await self.redis_cache.get_or_fetch(
+            "scheduled",
+            SURFACE_ID,
+            fetch_fn=self.fetch_fn,
+            serialize_fn=self.serialize_fn,
+            deserialize_fn=bad_deserialize,
+        )
+
+        assert result == ["item1", "item2"]
+        self.fetch_fn.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_stale_hit_lock_loser_deserialize_error_falls_through(self) -> None:
+        """Fall through to backend when stale data can't be deserialized and lock is held."""
+        items_data = [{"v": "stale"}]
+        self.mock_cache.get.return_value = _make_stale_envelope(items_data)
+        # First set_nx returns False (lock loser), second returns True (lock released)
+        self.mock_cache.set_nx.side_effect = [False, True]
+
+        def bad_deserialize(data: list[dict]) -> list:
+            raise ValueError("schema changed")
+
+        result = await self.redis_cache.get_or_fetch(
+            "scheduled",
+            SURFACE_ID,
+            fetch_fn=self.fetch_fn,
+            serialize_fn=self.serialize_fn,
+            deserialize_fn=bad_deserialize,
+        )
+
+        assert result == ["item1", "item2"]
+        self.fetch_fn.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_stale_hit_deserialize_error_both_locks_fail_raises_unavailable(
+        self,
+    ) -> None:
+        """Raise CorpusCacheUnavailable when stale deserialization fails and both locks fail."""
+        items_data = [{"v": "stale"}]
+        self.mock_cache.get.return_value = _make_stale_envelope(items_data)
+        self.mock_cache.set_nx.return_value = False
+
+        def bad_deserialize(data: list[dict]) -> list:
+            raise ValueError("schema changed")
+
+        with pytest.raises(CorpusCacheUnavailable):
+            await self.redis_cache.get_or_fetch(
+                "scheduled",
+                SURFACE_ID,
+                fetch_fn=self.fetch_fn,
+                serialize_fn=self.serialize_fn,
+                deserialize_fn=bad_deserialize,
+            )
+
+        self.fetch_fn.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_redis_down_raises_unavailable(self) -> None:
+        """Raise CorpusCacheUnavailable when Redis is completely unavailable."""
+        self.mock_cache.get.side_effect = CacheAdapterError("connection refused")
+        self.mock_cache.set_nx.side_effect = CacheAdapterError("connection refused")
+
+        with pytest.raises(CorpusCacheUnavailable):
+            await self.redis_cache.get_or_fetch(
+                "scheduled",
+                SURFACE_ID,
+                fetch_fn=self.fetch_fn,
+                serialize_fn=self.serialize_fn,
+                deserialize_fn=self.deserialize_fn,
+            )
+
+        self.fetch_fn.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_non_numeric_expires_at_treated_as_miss(self) -> None:
+        """Treat an envelope with non-numeric expires_at as a cache miss."""
+        self.mock_cache.get.return_value = orjson.dumps(
+            {"expires_at": "not-a-number", "data": [{"v": "corrupted"}]}
+        )
+        self.mock_cache.set_nx.return_value = True
+
+        result = await self.redis_cache.get_or_fetch(
+            "scheduled",
+            SURFACE_ID,
+            fetch_fn=self.fetch_fn,
+            serialize_fn=self.serialize_fn,
+            deserialize_fn=self.deserialize_fn,
+        )
+
+        assert result == ["item1", "item2"]
+        self.fetch_fn.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_cancelled_error_releases_lock(self) -> None:
+        """Release the lock even when the fetch task is cancelled."""
+        self.mock_cache.get.return_value = None
+        self.mock_cache.set_nx.return_value = True
+
+        async def cancelled_fetch() -> list:
+            raise asyncio.CancelledError()
+
+        with pytest.raises(asyncio.CancelledError):
+            await self.redis_cache.get_or_fetch(
+                "scheduled",
+                SURFACE_ID,
+                fetch_fn=cancelled_fetch,
+                serialize_fn=self.serialize_fn,
+                deserialize_fn=self.deserialize_fn,
+            )
+
+        self.mock_cache.delete.assert_called_once_with("curated:v1:lock:scheduled:NEW_TAB_EN_US")
+
+    @pytest.mark.asyncio
+    async def test_malformed_envelope_missing_key_falls_through(self) -> None:
+        """Treat a JSON blob missing required keys as a cache miss."""
+        self.mock_cache.get.return_value = orjson.dumps({"wrong_key": 123})
+        self.mock_cache.set_nx.return_value = True
+
+        result = await self.redis_cache.get_or_fetch(
+            "scheduled",
+            SURFACE_ID,
+            fetch_fn=self.fetch_fn,
+            serialize_fn=self.serialize_fn,
+            deserialize_fn=self.deserialize_fn,
+        )
+
+        assert result == ["item1", "item2"]
+        self.fetch_fn.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_empty_list_is_cached(self) -> None:
+        """Cache and return an empty list from the backend."""
+        self.mock_cache.get.return_value = None
+        self.mock_cache.set_nx.return_value = True
+        self.fetch_fn.return_value = []
+
+        result = await self.redis_cache.get_or_fetch(
+            "scheduled",
+            SURFACE_ID,
+            fetch_fn=self.fetch_fn,
+            serialize_fn=self.serialize_fn,
+            deserialize_fn=self.deserialize_fn,
+        )
+
+        assert result == []
+        self.mock_cache.set.assert_called_once()
+
+
+class TestRedisCachedScheduledSurface:
+    """Tests for the RedisCachedScheduledSurface wrapper."""
+
+    def setup_method(self) -> None:
+        """Set up mock backend and cache."""
+        self.mock_backend = AsyncMock()
+        self.mock_cache = AsyncMock()
+        self.metrics_client = MagicMock(spec=aiodogstatsd.Client)
+        self.wrapper = RedisCachedScheduledSurface(
+            self.mock_backend, self.mock_cache, CONFIG, self.metrics_client
+        )
+
+    @pytest.mark.asyncio
+    async def test_fresh_hit_returns_deserialized_items(self) -> None:
+        """Return CorpusItem list from a fresh Redis cache hit."""
+        item = generate_corpus_item()
+        items_data = [item.model_dump(mode="json")]
+        self.mock_cache.get.return_value = _make_fresh_envelope(items_data)
+
+        result = await self.wrapper.fetch(SURFACE_ID, days_offset=0)
+
+        assert len(result) == 1
+        assert result[0].corpusItemId == "id"
+        self.mock_backend.fetch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_delegates_to_backend(self) -> None:
+        """Delegate to the wrapped backend on cache miss."""
+        item = generate_corpus_item()
+        self.mock_cache.get.return_value = None
+        self.mock_cache.set_nx.return_value = True
+        self.mock_backend.fetch.return_value = [item]
+
+        result = await self.wrapper.fetch(SURFACE_ID)
+
+        assert len(result) == 1
+        assert result[0].corpusItemId == "id"
+        self.mock_backend.fetch.assert_called_once_with(SURFACE_ID, 0)
+
+
+class TestRedisCachedSections:
+    """Tests for the RedisCachedSections wrapper."""
+
+    def setup_method(self) -> None:
+        """Set up mock backend and cache."""
+        self.mock_backend = AsyncMock()
+        self.mock_cache = AsyncMock()
+        self.metrics_client = MagicMock(spec=aiodogstatsd.Client)
+        self.wrapper = RedisCachedSections(
+            self.mock_backend, self.mock_cache, CONFIG, self.metrics_client
+        )
+
+    @pytest.mark.asyncio
+    async def test_fresh_hit_returns_deserialized_sections(self) -> None:
+        """Return CorpusSection list from a fresh Redis cache hit."""
+        section = _make_corpus_section()
+        sections_data = [section.model_dump(mode="json")]
+        self.mock_cache.get.return_value = _make_fresh_envelope(sections_data)
+
+        result = await self.wrapper.fetch(SURFACE_ID)
+
+        assert len(result) == 1
+        assert result[0].title == "Test Section"
+        self.mock_backend.fetch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_delegates_to_backend(self) -> None:
+        """Delegate to the wrapped backend on cache miss."""
+        section = _make_corpus_section()
+        self.mock_cache.get.return_value = None
+        self.mock_cache.set_nx.return_value = True
+        self.mock_backend.fetch.return_value = [section]
+
+        result = await self.wrapper.fetch(SURFACE_ID)
+
+        assert len(result) == 1
+        assert result[0].title == "Test Section"
+        self.mock_backend.fetch.assert_called_once_with(SURFACE_ID)


### PR DESCRIPTION
**PR 2/4** to implement shared caching of curated recommendations between pods.

Stack: [1/4](https://github.com/mozilla-services/merino-py/pull/1438) infra + architecture doc → 2/4 (this) → [3/4](https://github.com/mozilla-services/merino-py/pull/1440) integration tests → [4/4](https://github.com/mozilla-services/merino-py/pull/1441) wire-up.

> ⚠️ Base of this PR is `hnt-1890-cache-1-infra` (PR 1/4), not `main`. Review after PR 1/4 has been approved — that PR establishes the architecture this one implements.

## References

JIRA: [HNT-1890](https://mozilla-hub.atlassian.net/browse/HNT-1890)

## Description

Implements `RedisCorpusCache` — the distributed stale-while-revalidate (SWR) cache that wraps the Pocket Corpus GraphQL backends. **Not yet wired into the providers** in this PR; consumer wiring lands in PR 4/4. With `cache = "none"` (the default added in this PR), the class is unreachable from production code, so this PR is behavior-preserving.

The architecture and full rationale live in [`docs/operations/curated-recommendations/corpus-cache.md`](https://github.com/mozilla-services/merino-py/blob/hnt-1890-cache-1-infra/docs/operations/curated-recommendations/corpus-cache.md) (added in PR 1/4).

### What's in this PR

- **`merino/curated_recommendations/corpus_backends/redis_cache.py`** (~322 LOC) — `RedisCorpusCache` and the `RedisCachedScheduledSurface` / `RedisCachedSections` adapters. Accepts an injected `CorpusCacheConfig` dataclass, so the class is independently testable without Dynaconf or app startup.
- **`merino/configs/default.toml`** — new `[default.curated_recommendations.corpus_cache]` section (`cache="none"`, `soft_ttl_sec=60`, `hard_ttl_sec=86400`, `lock_ttl_sec=30`, `key_prefix="curated:v1"`).
- **`merino/configs/__init__.py`** — Dynaconf validators for the new section (allowed values, type/range checks).
- **`tests/unit/curated_recommendations/corpus_backends/test_redis_cache.py`** (~616 LOC) — unit suite covering SWR semantics, lock contention between concurrent callers, cold-miss/503 path, stale deserialization, retry-after-lock-held, and error handling.

### Implementation decisions specific to this PR

| Decision | Choice | Why |
|---|---|---|
| Cache format | Pydantic model dicts via orjson | Processed models cached, not raw GraphQL. Saves CPU across the ~300 pods |
| `CorpusCacheConfig` injection | Dataclass passed at construction | Keeps `redis_cache.py` decoupled from `merino.configs.settings` and trivially unit-testable |
| Soft TTL default | 60s | Average propagation time to NewTab is ~half this value (~30s avg) |
| Hard TTL default | 1 day | Safety net so data survives extended Corpus API outages |

Integration tests (real Redis via testcontainers) ship in **PR 3/4**.

## PR Review Checklist

- [x] Conforms to Contribution Guidelines
- [x] PR title starts with JIRA reference
- [ ] `[load test: (abort|skip|warn)]` keywords applied (n/a — code unreachable until PR 4/4)
- [x] Documentation updated (in PR 1/4)
- [x] Test coverage expanded (unit; integration in PR 3/4)


[HNT-1890]: https://mozilla-hub.atlassian.net/browse/HNT-1890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ