### PR TITLE
DISCO-4164 Fetching yesterdays games correctly for sports provider

### DIFF
--- a/merino/providers/suggest/sports/backends/sportsdata/common/sports.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/sports.py
@@ -287,10 +287,10 @@ class NHL(Sport):
         self.load_schedules_from_source(response, event_timezone=local_timezone)
         date_list = []
         for _id, event in list(self.events.items()):
-            day = event.date.strftime("%Y-%b-%d").upper()
-            if (
-                not event.status.is_scheduled() and day not in date_list
-            ):  # pragma: no cover "covered by test_nhl_update_events"
+            # sportsdata.io keys date-by-day endpoints on the league's local game day,
+            # not UTC. event.date is UTC, so a 10pm-ET game lives on the prior day's URL.
+            day = event.date.astimezone(local_timezone).strftime("%Y-%b-%d").upper()
+            if not event.status.is_scheduled() and day not in date_list:
                 url = f"{self.base_url}/GamesByDate/{day}"
                 response = await get_data(
                     client=client,
@@ -400,7 +400,9 @@ class NBA(Sport):
         # update scores based on events:
         # Events may cross multiple days, so we should update those scores.
         for _id, event in list(self.events.items()):
-            day = event.date.strftime("%Y-%b-%d").upper()
+            # sportsdata.io keys date-by-day endpoints on the league's local game day,
+            # not UTC. event.date is UTC, so a 10pm-ET game lives on the prior day's URL.
+            day = event.date.astimezone(local_timezone).strftime("%Y-%b-%d").upper()
             if not event.status.is_scheduled() and day not in date_list:
                 url = f"{self.base_url}/ScoresBasic/{day}"
                 response = await get_data(
@@ -618,7 +620,6 @@ class MLB(Sport):
         local_timezone = ZoneInfo("America/New_York")
         logger.debug(f"{LOGGING_TAG} Getting {self.name} schedules")
         url = f"{self.base_url}/SchedulesBasic/{self.season}"
-        local_timezone = ZoneInfo("UTC")
         response = await get_data(
             client=client,
             url=url,
@@ -631,7 +632,9 @@ class MLB(Sport):
         # update scores based on events
         # Events may cross multiple days, so we should update those scores.
         for _id, event in list(self.events.items()):
-            day = event.date.strftime("%Y-%b-%d").upper()
+            # sportsdata.io keys date-by-day endpoints on the league's local game day,
+            # not UTC. event.date is UTC, so a 10pm-ET game lives on the prior day's URL.
+            day = event.date.astimezone(local_timezone).strftime("%Y-%b-%d").upper()
             if not event.status.is_scheduled() and day not in date_list:
                 url = f"{self.base_url}/ScoresBasic/{day}"
                 response = await get_data(

--- a/tests/unit/providers/suggest/sports/backends/common/test_sports.py
+++ b/tests/unit/providers/suggest/sports/backends/common/test_sports.py
@@ -1799,6 +1799,55 @@ async def test_nba_update_events(
         ]
 
 
+@freezegun.freeze_time("2026-05-05T12:00:00", tz_offset=0)
+@pytest.mark.asyncio
+async def test_nba_update_events_score_url_uses_local_game_day(
+    mock_client: AsyncClient,
+    mocker: MockerFixture,
+) -> None:
+    """ScoresBasic URL must be keyed on the league's ET game day, not UTC.
+
+    Regression for DISCO-4164: an evening-ET game whose DateTimeUTC rolls into the
+    next UTC day was being looked up under the wrong /ScoresBasic/{day} endpoint,
+    so its score never landed.
+    """
+    nba = NBA(settings=settings.providers.sports)
+    nba.load_teams_from_source(nba_teams_payload())
+    nba.season = "2026POST"
+    nba.event_ttl = timedelta(weeks=2)
+
+    # 9:30pm ET on May 4, which is 01:30 UTC on May 5 — the bug case.
+    game_utc = "2026-05-05T01:30:00"
+    schedules_payload = nba_schedule_payload()
+    schedules_payload[0].update(
+        {
+            "Day": "2026-05-04T00:00:00",
+            "DateTime": "2026-05-04T21:30:00",
+            "DateTimeUTC": game_utc,
+            "Status": "Final",
+        }
+    )
+    schedules_payload[1].update(
+        {
+            "Day": "2026-05-04T00:00:00",
+            "DateTime": "2026-05-04T21:30:00",
+            "DateTimeUTC": game_utc,
+            "Status": "Scheduled",
+        }
+    )
+
+    get_data = mocker.patch(
+        "merino.providers.suggest.sports.backends.sportsdata.common.sports.get_data",
+        side_effect=[schedules_payload, []],
+    )
+
+    await nba.update_events(client=mock_client)
+
+    urls = [call.kwargs["url"] for call in get_data.call_args_list]
+    assert "https://api.sportsdata.io/v3/nba/scores/json/ScoresBasic/2026-MAY-04" in urls
+    assert "https://api.sportsdata.io/v3/nba/scores/json/ScoresBasic/2026-MAY-05" not in urls
+
+
 @freezegun.freeze_time("2025-09-22T00:00:00", tz_offset=0)
 @pytest.mark.asyncio
 async def test_mlb_update_events(


### PR DESCRIPTION
## References

JIRA: [DISCO-4164](https://mozilla-hub.atlassian.net/browse/DISCO-4164)

## Description
The score-fetch loop formatted event.date (a UTC datetime) directly into the `ScoresBasic/{day}` URL, but sportsdata.io keys those endpoints on the league's local game day (Eastern Time for NBA, NHL, MLB). 

Any evening-ET game whose UTC instant rolled into the next day, including every West Coast tip-off, was looked up under a `{day}` that didn't contain the game, so its score never landed in Elasticsearch. 

NBA playoffs surfaced it because most games tip after 9pm ET; UCL and WCS were unaffected because their local_timezone was already UTC.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2271)


[DISCO-4164]: https://mozilla-hub.atlassian.net/browse/DISCO-4164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ