### PR TITLE
HNT-1890 (3/4): integration tests for RedisCorpusCache against real Redis

### DIFF
--- a/tests/integration/api/v1/curated_recommendations/corpus_backends/test_redis_cache.py
+++ b/tests/integration/api/v1/curated_recommendations/corpus_backends/test_redis_cache.py
@@ -1,0 +1,155 @@
+"""Integration tests for the Redis L2 corpus cache with a real Redis instance."""
+
+import logging
+
+import aiodogstatsd
+import pytest
+import pytest_asyncio
+from typing import AsyncGenerator
+from unittest.mock import MagicMock
+
+from redis.asyncio import Redis
+from testcontainers.core.waiting_utils import wait_for_logs
+from testcontainers.redis import AsyncRedisContainer
+
+from merino.cache.redis import RedisAdapter
+from merino.curated_recommendations.corpus_backends.protocol import SurfaceId
+from merino.curated_recommendations.corpus_backends.redis_cache import (
+    CorpusCacheConfig,
+    _RedisCorpusCache,
+)
+
+logger = logging.getLogger(__name__)
+
+CONFIG = CorpusCacheConfig(
+    soft_ttl_sec=60,
+    hard_ttl_sec=600,
+    lock_ttl_sec=30,
+    key_prefix="curated:v1",
+)
+
+SURFACE_ID = SurfaceId.NEW_TAB_EN_US
+
+
+@pytest.fixture(scope="module")
+def redis_container() -> AsyncRedisContainer:
+    """Create and return a docker container for Redis."""
+    logger.info("Starting up redis container")
+    container = AsyncRedisContainer().start()
+
+    delay = wait_for_logs(container, "Server initialized")
+    logger.info(f"\n Redis server started with delay: {delay} seconds")
+
+    yield container
+
+    container.stop()
+    logger.info("\n Redis container stopped")
+
+
+@pytest_asyncio.fixture(name="redis_client")
+async def fixture_redis_client(
+    redis_container: AsyncRedisContainer,
+) -> AsyncGenerator[Redis, None]:
+    """Create and return a Redis client, flushed after each test."""
+    client = await redis_container.get_async_client()
+
+    yield client
+
+    await client.flushall()
+
+
+@pytest.fixture(name="cache")
+def fixture_cache(redis_client: Redis) -> RedisAdapter:
+    """Create a RedisAdapter wrapping the test Redis client."""
+    return RedisAdapter(redis_client)
+
+
+@pytest.fixture(name="redis_cache")
+def fixture_redis_cache(cache: RedisAdapter) -> _RedisCorpusCache:
+    """Create a _RedisCorpusCache with a real Redis backend."""
+    metrics = MagicMock(spec=aiodogstatsd.Client)
+    return _RedisCorpusCache(cache, CONFIG, metrics)
+
+
+class TestHappyPath:
+    """Integration tests for the Redis corpus cache happy path."""
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_then_hit(self, redis_cache: _RedisCorpusCache) -> None:
+        """First call fetches from backend and writes to Redis. Second call returns cached data."""
+        fetch_count = 0
+
+        async def fetch_fn() -> list[str]:
+            nonlocal fetch_count
+            fetch_count += 1
+            return ["item1", "item2"]
+
+        def serialize_fn(items: list) -> list[dict]:
+            return [{"v": i} for i in items]
+
+        def deserialize_fn(data: list[dict]) -> list:
+            return [d["v"] for d in data]
+
+        # First call: cache miss → fetches from backend, writes to Redis
+        result1 = await redis_cache.get_or_fetch(
+            "scheduled",
+            SURFACE_ID,
+            fetch_fn=fetch_fn,
+            serialize_fn=serialize_fn,
+            deserialize_fn=deserialize_fn,
+        )
+        assert result1 == ["item1", "item2"]
+        assert fetch_count == 1
+
+        # Second call: cache hit → returns from Redis without calling backend
+        result2 = await redis_cache.get_or_fetch(
+            "scheduled",
+            SURFACE_ID,
+            fetch_fn=fetch_fn,
+            serialize_fn=serialize_fn,
+            deserialize_fn=deserialize_fn,
+        )
+        assert result2 == ["item1", "item2"]
+        assert fetch_count == 1  # Not incremented — served from cache
+
+    @pytest.mark.asyncio
+    async def test_distributed_lock_prevents_concurrent_fetches(
+        self, redis_cache: _RedisCorpusCache
+    ) -> None:
+        """Only one caller fetches when 10 coroutines hit a cache miss concurrently."""
+        import asyncio
+
+        fetch_count = 0
+
+        async def slow_fetch_fn() -> list[str]:
+            nonlocal fetch_count
+            fetch_count += 1
+            await asyncio.sleep(0.1)
+            return ["item1"]
+
+        def serialize_fn(items: list) -> list[dict]:
+            return [{"v": i} for i in items]
+
+        def deserialize_fn(data: list[dict]) -> list:
+            return [d["v"] for d in data]
+
+        # Launch 10 concurrent get_or_fetch calls to ensure overlap
+        calls = [
+            redis_cache.get_or_fetch(
+                "scheduled",
+                SURFACE_ID,
+                fetch_fn=slow_fetch_fn,
+                serialize_fn=serialize_fn,
+                deserialize_fn=deserialize_fn,
+            )
+            for _ in range(10)
+        ]
+        results = await asyncio.gather(*calls)
+
+        # All 10 callers should succeed: the lock winner fetches and writes to Redis
+        # in 100ms, well before the 500ms retry delay of lock losers.
+        for r in results:
+            assert r == ["item1"]
+
+        # Only one fetch should have occurred (the lock winner)
+        assert fetch_count == 1


### PR DESCRIPTION
**PR 3/4** to implement shared caching of curated recommendations between pods.

Stack: [1/4](https://github.com/mozilla-services/merino-py/pull/1438) infra → [2/4](https://github.com/mozilla-services/merino-py/pull/1439) impl → 3/4 (this) → 4/4 wire-up.

> ⚠️ Base of this PR is `hnt-1890-cache-2-impl` (PR 2/4), not `main`.

## References

JIRA: [HNT-1890](https://mozilla-hub.atlassian.net/browse/HNT-1890)

## Description

Adds end-to-end integration tests for `RedisCorpusCache` against a real Redis instance (testcontainers). These cover paths that unit tests with a mocked adapter can't fully verify:

- Actual `SET NX EX` semantics under contention.
- Lock TTL expiration when a holder fails to release.
- Multi-client lock-acquisition races.
- orjson round-tripping of `CorpusItem` Pydantic models through Redis.

Split out from PR 2/4 to keep that PR's review focus on the SWR algorithm itself; integration tests are independently verifiable once the unit tests are accepted.

## PR Review Checklist

- [x] Conforms to Contribution Guidelines
- [x] PR title starts with JIRA reference
- [ ] `[load test: (abort|skip|warn)]` keywords applied (n/a)
- [x] Documentation updated (n/a — landed in PR 2/4)
- [x] Test coverage expanded

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2248)


[HNT-1890]: https://mozilla-hub.atlassian.net/browse/HNT-1890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ