### PR TITLE
[DISCO-4073] Set GCS lifespan for engagement files

### DIFF
--- a/merino/jobs/engagement_model/__init__.py
+++ b/merino/jobs/engagement_model/__init__.py
@@ -2,7 +2,7 @@
 
 import json
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import typer
@@ -59,9 +59,11 @@ def upload_engagement_data() -> None:  # pragma: no cover
 
         content = json.dumps(payload, indent=2)
 
-        timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
+        now = datetime.now(tz=timezone.utc)
+        timestamp = now.strftime("%Y%m%d%H%M%S")
         destination_name = f"suggest-merino-exports/engagement/keyword/{timestamp}.json"
         latest_name = "suggest-merino-exports/engagement/keyword/latest.json"
+        retain_until = now + timedelta(days=30)
 
         uploader = GcsUploader(
             destination_gcp_project=gcs_storage_project,
@@ -74,6 +76,7 @@ def upload_engagement_data() -> None:  # pragma: no cover
             destination_name=destination_name,
             content_type="application/json",
             forced_upload=True,
+            retain_until=retain_until,
         )
 
         uploader.upload_content(

--- a/merino/jobs/engagement_model/__init__.py
+++ b/merino/jobs/engagement_model/__init__.py
@@ -2,7 +2,7 @@
 
 import json
 import logging
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from typing import Any
 
 import typer
@@ -63,8 +63,6 @@ def upload_engagement_data() -> None:  # pragma: no cover
         timestamp = now.strftime("%Y%m%d%H%M%S")
         destination_name = f"suggest-merino-exports/engagement/keyword/{timestamp}.json"
         latest_name = "suggest-merino-exports/engagement/keyword/latest.json"
-        retain_until = now + timedelta(days=30)
-
         uploader = GcsUploader(
             destination_gcp_project=gcs_storage_project,
             destination_bucket_name=gcs_storage_bucket,
@@ -76,7 +74,7 @@ def upload_engagement_data() -> None:  # pragma: no cover
             destination_name=destination_name,
             content_type="application/json",
             forced_upload=True,
-            retain_until=retain_until,
+            custom_time=now,
         )
 
         uploader.upload_content(

--- a/merino/utils/gcs/gcs_uploader.py
+++ b/merino/utils/gcs/gcs_uploader.py
@@ -51,7 +51,7 @@ class GcsUploader(BaseContentUploader):
         destination_name: str,
         content_type: str = "text/plain",
         forced_upload: bool = False,
-        retain_until: datetime | None = None,
+        custom_time: datetime | None = None,
     ) -> Blob:
         """Upload the content then return the blob."""
         bucket: Bucket = self.storage_client.bucket(self.bucket_name)
@@ -66,9 +66,8 @@ class GcsUploader(BaseContentUploader):
                 )
                 destination_blob.make_public()
 
-                if retain_until is not None:
-                    destination_blob.retention.mode = "Unlocked"
-                    destination_blob.retention.retain_until_time = retain_until
+                if custom_time is not None:
+                    destination_blob.custom_time = custom_time
                     destination_blob.patch()
 
         except Exception as e:

--- a/merino/utils/gcs/gcs_uploader.py
+++ b/merino/utils/gcs/gcs_uploader.py
@@ -1,6 +1,7 @@
 """Uploads Content to GCS"""
 
 import logging
+from datetime import datetime
 from typing import Callable
 from urllib.parse import urljoin
 
@@ -50,6 +51,7 @@ class GcsUploader(BaseContentUploader):
         destination_name: str,
         content_type: str = "text/plain",
         forced_upload: bool = False,
+        retain_until: datetime | None = None,
     ) -> Blob:
         """Upload the content then return the blob."""
         bucket: Bucket = self.storage_client.bucket(self.bucket_name)
@@ -63,6 +65,11 @@ class GcsUploader(BaseContentUploader):
                     content_type=content_type,
                 )
                 destination_blob.make_public()
+
+                if retain_until is not None:
+                    destination_blob.retention.mode = "Unlocked"
+                    destination_blob.retention.retain_until_time = retain_until
+                    destination_blob.patch()
 
         except Exception as e:
             logger.error(f"Exception {e} occurred while uploading {destination_name}")

--- a/tests/integration/utils/gcs/__init__.py
+++ b/tests/integration/utils/gcs/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for GCS utilities."""

--- a/tests/integration/utils/gcs/test_gcs_uploader.py
+++ b/tests/integration/utils/gcs/test_gcs_uploader.py
@@ -1,0 +1,80 @@
+"""Integration tests for GcsUploader using a fake-gcs-server container."""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from merino.utils.gcs.gcs_uploader import GcsUploader
+
+
+@pytest.fixture
+def gcs_uploader(gcs_storage_client, gcs_storage_bucket) -> GcsUploader:
+    """Return a GcsUploader pointed at the test bucket."""
+    return GcsUploader(
+        destination_gcp_project=gcs_storage_client.project,
+        destination_bucket_name=gcs_storage_bucket.name,
+        destination_cdn_hostname="",
+    )
+
+
+def test_upload_content_without_retain_until(gcs_uploader, gcs_storage_bucket):
+    """Test that blob is uploaded and accessible when retain_until is not set."""
+    content = b"hello world"
+    blob_name = "no_retain.txt"
+
+    result = gcs_uploader.upload_content(content, blob_name)
+
+    assert result is not None
+    assert result.name == blob_name
+    uploaded = gcs_storage_bucket.get_blob(blob_name)
+    assert uploaded is not None
+    assert uploaded.download_as_bytes() == content
+
+
+def test_upload_content_with_retain_until(gcs_uploader, gcs_storage_bucket):
+    """Test that blob is uploaded and retain_until_time is set on the blob when retain_until is provided."""
+    content = b"retained content"
+    blob_name = "retain_until.txt"
+    retain_time = datetime(2030, 6, 1, tzinfo=timezone.utc)
+
+    result = gcs_uploader.upload_content(content, blob_name, retain_until=retain_time)
+
+    assert result is not None
+    assert result.name == blob_name
+
+    uploaded = gcs_storage_bucket.get_blob(blob_name)
+    assert uploaded is not None
+    assert uploaded.download_as_bytes() == content
+
+    uploaded.reload()
+    if uploaded.retention.retain_until_time is not None:
+        assert uploaded.retention.retain_until_time == retain_time
+        assert uploaded.retention.mode == "Unlocked"
+
+
+def test_upload_content_skips_existing_blob(gcs_uploader, gcs_storage_bucket):
+    """Test that existing blob is not overwritten when forced_upload is False."""
+    blob_name = "skip_existing.txt"
+    original = b"original"
+    updated = b"updated"
+
+    gcs_uploader.upload_content(original, blob_name)
+    gcs_uploader.upload_content(updated, blob_name, forced_upload=False)
+
+    stored = gcs_storage_bucket.get_blob(blob_name)
+    assert stored is not None
+    assert stored.download_as_bytes() == original
+
+
+def test_upload_content_force_overwrites_existing(gcs_uploader, gcs_storage_bucket):
+    """Test that existing blob is overwritten when forced_upload is True."""
+    blob_name = "force_overwrite.txt"
+    original = b"original"
+    updated = b"updated"
+
+    gcs_uploader.upload_content(original, blob_name)
+    gcs_uploader.upload_content(updated, blob_name, forced_upload=True)
+
+    stored = gcs_storage_bucket.get_blob(blob_name)
+    assert stored is not None
+    assert stored.download_as_bytes() == updated

--- a/tests/integration/utils/gcs/test_gcs_uploader.py
+++ b/tests/integration/utils/gcs/test_gcs_uploader.py
@@ -17,10 +17,10 @@ def gcs_uploader(gcs_storage_client, gcs_storage_bucket) -> GcsUploader:
     )
 
 
-def test_upload_content_without_retain_until(gcs_uploader, gcs_storage_bucket):
-    """Test that blob is uploaded and accessible when retain_until is not set."""
+def test_upload_content_without_custom_time(gcs_uploader, gcs_storage_bucket):
+    """Test that blob is uploaded and accessible when custom_time is not set."""
     content = b"hello world"
-    blob_name = "no_retain.txt"
+    blob_name = "no_custom_time.txt"
 
     result = gcs_uploader.upload_content(content, blob_name)
 
@@ -31,13 +31,13 @@ def test_upload_content_without_retain_until(gcs_uploader, gcs_storage_bucket):
     assert uploaded.download_as_bytes() == content
 
 
-def test_upload_content_with_retain_until(gcs_uploader, gcs_storage_bucket):
-    """Test that blob is uploaded and retain_until_time is set on the blob when retain_until is provided."""
-    content = b"retained content"
-    blob_name = "retain_until.txt"
-    retain_time = datetime(2030, 6, 1, tzinfo=timezone.utc)
+def test_upload_content_with_custom_time(gcs_uploader, gcs_storage_bucket):
+    """Test that blob is uploaded and custom_time is set on the blob when custom_time is provided."""
+    content = b"test content"
+    blob_name = "custom_time.txt"
+    custom_time = datetime(2030, 6, 1, tzinfo=timezone.utc)
 
-    result = gcs_uploader.upload_content(content, blob_name, retain_until=retain_time)
+    result = gcs_uploader.upload_content(content, blob_name, custom_time=custom_time)
 
     assert result is not None
     assert result.name == blob_name
@@ -47,9 +47,8 @@ def test_upload_content_with_retain_until(gcs_uploader, gcs_storage_bucket):
     assert uploaded.download_as_bytes() == content
 
     uploaded.reload()
-    if uploaded.retention.retain_until_time is not None:
-        assert uploaded.retention.retain_until_time == retain_time
-        assert uploaded.retention.mode == "Unlocked"
+    if uploaded.custom_time is not None:
+        assert uploaded.custom_time == custom_time
 
 
 def test_upload_content_skips_existing_blob(gcs_uploader, gcs_storage_bucket):

--- a/tests/unit/jobs/engagement_model/test_init.py
+++ b/tests/unit/jobs/engagement_model/test_init.py
@@ -1,6 +1,7 @@
 """Unit tests for engagement_model CLI."""
 
 import json
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 from merino.jobs.engagement_model import upload_engagement_data
@@ -44,8 +45,11 @@ def test_upload_engagement_data_success() -> None:
     mock_settings.engagement.gcs_storage_bucket = "test-bucket"
     mock_settings.engagement.gcs_storage_project = "test-storage-project"
 
+    fixed_now = datetime(2026, 3, 16, 12, 0, 0, tzinfo=timezone.utc)
+    expected_retain_until = fixed_now + timedelta(days=30)
+
     mock_datetime = MagicMock()
-    mock_datetime.now.return_value.strftime.return_value = "20260316120000"
+    mock_datetime.now.return_value = fixed_now
 
     with (
         patch("merino.jobs.engagement_model.settings", mock_settings),
@@ -95,6 +99,7 @@ def test_upload_engagement_data_success() -> None:
         destination_name="suggest-merino-exports/engagement/keyword/20260316120000.json",
         content_type="application/json",
         forced_upload=True,
+        retain_until=expected_retain_until,
     )
     mock_uploader.upload_content.assert_any_call(
         content=expected_keyword_content,

--- a/tests/unit/jobs/engagement_model/test_init.py
+++ b/tests/unit/jobs/engagement_model/test_init.py
@@ -1,7 +1,7 @@
 """Unit tests for engagement_model CLI."""
 
 import json
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 from merino.jobs.engagement_model import upload_engagement_data
@@ -46,7 +46,6 @@ def test_upload_engagement_data_success() -> None:
     mock_settings.engagement.gcs_storage_project = "test-storage-project"
 
     fixed_now = datetime(2026, 3, 16, 12, 0, 0, tzinfo=timezone.utc)
-    expected_retain_until = fixed_now + timedelta(days=30)
 
     mock_datetime = MagicMock()
     mock_datetime.now.return_value = fixed_now
@@ -99,7 +98,7 @@ def test_upload_engagement_data_success() -> None:
         destination_name="suggest-merino-exports/engagement/keyword/20260316120000.json",
         content_type="application/json",
         forced_upload=True,
-        retain_until=expected_retain_until,
+        custom_time=fixed_now,
     )
     mock_uploader.upload_content.assert_any_call(
         content=expected_keyword_content,


### PR DESCRIPTION
## References

JIRA: [DISCO-4073](https://mozilla-hub.atlassian.net/browse/DISCO-4073)

The engagement job uploads a new timestamped file on every run. Without auto-deletion, old files accumulate indefinitely. Each timestamped file now has `custom_time` set at upload time, which a GCS lifecycle rule uses to delete files 30 days after upload without risk of removing a file still in use.

Note: The lifecycle rule has been added through terraform in a [separate PR](https://github.com/mozilla-services/cloudops-infra/pull/6871) 

Changes
- Added a `custom_time` parameter to `GcsUploader.upload_content` that sets `blob.custom_time` after upload.
- Updated the engagement model job to pass `custom_time=now` when uploading timestamped engagement files
- Added integration tests


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2259)


[DISCO-4073]: https://mozilla-hub.atlassian.net/browse/DISCO-4073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ