### PR TITLE
fix(sports): fix api key fallback resolution

### DIFF
--- a/merino/providers/suggest/sports/backends/sportsdata/common/data.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/data.py
@@ -287,8 +287,11 @@ class Sport:
         # Set defaults for overrides
         # NOTE: This also handles a potential typo in the AirFlow environment variable name.
         # See https://mozilla-hub.atlassian.net/browse/DISCO-3802
-        self.api_key = api_key or settings.sportsdata.get(
-            "api_key", os.environ.get("MERINO_PROVIDERS__SPORTS__SPORTSDATA_API_KEY")
+        self.api_key = (
+            api_key
+            or settings.sportsdata.get("api_key")
+            or os.environ.get("MERINO_PROVIDERS__SPORTS__SPORTSDATA_API_KEY")
+            or ""
         )
         logger.info(f"{LOGGING_TAG} SportsData API Key: {self.api_key[:4] or 'None'}")
         self.base_url = base_url


### PR DESCRIPTION
## References

JIRA: [DISCO-4169]

## Description
Fixes fallback for environment variable value in prod/stage environments.

making a real regression test for this wasn't juice worth the squeeze, but the issue is that "" is not falsy enough (has to be None) to trigger use of the fallback for dictionary `get`. Console example:

```python
>>> None or {'a': ""}.get("a", "abc")
''
>>> None or "" or "abc"
'abc'
```

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2289)


[DISCO-4169]: https://mozilla-hub.atlassian.net/browse/DISCO-4169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ