### PR TITLE
DISCO-4078 Add world cup soccer endpoint (v1 with mock data)

### DIFF
--- a/merino/main.py
+++ b/merino/main.py
@@ -29,6 +29,10 @@ tags_metadata = [
         "name": "providers",
         "description": "Get a list of Firefox Suggest providers and their availability.",
     },
+    {
+        "name": "wcs",
+        "description": "World Cup Soccer match data for the New Tab widget.",
+    },
 ]
 
 logger = logging.getLogger(__name__)

--- a/merino/providers/wcs/__init__.py
+++ b/merino/providers/wcs/__init__.py
@@ -1,0 +1,10 @@
+"""Module dedicated to providing World Cup Soccer match data to New Tab."""
+
+from merino.providers.wcs.provider import WcsProvider
+
+_provider = WcsProvider()
+
+
+def get_provider() -> WcsProvider:
+    """Return the singleton WCS provider for FastAPI's `Depends`."""
+    return _provider

--- a/merino/providers/wcs/fake_data.py
+++ b/merino/providers/wcs/fake_data.py
@@ -1,0 +1,109 @@
+"""Static teams and match templates for the WCS match endpoint.
+
+Match dates are generated relative to the requested anchor date so every
+response contains two completed (yesterday), two in-progress (today), and
+two upcoming (tomorrow) events.
+"""
+
+from datetime import UTC, date, datetime, time, timedelta
+
+from merino.utils.logos import LogoCategory, get_logo_url
+from merino.providers.wcs.protocol import EventInfo, TeamInfo
+
+
+def _team(
+    key: str,
+    global_team_id: int,
+    name: str,
+    region: str,
+    colors: list[str],
+    group: str,
+) -> TeamInfo:
+    icon = get_logo_url(LogoCategory.Nations, key)
+    return TeamInfo(
+        key=key,
+        global_team_id=global_team_id,
+        name=name,
+        region=region,
+        colors=colors,
+        icon=icon,
+        group=group,
+        eliminated=False,
+        standing={"wins": 0, "losses": 0, "draws": 0, "points": 0},
+    )
+
+
+# Real WCS team_IDs are 90000000-offset; named colors mirror the upstream feed.
+_TEAMS: dict[str, TeamInfo] = {
+    t.key: t
+    for t in [
+        _team("BRA", 90000001, "Brazil", "BRA", ["Yellow", "Green", "Blue"], "Group A"),
+        _team("ARG", 90000002, "Argentina", "ARG", ["Sky Blue", "White"], "Group A"),
+        _team("GER", 90000003, "Germany", "GER", ["Black", "Red", "Yellow"], "Group B"),
+        _team("FRA", 90000004, "France", "FRA", ["Blue", "White", "Red"], "Group B"),
+        _team("ENG", 90000005, "England", "ENG", ["White", "Red"], "Group C"),
+        _team("USA", 90000006, "United States", "USA", ["Navy", "White", "Red"], "Group C"),
+    ]
+}
+
+
+# (day_offset, hour_utc, home, away, status_type, home_score, away_score,
+#  home_extra, away_extra, home_penalty, away_penalty, period, clock, status)
+#
+# Yesterday's GER vs FRA went to extra time and penalties — the only fixture
+# that exercises the extra/penalty fields. The live BRA vs GER is in extra
+# time so its `clock` shows the "90+x" format.
+_TEMPLATES: list[tuple] = [
+    (-1, 14, "BRA", "ARG", "past", 2, 1, None, None, None, None, "FT", "90", "Final"),
+    (-1, 18, "GER", "FRA", "past", 1, 1, 1, 1, 5, 4, "FT(P)", "120", "Final"),
+    (0, 14, "ENG", "USA", "live", 1, 0, None, None, None, None, "2", "67", "In Progress"),
+    (0, 17, "BRA", "GER", "live", 2, 2, None, None, None, None, "ET", "90+15", "In Progress"),
+    (1, 15, "ARG", "ENG", "scheduled", None, None, None, None, None, None, "1", "0", "Scheduled"),
+    (1, 19, "FRA", "USA", "scheduled", None, None, None, None, None, None, "1", "0", "Scheduled"),
+]
+
+
+def build_events(anchor: date) -> list[EventInfo]:
+    """Build the full set of fake events anchored to `anchor` (UTC).
+
+    Output is byte-stable for a given anchor: identifiers and timestamps are
+    derived from the anchor and the template index, with no clock reads.
+    """
+    events: list[EventInfo] = []
+    for index, (
+        day_offset,
+        hour,
+        home_key,
+        away_key,
+        status_type,
+        home_score,
+        away_score,
+        home_extra,
+        away_extra,
+        home_penalty,
+        away_penalty,
+        period,
+        clock,
+        status,
+    ) in enumerate(_TEMPLATES):
+        event_dt = datetime.combine(anchor + timedelta(days=day_offset), time(hour, tzinfo=UTC))
+        events.append(
+            EventInfo(
+                date=event_dt.isoformat(),
+                global_event_id=1000 + index,
+                home_team=_TEAMS[home_key],
+                away_team=_TEAMS[away_key],
+                period=period,
+                home_score=home_score,
+                away_score=away_score,
+                home_extra=home_extra,
+                away_extra=away_extra,
+                home_penalty=home_penalty,
+                away_penalty=away_penalty,
+                clock=clock,
+                updated=int(event_dt.timestamp()) - 3600,
+                status=status,
+                status_type=status_type,
+            )
+        )
+    return events

--- a/merino/providers/wcs/protocol.py
+++ b/merino/providers/wcs/protocol.py
@@ -1,0 +1,53 @@
+"""World Cup Soccer match endpoint request and response models."""
+
+from pydantic import BaseModel, ConfigDict, Field, HttpUrl
+
+
+class TeamInfo(BaseModel):
+    """A competing team."""
+
+    key: str = Field(description="Abbreviated 3-letter team code, e.g. 'BRA'.")
+    global_team_id: int = Field(description="Stable identifier for this team.")
+    name: str = Field(description="Long form team name, e.g. 'Brazil'.")
+    region: str = Field(description="ISO3 region designation; may differ from `name`.")
+    colors: list[str] = Field(description="Branding colors, primary first.")
+    icon: HttpUrl | None = Field(default=None, description="Team flag URL, if available.")
+    group: str = Field(description="Group label for this team, e.g. 'Group A'.")
+    eliminated: bool = Field(description="True once the team is out of the tournament.")
+    standing: dict[str, int] = Field(description="Group standings: wins, losses, draws, points.")
+
+
+class EventInfo(BaseModel):
+    """A single match event."""
+
+    date: str = Field(description="UTC ISO datetime for the start of the event.")
+    global_event_id: int = Field(description="Stable identifier for this event.")
+    home_team: TeamInfo
+    away_team: TeamInfo
+    period: str = Field(description="Period descriptor: '1', '2', 'Extra', etc.")
+    home_score: int | None
+    away_score: int | None
+    home_extra: int | None
+    away_extra: int | None
+    home_penalty: int | None
+    away_penalty: int | None
+    clock: str = Field(description="Elapsed minutes; extra time as '90+3'.")
+    updated: int = Field(description="UTC unix timestamp of the last record update.")
+    status: str = Field(description="Game status: 'Scheduled', 'In Progress', 'Final', etc.")
+    status_type: str = Field(description="Simplified status: 'past' | 'live' | 'scheduled'.")
+    query: str | None = Field(default=None, description="Optional click-through query.")
+    sport: str = Field(default="soccer", description="Sport identifier.")
+
+
+class MatchesResponse(BaseModel):
+    """Response payload for `GET /api/v1/wcs/matches`.
+
+    Each bucket is sorted by `EventInfo.date` ascending. `next_` is aliased to
+    `next` on the wire; populate by either name in Python.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    previous: list[EventInfo]
+    current: list[EventInfo]
+    next_: list[EventInfo] = Field(alias="next")

--- a/merino/providers/wcs/provider.py
+++ b/merino/providers/wcs/provider.py
@@ -1,0 +1,59 @@
+"""World Cup Soccer match provider."""
+
+from datetime import date, datetime, timedelta
+
+from merino.providers.wcs.fake_data import build_events
+from merino.providers.wcs.protocol import EventInfo, MatchesResponse
+
+_WINDOW = timedelta(days=7)
+
+
+class WcsProvider:
+    """Serves match data for the World Cup Soccer endpoint."""
+
+    def get_matches(
+        self,
+        target_date: date,
+        limit: int | None,
+        team_keys: frozenset[str] | None,
+    ) -> MatchesResponse:
+        """Return matches in the +/- 7 day window around `target_date`.
+
+        Events are bucketed into `previous`, `current`, and `next` relative to
+        `target_date` and sorted ascending by event date. `limit` keeps the
+        entries closest to `target_date` in each bucket; `team_keys` restricts
+        results to matches involving any of the listed teams.
+        """
+        previous: list[EventInfo] = []
+        current: list[EventInfo] = []
+        next_: list[EventInfo] = []
+
+        # Sorting up-front means each bucket inherits ascending order without
+        # a per-bucket sort pass.
+        for event in sorted(build_events(target_date), key=lambda e: e.date):
+            event_date = _event_date(event)
+            if abs(event_date - target_date) > _WINDOW:
+                continue
+            if team_keys is not None and not _has_team(event, team_keys):
+                continue
+            if event_date < target_date:
+                previous.append(event)
+            elif event_date == target_date:
+                current.append(event)
+            else:
+                next_.append(event)
+
+        if limit is not None:
+            previous, current, next_ = previous[-limit:], current[:limit], next_[:limit]
+
+        return MatchesResponse(previous=previous, current=current, next_=next_)
+
+
+def _event_date(event: EventInfo) -> date:
+    """Return the UTC calendar date of `event`."""
+    return datetime.fromisoformat(event.date).date()
+
+
+def _has_team(event: EventInfo, team_keys: frozenset[str]) -> bool:
+    """Return True if either side of `event` plays for one of `team_keys`."""
+    return event.home_team.key in team_keys or event.away_team.key in team_keys

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -2,6 +2,8 @@
 
 import logging
 from asyncio import Task
+from datetime import UTC, datetime
+from datetime import date as Date
 from functools import partial
 from itertools import chain
 from typing import Annotated, Literal
@@ -74,6 +76,9 @@ from merino.utils.query_processing.normalization.pipeline import tier_a
 from merino.providers.games import get_particle_provider
 from merino.providers.games.particle.backends.protocol import Particle
 from merino.providers.games.particle.provider import Provider as ParticleProvider
+from merino.providers.wcs import get_provider as get_wcs_provider
+from merino.providers.wcs.protocol import MatchesResponse
+from merino.providers.wcs.provider import WcsProvider
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -669,3 +674,34 @@ async def get_game_particle(
         content=jsonable_encoder(particle_data),
         headers={"Cache-Control": (f"private, max-age={_games_particle_ttl}")},
     )
+
+
+@router.get(
+    "/wcs/matches",
+    tags=["wcs"],
+    summary="World Cup Soccer matches in the +/- 7 day window around `date`",
+    response_model=MatchesResponse,
+    response_model_by_alias=True,
+)
+async def get_wcs_matches(
+    date: Annotated[
+        Date | None, Query(description="RFC date YYYY-MM-DD; defaults to today UTC.")
+    ] = None,
+    limit: Annotated[int | None, Query(ge=1, le=100)] = None,
+    teams: Annotated[
+        str | None,
+        Query(description="Comma-separated 3-letter team keys, e.g. 'BRA,ARG'."),
+    ] = None,
+    provider: WcsProvider = Depends(get_wcs_provider),
+) -> MatchesResponse:
+    """Return matches grouped into `previous`, `current`, and `next`.
+
+    The window is `+/- 7 days` around `date`. `current` holds matches on `date`,
+    `previous` is older, `next` is newer. Each bucket is sorted ascending by
+    event date. Returns fake-but-plausible data until the vendor backend lands.
+    """
+    target_date = date or datetime.now(UTC).date()
+    team_keys = (
+        frozenset(t.strip().upper() for t in teams.split(",") if t.strip()) if teams else None
+    )
+    return provider.get_matches(target_date, limit, team_keys)

--- a/tests/integration/api/v1/wcs/__init__.py
+++ b/tests/integration/api/v1/wcs/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for `/api/v1/wcs/*` endpoints."""

--- a/tests/integration/api/v1/wcs/test_matches.py
+++ b/tests/integration/api/v1/wcs/test_matches.py
@@ -1,0 +1,83 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Integration tests for `GET /api/v1/wcs/matches`."""
+
+from starlette.testclient import TestClient
+
+
+_PATH = "/api/v1/wcs/matches"
+# Pick an anchor inside the fake-data window so buckets are populated.
+_ANCHOR = "2026-06-15"
+
+
+def test_default_date_returns_three_buckets(client: TestClient) -> None:
+    """A no-arg call returns the three bucket keys with list values."""
+    response = client.get(_PATH)
+    assert response.status_code == 200
+
+    body = response.json()
+    assert set(body.keys()) == {"previous", "current", "next"}
+    assert isinstance(body["previous"], list)
+    assert isinstance(body["current"], list)
+    assert isinstance(body["next"], list)
+
+
+def test_response_uses_alias_next(client: TestClient) -> None:
+    """The JSON key must be `next`, not the Python `next_` field name."""
+    body = client.get(_PATH).json()
+    assert "next" in body
+    assert "next_" not in body
+
+
+def test_explicit_date_is_deterministic(client: TestClient) -> None:
+    """Same `date` param yields byte-identical payloads."""
+    a = client.get(_PATH, params={"date": _ANCHOR}).json()
+    b = client.get(_PATH, params={"date": _ANCHOR}).json()
+    assert a == b
+
+
+def test_two_matches_per_bucket(client: TestClient) -> None:
+    """Each of `previous`, `current`, `next` has exactly two events sharing a status."""
+    body = client.get(_PATH, params={"date": _ANCHOR}).json()
+    assert len(body["previous"]) == 2
+    assert len(body["current"]) == 2
+    assert len(body["next"]) == 2
+    assert all(e["status"] == "Final" for e in body["previous"])
+    assert all(e["status"] == "In Progress" for e in body["current"])
+    assert all(e["status"] == "Scheduled" for e in body["next"])
+
+
+def test_limit_clamps_each_bucket(client: TestClient) -> None:
+    """`limit` caps each bucket independently."""
+    body = client.get(_PATH, params={"date": _ANCHOR, "limit": 1}).json()
+    assert len(body["previous"]) <= 1
+    assert len(body["current"]) <= 1
+    assert len(body["next"]) <= 1
+
+
+def test_teams_filter(client: TestClient) -> None:
+    """`teams` filter keeps only events with that key on either side."""
+    body = client.get(_PATH, params={"date": _ANCHOR, "teams": "BRA"}).json()
+    events = body["previous"] + body["current"] + body["next"]
+
+    assert events
+    for event in events:
+        assert "BRA" in {event["home_team"]["key"], event["away_team"]["key"]}
+
+
+def test_invalid_date_returns_400(client: TestClient) -> None:
+    """Merino's validation handler in main.py converts FastAPI's 422 to 400."""
+    response = client.get(_PATH, params={"date": "not-a-date"})
+    assert response.status_code == 400
+
+
+def test_team_icons_resolve_to_cdn_urls(client: TestClient) -> None:
+    """End-to-end check that get_logo_url(LogoCategory.Nations, key) resolves."""
+    body = client.get(_PATH, params={"date": _ANCHOR}).json()
+    events = body["previous"] + body["current"] + body["next"]
+
+    assert events
+    icons = [e["home_team"]["icon"] for e in events] + [e["away_team"]["icon"] for e in events]
+    assert any(icon and icon.startswith("https://") for icon in icons)

--- a/tests/unit/providers/wcs/__init__.py
+++ b/tests/unit/providers/wcs/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for the WCS module."""

--- a/tests/unit/providers/wcs/test_provider.py
+++ b/tests/unit/providers/wcs/test_provider.py
@@ -1,0 +1,108 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Unit tests for the WCS matches provider."""
+
+from datetime import date, datetime
+
+from merino.providers.wcs.provider import WcsProvider
+
+
+_ANCHOR = date(2026, 6, 15)
+
+
+def _dates(events) -> list[date]:
+    return [datetime.fromisoformat(e.date).date() for e in events]
+
+
+def test_buckets_split_by_date() -> None:
+    """Each bucket holds events on the correct side of `target_date`."""
+    response = WcsProvider().get_matches(_ANCHOR, limit=None, team_keys=None)
+
+    assert all(d < _ANCHOR for d in _dates(response.previous))
+    assert all(d == _ANCHOR for d in _dates(response.current))
+    assert all(d > _ANCHOR for d in _dates(response.next_))
+
+
+def test_window_excludes_outside_range() -> None:
+    """No event lands more than 7 days from the anchor."""
+    response = WcsProvider().get_matches(_ANCHOR, limit=None, team_keys=None)
+
+    for event in response.previous + response.current + response.next_:
+        delta = abs((datetime.fromisoformat(event.date).date() - _ANCHOR).days)
+        assert delta <= 7
+
+
+def test_buckets_sorted_ascending_by_date() -> None:
+    """Each bucket is sorted by event date ascending."""
+    response = WcsProvider().get_matches(_ANCHOR, limit=None, team_keys=None)
+
+    for bucket in (response.previous, response.current, response.next_):
+        assert bucket == sorted(bucket, key=lambda e: e.date)
+
+
+def test_limit_keeps_closest_to_target_date() -> None:
+    """`previous` keeps the most-recent N, `next` keeps the soonest N."""
+    full = WcsProvider().get_matches(_ANCHOR, limit=None, team_keys=None)
+    limited = WcsProvider().get_matches(_ANCHOR, limit=1, team_keys=None)
+
+    assert len(limited.previous) <= 1
+    assert len(limited.current) <= 1
+    assert len(limited.next_) <= 1
+    if full.previous and limited.previous:
+        assert limited.previous[-1].date == full.previous[-1].date
+    if full.next_ and limited.next_:
+        assert limited.next_[0].date == full.next_[0].date
+
+
+def test_teams_filter_matches_either_side() -> None:
+    """Filter retains events where either home or away `key` is in the set."""
+    response = WcsProvider().get_matches(_ANCHOR, limit=None, team_keys=frozenset({"BRA"}))
+    events = response.previous + response.current + response.next_
+
+    assert events
+    for event in events:
+        assert "BRA" in {event.home_team.key, event.away_team.key}
+
+
+def test_response_is_deterministic_for_same_anchor() -> None:
+    """Two calls with the same anchor produce identical payloads."""
+    a = WcsProvider().get_matches(_ANCHOR, limit=None, team_keys=None)
+    b = WcsProvider().get_matches(_ANCHOR, limit=None, team_keys=None)
+
+    assert a.model_dump() == b.model_dump()
+
+
+def test_six_records_two_per_status_type() -> None:
+    """The fake set has exactly two past, two live, and two scheduled matches."""
+    response = WcsProvider().get_matches(_ANCHOR, limit=None, team_keys=None)
+
+    assert len(response.previous) == 2
+    assert len(response.current) == 2
+    assert len(response.next_) == 2
+    assert all(e.status_type == "past" for e in response.previous)
+    assert all(e.status_type == "live" for e in response.current)
+    assert all(e.status_type == "scheduled" for e in response.next_)
+
+
+def test_extra_and_penalty_populated_on_one_finalized_match() -> None:
+    """Exactly one finalized match exposes extra-time and penalty-shootout values."""
+    response = WcsProvider().get_matches(_ANCHOR, limit=None, team_keys=None)
+
+    finalized_with_extras = [
+        e for e in response.previous if e.home_extra is not None and e.home_penalty is not None
+    ]
+    assert len(finalized_with_extras) == 1
+    event = finalized_with_extras[0]
+    assert event.away_extra is not None
+    assert event.away_penalty is not None
+
+
+def test_live_extra_time_match_shows_clock_in_extra_play() -> None:
+    """A live match in extra time renders its clock in '90+x' form."""
+    response = WcsProvider().get_matches(_ANCHOR, limit=None, team_keys=None)
+
+    in_extra = [e for e in response.current if e.period == "ET"]
+    assert len(in_extra) == 1
+    assert in_extra[0].clock.startswith("90+")


### PR DESCRIPTION
## References

JIRA: [DISCO-4078](https://mozilla-hub.atlassian.net/browse/DISCO-4078)

## Description
Implement the `api/v1/wcs/matches` endpoint with mock data. Wired in the real world flags for each country.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2253)


[DISCO-4078]: https://mozilla-hub.atlassian.net/browse/DISCO-4078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ