### PR TITLE
HNT-1890 (4/4): wire RedisCorpusCache into providers + enable in staging

### DIFF
--- a/merino/configs/stage.toml
+++ b/merino/configs/stage.toml
@@ -52,6 +52,9 @@ gcs_enabled = false
 # MERINO_PROVIDERS__TOP_PICKS__DOMAIN_DATA_SOURCE
 domain_data_source = "remote"
 
+[stage.curated_recommendations.corpus_cache]
+cache = "redis"
+
 [stage.curated_recommendations.gcs]
 # MERINO__CURATED_RECOMMENDATIONS__GCS__BUCKET_NAME
 # GCS bucket that contains aggregate engagement and prior data

--- a/merino/curated_recommendations/__init__.py
+++ b/merino/curated_recommendations/__init__.py
@@ -6,7 +6,17 @@
 import logging
 import random
 
+from merino.cache.redis import RedisAdapter, create_redis_clients
 from merino.configs import settings
+from merino.curated_recommendations.corpus_backends.protocol import (
+    ScheduledSurfaceProtocol,
+    SectionsProtocol,
+)
+from merino.curated_recommendations.corpus_backends.redis_cache import (
+    CorpusCacheConfig,
+    RedisCachedScheduledSurface,
+    RedisCachedSections,
+)
 from merino.curated_recommendations.corpus_backends.scheduled_surface_backend import (
     ScheduledSurfaceBackend,
     CorpusApiGraphConfig,
@@ -169,6 +179,49 @@ def init_ml_cohort_model_backend() -> CohortModelBackend:
         return EmptyCohortModel()
 
 
+def _init_corpus_cache(
+    scheduled_surface_backend: ScheduledSurfaceProtocol,
+    sections_backend: SectionsProtocol,
+) -> tuple[ScheduledSurfaceProtocol, SectionsProtocol, RedisAdapter | None]:
+    """Optionally wrap corpus backends with a Redis L2 cache layer.
+
+    Returns the backends (possibly wrapped) and the Redis adapter (if created).
+    The caller owns the adapter and is responsible for closing it on shutdown.
+    """
+    cache_settings = settings.curated_recommendations.corpus_cache
+    if cache_settings.cache != "redis":
+        return scheduled_surface_backend, sections_backend, None
+
+    try:
+        logger.info("Initializing Redis L2 cache for corpus backends")
+        adapter = RedisAdapter(
+            *create_redis_clients(
+                primary=settings.redis.server,
+                replica=settings.redis.replica,
+                max_connections=settings.redis.max_connections,
+                socket_connect_timeout=settings.redis.socket_connect_timeout_sec,
+                socket_timeout=settings.redis.socket_timeout_sec,
+            )
+        )
+        config = CorpusCacheConfig(
+            soft_ttl_sec=cache_settings.soft_ttl_sec,
+            hard_ttl_sec=cache_settings.hard_ttl_sec,
+            lock_ttl_sec=cache_settings.lock_ttl_sec,
+            key_prefix=cache_settings.key_prefix,
+        )
+        metrics_client = get_metrics_client()
+        return (
+            RedisCachedScheduledSurface(
+                scheduled_surface_backend, adapter, config, metrics_client
+            ),
+            RedisCachedSections(sections_backend, adapter, config, metrics_client),
+            adapter,
+        )
+    except Exception as e:
+        logger.error("Failed to initialize Redis corpus cache, proceeding without it: %s", e)
+        return scheduled_surface_backend, sections_backend, None
+
+
 def init_provider() -> None:
     """Initialize the curated recommendations' provider."""
     global _provider
@@ -179,18 +232,22 @@ def init_provider() -> None:
     ml_recommendations_backend = init_ml_recommendations_backend()
     cohort_model_backend = init_ml_cohort_model_backend()
 
-    scheduled_surface_backend = ScheduledSurfaceBackend(
+    scheduled_surface_backend: ScheduledSurfaceProtocol = ScheduledSurfaceBackend(
         http_client=create_http_client(base_url=""),
         graph_config=CorpusApiGraphConfig(),
         metrics_client=get_metrics_client(),
         manifest_provider=get_manifest_provider(),
     )
 
-    sections_backend = SectionsBackend(
+    sections_backend: SectionsProtocol = SectionsBackend(
         http_client=create_http_client(base_url=""),
         graph_config=CorpusApiGraphConfig(),
         metrics_client=get_metrics_client(),
         manifest_provider=get_manifest_provider(),
+    )
+
+    scheduled_surface_backend, sections_backend, cache_adapter = _init_corpus_cache(
+        scheduled_surface_backend, sections_backend
     )
 
     _provider = CuratedRecommendationsProvider(
@@ -201,6 +258,7 @@ def init_provider() -> None:
         local_model_backend=local_model_backend,
         ml_recommendations_backend=ml_recommendations_backend,
         cohort_model_backend=cohort_model_backend,
+        cache_adapter=cache_adapter,
     )
     _legacy_provider = LegacyCuratedRecommendationsProvider()
 
@@ -215,3 +273,15 @@ def get_legacy_provider() -> LegacyCuratedRecommendationsProvider:
     """Return the legacy curated recommendations provider"""
     global _legacy_provider
     return _legacy_provider
+
+
+async def shutdown() -> None:
+    """Clean up resources used by curated recommendations."""
+    try:
+        provider = _provider
+    except NameError:
+        return
+    try:
+        await provider.shutdown()
+    except Exception:
+        logger.warning("Error shutting down curated recommendations", exc_info=True)

--- a/merino/curated_recommendations/corpus_backends/scheduled_surface_backend.py
+++ b/merino/curated_recommendations/corpus_backends/scheduled_surface_backend.py
@@ -47,11 +47,11 @@ class ScheduledSurfaceBackend(ScheduledSurfaceProtocol):
     metrics_client: aiodogstatsd.Client
     manifest_provider: ManifestProvider
 
-    # Time-to-live was chosen because 2 minutes (+/- 10 s) is short enough that updates by curators
-    # such as breaking news or editorial corrections propagate fast enough, and that the request
-    # rate to the scheduledSurface query stays close to the historic rate of ~100 requests/minute.
-    cache_time_to_live_min = timedelta(seconds=110)
-    cache_time_to_live_max = timedelta(seconds=130)
+    # Balance between propagating time-sensitive content (breaking news, editorial corrections)
+    # quickly and reducing backend load. With the L2 Redis cache, the total worst-case staleness
+    # is L1 TTL + L2 soft TTL (~120s), comparable to the previous L1-only TTL of ~120s.
+    cache_time_to_live_min = timedelta(seconds=50)
+    cache_time_to_live_max = timedelta(seconds=70)
     _cache: dict
     _background_tasks: set[asyncio.Task]
 

--- a/merino/curated_recommendations/corpus_backends/sections_backend.py
+++ b/merino/curated_recommendations/corpus_backends/sections_backend.py
@@ -80,7 +80,7 @@ class SectionsBackend(SectionsProtocol):
         self._background_tasks = set()
 
     @stale_while_revalidate(
-        wait_expiration=WaitRandomExpiration(timedelta(seconds=110), timedelta(seconds=130)),
+        wait_expiration=WaitRandomExpiration(timedelta(seconds=50), timedelta(seconds=70)),
         cache=lambda self: self._cache,
         jobs=lambda self: self._background_tasks,
     )

--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -4,6 +4,7 @@ import logging
 from typing import cast
 
 
+from merino.cache.protocol import CacheAdapter
 from merino.curated_recommendations import LocalModelBackend, MLRecsBackend
 from merino.curated_recommendations.ml_backends.protocol import (
     LOCAL_MODEL_MODEL_ID_KEY,
@@ -65,6 +66,7 @@ class CuratedRecommendationsProvider:
         local_model_backend: LocalModelBackend,
         ml_recommendations_backend: MLRecsBackend,
         cohort_model_backend: CohortModelBackend,
+        cache_adapter: CacheAdapter | None = None,
     ) -> None:
         self.scheduled_surface_backend = scheduled_surface_backend
         self.engagement_backend = engagement_backend
@@ -73,6 +75,12 @@ class CuratedRecommendationsProvider:
         self.local_model_backend = local_model_backend
         self.ml_recommendations_backend = ml_recommendations_backend
         self.cohort_model_backend = cohort_model_backend
+        self._cache_adapter = cache_adapter
+
+    async def shutdown(self) -> None:
+        """Close resources owned by this provider."""
+        if self._cache_adapter is not None:
+            await self._cache_adapter.close()
 
     @staticmethod
     def is_sections_experiment(

--- a/merino/main.py
+++ b/merino/main.py
@@ -12,6 +12,7 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 
 from merino import curated_recommendations, governance
+from merino.curated_recommendations.corpus_backends.redis_cache import CorpusCacheUnavailable
 from merino.providers import rss
 from merino.configs.app_configs.config_logging import configure_logging
 from merino.configs.app_configs.config_sentry import configure_sentry
@@ -55,6 +56,7 @@ async def lifespan(app: FastAPI):
     # Shut down providers and clean up.
     await rss.shutdown_providers()
     await suggest.shutdown_providers()
+    await curated_recommendations.shutdown()
     await get_metrics_client().close()
 
 
@@ -72,6 +74,18 @@ async def validation_exception_handler(
     return ORJSONResponse(
         status_code=status.HTTP_400_BAD_REQUEST,
         content=jsonable_encoder({"detail": exc.errors()}),
+    )
+
+
+@app.exception_handler(CorpusCacheUnavailable)
+async def corpus_cache_unavailable_handler(
+    request: Request, exc: CorpusCacheUnavailable
+) -> ORJSONResponse:
+    """Return 503 from curated recommendations when the corpus cache has no data."""
+    logger.info("Corpus cache unavailable, returning 503: %s", exc)
+    return ORJSONResponse(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        content={"detail": "Service temporarily unavailable"},
     )
 
 

--- a/tests/unit/curated_recommendations/test_init.py
+++ b/tests/unit/curated_recommendations/test_init.py
@@ -1,0 +1,96 @@
+"""Unit tests for the curated_recommendations module init/shutdown."""
+
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import merino.curated_recommendations as cr_module
+from merino.cache.redis import RedisAdapter
+from merino.curated_recommendations.corpus_backends.redis_cache import (
+    RedisCachedScheduledSurface,
+    RedisCachedSections,
+)
+from merino.exceptions import CacheAdapterError
+
+
+class TestInitCorpusCache:
+    """Tests for _init_corpus_cache."""
+
+    def test_disabled_returns_backends_unchanged(self) -> None:
+        """When cache is not 'redis', return the original backends with no adapter."""
+        surface = MagicMock()
+        sections = MagicMock()
+
+        with patch.object(cr_module, "settings") as mock_settings:
+            mock_settings.curated_recommendations.corpus_cache.cache = "none"
+            s, sec, adapter = cr_module._init_corpus_cache(surface, sections)
+
+        assert s is surface
+        assert sec is sections
+        assert adapter is None
+
+    def test_redis_wraps_backends(self) -> None:
+        """When cache is 'redis', wrap backends with Redis-cached versions."""
+        surface = MagicMock()
+        sections = MagicMock()
+
+        with (
+            patch.object(cr_module, "settings") as mock_settings,
+            patch.object(
+                cr_module, "create_redis_clients", return_value=(MagicMock(), MagicMock())
+            ),
+            patch.object(cr_module, "get_metrics_client", return_value=MagicMock()),
+        ):
+            cache = mock_settings.curated_recommendations.corpus_cache
+            cache.cache = "redis"
+            cache.soft_ttl_sec = 60
+            cache.hard_ttl_sec = 86400
+            cache.lock_ttl_sec = 30
+            cache.key_prefix = "test"
+
+            s, sec, adapter = cr_module._init_corpus_cache(surface, sections)
+
+        assert isinstance(s, RedisCachedScheduledSurface)
+        assert isinstance(sec, RedisCachedSections)
+        assert isinstance(adapter, RedisAdapter)
+
+    def test_redis_error_falls_back(self, caplog: pytest.LogCaptureFixture) -> None:
+        """When Redis initialization fails, return original backends with no adapter."""
+        surface = MagicMock()
+        sections = MagicMock()
+
+        with (
+            patch.object(cr_module, "settings") as mock_settings,
+            patch.object(cr_module, "create_redis_clients", side_effect=Exception("conn refused")),
+            caplog.at_level(logging.ERROR, logger="merino.curated_recommendations"),
+        ):
+            mock_settings.curated_recommendations.corpus_cache.cache = "redis"
+
+            s, sec, adapter = cr_module._init_corpus_cache(surface, sections)
+
+        assert s is surface
+        assert sec is sections
+        assert adapter is None
+        assert any("Failed to initialize" in r.message for r in caplog.records)
+
+
+class TestShutdown:
+    """Tests for curated_recommendations.shutdown() error handling."""
+
+    @pytest.mark.asyncio
+    async def test_shutdown_does_not_propagate_close_error(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Shutdown should log a warning and not propagate exceptions from provider.shutdown()."""
+        mock_provider = AsyncMock()
+        mock_provider.shutdown.side_effect = CacheAdapterError("connection reset")
+        monkeypatch.setattr(cr_module, "_provider", mock_provider, raising=False)
+
+        with caplog.at_level(logging.WARNING, logger="merino.curated_recommendations"):
+            await cr_module.shutdown()
+
+        assert any(
+            "Error shutting down curated recommendations" in record.message
+            for record in caplog.records
+        )


### PR DESCRIPTION
**PR 4/4** to implement shared caching of curated recommendations between pods. This PR makes the shared cache live in staging.

Stack: [1/4](https://github.com/mozilla-services/merino-py/pull/1438) infra → [2/4](https://github.com/mozilla-services/merino-py/pull/1439) impl → [3/4](https://github.com/mozilla-services/merino-py/pull/1440) integration tests → 4/4 (this).

> ⚠️ Base of this PR is `hnt-1890-cache-3-integration-tests` (PR 3/4), not `main`. Merge order: 1 → 2 → 3 → 4.

## References

JIRA: [HNT-1890](https://mozilla-hub.atlassian.net/browse/HNT-1890)

## Description

Wires `RedisCorpusCache` into the curated-recommendations subsystem and turns it on in staging. After this PR, ~300 production pods stop hitting the Pocket Corpus GraphQL API independently — one pod fetches and the rest read from Redis (in staging first; production is a separate config change).

### What's wired

- **`merino/curated_recommendations/__init__.py`** — when `cache = "redis"`, builds a `RedisAdapter` via `create_redis_clients` and wraps `ScheduledSurfaceBackend` / `SectionsBackend` with their `RedisCached*` counterparts. Adds `shutdown()` to close the adapter cleanly.
- **`merino/main.py`** — lifespan registration + a global FastAPI exception handler that converts `CorpusCacheUnavailable` into HTTP 503.
- **`corpus_backends/{scheduled_surface,sections}_backend.py`** — hooks the existing L1 SWR cache to consult the L2 cache during revalidation. **L1 SWR TTLs are cut roughly in half** (110–130s → 50–70s), because L2 now absorbs the load this would otherwise generate. Reviewers: this is the only behavior change for clients running `cache = "none"`, so confirm it's acceptable.
- **`merino/configs/stage.toml`** — sets `cache = \"redis\"` in staging.
- **`tests/unit/curated_recommendations/test_init.py`** — covers `cache=\"none\"`, `cache=\"redis\"`, and missing-Redis-config paths.

### Implementation decisions

| Decision | Choice | Why |
|---|---|---|
| L1 lock | `asyncio.Lock` per cache entry | Coordinates concurrent revalidation within a single pod and keeps Redis traffic to one coroutine per entry per pod |
| L1 TTL change | 110–130s → 50–70s | Tighter L1 surfaces fresh content faster; L2 prevents this from becoming Corpus API load |
| Staging rollout | `cache = \"redis\"` in `stage.toml` | Soaks in staging before production. [Capacity confirmed with Nan](https://mozilla.slack.com/archives/C04EG0ZKTC0/p1776104552490389): 5 MB storage, 40 IOPS |
| Cold miss on lock-held | 503 Service Unavailable | Prevents connection pile-up; Firefox shows cached NewTab content |

### Rollout plan (post-merge)

1. **Staging**: enabled by this PR's `stage.toml` change. Monitor corpus API QPS drop and Redis hit rate.
2. **Production**: separate config change after staging soak — either set `cache = \"redis\"` in `production.toml` or override via `MERINO_CURATED_RECOMMENDATIONS__CORPUS_CACHE__CACHE=redis` env var.
3. **Alerting**: add a request-volume alert in Apollo based on the new (lower) baseline so we detect cache failures (pods falling back to direct API calls).

## PR Review Checklist

- [x] Conforms to Contribution Guidelines
- [x] PR title starts with JIRA reference
- [ ] `[load test: (abort|skip|warn)]` keywords applied (consider for the wire-up commit)
- [x] Documentation updated (landed in PR 2/4)
- [x] Test coverage expanded

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2247)


[HNT-1890]: https://mozilla-hub.atlassian.net/browse/HNT-1890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ