### PR TITLE
DISCO-4129 Hardcode prod CDN url for staging logos

### DIFF
--- a/merino/providers/wcs/fake_data.py
+++ b/merino/providers/wcs/fake_data.py
@@ -7,8 +7,20 @@ two upcoming (tomorrow) events.
 
 from datetime import UTC, date, datetime, time, timedelta
 
-from merino.utils.logos import LogoCategory, get_logo_url
+from pydantic import HttpUrl
+
 from merino.providers.wcs.protocol import EventInfo, TeamInfo
+from merino.utils.logos import LogoCategory, load_manifest
+
+# Stage's `image_gcs_v2.cdn_hostname` is unset, so `get_logo_url` produces
+# `https://logos/...`. Pin to the prod bucket directly so stage renders the
+# same flags as production. Remove once SRE wires up the stage CDN host.
+_LOGO_HOST = "https://storage.googleapis.com/merino-images-prod"
+
+
+def _icon(key: str) -> HttpUrl | None:
+    entry = load_manifest().get(LogoCategory.Nations, key)
+    return HttpUrl(f"{_LOGO_HOST}/{entry.url}") if entry else None
 
 
 def _team(
@@ -19,14 +31,13 @@ def _team(
     colors: list[str],
     group: str,
 ) -> TeamInfo:
-    icon = get_logo_url(LogoCategory.Nations, key)
     return TeamInfo(
         key=key,
         global_team_id=global_team_id,
         name=name,
         region=region,
         colors=colors,
-        icon=icon,
+        icon=_icon(key),
         group=group,
         eliminated=False,
         standing={"wins": 0, "losses": 0, "draws": 0, "points": 0},

--- a/tests/integration/api/v1/wcs/test_matches.py
+++ b/tests/integration/api/v1/wcs/test_matches.py
@@ -73,11 +73,12 @@ def test_invalid_date_returns_400(client: TestClient) -> None:
     assert response.status_code == 400
 
 
-def test_team_icons_resolve_to_cdn_urls(client: TestClient) -> None:
-    """End-to-end check that get_logo_url(LogoCategory.Nations, key) resolves."""
+def test_team_icons_pinned_to_prod_logo_bucket(client: TestClient) -> None:
+    """Stage lacks a CDN host override, so icons hardcode the prod GCS bucket."""
     body = client.get(_PATH, params={"date": _ANCHOR}).json()
     events = body["previous"] + body["current"] + body["next"]
 
     assert events
     icons = [e["home_team"]["icon"] for e in events] + [e["away_team"]["icon"] for e in events]
-    assert any(icon and icon.startswith("https://") for icon in icons)
+    expected_prefix = "https://storage.googleapis.com/merino-images-prod/logos/nations/nations_"
+    assert all(icon and icon.startswith(expected_prefix) for icon in icons)


### PR DESCRIPTION
## References

JIRA: [DISCO-4129](https://mozilla-hub.atlassian.net/browse/DISCO-4129)

## Description
We don't set ENV in staging for our CDN. We want to return mock data to the client teams early, so we deployed this mock on staging, and serve it via the hardcoded CDN url.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2254)


[DISCO-4129]: https://mozilla-hub.atlassian.net/browse/DISCO-4129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ