### PR TITLE
[DISCO-4162] Suggest: tuning adm engagement data

### DIFF
--- a/merino/jobs/engagement_model/__init__.py
+++ b/merino/jobs/engagement_model/__init__.py
@@ -38,7 +38,8 @@ def upload_engagement_data() -> None:  # pragma: no cover
         wiki_data_downloader = WikiDownloader(gcs_bq_project)
 
         amp_historical: list[dict[str, Any]] = amp_data_downloader.download_historical_data()
-        amp_live: list[dict[str, Any]] = amp_data_downloader.download_live_data()
+        amp_historical = amp_data_downloader.apply_click_adjustment(amp_historical)
+        amp_live: list[dict[str, Any]] = []
         wiki_data: dict[str, int] = wiki_data_downloader.download_data()
 
         transformed_amp_data = amp_data_downloader.transform_data(

--- a/merino/jobs/engagement_model/amp_data_downloader.py
+++ b/merino/jobs/engagement_model/amp_data_downloader.py
@@ -20,7 +20,7 @@ SELECT
  COUNT(*) AS impressions
 FROM `moz-fx-data-shared-prod.search_terms_derived.suggest_impression_sanitized_v3`
 WHERE
- submission_timestamp BETWEEN TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 16 DAY) AND TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 2 DAY)
+ submission_timestamp BETWEEN TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 14 DAY) AND CURRENT_TIMESTAMP()
 AND query is not NULL
 GROUP BY 1, 2
 HAVING impressions > 500

--- a/merino/jobs/engagement_model/amp_data_downloader.py
+++ b/merino/jobs/engagement_model/amp_data_downloader.py
@@ -20,7 +20,7 @@ SELECT
  COUNT(*) AS impressions
 FROM `moz-fx-data-shared-prod.search_terms_derived.suggest_impression_sanitized_v3`
 WHERE
- submission_timestamp BETWEEN TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 9 DAY) AND TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 2 DAY)
+ submission_timestamp BETWEEN TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 16 DAY) AND TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 2 DAY)
 AND query is not NULL
 GROUP BY 1, 2
 HAVING impressions > 500
@@ -132,6 +132,17 @@ ORDER BY 1, 4 DESC
             }
 
         return result
+
+    @staticmethod
+    def apply_click_adjustment(data: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Add 3 to the click count for each row where impressions >= 3.
+        This adjustment is based on the 95% confidence interval when observing 0 event
+        for a rare random variable (which follows a Poisson Distribution).
+        """
+        return [
+            {**row, "clicks": row["clicks"] + 3} if row["impressions"] >= 3 else row
+            for row in data
+        ]
 
     @staticmethod
     def aggregate_data(_transformed: dict[str, Any]) -> dict[str, int]:

--- a/tests/unit/jobs/engagement_model/test_amp_data_downloader.py
+++ b/tests/unit/jobs/engagement_model/test_amp_data_downloader.py
@@ -175,6 +175,19 @@ def test_transform_data_returns_empty_dict_for_empty_inputs():
     assert EngagementDataDownloader.transform_data(historical=[], live=[]) == {}
 
 
+def test_apply_click_adjustment_adds_3_to_clicks_when_impressions_at_least_3():
+    """Test that 3 is added to clicks for rows where impressions >= 3."""
+    data = [
+        {"advertiser": "mozilla", "query": "firefox", "impressions": 2, "clicks": 0},
+        {"advertiser": "firefox", "query": "browser", "impressions": 100, "clicks": 10},
+    ]
+    result = EngagementDataDownloader.apply_click_adjustment(data)
+    assert result == [
+        {"advertiser": "mozilla", "query": "firefox", "impressions": 2, "clicks": 0},
+        {"advertiser": "firefox", "query": "browser", "impressions": 100, "clicks": 13},
+    ]
+
+
 def test_aggregate_data_returns_zeros():
     """Test that aggregate_data returns zeros (not yet consumed)."""
     transformed = {

--- a/tests/unit/jobs/engagement_model/test_init.py
+++ b/tests/unit/jobs/engagement_model/test_init.py
@@ -13,25 +13,21 @@ def test_upload_engagement_data_success() -> None:
         {"advertiser": "mozilla", "query": "firefox", "impressions": 100, "clicks": 5},
         {"advertiser": "firefox", "query": "browser", "impressions": 200, "clicks": 10},
     ]
-    amp_keyword_live = [
-        {"advertiser": "mozilla", "query": "firefox", "impressions": 50, "clicks": 3},
-        {"advertiser": "chrome", "query": "search", "impressions": 80, "clicks": 2},
+    amp_keyword_historical_adjusted = [
+        {"advertiser": "mozilla", "query": "firefox", "impressions": 100, "clicks": 8},
+        {"advertiser": "firefox", "query": "browser", "impressions": 200, "clicks": 13},
     ]
     wiki_data = {"impressions": 300, "clicks": 20}
 
     transformed_amp_data = {
-        "mozilla/firefox": {
-            "historical": {"impressions": 100, "clicks": 5},
-            "live": {"impressions": 50, "clicks": 3},
-        },
-        "firefox/browser": {"historical": {"impressions": 200, "clicks": 10}},
-        "chrome/search": {"live": {"impressions": 80, "clicks": 2}},
+        "mozilla/firefox": {"historical": {"impressions": 100, "clicks": 8}},
+        "firefox/browser": {"historical": {"impressions": 200, "clicks": 13}},
     }
     aggregated_amp_data = {"impressions": 0, "clicks": 0}
 
     mock_amp_downloader = MagicMock()
     mock_amp_downloader.download_historical_data.return_value = amp_keyword_historical
-    mock_amp_downloader.download_live_data.return_value = amp_keyword_live
+    mock_amp_downloader.apply_click_adjustment.return_value = amp_keyword_historical_adjusted
     mock_amp_downloader.transform_data.return_value = transformed_amp_data
     mock_amp_downloader.aggregate_data.return_value = aggregated_amp_data
 
@@ -77,10 +73,11 @@ def test_upload_engagement_data_success() -> None:
     )
 
     mock_amp_downloader.download_historical_data.assert_called_once()
-    mock_amp_downloader.download_live_data.assert_called_once()
+    mock_amp_downloader.download_live_data.assert_not_called()
+    mock_amp_downloader.apply_click_adjustment.assert_called_once_with(amp_keyword_historical)
     mock_amp_downloader.transform_data.assert_called_once_with(
-        historical=amp_keyword_historical,
-        live=amp_keyword_live,
+        historical=amp_keyword_historical_adjusted,
+        live=[],
     )
     mock_amp_downloader.aggregate_data.assert_called_once_with(transformed_amp_data)
     mock_wiki_downloader.download_data.assert_called_once()


### PR DESCRIPTION
## References

JIRA: [DISCO-4162](https://mozilla-hub.atlassian.net/browse/DISCO-4162)

## Description
Change historical window to 14 days
Set live to empty
update clicks to increase by 3 if there are more than 3 impressions



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2267)


[DISCO-4162]: https://mozilla-hub.atlassian.net/browse/DISCO-4162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ