### PR TITLE
DISCO0-4168: re-enable wcs ingest

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -451,7 +451,7 @@ hourly_forecast_ttl_sec = 1800
 type="sports"
 # MERINO_PROVIDERS__SPORTS__SPORTS
 # e.g. ["NFL","NBA","NHL"]
-sports=["NFL","NBA","NHL","MLB","UCL"]
+sports=["NFL","NBA","NHL","MLB","UCL","WCS"]
 # required for WCS:
 cache="redis"
 # Index names for Elastic Search.


### PR DESCRIPTION
## References

JIRA: [DISCO-4168](https://mozilla-hub.atlassian.net/browse/DISCO-4168)

## Description
Re-applies #1466 (reverted in #1468) so the Suggest API loads the WCS sport. The k8s WCS ETL cron is live in stage as of the previous deploy and is writing events to its own Redis; this change wires the Airflow update path into Elasticsearch so /suggest returns WCS results.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2290)


[DISCO-4168]: https://mozilla-hub.atlassian.net/browse/DISCO-4168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ