### PR TITLE
chore(wcs): use long time window to fetch all events

### DIFF
--- a/merino/providers/suggest/sports/backends/sportsdata/common/sports.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/sports.py
@@ -653,7 +653,8 @@ class WCS(Sport):
                 default="https://api.sportsdata.io/v4/soccer/scores/json",
             ),
             cache_dir=settings.sportsdata.get("cache_dir"),
-            team_ttl=timedelta(weeks=4),
+            team_ttl=timedelta(weeks=12),
+            event_ttl=timedelta(weeks=12),
         )
         self._lock = asyncio.Lock()
         self.normalized_terms.update(


### PR DESCRIPTION


## References

[DISCO-4158]

## Description
Use long (12 weeks) time window to fetch all WCS events for suggest


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2268)


[DISCO-4158]: https://mozilla-hub.atlassian.net/browse/DISCO-4158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ