### PR TITLE
chore(jobs:wiki): bump forcemerge request timeout to 2 hrs

### DIFF
--- a/merino/jobs/wikipedia_indexer/indexer.py
+++ b/merino/jobs/wikipedia_indexer/indexer.py
@@ -100,8 +100,14 @@ class Indexer:
             self.elasticsearch.refresh_index(index=index_name)
             logger.info("Refreshed index", extra={"index": index_name})
 
-            # Force merge to a single segment for optimal read performance
-            self.elasticsearch.forcemerge(index=index_name, max_num_segments=1)
+            # Force merge to a single segment for optimal read performance.
+            # This is a long-running operation on large indices; use a 2-hour timeout.
+            self.elasticsearch.forcemerge(
+                index=index_name,
+                max_num_segments=1,
+                request_timeout=7200,
+                wait_for_completion=True,
+            )
             logger.info("Force merged index", extra={"index": index_name})
 
             # Flip the alias pointer to the new index and remove the previous index

--- a/merino/search/elastic.py
+++ b/merino/search/elastic.py
@@ -132,11 +132,22 @@ class ElasticSearchAdapter:
         indices = cast(dict[str, Any], self.get_client().indices.get_alias(name=alias))
         return list(indices.keys())
 
-    def forcemerge(self, *, index: str, max_num_segments: int = 1) -> None:
+    def forcemerge(
+        self,
+        *,
+        index: str,
+        max_num_segments: int = 1,
+        request_timeout: float | None = None,
+        wait_for_completion: bool | None = None,
+    ) -> None:
         """Force merge index segments to increase performance on read-only indices.
         See https://www.elastic.co/docs/deploy-manage/production-guidance/optimize-performance/search-speed#_force_merge_read_only_indices
         """
-        self.get_client().indices.forcemerge(index=index, max_num_segments=max_num_segments)
+        self.get_client().options(request_timeout=request_timeout).indices.forcemerge(
+            index=index,
+            max_num_segments=max_num_segments,
+            wait_for_completion=wait_for_completion,
+        )
 
     def update_aliases(self, *, actions: list[dict[str, Any]]) -> None:
         """Apply alias update actions atomically."""

--- a/tests/unit/search/test_elastic.py
+++ b/tests/unit/search/test_elastic.py
@@ -238,10 +238,15 @@ def test_forcemerge_calls_indices_forcemerge(
 ) -> None:
     """Verify that forcemerge calls indices.forcemerge with the provided index and segment count."""
     client = _mock_client()
+    scoped_client = _mock_client()
+    client.options.return_value = scoped_client
     monkeypatch.setattr(adapter, "get_client", MagicMock(return_value=client))
 
-    adapter.forcemerge(index="my-index", max_num_segments=1)
-    client.indices.forcemerge.assert_called_once_with(index="my-index", max_num_segments=1)
+    adapter.forcemerge(index="my-index", max_num_segments=1, wait_for_completion=True)
+    client.options.assert_called_once_with(request_timeout=None)
+    scoped_client.indices.forcemerge.assert_called_once_with(
+        index="my-index", max_num_segments=1, wait_for_completion=True
+    )
 
 
 def test_update_aliases_calls_indices_update_aliases(


### PR DESCRIPTION
Due to timeout observed in airflow jobs

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2251)
