### PR TITLE
[DISCO-4180] chore: Allow dual redis connections

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -251,6 +251,12 @@ socket_connect_timeout_sec = 3
 # Timeout to interact with Redis in seconds
 socket_timeout_sec = 3
 
+# MERINO_REDIS__WCS_SERVER - URI to the WCS Redis primary endpoint.
+wcs_server = "redis://localhost:6379"
+
+# MERINO_REDIS__WCS_REPLICA - URI to the WCS Redis replica endpoint.
+wcs_replica = "redis://localhost:6379"
+
 [default.sentry]
 # MERINO_SENTRY__MODE
 # Any of "release", "debug", or "disabled".

--- a/merino/jobs/sportsdata_jobs/__init__.py
+++ b/merino/jobs/sportsdata_jobs/__init__.py
@@ -304,8 +304,8 @@ if elastic_credentials.validate():
         cache = (
             RedisAdapter(
                 *create_redis_clients(
-                    settings.redis.server,
-                    settings.redis.replica,
+                    settings.redis.wcs_server,
+                    settings.redis.wcs_replica,
                     settings.redis.max_connections,
                     settings.redis.socket_connect_timeout_sec,
                     settings.redis.socket_timeout_sec,

--- a/merino/providers/suggest/manager.py
+++ b/merino/providers/suggest/manager.py
@@ -373,8 +373,8 @@ def _create_provider(provider_id: str, setting: Settings) -> BaseProvider:
             cache = (
                 RedisAdapter(
                     *create_redis_clients(
-                        settings.redis.server,
-                        settings.redis.replica,
+                        settings.redis.wcs_server,
+                        settings.redis.wcs_replica,
                         settings.redis.max_connections,
                         settings.redis.socket_connect_timeout_sec,
                         settings.redis.socket_timeout_sec,


### PR DESCRIPTION
## References

JIRA: [DISCO-4180](https://mozilla-hub.atlassian.net/browse/DISCO-4180)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->

Webservice-infra changes: https://github.com/mozilla/webservices-infra/pull/10896


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2291)


[DISCO-4180]: https://mozilla-hub.atlassian.net/browse/DISCO-4180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ