### PR TITLE
[DISCO-4175] feat(wcs): update command for syncing wcs data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,8 @@ ENV PATH="$APP_HOME/.venv/bin:$PATH"
 # Create a build context that can be used for running merino jobs
 FROM app_base AS job_runner
 
+USER app
+
 # Set entrypoint to use uv
 ENTRYPOINT ["uv", "run", "--no-project", "python", "-m", "merino.jobs.cli"]
 

--- a/merino/jobs/sportsdata_jobs/__init__.py
+++ b/merino/jobs/sportsdata_jobs/__init__.py
@@ -20,6 +20,7 @@ hardcoded in the calling function for now, but is based on the file creation tim
 """
 
 import asyncio
+import copy
 import logging
 import typer
 import sys
@@ -27,7 +28,11 @@ from time import time
 from datetime import datetime, timedelta, timezone
 from httpx import AsyncClient
 from dynaconf.base import LazySettings
-from typing import cast
+from typing import TYPE_CHECKING
+from sentry_sdk.crons import monitor
+
+if TYPE_CHECKING:
+    from sentry_sdk._types import MonitorConfig
 
 from aiodogstatsd import Client
 
@@ -55,6 +60,24 @@ from merino.providers.suggest.sports.backends.sportsdata.common.sports import (
 )
 from merino.utils.http_client import create_http_client
 from merino.utils.metrics import get_metrics_client
+
+
+# Sentry monitor config for WCS cron jobs
+wcs_monitor_config: "MonitorConfig" = {
+    "schedule": {"type": "crontab", "value": "*/3 * * * *"},
+    # If an expected check-in doesn't come in `checkin_margin`
+    # minutes, it'll be considered missed
+    "checkin_margin": 2,
+    # The check-in is allowed to run for `max_runtime` minutes
+    # before it's considered failed
+    "max_runtime": 3,
+    # It'll take `failure_issue_threshold` consecutive failed
+    # check-ins to create an issue
+    "failure_issue_threshold": 2,
+    # It'll take `recovery_threshold` OK check-ins to resolve
+    # an issue
+    "recovery_threshold": 3,
+}
 
 
 class Options:
@@ -238,6 +261,19 @@ class SportDataUpdater:
             await sport.update_teams(client=self.client)
         await sport.cache_teams()  # type: ignore
 
+    async def update_and_cache_wcs(self) -> None:
+        """Update Elasticsearch data and refresh the widget cache."""
+        sport = self.sports.get("WCS")
+        if sport is None:
+            return
+        with monitor(monitor_slug="wcs-etl", monitor_config=wcs_monitor_config):
+            # TODO: Ensure errors bubble up to caller or are otherwise elevated
+            # so we can track success/fail here
+            await self.store.startup()
+            await self.update_data()
+            await self.update_widget()
+            await self.store.shutdown()
+
 
 logger = logging.getLogger(__name__)
 sports_settings = settings.providers.sports
@@ -324,6 +360,24 @@ def update_widget():
     """Update widget based info"""
     if provider:
         asyncio.run(provider.update_widget())
+    else:
+        logger.error("Sports provider unavailable.")
+
+
+@cli.command("update-and-cache-wcs")
+def update_and_cache_wcs():
+    """Update Elasticsearch data and refresh the widget cache for WCS (only)."""
+    if store and cache:
+        wcs_only_settings = copy.copy(sports_settings)
+        wcs_only_settings.sports = ["WCS"]
+        wcs_provider = SportDataUpdater(
+            settings=wcs_only_settings,
+            store=store,
+            cache=cache,
+            connect_timeout=sports_settings.get("connect_timeout"),
+            read_timeout=sports_settings.get("read_timeout"),
+        )
+        asyncio.run(wcs_provider.update_and_cache_wcs())
     else:
         logger.error("Sports provider unavailable.")
 

--- a/merino/jobs/sportsdata_jobs/__init__.py
+++ b/merino/jobs/sportsdata_jobs/__init__.py
@@ -67,7 +67,7 @@ wcs_monitor_config: "MonitorConfig" = {
     "schedule": {"type": "crontab", "value": "*/3 * * * *"},
     # If an expected check-in doesn't come in `checkin_margin`
     # minutes, it'll be considered missed
-    "checkin_margin": 2,
+    "checkin_margin": 1,
     # The check-in is allowed to run for `max_runtime` minutes
     # before it's considered failed
     "max_runtime": 3,


### PR DESCRIPTION
## References

JIRA: [DISCO-4175](https://mozilla-hub.atlassian.net/browse/DISCO-4175)

## Description
Update job command to sync in redis and elasticsearch. Overrides the settings so that WCS and only WCS is synced.

Includes Sentry monitoring check-ins to automatically alert if job fails or does not check in on expected timeline.

Used by https://github.com/mozilla/webservices-infra/pull/10880

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2278)


[DISCO-4175]: https://mozilla-hub.atlassian.net/browse/DISCO-4175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ