### PR TITLE
[DISCO-4171] feat: Add a threshold tag for the thompson sampling metrics

### DIFF
--- a/merino/optimizers/models.py
+++ b/merino/optimizers/models.py
@@ -35,6 +35,12 @@ class EngagementMetrics(BaseModel):
         """Derive a property for not engaged activities adjusted to be no less than 1."""
         return max(self.attempted - self.engaged, 1)
 
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def ratio(self) -> float:
+        """Derive a property for the engagement ratio."""
+        return self.engaged / self.attempted
+
 
 class ThompsonConfig(BaseModel):
     """Model for Thompson sampling configuration."""

--- a/merino/optimizers/thompson.py
+++ b/merino/optimizers/thompson.py
@@ -15,6 +15,20 @@ class ThompsonSampler:
     def __init__(self, config: ThompsonConfig) -> None:
         self.config = config
 
+    def below_threshold(self, candidate: ThompsonCandidate) -> bool:
+        """Check if the given candidate's engagement ratio is below that of the dummy candidate.
+
+        Params:
+            - `candidate`: a candidates of type `ThompsonCandidate`.
+        Returns:
+            A boolean. True if the candidate's engagement ratio is below the dummy's CTR,
+            otherwise false. When the dummy is unset, this always returns false.
+        """
+        dummy_ratio: float = (
+            self.config.dummy_candidate.ratio if self.config.dummy_candidate else 0
+        )
+        return candidate.metrics.ratio < dummy_ratio
+
     def sample(self, candidates: list[ThompsonCandidate]) -> ThompsonCandidate | None:
         """Apply Thompson sampling to a set of candidates.
 

--- a/merino/providers/suggest/adm/provider.py
+++ b/merino/providers/suggest/adm/provider.py
@@ -273,11 +273,14 @@ class Provider(BaseProvider):
                 for i, suggestion in enumerate(suggestions)
             ]
 
-            tags = {}
+            tags: dict[str, Any] = {}
             if suggestions:
                 # FIXME(nanj): this uses the first element as the subject as `suggestions`
                 # should always be a singleton list. Update it if that's false in the future.
                 tags["subject"] = suggestions[0].advertiser.lower()
+                tags["below_threshold"] = cast(ThompsonSampler, self.thompson).below_threshold(
+                    candidates[0]
+                )
 
             # If it's the only candidate with an attempted count less than the threshold, skip sampling.
             if len(candidates) == 1 and candidates[0].metrics.attempted < self.min_attempted_count:

--- a/merino/providers/suggest/adm/provider.py
+++ b/merino/providers/suggest/adm/provider.py
@@ -273,13 +273,15 @@ class Provider(BaseProvider):
                 for i, suggestion in enumerate(suggestions)
             ]
 
-            tags: dict[str, Any] = {}
+            tags = {}
             if suggestions:
                 # FIXME(nanj): this uses the first element as the subject as `suggestions`
                 # should always be a singleton list. Update it if that's false in the future.
                 tags["subject"] = suggestions[0].advertiser.lower()
-                tags["below_threshold"] = cast(ThompsonSampler, self.thompson).below_threshold(
-                    candidates[0]
+                tags["below_threshold"] = (
+                    "true"
+                    if cast(ThompsonSampler, self.thompson).below_threshold(candidates[0])
+                    else "false"
                 )
 
             # If it's the only candidate with an attempted count less than the threshold, skip sampling.

--- a/metrics.yaml
+++ b/metrics.yaml
@@ -248,6 +248,10 @@ suggest/adm:
       - name: subject
         description: |
           The identifier of the subject that has gone through Thompson sampling
+      - name: below_threshold
+        description: |
+          Whether the engagement ratio of the selected/suppressed candidate is below
+          that of the dummy candidate.
     scope: |
       The "api/v1/suggest" API endpoint.
     alert_policy: []

--- a/tests/unit/optimizers/test_models.py
+++ b/tests/unit/optimizers/test_models.py
@@ -53,6 +53,19 @@ class TestEngagementMetrics:
         assert m.engaged == 5
         assert m.attempted == 5
 
+    @pytest.mark.parametrize(
+        "engaged, attempted, ratio",
+        [
+            (0, 0, 1 / 1),  # 0 counters will be adjusted
+            (1, 5, 1 / 5),
+            (5, 5, 5 / 5),
+        ],
+    )
+    def test_ratio(self, engaged: int, attempted: int, ratio: float) -> None:
+        """Ratio should be calculated."""
+        m = EngagementMetrics(engaged=engaged, attempted=attempted)
+        assert m.ratio == pytest.approx(ratio)
+
 
 class TestThompsonConfig:
     """Tests for ThompsonConfig model."""

--- a/tests/unit/optimizers/test_thompson.py
+++ b/tests/unit/optimizers/test_thompson.py
@@ -31,6 +31,15 @@ class TestThompsonSamplerSingleCandidate:
         candidate = make_candidate("a", engaged=5, attempted=10)
         assert sampler.sample([candidate]) is candidate
 
+    def test_below_threshold_without_dummy(self) -> None:
+        """Always return false if no dummy."""
+        sampler = ThompsonSampler(config=ThompsonConfig(random_seed=0))
+        candidate = make_candidate("a", engaged=5, attempted=10)
+        assert not sampler.below_threshold(candidate)
+
+        candidate = make_candidate("a", engaged=0, attempted=0)
+        assert not sampler.below_threshold(candidate)
+
     def test_single_candidate_dummy_always_wins(self) -> None:
         """A dummy with near-certain engagement beats a very poor candidate."""
         # dummy: engaged=1000, not_engaged=1 → beta sample ≈ 1.0
@@ -39,6 +48,13 @@ class TestThompsonSamplerSingleCandidate:
         sampler = ThompsonSampler(config=ThompsonConfig(dummy_candidate=dummy, random_seed=0))
         candidate = make_candidate("a", engaged=1, attempted=1000)
         assert sampler.sample([candidate]) is None
+
+    def test_below_threshold_with_dummy(self) -> None:
+        """Compare threshold with dummy."""
+        dummy = EngagementMetrics(engaged=1000, attempted=1001)
+        sampler = ThompsonSampler(config=ThompsonConfig(dummy_candidate=dummy, random_seed=0))
+        candidate = make_candidate("a", engaged=5, attempted=10)
+        assert sampler.below_threshold(candidate)
 
     def test_single_candidate_dummy_always_loses(self) -> None:
         """A very poor dummy never beats a near-certain candidate."""

--- a/tests/unit/providers/suggest/adm/test_provider_thompson.py
+++ b/tests/unit/providers/suggest/adm/test_provider_thompson.py
@@ -70,7 +70,7 @@ async def test_query_with_thompson_returns_suggestion(
     ]
     statsd_mock.increment.assert_called_once_with(
         "providers.adm.thompson.select",
-        tags={"outcome": "selected", "subject": "example.org", "below_threshold": False},
+        tags={"outcome": "selected", "subject": "example.org", "below_threshold": "false"},
     )
 
 
@@ -94,7 +94,7 @@ async def test_query_with_thompson_dummy_suppresses_suggestion(
     assert res == []
     statsd_mock.increment.assert_called_once_with(
         "providers.adm.thompson.select",
-        tags={"outcome": "suppressed", "subject": "example.org", "below_threshold": False},
+        tags={"outcome": "suppressed", "subject": "example.org", "below_threshold": "false"},
     )
 
 
@@ -227,7 +227,7 @@ async def test_query_with_thompson_single_candidate_below_threshold_returns_sugg
     ]
     statsd_mock.increment.assert_called_once_with(
         "providers.adm.thompson.select",
-        tags={"outcome": "skipped", "subject": "example.org", "below_threshold": True},
+        tags={"outcome": "skipped", "subject": "example.org", "below_threshold": "true"},
     )
 
 
@@ -296,7 +296,7 @@ async def test_query_with_thompson_returns_fallback_when_fallback_enabled(
     ]
     statsd_mock.increment.assert_called_once_with(
         "providers.adm.thompson.select",
-        tags={"outcome": "selected", "subject": "example.org", "below_threshold": False},
+        tags={"outcome": "selected", "subject": "example.org", "below_threshold": "false"},
     )
 
 
@@ -337,5 +337,5 @@ async def test_query_with_thompson_dummy_return_suggestion_when_fallback_enabled
     ]
     statsd_mock.increment.assert_called_once_with(
         "providers.adm.thompson.select",
-        tags={"outcome": "suppressed", "subject": "example.org", "below_threshold": False},
+        tags={"outcome": "suppressed", "subject": "example.org", "below_threshold": "false"},
     )

--- a/tests/unit/providers/suggest/adm/test_provider_thompson.py
+++ b/tests/unit/providers/suggest/adm/test_provider_thompson.py
@@ -69,7 +69,8 @@ async def test_query_with_thompson_returns_suggestion(
         )
     ]
     statsd_mock.increment.assert_called_once_with(
-        "providers.adm.thompson.select", tags={"outcome": "selected", "subject": "example.org"}
+        "providers.adm.thompson.select",
+        tags={"outcome": "selected", "subject": "example.org", "below_threshold": False},
     )
 
 
@@ -92,7 +93,8 @@ async def test_query_with_thompson_dummy_suppresses_suggestion(
 
     assert res == []
     statsd_mock.increment.assert_called_once_with(
-        "providers.adm.thompson.select", tags={"outcome": "suppressed", "subject": "example.org"}
+        "providers.adm.thompson.select",
+        tags={"outcome": "suppressed", "subject": "example.org", "below_threshold": False},
     )
 
 
@@ -224,7 +226,8 @@ async def test_query_with_thompson_single_candidate_below_threshold_returns_sugg
         )
     ]
     statsd_mock.increment.assert_called_once_with(
-        "providers.adm.thompson.select", tags={"outcome": "skipped", "subject": "example.org"}
+        "providers.adm.thompson.select",
+        tags={"outcome": "skipped", "subject": "example.org", "below_threshold": True},
     )
 
 
@@ -292,7 +295,8 @@ async def test_query_with_thompson_returns_fallback_when_fallback_enabled(
         )
     ]
     statsd_mock.increment.assert_called_once_with(
-        "providers.adm.thompson.select", tags={"outcome": "selected", "subject": "example.org"}
+        "providers.adm.thompson.select",
+        tags={"outcome": "selected", "subject": "example.org", "below_threshold": False},
     )
 
 
@@ -332,5 +336,6 @@ async def test_query_with_thompson_dummy_return_suggestion_when_fallback_enabled
         )
     ]
     statsd_mock.increment.assert_called_once_with(
-        "providers.adm.thompson.select", tags={"outcome": "suppressed", "subject": "example.org"}
+        "providers.adm.thompson.select",
+        tags={"outcome": "suppressed", "subject": "example.org", "below_threshold": False},
     )


### PR DESCRIPTION
## References

JIRA: [DISCO-4171](https://mozilla-hub.atlassian.net/browse/DISCO-4171)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->

To better understand the impact of Thompson sampling, a boolean tag is added to indicate whether the candidate's engagement ratio is below that of the baseline.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2276)


[DISCO-4171]: https://mozilla-hub.atlassian.net/browse/DISCO-4171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ