### PR TITLE
DISCO-4138 ADd live matches endpoint to world cup soccer (with mocks)

### DIFF
--- a/merino/providers/wcs/fake_data.py
+++ b/merino/providers/wcs/fake_data.py
@@ -37,7 +37,7 @@ def _team(
         name=name,
         region=region,
         colors=colors,
-        icon=_icon(key),
+        icon_url=_icon(key),
         group=group,
         eliminated=False,
         standing={"wins": 0, "losses": 0, "draws": 0, "points": 0},

--- a/merino/providers/wcs/protocol.py
+++ b/merino/providers/wcs/protocol.py
@@ -11,7 +11,7 @@ class TeamInfo(BaseModel):
     name: str = Field(description="Long form team name, e.g. 'Brazil'.")
     region: str = Field(description="ISO3 region designation; may differ from `name`.")
     colors: list[str] = Field(description="Branding colors, primary first.")
-    icon: HttpUrl | None = Field(default=None, description="Team flag URL, if available.")
+    icon_url: HttpUrl | None = Field(default=None, description="Team flag URL, if available.")
     group: str = Field(description="Group label for this team, e.g. 'Group A'.")
     eliminated: bool = Field(description="True once the team is out of the tournament.")
     standing: dict[str, int] = Field(description="Group standings: wins, losses, draws, points.")
@@ -51,3 +51,12 @@ class MatchesResponse(BaseModel):
     previous: list[EventInfo]
     current: list[EventInfo]
     next_: list[EventInfo] = Field(alias="next")
+
+
+class LiveMatchesResponse(BaseModel):
+    """Response payload for `GET /api/v1/wcs/live`.
+
+    Holds events with `status_type == "live"`, sorted by `date` ascending.
+    """
+
+    matches: list[EventInfo]

--- a/merino/providers/wcs/provider.py
+++ b/merino/providers/wcs/provider.py
@@ -1,9 +1,9 @@
 """World Cup Soccer match provider."""
 
-from datetime import date, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 
 from merino.providers.wcs.fake_data import build_events
-from merino.providers.wcs.protocol import EventInfo, MatchesResponse
+from merino.providers.wcs.protocol import EventInfo, LiveMatchesResponse, MatchesResponse
 
 _WINDOW = timedelta(days=7)
 
@@ -47,6 +47,20 @@ class WcsProvider:
             previous, current, next_ = previous[-limit:], current[:limit], next_[:limit]
 
         return MatchesResponse(previous=previous, current=current, next_=next_)
+
+    def get_live_matches(self, team_keys: frozenset[str] | None) -> LiveMatchesResponse:
+        """Return events currently in progress, sorted ascending by `date`.
+
+        Anchored to the current UTC date so the fake set always exposes its
+        `live` bucket. `team_keys` restricts results to matches with that team
+        on either side.
+        """
+        matches = [
+            event
+            for event in sorted(build_events(datetime.now(UTC).date()), key=lambda e: e.date)
+            if event.status_type == "live" and (team_keys is None or _has_team(event, team_keys))
+        ]
+        return LiveMatchesResponse(matches=matches)
 
 
 def _event_date(event: EventInfo) -> date:

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -77,7 +77,7 @@ from merino.providers.games import get_particle_provider
 from merino.providers.games.particle.backends.protocol import Particle
 from merino.providers.games.particle.provider import Provider as ParticleProvider
 from merino.providers.wcs import get_provider as get_wcs_provider
-from merino.providers.wcs.protocol import MatchesResponse
+from merino.providers.wcs.protocol import LiveMatchesResponse, MatchesResponse
 from merino.providers.wcs.provider import WcsProvider
 
 logger = logging.getLogger(__name__)
@@ -701,7 +701,34 @@ async def get_wcs_matches(
     event date. Returns fake-but-plausible data until the vendor backend lands.
     """
     target_date = date or datetime.now(UTC).date()
-    team_keys = (
-        frozenset(t.strip().upper() for t in teams.split(",") if t.strip()) if teams else None
-    )
+    team_keys = _parse_team_keys(teams)
     return provider.get_matches(target_date, limit, team_keys)
+
+
+@router.get(
+    "/wcs/live",
+    tags=["wcs"],
+    summary="World Cup Soccer matches currently in progress",
+    response_model=LiveMatchesResponse,
+)
+async def get_wcs_live(
+    teams: Annotated[
+        str | None,
+        Query(description="Comma-separated 3-letter team keys, e.g. 'BRA,ARG'."),
+    ] = None,
+    provider: WcsProvider = Depends(get_wcs_provider),
+) -> LiveMatchesResponse:
+    """Return matches with `status_type == "live"`, sorted ascending by date.
+
+    Anchored to the current UTC date. Returns fake-but-plausible data until
+    the vendor backend lands.
+    """
+    return provider.get_live_matches(_parse_team_keys(teams))
+
+
+def _parse_team_keys(teams: str | None) -> frozenset[str] | None:
+    """Parse a comma-separated list of team keys into an upper-case frozen set."""
+    if not teams:
+        return None
+    keys = frozenset(t.strip().upper() for t in teams.split(",") if t.strip())
+    return keys or None

--- a/tests/integration/api/v1/wcs/test_live.py
+++ b/tests/integration/api/v1/wcs/test_live.py
@@ -1,0 +1,44 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Integration tests for `GET /api/v1/wcs/live`."""
+
+from starlette.testclient import TestClient
+
+
+_PATH = "/api/v1/wcs/live"
+
+
+def test_returns_matches_envelope(client: TestClient) -> None:
+    """Response is `{"matches": [...]}` with a list of in-progress events."""
+    response = client.get(_PATH)
+    assert response.status_code == 200
+
+    body = response.json()
+    assert set(body.keys()) == {"matches"}
+    assert isinstance(body["matches"], list)
+    assert body["matches"]
+    assert all(e["status_type"] == "live" for e in body["matches"])
+
+
+def test_matches_sorted_ascending_by_date(client: TestClient) -> None:
+    """Matches come back ordered by event start time."""
+    matches = client.get(_PATH).json()["matches"]
+    assert matches == sorted(matches, key=lambda e: e["date"])
+
+
+def test_teams_filter(client: TestClient) -> None:
+    """`teams` filter keeps only matches with that key on either side."""
+    body = client.get(_PATH, params={"teams": "BRA"}).json()
+
+    assert body["matches"]
+    for event in body["matches"]:
+        assert "BRA" in {event["home_team"]["key"], event["away_team"]["key"]}
+
+
+def test_unknown_team_returns_empty_list(client: TestClient) -> None:
+    """A `teams` value that matches nothing yields an empty list, not an error."""
+    response = client.get(_PATH, params={"teams": "ZZZ"})
+    assert response.status_code == 200
+    assert response.json() == {"matches": []}

--- a/tests/integration/api/v1/wcs/test_matches.py
+++ b/tests/integration/api/v1/wcs/test_matches.py
@@ -79,6 +79,8 @@ def test_team_icons_pinned_to_prod_logo_bucket(client: TestClient) -> None:
     events = body["previous"] + body["current"] + body["next"]
 
     assert events
-    icons = [e["home_team"]["icon"] for e in events] + [e["away_team"]["icon"] for e in events]
+    icons = [e["home_team"]["icon_url"] for e in events] + [
+        e["away_team"]["icon_url"] for e in events
+    ]
     expected_prefix = "https://storage.googleapis.com/merino-images-prod/logos/nations/nations_"
     assert all(icon and icon.startswith(expected_prefix) for icon in icons)

--- a/tests/unit/providers/wcs/test_provider.py
+++ b/tests/unit/providers/wcs/test_provider.py
@@ -106,3 +106,39 @@ def test_live_extra_time_match_shows_clock_in_extra_play() -> None:
     in_extra = [e for e in response.current if e.period == "ET"]
     assert len(in_extra) == 1
     assert in_extra[0].clock.startswith("90+")
+
+
+def test_live_returns_only_in_progress_events() -> None:
+    """`get_live_matches` returns the two `live` events from the fake set."""
+    response = WcsProvider().get_live_matches(team_keys=None)
+
+    assert len(response.matches) == 2
+    assert all(e.status_type == "live" for e in response.matches)
+
+
+def test_live_matches_sorted_ascending_by_date() -> None:
+    """Live events are sorted ascending by `date`."""
+    matches = WcsProvider().get_live_matches(team_keys=None).matches
+    assert matches == sorted(matches, key=lambda e: e.date)
+
+
+def test_live_teams_filter_matches_either_side() -> None:
+    """Filter retains live events where either side plays for the listed team."""
+    response = WcsProvider().get_live_matches(team_keys=frozenset({"BRA"}))
+
+    assert response.matches
+    for event in response.matches:
+        assert "BRA" in {event.home_team.key, event.away_team.key}
+
+
+def test_live_unknown_team_returns_empty() -> None:
+    """No match for the filter yields an empty list, not an error."""
+    response = WcsProvider().get_live_matches(team_keys=frozenset({"ZZZ"}))
+    assert response.matches == []
+
+
+def test_live_is_deterministic_within_same_utc_day() -> None:
+    """Two calls in the same UTC day produce identical payloads."""
+    a = WcsProvider().get_live_matches(team_keys=None)
+    b = WcsProvider().get_live_matches(team_keys=None)
+    assert a.model_dump() == b.model_dump()


### PR DESCRIPTION
## References

JIRA: [DISCO-4138](https://mozilla-hub.atlassian.net/browse/DISCO-4138)

## Description
Adding `/api/v1/wcs/live` endpoint to return mocked live data.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2255)


[DISCO-4138]: https://mozilla-hub.atlassian.net/browse/DISCO-4138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ