### PR TITLE
[DISCO-4118] feat(elasticsearch): performance tuned index settings for wikipedia

### DIFF
--- a/merino/jobs/wikipedia_indexer/indexer.py
+++ b/merino/jobs/wikipedia_indexer/indexer.py
@@ -104,12 +104,6 @@ class Indexer:
             self.elasticsearch.forcemerge(index=index_name, max_num_segments=1)
             logger.info("Force merged index", extra={"index": index_name})
 
-            # Restore replicas now that indexing and merging are complete
-            self.elasticsearch.put_settings(
-                index=index_name, settings={"number_of_replicas": "1"}
-            )
-            logger.info("Restored replicas", extra={"index": index_name})
-
             # Flip the alias pointer to the new index and remove the previous index
             self._flip_alias_to_latest(index_name, elasticsearch_alias)
             logger.info(

--- a/merino/jobs/wikipedia_indexer/indexer.py
+++ b/merino/jobs/wikipedia_indexer/indexer.py
@@ -100,6 +100,16 @@ class Indexer:
             self.elasticsearch.refresh_index(index=index_name)
             logger.info("Refreshed index", extra={"index": index_name})
 
+            # Force merge to a single segment for optimal read performance
+            self.elasticsearch.forcemerge(index=index_name, max_num_segments=1)
+            logger.info("Force merged index", extra={"index": index_name})
+
+            # Restore replicas now that indexing and merging are complete
+            self.elasticsearch.put_settings(
+                index=index_name, settings={"number_of_replicas": "1"}
+            )
+            logger.info("Restored replicas", extra={"index": index_name})
+
             # Flip the alias pointer to the new index and remove the previous index
             self._flip_alias_to_latest(index_name, elasticsearch_alias)
             logger.info(

--- a/merino/jobs/wikipedia_indexer/settings/v1.py
+++ b/merino/jobs/wikipedia_indexer/settings/v1.py
@@ -31,11 +31,9 @@ def get_suggest_mapping(analyzer_suffix: str) -> dict:
 
 
 FR_INDEX_SETTINGS: dict = {
-    # Note: for all indices, we are starting with 0 replicas to maximize
-    # indexing speed, and updating to desired replica count after creation
-    "number_of_replicas": "0",
+    "number_of_replicas": "1",
     "refresh_interval": "-1",
-    "number_of_shards": "1", # <10gb
+    "number_of_shards": "1",  # <10gb
     "index.lifecycle.name": "frwiki_policy",
     "analysis": {
         "filter": {
@@ -112,7 +110,7 @@ FR_INDEX_SETTINGS: dict = {
 
 
 DE_INDEX_SETTINGS: dict = {
-    "number_of_replicas": "0",
+    "number_of_replicas": "1",
     "refresh_interval": "-1",
     "number_of_shards": "1",
     "index.lifecycle.name": "dewiki_policy",
@@ -169,7 +167,7 @@ DE_INDEX_SETTINGS: dict = {
 }
 
 EN_INDEX_SETTINGS: dict = {
-    "number_of_replicas": "0",
+    "number_of_replicas": "1",
     "refresh_interval": "-1",
     "number_of_shards": "1",
     "index.lifecycle.name": "enwiki_policy",
@@ -266,7 +264,7 @@ EN_INDEX_SETTINGS: dict = {
 
 
 IT_INDEX_SETTINGS: dict = {
-    "number_of_replicas": "0",
+    "number_of_replicas": "1",
     "refresh_interval": "-1",
     "number_of_shards": "1",
     "index.lifecycle.name": "itwiki_policy",
@@ -352,7 +350,7 @@ IT_INDEX_SETTINGS: dict = {
 
 
 PL_INDEX_SETTINGS: dict = {
-    "number_of_replicas": "0",
+    "number_of_replicas": "1",
     "refresh_interval": "-1",
     "number_of_shards": "1",
     "index.lifecycle.name": "plwiki_policy",

--- a/merino/jobs/wikipedia_indexer/settings/v1.py
+++ b/merino/jobs/wikipedia_indexer/settings/v1.py
@@ -31,9 +31,11 @@ def get_suggest_mapping(analyzer_suffix: str) -> dict:
 
 
 FR_INDEX_SETTINGS: dict = {
-    "number_of_replicas": "1",
+    # Note: for all indices, we are starting with 0 replicas to maximize
+    # indexing speed, and updating to desired replica count after creation
+    "number_of_replicas": "0",
     "refresh_interval": "-1",
-    "number_of_shards": "2",
+    "number_of_shards": "1", # <10gb
     "index.lifecycle.name": "frwiki_policy",
     "analysis": {
         "filter": {
@@ -110,9 +112,9 @@ FR_INDEX_SETTINGS: dict = {
 
 
 DE_INDEX_SETTINGS: dict = {
-    "number_of_replicas": "1",
+    "number_of_replicas": "0",
     "refresh_interval": "-1",
-    "number_of_shards": "2",
+    "number_of_shards": "1",
     "index.lifecycle.name": "dewiki_policy",
     "analysis": {
         "filter": {
@@ -167,9 +169,9 @@ DE_INDEX_SETTINGS: dict = {
 }
 
 EN_INDEX_SETTINGS: dict = {
-    "number_of_replicas": "1",
+    "number_of_replicas": "0",
     "refresh_interval": "-1",
-    "number_of_shards": "2",
+    "number_of_shards": "1",
     "index.lifecycle.name": "enwiki_policy",
     "analysis": {
         "filter": {
@@ -264,9 +266,9 @@ EN_INDEX_SETTINGS: dict = {
 
 
 IT_INDEX_SETTINGS: dict = {
-    "number_of_replicas": "1",
+    "number_of_replicas": "0",
     "refresh_interval": "-1",
-    "number_of_shards": "2",
+    "number_of_shards": "1",
     "index.lifecycle.name": "itwiki_policy",
     "analysis": {
         "filter": {
@@ -350,9 +352,9 @@ IT_INDEX_SETTINGS: dict = {
 
 
 PL_INDEX_SETTINGS: dict = {
-    "number_of_replicas": "1",
+    "number_of_replicas": "0",
     "refresh_interval": "-1",
-    "number_of_shards": "2",
+    "number_of_shards": "1",
     "index.lifecycle.name": "plwiki_policy",
     "analysis": {
         "filter": {

--- a/merino/search/elastic.py
+++ b/merino/search/elastic.py
@@ -138,10 +138,6 @@ class ElasticSearchAdapter:
         """
         self.get_client().indices.forcemerge(index=index, max_num_segments=max_num_segments)
 
-    def put_settings(self, *, index: str, settings: dict[str, Any]) -> None:
-        """Update dynamic index settings."""
-        self.get_client().indices.put_settings(index=index, settings=settings)
-
     def update_aliases(self, *, actions: list[dict[str, Any]]) -> None:
         """Apply alias update actions atomically."""
         self.get_client().indices.update_aliases(

--- a/merino/search/elastic.py
+++ b/merino/search/elastic.py
@@ -132,6 +132,16 @@ class ElasticSearchAdapter:
         indices = cast(dict[str, Any], self.get_client().indices.get_alias(name=alias))
         return list(indices.keys())
 
+    def forcemerge(self, *, index: str, max_num_segments: int = 1) -> None:
+        """Force merge index segments to increase performance on read-only indices.
+        See https://www.elastic.co/docs/deploy-manage/production-guidance/optimize-performance/search-speed#_force_merge_read_only_indices
+        """
+        self.get_client().indices.forcemerge(index=index, max_num_segments=max_num_segments)
+
+    def put_settings(self, *, index: str, settings: dict[str, Any]) -> None:
+        """Update dynamic index settings."""
+        self.get_client().indices.put_settings(index=index, settings=settings)
+
     def update_aliases(self, *, actions: list[dict[str, Any]]) -> None:
         """Apply alias update actions atomically."""
         self.get_client().indices.update_aliases(

--- a/tests/unit/search/test_elastic.py
+++ b/tests/unit/search/test_elastic.py
@@ -244,19 +244,6 @@ def test_forcemerge_calls_indices_forcemerge(
     client.indices.forcemerge.assert_called_once_with(index="my-index", max_num_segments=1)
 
 
-def test_put_settings_calls_indices_put_settings(
-    adapter: ElasticSearchAdapter, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Verify that put_settings calls indices.put_settings with the provided index and settings."""
-    client = _mock_client()
-    monkeypatch.setattr(adapter, "get_client", MagicMock(return_value=client))
-
-    adapter.put_settings(index="my-index", settings={"number_of_replicas": "1"})
-    client.indices.put_settings.assert_called_once_with(
-        index="my-index", settings={"number_of_replicas": "1"}
-    )
-
-
 def test_update_aliases_calls_indices_update_aliases(
     adapter: ElasticSearchAdapter, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/search/test_elastic.py
+++ b/tests/unit/search/test_elastic.py
@@ -233,6 +233,30 @@ def test_get_indices_for_alias_returns_keys(
     client.indices.get_alias.assert_called_once_with(name="my-alias")
 
 
+def test_forcemerge_calls_indices_forcemerge(
+    adapter: ElasticSearchAdapter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Verify that forcemerge calls indices.forcemerge with the provided index and segment count."""
+    client = _mock_client()
+    monkeypatch.setattr(adapter, "get_client", MagicMock(return_value=client))
+
+    adapter.forcemerge(index="my-index", max_num_segments=1)
+    client.indices.forcemerge.assert_called_once_with(index="my-index", max_num_segments=1)
+
+
+def test_put_settings_calls_indices_put_settings(
+    adapter: ElasticSearchAdapter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Verify that put_settings calls indices.put_settings with the provided index and settings."""
+    client = _mock_client()
+    monkeypatch.setattr(adapter, "get_client", MagicMock(return_value=client))
+
+    adapter.put_settings(index="my-index", settings={"number_of_replicas": "1"})
+    client.indices.put_settings.assert_called_once_with(
+        index="my-index", settings={"number_of_replicas": "1"}
+    )
+
+
 def test_update_aliases_calls_indices_update_aliases(
     adapter: ElasticSearchAdapter, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## References

JIRA: [DISCO-4118]

## Description

The en wikipedia index is consistently saturated, and nodes are rejecting read requests with 429 and/or timing out. We've already updated the cluster by requesting beefier instances, but we can also tune the index settings to improve performance:

* Force merge segments to 1 before cutover [see docs](https://www.elastic.co/docs/deploy-manage/production-guidance/optimize-performance/search-speed#_force_merge_read_only_indices)
* Reduce to 1 shard (data is < 10gb)

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2250)


[DISCO-4118]: https://mozilla-hub.atlassian.net/browse/DISCO-4118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ