### PR TITLE
DISCO-4167 Fix for showing todays game in favour of "next" game

### DIFF
--- a/merino/providers/suggest/sports/backends/sportsdata/common/elastic.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/elastic.py
@@ -716,8 +716,10 @@ class SportsDataStore(ElasticDataStore):
                         if "next" not in filter[sport]:
                             filter[sport]["next"] = event
                             continue
-                        # get the most recent "next" game
-                        if datetime.fromisoformat(filter[sport]["next"]["date"]) < event_date:
+                        # Keep the soonest scheduled game. Hits arrive sorted by date desc,
+                        # so without this comparator the farthest-future game wins and
+                        # today's game is shadowed by next week's. (DISCO-4167)
+                        if datetime.fromisoformat(filter[sport]["next"]["date"]) > event_date:
                             filter[sport]["next"] = event
                     if status.is_in_progress():
                         # remove the previous game info because we have a current one.

--- a/tests/unit/providers/suggest/sports/backends/common/test_elastic.py
+++ b/tests/unit/providers/suggest/sports/backends/common/test_elastic.py
@@ -332,10 +332,10 @@ async def test_sports_search_event_hits(
                 "updated": "2025-09-22T12:00:00+00:00",
             },
             "next": {
-                "date": "2025-09-25T12:00:00+00:00",
-                "es_score": 2.0,
+                "date": "2025-09-24T12:00:00+00:00",
+                "es_score": 2.1,
                 "event_status": GameStatus.Scheduled,
-                "label": "delta",
+                "label": "epsilon",
                 "sport": "NFL",
                 "status": "Scheduled",
                 "touched": "None",
@@ -345,6 +345,77 @@ async def test_sports_search_event_hits(
     }
 
     assert result == expected_result
+
+
+@freezegun.freeze_time("2026-05-05T17:25:00Z")
+@pytest.mark.asyncio
+@pytest.mark.parametrize("sport", ["MLB", "UCL"])
+async def test_sports_search_next_picks_soonest_scheduled(
+    sport_data_store: SportsDataStore,
+    es_client: AsyncMock,
+    sport: str,
+):
+    """Regression for DISCO-4167.
+
+    With multiple scheduled fixtures in the index (today + later this week),
+    `next` must hold the soonest one. Hits arrive sorted `date: desc`, so a
+    naive comparator keeps the farthest-future game and shadows today's.
+    """
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    today = now + datetime.timedelta(hours=5)
+    tomorrow = now + datetime.timedelta(days=1)
+    next_week = now + datetime.timedelta(days=7)
+
+    hits = [
+        {
+            "_score": 1.0,
+            "_source": {
+                "event": json.dumps(
+                    {
+                        "sport": sport,
+                        "status": "Scheduled",
+                        "label": "next-week",
+                        "date": next_week.isoformat(),
+                        "updated": now.isoformat(),
+                    }
+                )
+            },
+        },
+        {
+            "_score": 1.0,
+            "_source": {
+                "event": json.dumps(
+                    {
+                        "sport": sport,
+                        "status": "Scheduled",
+                        "label": "tomorrow",
+                        "date": tomorrow.isoformat(),
+                        "updated": now.isoformat(),
+                    }
+                )
+            },
+        },
+        {
+            "_score": 1.0,
+            "_source": {
+                "event": json.dumps(
+                    {
+                        "sport": sport,
+                        "status": "Scheduled",
+                        "label": "today",
+                        "date": today.isoformat(),
+                        "updated": now.isoformat(),
+                    }
+                )
+            },
+        },
+    ]
+    es_client.search.return_value = {"hits": {"total": {"value": 3}, "hits": hits}}
+
+    result = await sport_data_store.search_events(q="game", language_code="en", mix_sports=False)
+
+    assert result[sport]["next"]["label"] == "today"
+    assert result[sport]["next"]["date"] == today.isoformat()
 
 
 @freezegun.freeze_time("2025-09-22T12:00:00Z")


### PR DESCRIPTION
## References

JIRA: [DISCO-4167](https://mozilla-hub.atlassian.net/browse/DISCO-4167)

## Description
`search_events` ranked Scheduled hits with a < comparator against ES results sorted date: desc, so next always held the farthest-future fixture and today's MLB/UCL games were shadowed by next week's. Flipping it to > keeps the soonest upcoming game; updated the existing test that had codified the broken behavior and added a parametrized regression covering both leagues.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2272)


[DISCO-4167]: https://mozilla-hub.atlassian.net/browse/DISCO-4167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ