### PR TITLE
[AIMOD-1167] Reduce Query Normalization Cache Size

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -376,8 +376,8 @@ finance_tickers_file = "dev/query_normalization/finance_tickers.json"
 
 # MERINO_QUERY_NORMALIZATION__WORDSEGMENT_CACHE_SIZE
 # Max entries in the wordsegment LRU cache. Each entry is a token->segmentation
-# mapping (~200 bytes). 10000 entries ≈ 2 MB.
-wordsegment_cache_size = 10000
+# mapping (~200 bytes). 1000 entries ≈ 0.2 MB.
+wordsegment_cache_size = 1000
 
 # MERINO_QUERY_NORMALIZATION__PROVIDERS
 # List of provider names that receive normalized queries.


### PR DESCRIPTION
## References

JIRA: [AIMOD-1167](https://mozilla-hub.atlassian.net/browse/AIMOD-1167?atlOrigin=eyJpIjoiY2YyNzI0MjE2YmIzNDExNWI4ODY0YzQxODQzZWQwZTMiLCJwIjoiaiJ9)

## Description
Query Normalization latency is already sub 1ms and there's slight concern that that pipeline has increased memory footprint a bit. This pr should reduce in-memory footprint ~4-10MB.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2264)


[AIMOD-1167]: https://mozilla-hub.atlassian.net/browse/AIMOD-1167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ