### PR TITLE
fix(gha): build locust in non-root directory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Run jobs: `uv run merino-jobs --help` (e.g. `uv run merino-jobs wikipedia-indexe
 ## Critical Gotchas
 
 - **MERINO_ENV=testing** must be set when running tests. Without it, development config loads and tests break. All Makefile test targets set this automatically.
-- **Python 3.13 only**. Pinned in `.python-version`.
+- **Python 3.14 only**. Pinned in `.python-version`.
 - **Line length is 99**, not 88 or 120.
 - **Warnings are errors** in tests (`filterwarnings = ["error"]`). Any warning from code or deps fails the test.
 - **95% code coverage** required. New code without tests fails CI.

--- a/tests/load/Dockerfile
+++ b/tests/load/Dockerfile
@@ -9,6 +9,8 @@ LABEL maintainer="Content Discovery Services (DISCO) Team <disco-team@mozilla.co
 # Install uv
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
+WORKDIR /app
+
 # Copy over app dependencies
 COPY ./pyproject.toml ./uv.lock ./
 
@@ -24,7 +26,7 @@ RUN apt-get update && \
 
 ENV LANG=C.UTF-8
 ENV PYTHONUNBUFFERED=1
-ENV PYTHON_VENV=/.venv
+ENV PYTHON_VENV=/app/.venv
 ENV PATH="${PYTHON_VENV}/bin:${PATH}"
 
 # Add locust as a non-root user


### PR DESCRIPTION


## References


## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->
* fix(gha): build locust in non-root directory

Per claude, the hatchling safe_walk on the root directory will enumerate entries in `/proc` which might be closed or die, resulting in flaky failures when running os.stat(root) on the now-deleted path

e.g. FileNotFoundError: [Errno 2] No such file or directory: '/proc/1478/task/1494/fd/39'

* chore(claude): update version to reflect python 3.14 update


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2269)
