### PR TITLE
Bug/disco 4190 name

### DIFF
--- a/merino/providers/suggest/sports/backends/sportsdata/protocol.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/protocol.py
@@ -1,6 +1,6 @@
 """Protocol for sport suggestion backends."""
 
-from typing import Any, Optional
+from typing import Any, Optional, cast
 from datetime import datetime
 from pydantic import HttpUrl
 
@@ -62,10 +62,12 @@ class SportEventDetail(BaseModel):
                 return None
             return get_logo_url(category, key)
 
+        sport_map = {"fifa": "World Cup"}
         home_team_key = event.get("home_team", {}).get("key")
         away_team_key = event.get("away_team", {}).get("key")
+        sport = sport_map.get(event["sport"].lower(), event["sport"])
         return cls(
-            sport=event["sport"],
+            sport=cast(str, sport),
             query=build_query(event),
             # The following essentially converts `Z$` to `+00:00`, which
             # keeps the output consistent with prior versions

--- a/tests/unit/providers/suggest/sports/backends/test_sports_backend.py
+++ b/tests/unit/providers/suggest/sports/backends/test_sports_backend.py
@@ -378,6 +378,23 @@ def test_sport_event_detail_category(sport: str, expected_category: SportCategor
     assert result.sport_category == expected_category
 
 
+def test_sport_event_detail_remap() -> None:  # WCS, Widget
+    """Test sport name mapping and fallback behavior"""
+    event: dict = {
+        "sport": "fifa",
+        "date": "2025-10-01T00:00:00+00:00",
+        "event_status": GameStatus.Scheduled,
+        "home_team": {"key": "HOM", "name": "Home Team", "colors": ["000000"]},
+        "away_team": {"key": "AWY", "name": "Away Team", "colors": ["FFFFFF"]},
+        "home_score": None,
+        "away_score": None,
+        "touched": "2025-10-01T00:00:00+00:00",
+    }
+
+    result = SportEventDetail.from_event_dict(event)
+    assert result.sport == "World Cup"
+
+
 def test_sport_event_detail_icon_set_when_team_in_manifest(
     mocker: MockerFixture, make_manifest
 ) -> None:


### PR DESCRIPTION
## References

JIRA: [DISCO-4190](https://mozilla-hub.atlassian.net/browse/DISCO-4190)

## Description
Map the prior sport name to "World Cup" when needed.
(This is for outbound "suggestions")




## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2296)


[DISCO-4190]: https://mozilla-hub.atlassian.net/browse/DISCO-4190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ