### PR TITLE
Adjust amount of boosting for local reranking

### DIFF
--- a/merino/curated_recommendations/prior_backends/engagment_rescaler.py
+++ b/merino/curated_recommendations/prior_backends/engagment_rescaler.py
@@ -23,7 +23,7 @@ PESSIMISTIC_PRIOR_ALPHA_SCALE_SUBTOPIC = 0.35
 
 
 LOCAL_RERANK_WEGHT = (
-    110.0  # Experiment weight settings 60-10 server-local boosting.
+    90.0  # Experiment weight settings 60-10 server-local boosting.
           # Given high ctr item 0.005 and interest of 0.5 that would
           # add an effective 0.08 boost that would be divided by the
           # value specified here. (60.0 => 0.0013, 100 => 0.0008)

--- a/merino/curated_recommendations/prior_backends/engagment_rescaler.py
+++ b/merino/curated_recommendations/prior_backends/engagment_rescaler.py
@@ -23,10 +23,10 @@ PESSIMISTIC_PRIOR_ALPHA_SCALE_SUBTOPIC = 0.35
 
 
 LOCAL_RERANK_WEGHT = (
-    90.0  # Experiment weight settings 60-10 server-local boosting.
-          # Given high ctr item 0.005 and interest of 0.5 that would
-          # add an effective 0.08 boost that would be divided by the
-          # value specified here. (60.0 => 0.0013, 100 => 0.0008)
+    80.0  # Experiment weight settings 60-10 server-local boosting.
+    # Given high ctr item 0.005 and interest of 0.5 that would
+    # add an effective 0.083 (.5/6) boost that would be divided by the
+    # value specified here. (60.0 => 0.0013, 100 => 0.0008)
 )
 
 FIXED_ITEM_TARGET_ARTICLE_IMPRESSIONS = 12000

--- a/merino/curated_recommendations/prior_backends/engagment_rescaler.py
+++ b/merino/curated_recommendations/prior_backends/engagment_rescaler.py
@@ -23,7 +23,10 @@ PESSIMISTIC_PRIOR_ALPHA_SCALE_SUBTOPIC = 0.35
 
 
 LOCAL_RERANK_WEGHT = (
-    30.0  # Gives items a slight boost. Ave ctr 0.002, and this number is multipled, then
+    110.0  # Experiment weight settings 60-10 server-local boosting.
+          # Given high ctr item 0.005 and interest of 0.5 that would
+          # add an effective 0.08 boost that would be divided by the
+          # value specified here. (60.0 => 0.0013, 100 => 0.0008)
 )
 
 FIXED_ITEM_TARGET_ARTICLE_IMPRESSIONS = 12000


### PR DESCRIPTION
## References

https://mozilla-hub.atlassian.net/browse/AIMOD-1197

## Description
Adjust the server score value that affects local re-reranking in inferred personalization. The initial results show that clicks are down somewhat in the treatment branch, which suggests that perhaps the local re-ranking is turned up a bit too much.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2277)
