### PR TITLE
[DISCO-4148] - Enable UCL test support 

### DIFF
--- a/merino/jobs/sportsdata_jobs/__init__.py
+++ b/merino/jobs/sportsdata_jobs/__init__.py
@@ -46,8 +46,7 @@ from merino.providers.suggest.sports.backends.sportsdata.common.sports import (
     NBA,
     NHL,
     MLB,
-    # UCL,
-    # MLB,
+    UCL,
     # EPL,
 )
 from merino.utils.http_client import create_http_client
@@ -109,8 +108,8 @@ class SportDataUpdater:
                     sport = NBA(settings)
                 case "NHL":
                     sport = NHL(settings)
-                # case "UCL":
-                #    sport = UCL(settings)
+                case "UCL":
+                    sport = UCL(settings)
                 case "MLB":
                     sport = MLB(settings)
                 # case "EPL":

--- a/merino/providers/suggest/sports/backends/sportsdata/common/sports.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/sports.py
@@ -518,7 +518,7 @@ class UCL(Sport):
         for _id, event in self.events.items():
             day = event.date.strftime("%Y-%b-%d").upper()
             if not event.status.is_scheduled() and day not in date_list:
-                url = f"{self.base_url}/ScoresBasic/{day}?key={self.api_key}"
+                url = f"{self.base_url}/ScoresBasic/{self.name}/{day}?key={self.api_key}"
                 response = await get_data(
                     client=client,
                     url=url,


### PR DESCRIPTION
## References

JIRA: [DISCO-4148](https://mozilla-hub.atlassian.net/browse/DISCO-4148)

## Description
This enables soccer UCL to validate calls for the WCS widget



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2256)


[DISCO-4148]: https://mozilla-hub.atlassian.net/browse/DISCO-4148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ