### PR TITLE
Canada Inferred Personalization

### DIFF
--- a/merino/curated_recommendations/ml_backends/protocol.py
+++ b/merino/curated_recommendations/ml_backends/protocol.py
@@ -52,6 +52,7 @@ class ModelData(BaseModel):
     model_type: ModelType
     # Whether to rescale the values based on 1 max value
     rescale: bool
+    ctr_prior_strength: float | None = None
     day_time_weighting: DayTimeWeightingConfig
     # Output key, and inputs for how fields affect it
     interest_vector: dict[str, InterestVectorConfig]

--- a/merino/curated_recommendations/ml_backends/static_local_model.py
+++ b/merino/curated_recommendations/ml_backends/static_local_model.py
@@ -3,7 +3,7 @@
 from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 
-from merino.curated_recommendations.corpus_backends.protocol import Topic
+from merino.curated_recommendations.corpus_backends.protocol import SurfaceId, Topic
 from merino.curated_recommendations.ml_backends.protocol import (
     InferredLocalModel,
     LocalModelBackend,
@@ -38,8 +38,9 @@ CONTEXTUAL_RANKING_TREATMENT_COUNTRY = "contextual-ranking-content-country"
 
 CTR_TOPIC_MODEL_ID = "ctr_model_topic_1"
 CTR_SECTION_MODEL_ID = "ctr_model_section_1"
+SMALL_POPULATION_MODEL_ID = "inferred-small-v1"
 
-SUPPORTED_LIVE_MODELS = {SERVER_V3_MODEL_ID}
+SUPPORTED_LIVE_MODELS = {SERVER_V3_MODEL_ID, SMALL_POPULATION_MODEL_ID}
 
 DEFAULT_PRODUCTION_MODEL_ID = SERVER_V3_MODEL_ID
 EXPERIMENT_PRODUCTION_MODEL_ID = SERVER_V3_MODEL_ID  # Because we just have a few features zeroed out, we can use the same model id
@@ -181,12 +182,16 @@ class FakeLocalModelSections(LocalModelBackend):
 MODEL_P_VALUE = 0.92
 MODEL_Q_VALUE = 0.0288
 
+MODEL_P_VALUE_SMALL_POPULATION = 0.9686
+MODEL_Q_VALUE_SMALL_POPULATION = 0.0314
 
 OFF_THRESH_VALUE = 100
 
 THRESHOLDS_V3_NORMALIZED = [0.25, 0.46, 0.8]
 THRESHOLDS_V3_NON_NORMALIZED = [0.002, 0.008, 0.017]
 THRESHOLDS_V3_NON_NORMALIZED_ALL_TOPICS = [0.0001, 0.002, 0.004]
+
+THRESHOLDS_SMALL_POPULATION = [1.4]
 
 SUBTOPIC_TOPIC_BLEND_RATIO = 0.15
 
@@ -212,6 +217,34 @@ class PrivacyOverridesForFivePercentExperimentUS(PrivacyOverrides):
         super().__init__(**data)
 
 
+
+v3_limited_topics = [
+    # Top clicked in most popular, though food was dropped for parenting
+    Topic.SPORTS.value,
+    Topic.ARTS.value,
+    Topic.POLITICS.value,
+    Topic.PARENTING.value,
+    Topic.FOOD.value,
+    Topic.TECHNOLOGY.value,
+    Topic.SCIENCE.value,
+    # Time zone is added for 8th private feature
+]
+
+small_population_topics = [
+    Topic.SPORTS.value,
+    Topic.SCIENCE.value,
+    # Time zone is added for last feature
+]
+
+# These are the only features supported in a small experiment (in addition to time zone)
+v3_small_experiment_topics = {
+    Topic.SPORTS.value,
+    Topic.SCIENCE.value,
+    Topic.POLITICS.value,
+    Topic.ARTS.value,
+}
+
+
 # Creates a limited model based on topics. Topics features are stored with a t_
 # in telemetry.
 class SuperInferredModel(LocalModelBackend):
@@ -223,28 +256,6 @@ class SuperInferredModel(LocalModelBackend):
      Based on data analysis these were the most impactful topics from personalization when limited to 5
      The last dimension is a combination of other topics.
     """
-
-    v3_limited_topics = [
-        # Top clicked in most popular, though food was dropped for parenting
-        Topic.SPORTS.value,
-        Topic.ARTS.value,
-        Topic.POLITICS.value,
-        Topic.PARENTING.value,
-        Topic.FOOD.value,
-        Topic.TECHNOLOGY.value,
-        Topic.SCIENCE.value,
-        # Time zone is added for 8th private feature
-    ]
-
-    # These are the only features supported in a small experiment (in addition to time zone)
-    v3_small_experiment_topics = {
-        Topic.SPORTS.value,
-        Topic.SCIENCE.value,
-        Topic.POLITICS.value,
-        Topic.ARTS.value,
-    }
-
-    limited_topics_set = set(v3_limited_topics)
 
     @staticmethod
     def _get_topic(
@@ -279,19 +290,27 @@ class SuperInferredModel(LocalModelBackend):
         )
 
     @staticmethod
-    def _get_time_zone() -> InterestVectorConfig:
+    def _get_time_zone(small_population=False) -> InterestVectorConfig:
         """Time zone key has special functionality in Firefox, but we must specifiy threshols here
         based on UTC offset +24 (positive values). These thresholds support the 4 continental US zones
         """
         now: datetime = datetime.now(ZoneInfo("America/Los_Angeles"))
         offset: timedelta = now.utcoffset() or timedelta(0)
         pacific_bucket: float = (offset.total_seconds() / 3600) % 24
-        return InterestVectorConfig(
-            features={},
-            thresholds=[pacific_bucket + 0.1, pacific_bucket + 1.1, pacific_bucket + 2.1],
-            diff_p=MODEL_P_VALUE,
-            diff_q=MODEL_Q_VALUE,
-        )
+        if small_population:
+            return InterestVectorConfig(
+                features={},
+                thresholds=[pacific_bucket + 1.1], # split west from east
+                diff_p=MODEL_P_VALUE_SMALL_POPULATION,
+                diff_q=MODEL_Q_VALUE_SMALL_POPULATION,
+            )
+        else:
+            return InterestVectorConfig(
+                features={},
+                thresholds=[pacific_bucket + 0.1, pacific_bucket + 1.1, pacific_bucket + 2.1],
+                diff_p=MODEL_P_VALUE,
+                diff_q=MODEL_Q_VALUE,
+            )
 
     @staticmethod
     def _get_section(section_name: str, thresholds: list[float]) -> InterestVectorConfig:
@@ -304,46 +323,46 @@ class SuperInferredModel(LocalModelBackend):
         )
 
     def _build_local(
-        self, model_id, surface_id, small_experiment=False, include_local_reranking=False
+        self, model_id, surface_id, topics:list[str], small_experiment=False, small_population=False, include_local_reranking=False,
     ) -> InferredLocalModel | None:
-        model_thresholds = THRESHOLDS_V3_NORMALIZED
+        model_thresholds = THRESHOLDS_SMALL_POPULATION if small_population else THRESHOLDS_V3_NORMALIZED
         private_features: list[str] | None = None
-
         section_features = (
             {
                 a: self._get_section(a, model_thresholds)
                 for a in BASE_SECTIONS_FOR_LOCAL_MODEL
-                if a not in self.limited_topics_set
+                if a not in topics
             }
             if include_local_reranking
             else {}
         )
 
-        private_features = self.v3_limited_topics + [TIME_ZONE_OFFSET_INFERRED_KEY]
+        private_features = topics + [TIME_ZONE_OFFSET_INFERRED_KEY]
 
         if small_experiment:
             topic_features = {
                 a: self._get_topic(
-                    a, model_thresholds, disable_feature=a not in self.v3_small_experiment_topics
+                    a, model_thresholds, disable_feature=a not in v3_small_experiment_topics
                 )
-                for a in self.v3_limited_topics
+                for a in topics
             }
         else:
             topic_features = {
-                a: self._get_topic(a, model_thresholds) for a in self.v3_limited_topics
+                a: self._get_topic(a, model_thresholds) for a in topics
             }
 
         model_data: ModelData = ModelData(
             model_type=ModelType.CTR,
             rescale=True,
             noise_scale=0.0,
+            ctr_prior_strength=100 if small_experiment else None,
             day_time_weighting=DayTimeWeightingConfig(
                 days=[30],
                 relative_weight=[1],
             ),
             interest_vector={
                 **topic_features,
-                TIME_ZONE_OFFSET_INFERRED_KEY: self._get_time_zone(),
+                TIME_ZONE_OFFSET_INFERRED_KEY: self._get_time_zone(small_population),
                 **section_features,
             },
             private_features=private_features,
@@ -385,16 +404,11 @@ class SuperInferredModel(LocalModelBackend):
 
         if model_id is None:  ## this is the "get" call for building the model sent in the response
             ## switch on experiment name, not using util because we have string name instead of request object
-            if (
-                experiment_name is None  # Default
-                or experiment_name == INFERRED_LOCAL_EXPERIMENT_NAME_V4
-                or experiment_name == f"optin-{INFERRED_LOCAL_EXPERIMENT_NAME_V4}"
-            ):
-                # We don't have to check for branch here as control won't call inferred code
-                return self._build_local(SERVER_V3_MODEL_ID, surface_id)
-            else:
+            if surface_id == SurfaceId.NEW_TAB_EN_US.value and experiment_name is not None:
                 return self._build_local(
-                    EXPERIMENT_PRODUCTION_MODEL_ID, surface_id, small_experiment=True
+                    EXPERIMENT_PRODUCTION_MODEL_ID, surface_id, topics=v3_limited_topics, small_experiment=True
                 )
-        # Normally we would pick the model based on model_id here, but we are supporting only one right now
-        return self._build_local(SERVER_V3_MODEL_ID, surface_id)
+        if surface_id == SurfaceId.NEW_TAB_EN_CA.value:
+            return self._build_local(SMALL_POPULATION_MODEL_ID, surface_id, topics=small_population_topics, small_population=True, include_local_reranking=True)
+        else:
+            return self._build_local(SERVER_V3_MODEL_ID, surface_id, topics=v3_limited_topics)

--- a/merino/curated_recommendations/ml_backends/static_local_model.py
+++ b/merino/curated_recommendations/ml_backends/static_local_model.py
@@ -198,6 +198,7 @@ SUBTOPIC_TOPIC_BLEND_RATIO = 0.15
 TIME_ZONE_OFFSET_INFERRED_KEY = "timeZoneOffset"
 
 CLICK_RANDOMIZATION_EPSILON_MICRO_FOR_EXPERIMENT = 14700000
+CLICK_RANDOMIZATION_EPSILON_MICRO_FOR_SMALL_COUNTRY = 9780000
 
 SPECIAL_ALL_TOPIC_KEYWOWRD = "all"
 
@@ -215,7 +216,6 @@ class PrivacyOverridesForFivePercentExperimentUS(PrivacyOverrides):
             "daily_click_event_cap", 2
         )  # Cap of 10 click events per day to reduce risk of outliers
         super().__init__(**data)
-
 
 
 v3_limited_topics = [
@@ -300,7 +300,7 @@ class SuperInferredModel(LocalModelBackend):
         if small_population:
             return InterestVectorConfig(
                 features={},
-                thresholds=[pacific_bucket + 1.1], # split west from east
+                thresholds=[pacific_bucket + 1.1],  # split west from east
                 diff_p=MODEL_P_VALUE_SMALL_POPULATION,
                 diff_q=MODEL_Q_VALUE_SMALL_POPULATION,
             )
@@ -323,9 +323,17 @@ class SuperInferredModel(LocalModelBackend):
         )
 
     def _build_local(
-        self, model_id, surface_id, topics:list[str], small_experiment=False, small_population=False, include_local_reranking=False,
+        self,
+        model_id,
+        surface_id,
+        topics: list[str],
+        small_experiment=False,
+        small_population=False,
+        include_local_reranking=False,
     ) -> InferredLocalModel | None:
-        model_thresholds = THRESHOLDS_SMALL_POPULATION if small_population else THRESHOLDS_V3_NORMALIZED
+        model_thresholds = (
+            THRESHOLDS_SMALL_POPULATION if small_population else THRESHOLDS_V3_NORMALIZED
+        )
         private_features: list[str] | None = None
         section_features = (
             {
@@ -347,15 +355,13 @@ class SuperInferredModel(LocalModelBackend):
                 for a in topics
             }
         else:
-            topic_features = {
-                a: self._get_topic(a, model_thresholds) for a in topics
-            }
+            topic_features = {a: self._get_topic(a, model_thresholds) for a in topics}
 
         model_data: ModelData = ModelData(
             model_type=ModelType.CTR,
             rescale=True,
             noise_scale=0.0,
-            ctr_prior_strength=100 if small_experiment else None,
+            ctr_prior_strength=100 if small_population else None,
             day_time_weighting=DayTimeWeightingConfig(
                 days=[30],
                 relative_weight=[1],
@@ -368,9 +374,10 @@ class SuperInferredModel(LocalModelBackend):
             private_features=private_features,
         )
         # No privacy overrides until this is implemented in Merino
-        privacy_overrides: PrivacyOverrides | None = (
-            PrivacyOverridesForFivePercentExperimentUS() if small_experiment else None
-        )
+        privacy_overrides: PrivacyOverrides | None = None
+        if small_experiment:
+            privacy_overrides = PrivacyOverridesForFivePercentExperimentUS()
+
         return InferredLocalModel(
             model_id=model_id,
             surface_id=surface_id,
@@ -406,9 +413,18 @@ class SuperInferredModel(LocalModelBackend):
             ## switch on experiment name, not using util because we have string name instead of request object
             if surface_id == SurfaceId.NEW_TAB_EN_US.value and experiment_name is not None:
                 return self._build_local(
-                    EXPERIMENT_PRODUCTION_MODEL_ID, surface_id, topics=v3_limited_topics, small_experiment=True
+                    EXPERIMENT_PRODUCTION_MODEL_ID,
+                    surface_id,
+                    topics=v3_limited_topics,
+                    small_experiment=True,
                 )
         if surface_id == SurfaceId.NEW_TAB_EN_CA.value:
-            return self._build_local(SMALL_POPULATION_MODEL_ID, surface_id, topics=small_population_topics, small_population=True, include_local_reranking=True)
+            return self._build_local(
+                SMALL_POPULATION_MODEL_ID,
+                surface_id,
+                topics=small_population_topics,
+                small_population=True,
+                include_local_reranking=True,
+            )
         else:
             return self._build_local(SERVER_V3_MODEL_ID, surface_id, topics=v3_limited_topics)

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -41,6 +41,8 @@ from merino.curated_recommendations.engagement_backends.protocol import (
 from merino.curated_recommendations.localization import LOCALIZED_SECTION_TITLES
 from merino.curated_recommendations.ml_backends.static_local_model import (
     DEFAULT_PRODUCTION_MODEL_ID,
+    SMALL_POPULATION_MODEL_ID,
+    SuperInferredModel,
 )
 
 from merino.curated_recommendations.ml_backends.protocol import (
@@ -2506,6 +2508,32 @@ class TestSections:
             assert local_model is not None
         else:
             assert local_model is None
+
+    def test_en_ca_returns_small_population_model(
+        self, monkeypatch, corpus_provider, client: TestClient
+    ):
+        """Sanity test: EN-CA with empty inferredInterests returns the small-population model id and content."""
+        monkeypatch.setattr(corpus_provider, "local_model_backend", SuperInferredModel())
+
+        response = client.post(
+            "/api/v1/curated-recommendations",
+            json={
+                "locale": Locale.EN_CA,
+                "feeds": ["sections"],
+                "inferredInterests": {},
+            },
+        )
+        assert response.status_code == 200
+        data = response.json()
+
+        local_model = data["inferredLocalModel"]
+        assert local_model is not None
+        assert local_model["model_id"] == SMALL_POPULATION_MODEL_ID
+
+        feeds = data["feeds"]
+        sections = {name: section for name, section in feeds.items() if section is not None}
+        assert "top_stories_section" in sections
+        assert len(sections["top_stories_section"]["recommendations"]) > 0
 
     def test_topic_model_interest_vector_most_popular(self, monkeypatch, client: TestClient):
         """Test the curated recommendations endpoint ranks sections accorcding to inferredInterests"""

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -2535,6 +2535,35 @@ class TestSections:
         assert "top_stories_section" in sections
         assert len(sections["top_stories_section"]["recommendations"]) > 0
 
+    def test_en_ca_with_small_population_values_returns_result(
+        self, monkeypatch, corpus_provider, client: TestClient
+    ):
+        """Sanity test: EN-CA with small-population dp values returns the model id and content."""
+        monkeypatch.setattr(corpus_provider, "local_model_backend", SuperInferredModel())
+
+        response = client.post(
+            "/api/v1/curated-recommendations",
+            json={
+                "locale": Locale.EN_CA,
+                "feeds": ["sections"],
+                "inferredInterests": {
+                    "values": ["11", "10", "10"],
+                    "model_id": SMALL_POPULATION_MODEL_ID,
+                },
+            },
+        )
+        assert response.status_code == 200
+        data = response.json()
+
+        local_model = data["inferredLocalModel"]
+        assert local_model is not None
+        assert local_model["model_id"] == SMALL_POPULATION_MODEL_ID
+
+        feeds = data["feeds"]
+        sections = {name: section for name, section in feeds.items() if section is not None}
+        assert "top_stories_section" in sections
+        assert len(sections["top_stories_section"]["recommendations"]) > 0
+
     def test_topic_model_interest_vector_most_popular(self, monkeypatch, client: TestClient):
         """Test the curated recommendations endpoint ranks sections accorcding to inferredInterests"""
         np.random.seed(43)  # NumPy's RNG (used internally by scikit-learn)

--- a/tests/unit/curated_recommendations/ml_backends/test_static_local_model.py
+++ b/tests/unit/curated_recommendations/ml_backends/test_static_local_model.py
@@ -6,12 +6,17 @@ from types import SimpleNamespace
 from merino.curated_recommendations.corpus_backends.protocol import Topic, SurfaceId
 from merino.curated_recommendations.ml_backends.static_local_model import (
     EXPERIMENT_PRODUCTION_MODEL_ID,
+    MODEL_P_VALUE_SMALL_POPULATION,
+    MODEL_Q_VALUE_SMALL_POPULATION,
     SERVER_V3_MODEL_ID,
+    SMALL_POPULATION_MODEL_ID,
+    THRESHOLDS_SMALL_POPULATION,
     THRESHOLDS_V3_NORMALIZED,
     TIME_ZONE_OFFSET_INFERRED_KEY,
     FakeLocalModelSections,
     SuperInferredModel,
     CTR_SECTION_MODEL_ID,
+    small_population_topics,
 )
 from merino.curated_recommendations.ml_backends.protocol import (
     CohortModelBackend,
@@ -636,9 +641,9 @@ def test_get_with_experiment_and_model_id_correct_branch_returns_model(
 
 
 def test_get_dummy_experiment_name(model_limited):
-    """Control check: an unknown experiment name and no model_id defaults to reduced model."""
+    """An experiment name on the EN-US surface triggers the small_experiment branch."""
     result = model_limited.get(
-        TEST_SURFACE,
+        SurfaceId.NEW_TAB_EN_US.value,
         model_id=None,
         experiment_name="moo",
         experiment_branch="cow",
@@ -651,6 +656,9 @@ def test_get_dummy_experiment_name(model_limited):
     assert TIME_ZONE_OFFSET_INFERRED_KEY in result.model_data.private_features
 
     assert result.model_data.private_features and len(result.model_data.private_features) > 0
+
+    # small_experiment sets a CTR prior strength
+    assert result.model_data.ctr_prior_strength == 100
 
     # Some interests have been removed
     zeroed_interest = result.model_data.interest_vector[Topic.TECHNOLOGY.value]
@@ -667,3 +675,68 @@ def test_get_dummy_experiment_name(model_limited):
     assert result.privacy_overrides.random_content_click_probability_epsilon_micro > 1000
     assert result.privacy_overrides.iv_in_telemetry is False
     assert result.privacy_overrides.local_popular_today_rerank is None
+
+
+def test_non_en_us_surface_with_experiment_name_does_not_use_small_experiment(model_limited):
+    """The small_experiment branch is gated on EN-US: other surfaces fall through to default."""
+    result = model_limited.get(
+        TEST_SURFACE,
+        model_id=None,
+        experiment_name="moo",
+        experiment_branch="cow",
+    )
+    assert result is not None
+    assert result.model_id == SERVER_V3_MODEL_ID
+    # default path: no small_experiment privacy overrides, no ctr prior strength
+    assert result.privacy_overrides is None
+    assert result.model_data.ctr_prior_strength is None
+    # TECHNOLOGY is not zeroed out in the default path
+    tech = result.model_data.interest_vector[Topic.TECHNOLOGY.value]
+    assert tech.thresholds == THRESHOLDS_V3_NORMALIZED
+
+
+def test_get_en_ca_returns_small_population_model(model_limited):
+    """EN-CA surface returns the small-population model with reranking and small thresholds."""
+    result = model_limited.get(SurfaceId.NEW_TAB_EN_CA.value)
+
+    assert isinstance(result, InferredLocalModel)
+    assert result.model_id == SMALL_POPULATION_MODEL_ID
+    assert result.surface_id == SurfaceId.NEW_TAB_EN_CA.value
+
+    # Topic features are restricted to small_population_topics
+    iv = result.model_data.interest_vector
+    for topic in small_population_topics:
+        assert topic in iv
+        assert iv[topic].thresholds == THRESHOLDS_SMALL_POPULATION
+    # Topics from v3_limited_topics that aren't in small_population_topics are NOT included
+    assert Topic.ARTS.value not in iv
+    assert Topic.POLITICS.value not in iv
+
+    # Time zone uses a single split-threshold and small-population p/q
+    tz = iv[TIME_ZONE_OFFSET_INFERRED_KEY]
+    assert len(tz.thresholds) == 1
+    assert tz.diff_p == MODEL_P_VALUE_SMALL_POPULATION
+    assert tz.diff_q == MODEL_Q_VALUE_SMALL_POPULATION
+
+    # include_local_reranking=True -> section features present (excluding topics already in the model)
+    section_keys = set(iv.keys()) - set(small_population_topics) - {TIME_ZONE_OFFSET_INFERRED_KEY}
+    assert len(section_keys) > 0
+
+    # private_features = topics + time zone (no sections)
+    assert result.model_data.private_features == [
+        *small_population_topics,
+        TIME_ZONE_OFFSET_INFERRED_KEY,
+    ]
+
+    # Not a small_experiment, so no privacy overrides and no CTR prior strength
+    assert result.privacy_overrides is None
+    assert result.model_data.ctr_prior_strength is None
+
+
+def test_small_population_model_id_is_supported(model_limited):
+    """SMALL_POPULATION_MODEL_ID is in SUPPORTED_LIVE_MODELS and can be requested."""
+    result = model_limited.get(
+        SurfaceId.NEW_TAB_EN_CA.value, model_id=SMALL_POPULATION_MODEL_ID
+    )
+    assert result is not None
+    assert result.model_id == SMALL_POPULATION_MODEL_ID

--- a/tests/unit/curated_recommendations/ml_backends/test_static_local_model.py
+++ b/tests/unit/curated_recommendations/ml_backends/test_static_local_model.py
@@ -658,7 +658,7 @@ def test_get_dummy_experiment_name(model_limited):
     assert result.model_data.private_features and len(result.model_data.private_features) > 0
 
     # small_experiment sets a CTR prior strength
-    assert result.model_data.ctr_prior_strength == 100
+    assert result.model_data.ctr_prior_strength is None
 
     # Some interests have been removed
     zeroed_interest = result.model_data.interest_vector[Topic.TECHNOLOGY.value]
@@ -709,8 +709,11 @@ def test_get_en_ca_returns_small_population_model(model_limited):
         assert topic in iv
         assert iv[topic].thresholds == THRESHOLDS_SMALL_POPULATION
     # Topics from v3_limited_topics that aren't in small_population_topics are NOT included
-    assert Topic.ARTS.value not in iv
-    assert Topic.POLITICS.value not in iv
+    assert Topic.SPORTS.value in result.model_data.private_features
+    assert Topic.SPORTS.value in iv
+
+    assert Topic.ARTS.value not in result.model_data.private_features
+    assert Topic.ARTS.value in iv  # local sections ranking
 
     # Time zone uses a single split-threshold and small-population p/q
     tz = iv[TIME_ZONE_OFFSET_INFERRED_KEY]
@@ -728,15 +731,14 @@ def test_get_en_ca_returns_small_population_model(model_limited):
         TIME_ZONE_OFFSET_INFERRED_KEY,
     ]
 
-    # Not a small_experiment, so no privacy overrides and no CTR prior strength
+    # Not a small_experiment, so no privacy overrides
     assert result.privacy_overrides is None
-    assert result.model_data.ctr_prior_strength is None
+    # We are using newer thresholding method with prior impressions
+    assert result.model_data.ctr_prior_strength > 0
 
 
 def test_small_population_model_id_is_supported(model_limited):
     """SMALL_POPULATION_MODEL_ID is in SUPPORTED_LIVE_MODELS and can be requested."""
-    result = model_limited.get(
-        SurfaceId.NEW_TAB_EN_CA.value, model_id=SMALL_POPULATION_MODEL_ID
-    )
+    result = model_limited.get(SurfaceId.NEW_TAB_EN_CA.value, model_id=SMALL_POPULATION_MODEL_ID)
     assert result is not None
     assert result.model_id == SMALL_POPULATION_MODEL_ID


### PR DESCRIPTION
## References

JIRA: https://mozilla-hub.atlassian.net/browse/AIMOD-296
The experiment is described in this document

Define new inferred personalization parameters and model ID for the Canada surface. Enable local personalization as a fallback.

This PR does not enable contextual ranking or the cohort modeling for Canada. That will be in a future PR when we have enough trained data.

https://mozilla-hub.atlassian.net/wiki/spaces/FPS/pages/2615738375/Inferred+Personalization+-+Canada+Launch


The privacy values for 'small population' experiment are computed in this [ml-service PR](https://github.com/mozilla/content-ml-services/pull/1144/changes#diff-51995c3069b1126212f2d88b31991197b5a25a0b9b41159eaf06ac294a2532b4). 

## Description


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2257)
