### PR TITLE
AIMOD-137 - Generalize article exploration and expand Fixed tiles to Canada

### DIFF
--- a/merino/curated_recommendations/prior_backends/constant_prior.py
+++ b/merino/curated_recommendations/prior_backends/constant_prior.py
@@ -18,6 +18,7 @@ class ConstantPrior(PriorBackend):
         return Prior(
             alpha=188,  # beta * P99 German NewTab CTR for 2023-03-28 to 2023-04-05 (1.5%)
             beta=12500,  # 0.5% of median German NewTab item impressions for 2023-03-28 to 2023-04-05
+            total_impressions_per_day=100_000_000
         )
 
     @property

--- a/merino/curated_recommendations/prior_backends/constant_prior.py
+++ b/merino/curated_recommendations/prior_backends/constant_prior.py
@@ -18,7 +18,7 @@ class ConstantPrior(PriorBackend):
         return Prior(
             alpha=188,  # beta * P99 German NewTab CTR for 2023-03-28 to 2023-04-05 (1.5%)
             beta=12500,  # 0.5% of median German NewTab item impressions for 2023-03-28 to 2023-04-05
-            total_impressions_per_day=100_000_000,
+            total_impressions_per_day=30_000_000,
         )
 
     @property

--- a/merino/curated_recommendations/prior_backends/constant_prior.py
+++ b/merino/curated_recommendations/prior_backends/constant_prior.py
@@ -18,7 +18,7 @@ class ConstantPrior(PriorBackend):
         return Prior(
             alpha=188,  # beta * P99 German NewTab CTR for 2023-03-28 to 2023-04-05 (1.5%)
             beta=12500,  # 0.5% of median German NewTab item impressions for 2023-03-28 to 2023-04-05
-            total_impressions_per_day=100_000_000
+            total_impressions_per_day=100_000_000,
         )
 
     @property

--- a/merino/curated_recommendations/prior_backends/engagment_rescaler.py
+++ b/merino/curated_recommendations/prior_backends/engagment_rescaler.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from merino.curated_recommendations.prior_backends.protocol import EngagementRescaler
+from merino.curated_recommendations.prior_backends.protocol import EngagementRescaler, Prior
 from merino.curated_recommendations.protocol import ITEM_SUBTOPIC_FLAG, CuratedRecommendation
 
 from datetime import datetime, timezone
@@ -125,22 +125,24 @@ class CrawledContentPinnedFreshRescaler(CrawledContentRescaler):
         data.setdefault(
             "fresh_items_top_stories_fixed_position", 4
         )  # Because there are 2 ads, typically 4 is position 6 (0 based)
-        data.setdefault(
-            "fresh_items_top_stories_fixed_est_imp_per_cycle", EST_TOP_STORY_TILE_IMP_PER_CYCLE
-        )
         data.setdefault("fresh_items_top_stories_max_percentage", 0.03)
         super().__init__(**data)
 
-    def compute_estimated_fresh_per_cycle(self) -> int:
-        """Compute the estimated number of impressions for fresh items in each telemetry update cycle,
-        based on the fixed estimate for top story tile impressions and normalized by hour.
+    def compute_estimated_fresh_per_cycle(self, prior: Prior) -> int:
+        """Compute the estimated number of impressions that a single top stories tile gets in a content refresh cycle
+        based on total impressions and normalized by hour.
         """
+        impressions_per_period = prior.total_impressions_per_day / 24. / 6. # Period every 10 minutes ~5 per hour
+        impressions_for_tile_for_period = impressions_per_period / 2. / 7. # Top stories about half of impressions. 1 in 7 tiles
         utc_hour = datetime.now(tz=timezone.utc).hour
         if utc_hour >= 0 and utc_hour < len(US_UTC_RELATIVE_IMPRESSIONS_NORM):
             scale = US_UTC_RELATIVE_IMPRESSIONS_NORM[utc_hour]
         else:
             scale = 1.0
-        return round(self.fresh_items_top_stories_fixed_est_imp_per_cycle * scale)
+        print(impressions_for_tile_for_period)
+        print("scaled")
+        print(impressions_for_tile_for_period * scale)
+        return round(impressions_for_tile_for_period * scale)
 
 
 IE_EXPERIMENT_TREATMENT_PERCENT = 0.10

--- a/merino/curated_recommendations/prior_backends/engagment_rescaler.py
+++ b/merino/curated_recommendations/prior_backends/engagment_rescaler.py
@@ -21,6 +21,9 @@ BLOCKED_FROM_MOST_POPULAR_SCALER = 5.0
 PESSIMISTIC_PRIOR_ALPHA_SCALE = 0.4
 PESSIMISTIC_PRIOR_ALPHA_SCALE_SUBTOPIC = 0.35
 
+TILE_6_PERCENTAGE_OF_DAILY_IMPRESSIONS = (
+    0.1  # Generated via https://sql.telemetry.mozilla.org/queries/116006 (using tile 6)
+)
 
 LOCAL_RERANK_WEGHT = (
     80.0  # Experiment weight settings 60-10 server-local boosting.
@@ -28,15 +31,6 @@ LOCAL_RERANK_WEGHT = (
     # add an effective 0.083 (.5/6) boost that would be divided by the
     # value specified here. (60.0 => 0.0013, 100 => 0.0008)
 )
-
-FIXED_ITEM_TARGET_ARTICLE_IMPRESSIONS = 12000
-
-EST_DAILY_IMPRESSIONS_TOP_STORY_TILE = (
-    21_000_000  # Generated via https://sql.telemetry.mozilla.org/queries/116006 (using tile 6)
-)
-EST_TOP_STORY_TILE_IMP_PER_CYCLE = (
-    EST_DAILY_IMPRESSIONS_TOP_STORY_TILE // 24 // 7
-)  # Assuming 7 ETL data cycles per hour. We actually have a1round 6 but estimating as higher boosts the rate of fresh items
 
 # Normalized relative impresions per hour. Generated via https://sql.telemetry.mozilla.org/queries/115220
 US_UTC_RELATIVE_IMPRESSIONS_NORM = [
@@ -130,18 +124,20 @@ class CrawledContentPinnedFreshRescaler(CrawledContentRescaler):
 
     def compute_estimated_fresh_per_cycle(self, prior: Prior) -> int:
         """Compute the estimated number of impressions that a single top stories tile gets in a content refresh cycle
-        based on total impressions and normalized by hour.
+        based on total impressions and normalized by hour. This is used to tell how often to blast/vs throttle
+        fresh stories.
         """
-        impressions_per_period = prior.total_impressions_per_day / 24. / 6. # Period every 10 minutes ~5 per hour
-        impressions_for_tile_for_period = impressions_per_period / 2. / 7. # Top stories about half of impressions. 1 in 7 tiles
+        impressions_per_period = (
+            prior.total_impressions_per_day / 24.0 / 6.0
+        )  # Period every 10 minutes ~5 per hour
+        impressions_for_tile_for_period = (
+            impressions_per_period * TILE_6_PERCENTAGE_OF_DAILY_IMPRESSIONS
+        )
         utc_hour = datetime.now(tz=timezone.utc).hour
         if utc_hour >= 0 and utc_hour < len(US_UTC_RELATIVE_IMPRESSIONS_NORM):
             scale = US_UTC_RELATIVE_IMPRESSIONS_NORM[utc_hour]
         else:
             scale = 1.0
-        print(impressions_for_tile_for_period)
-        print("scaled")
-        print(impressions_for_tile_for_period * scale)
         return round(impressions_for_tile_for_period * scale)
 
 

--- a/merino/curated_recommendations/prior_backends/gcs_prior.py
+++ b/merino/curated_recommendations/prior_backends/gcs_prior.py
@@ -16,7 +16,9 @@ class PriorStats(BaseModel):
 
     region: str | None = None
     average_ctr_top2_items: float
+    average_ctr_top10_items: float
     impressions_per_item: float
+    total_impressions_per_day: float
 
 
 class GcsPrior(PriorBackend):
@@ -49,7 +51,9 @@ class GcsPrior(PriorBackend):
         # Set alpha to create an optimistic prior, so every item is explored to discover its CTR.
         alpha = beta * prior_stats.average_ctr_top2_items
 
-        return Prior(region=prior_stats.region, alpha=alpha, beta=beta)
+        total_impressions_per_day = prior_stats.total_impressions_per_day
+
+        return Prior(region=prior_stats.region, alpha=alpha, beta=beta, total_impressions_per_day=total_impressions_per_day)
 
     def _fetch_callback(self, data: str) -> None:
         """Process the raw blob data and update the cache.

--- a/merino/curated_recommendations/prior_backends/gcs_prior.py
+++ b/merino/curated_recommendations/prior_backends/gcs_prior.py
@@ -53,7 +53,12 @@ class GcsPrior(PriorBackend):
 
         total_impressions_per_day = prior_stats.total_impressions_per_day
 
-        return Prior(region=prior_stats.region, alpha=alpha, beta=beta, total_impressions_per_day=total_impressions_per_day)
+        return Prior(
+            region=prior_stats.region,
+            alpha=alpha,
+            beta=beta,
+            total_impressions_per_day=total_impressions_per_day,
+        )
 
     def _fetch_callback(self, data: str) -> None:
         """Process the raw blob data and update the cache.

--- a/merino/curated_recommendations/prior_backends/protocol.py
+++ b/merino/curated_recommendations/prior_backends/protocol.py
@@ -12,6 +12,7 @@ class Prior(BaseModel):
     region: str | None = None
     alpha: float
     beta: float
+    total_impressions_per_day: float
 
 
 class PriorBackend(Protocol):
@@ -61,10 +62,6 @@ class EngagementRescaler(BaseModel):
         int | None  # Fixed position to host bulk of fresh stories
     ) = None
 
-    fresh_items_top_stories_fixed_est_imp_per_cycle: (
-        int  # Estimated number of impressions for this tile in a period (eg 20 mins)
-    ) = 0
-
     def __init__(self, **data: Any):
         super().__init__(**data)
 
@@ -78,8 +75,8 @@ class EngagementRescaler(BaseModel):
         """Update priors values based on whether item is unique to the experiment."""
         return alpha, beta
 
-    def compute_estimated_fresh_per_cycle(self) -> int:
+    def compute_estimated_fresh_per_cycle(self, prior: Prior) -> int:
         """Compute the estimated number of impressions for fresh items in each telemetry update cycle,
         based on the fixed estimate for top story tile impressions and normalized by hour.
         """
-        return self.fresh_items_top_stories_fixed_est_imp_per_cycle
+        return prior.total_impressions_per_day

--- a/merino/curated_recommendations/prior_backends/protocol.py
+++ b/merino/curated_recommendations/prior_backends/protocol.py
@@ -76,7 +76,9 @@ class EngagementRescaler(BaseModel):
         return alpha, beta
 
     def compute_estimated_fresh_per_cycle(self, prior: Prior) -> int:
-        """Compute the estimated number of impressions for fresh items in each telemetry update cycle,
-        based on the fixed estimate for top story tile impressions and normalized by hour.
+        """Compute the estimated number of impressions that a single top stories tile gets in a content refresh cycle
+        based on total impressions and normalized by hour.
+
+        This function should be subclassed
         """
-        return prior.total_impressions_per_day
+        return int(prior.total_impressions_per_day)

--- a/merino/curated_recommendations/rankers/contextual_ranker.py
+++ b/merino/curated_recommendations/rankers/contextual_ranker.py
@@ -136,7 +136,6 @@ class ContextualRanker(Ranker):
                 no_opens = self.ml_backend.get_adjusted_impressions(
                     rec.corpusItemId, self.surface_id
                 )
-                # beta_value_for_fresh_check = self.prior_backend.get(region) or
             score += boost_interest(rec)
             remaining_fresh_impressions = 0
             if fresh_items_limit_prior_threshold_multiplier > 0 and not rec.isTimeSensitive:

--- a/merino/curated_recommendations/rankers/contextual_ranker.py
+++ b/merino/curated_recommendations/rankers/contextual_ranker.py
@@ -122,8 +122,6 @@ class ContextualRanker(Ranker):
                 mean, stdev = contextual_scores.get_score_pair(rec.corpusItemId)
 
             beta_value_for_fresh_check = non_rescaled_b_prior
-            print("beta value")
-            print(non_rescaled_b_prior)
             if mean is None or stdev is None:
                 # Fall back to Thompson sampling if no ML score is found because no data has come in yet
                 alpha_val = opens + max(a_prior, 1e-18)

--- a/merino/curated_recommendations/rankers/contextual_ranker.py
+++ b/merino/curated_recommendations/rankers/contextual_ranker.py
@@ -32,12 +32,6 @@ from merino.curated_recommendations.rankers.utils import (
     renumber_sections,
 )
 
-# We are still learning how to compute how many impressions before we can trust the ranker score completely.
-# Because Contexual ranking is an experiment, the value is somewhat arbitrary because the impression counts
-# we're looking at are total impressions and we care about impressions with the inferred interests. When
-# contexual is rolled out we can use a dynamic computed value based on daily impressions.
-
-CONTEXUAL_AVG_BETA_VALUE = 12000
 
 logger = logging.getLogger(__name__)
 
@@ -128,6 +122,8 @@ class ContextualRanker(Ranker):
                 mean, stdev = contextual_scores.get_score_pair(rec.corpusItemId)
 
             beta_value_for_fresh_check = non_rescaled_b_prior
+            print("beta value")
+            print(non_rescaled_b_prior)
             if mean is None or stdev is None:
                 # Fall back to Thompson sampling if no ML score is found because no data has come in yet
                 alpha_val = opens + max(a_prior, 1e-18)
@@ -142,7 +138,7 @@ class ContextualRanker(Ranker):
                 no_opens = self.ml_backend.get_adjusted_impressions(
                     rec.corpusItemId, self.surface_id
                 )
-                beta_value_for_fresh_check = CONTEXUAL_AVG_BETA_VALUE
+                # beta_value_for_fresh_check = self.prior_backend.get(region) or
             score += boost_interest(rec)
             remaining_fresh_impressions = 0
             if fresh_items_limit_prior_threshold_multiplier > 0 and not rec.isTimeSensitive:

--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -682,7 +682,7 @@ def get_top_story_list(
     extra_source_depth: int = 10,
     rescaler: EngagementRescaler | None = None,
     relax_constraints_for_personalization=False,
-    prior: Prior | None = None
+    prior: Prior | None = None,
 ) -> list[CuratedRecommendation]:
     """Build a top story list of top_count items from a full list. Adds some extra items from further down
     in the list of recs with some care to not use the same topic more than once.
@@ -707,9 +707,16 @@ def get_top_story_list(
     fresh_story_for_fixed_position = None
 
     # Pick a fresh story at random for position
-    if rescaler and rescaler.fresh_items_top_stories_fixed_position is not None and prior is not None:
+    if (
+        rescaler
+        and rescaler.fresh_items_top_stories_fixed_position is not None
+        and prior is not None
+    ):
         fixed_fresh_item_position = rescaler.fresh_items_top_stories_fixed_position or 0
-        print(f"fresh per cycle estimate for {prior.region} ", rescaler.compute_estimated_fresh_per_cycle(prior))
+        print(
+            f"fresh per cycle estimate for {prior.region} ",
+            rescaler.compute_estimated_fresh_per_cycle(prior),
+        )
         fresh_story_for_fixed_position, rest_of_stories = pick_random_fresh_story(
             items, rescaler.compute_estimated_fresh_per_cycle(prior)
         )
@@ -896,7 +903,7 @@ async def get_sections(
         TOP_STORIES_SECTION_EXTRA_COUNT,
         rescaler=rescaler,
         relax_constraints_for_personalization=False,  # In the future we can set to true for non-empty personal_interests
-        prior=prior
+        prior=prior,
     )
 
     # 9. Create a global rank lookup from the already-ranked recommendations

--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -713,10 +713,6 @@ def get_top_story_list(
         and prior is not None
     ):
         fixed_fresh_item_position = rescaler.fresh_items_top_stories_fixed_position or 0
-        print(
-            f"fresh per cycle estimate for {prior.region} ",
-            rescaler.compute_estimated_fresh_per_cycle(prior),
-        )
         fresh_story_for_fixed_position, rest_of_stories = pick_random_fresh_story(
             items, rescaler.compute_estimated_fresh_per_cycle(prior)
         )

--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -37,6 +37,7 @@ from merino.curated_recommendations.prior_backends.engagment_rescaler import (
     SchedulerHoldbackRescaler,
 )
 from merino.curated_recommendations.prior_backends.protocol import (
+    Prior,
     PriorBackend,
     EngagementRescaler,
 )
@@ -426,14 +427,16 @@ def get_ranking_rescaler_for_branch(
         return DECrawledContentRescaler()
 
     if surface_id == SurfaceId.NEW_TAB_EN_CA:
-        return CrawledContentRescaler()
+        if request.inferredInterests is None:
+            return CrawledContentRescaler()
+        else:
+            # Testing as part of the inferred personalization experiment
+            return CrawledContentPinnedFreshRescaler()
 
-    # While we preivously returned None for non-US, we know there are some section users
+    # While we previously returned None for non-US, we know there are some section users
     # who may not be in the US. This rescaler is required for all markets where data is getting
     # added throughout the day.
 
-    # The pinned fresh content rescaler is only available for the US market right now.
-    # Some additional work would be needed to make it work for other markets.
     return CrawledContentPinnedFreshRescaler()
 
 
@@ -679,6 +682,7 @@ def get_top_story_list(
     extra_source_depth: int = 10,
     rescaler: EngagementRescaler | None = None,
     relax_constraints_for_personalization=False,
+    prior: Prior | None = None
 ) -> list[CuratedRecommendation]:
     """Build a top story list of top_count items from a full list. Adds some extra items from further down
     in the list of recs with some care to not use the same topic more than once.
@@ -703,10 +707,11 @@ def get_top_story_list(
     fresh_story_for_fixed_position = None
 
     # Pick a fresh story at random for position
-    if rescaler and rescaler.fresh_items_top_stories_fixed_position is not None:
+    if rescaler and rescaler.fresh_items_top_stories_fixed_position is not None and prior is not None:
         fixed_fresh_item_position = rescaler.fresh_items_top_stories_fixed_position or 0
+        print(f"fresh per cycle estimate for {prior.region} ", rescaler.compute_estimated_fresh_per_cycle(prior))
         fresh_story_for_fixed_position, rest_of_stories = pick_random_fresh_story(
-            items, rescaler.compute_estimated_fresh_per_cycle()
+            items, rescaler.compute_estimated_fresh_per_cycle(prior)
         )
         items = rest_of_stories
 
@@ -884,12 +889,14 @@ async def get_sections(
     if is_contextual_ads_experiment(request):
         popular_today_layout = layout_4_large
 
+    prior = prior_backend.get(region)
     top_stories = get_top_story_list(
         all_ranked_corpus_recommendations,
         top_stories_count,
         TOP_STORIES_SECTION_EXTRA_COUNT,
         rescaler=rescaler,
         relax_constraints_for_personalization=False,  # In the future we can set to true for non-empty personal_interests
+        prior=prior
     )
 
     # 9. Create a global rank lookup from the already-ranked recommendations

--- a/tests/integration/api/v1/curated_recommendations/engagement_backends/test_gcs_prior.py
+++ b/tests/integration/api/v1/curated_recommendations/engagement_backends/test_gcs_prior.py
@@ -67,20 +67,20 @@ def blob(gcs_bucket):
                 "average_ctr_top2_items": 0.05,
                 "average_ctr_top10_items": 0.05,
                 "impressions_per_item": 15000,
-                "total_impressions_per_day": 100_000_000
+                "total_impressions_per_day": 100_000_000,
             },
             {
                 "region": "CA",
                 "average_ctr_top2_items": 0.04,
                 "average_ctr_top10_items": 0.05,
                 "impressions_per_item": 10000,
-                "total_impressions_per_day": 10_000_000
+                "total_impressions_per_day": 10_000_000,
             },
             {
                 "average_ctr_top2_items": 0.03,
                 "average_ctr_top10_items": 0.05,
                 "impressions_per_item": 8000,
-                "total_impressions_per_day": 110_000_000
+                "total_impressions_per_day": 110_000_000,
             },
         ],
     )
@@ -110,9 +110,15 @@ async def test_gcs_prior_fetches_data(gcs_storage_client, gcs_bucket, metrics_cl
     gcs_prior = create_gcs_prior(gcs_storage_client, gcs_bucket, metrics_client)
     await wait_until_prior_is_updated(gcs_prior)
 
-    assert gcs_prior.get("US") == Prior(region="US", alpha=37.5, beta=750.0, total_impressions_per_day=100_000_000)
-    assert gcs_prior.get("CA") == Prior(region="CA", alpha=20.0, beta=500.0, total_impressions_per_day=10_000_000)
-    assert gcs_prior.get() == Prior(region=None, alpha=12.0, beta=400.0, total_impressions_per_day=110_000_000)
+    assert gcs_prior.get("US") == Prior(
+        region="US", alpha=37.5, beta=750.0, total_impressions_per_day=100_000_000
+    )
+    assert gcs_prior.get("CA") == Prior(
+        region="CA", alpha=20.0, beta=500.0, total_impressions_per_day=10_000_000
+    )
+    assert gcs_prior.get() == Prior(
+        region=None, alpha=12.0, beta=400.0, total_impressions_per_day=110_000_000
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/integration/api/v1/curated_recommendations/engagement_backends/test_gcs_prior.py
+++ b/tests/integration/api/v1/curated_recommendations/engagement_backends/test_gcs_prior.py
@@ -65,16 +65,22 @@ def blob(gcs_bucket):
             {
                 "region": "US",
                 "average_ctr_top2_items": 0.05,
+                "average_ctr_top10_items": 0.05,
                 "impressions_per_item": 15000,
+                "total_impressions_per_day": 100_000_000
             },
             {
                 "region": "CA",
                 "average_ctr_top2_items": 0.04,
+                "average_ctr_top10_items": 0.05,
                 "impressions_per_item": 10000,
+                "total_impressions_per_day": 10_000_000
             },
             {
                 "average_ctr_top2_items": 0.03,
+                "average_ctr_top10_items": 0.05,
                 "impressions_per_item": 8000,
+                "total_impressions_per_day": 110_000_000
             },
         ],
     )
@@ -104,9 +110,9 @@ async def test_gcs_prior_fetches_data(gcs_storage_client, gcs_bucket, metrics_cl
     gcs_prior = create_gcs_prior(gcs_storage_client, gcs_bucket, metrics_client)
     await wait_until_prior_is_updated(gcs_prior)
 
-    assert gcs_prior.get("US") == Prior(region="US", alpha=37.5, beta=750.0)
-    assert gcs_prior.get("CA") == Prior(region="CA", alpha=20.0, beta=500.0)
-    assert gcs_prior.get() == Prior(region=None, alpha=12.0, beta=400.0)
+    assert gcs_prior.get("US") == Prior(region="US", alpha=37.5, beta=750.0, total_impressions_per_day=100_000_000)
+    assert gcs_prior.get("CA") == Prior(region="CA", alpha=20.0, beta=500.0, total_impressions_per_day=10_000_000)
+    assert gcs_prior.get() == Prior(region=None, alpha=12.0, beta=400.0, total_impressions_per_day=110_000_000)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/curated_recommendations/legacy/test_sections_adapter.py
+++ b/tests/unit/curated_recommendations/legacy/test_sections_adapter.py
@@ -140,7 +140,7 @@ class StubPriorBackend(PriorBackend):
     """Stub prior backend for testing."""
 
     def __init__(self, prior: Prior | None = None):
-        self._prior = prior or Prior(alpha=1, beta=10)
+        self._prior = prior or Prior(alpha=1, beta=10, total_impressions_per_day=10_000_000)
 
     def get(self, region: str | None = None) -> Prior:
         """Return stub prior."""

--- a/tests/unit/curated_recommendations/test_rankers.py
+++ b/tests/unit/curated_recommendations/test_rankers.py
@@ -347,7 +347,9 @@ class TestThompsonSampling:
         for rec in recs:
             rec.isTimeSensitive = False
 
-        prior_backend = StubPriorBackend(Prior(alpha=1, beta=10))
+        prior_backend = StubPriorBackend(
+            Prior(alpha=1, beta=10, total_impressions_per_day=1_000_000)
+        )
         engagement_backend = StubEngagementBackend(
             {
                 "fresh": (0, 4),  # impressions -> no_opens = 4
@@ -381,7 +383,9 @@ class TestThompsonSampling:
         for rec in recs:
             rec.isTimeSensitive = False
 
-        prior_backend = StubPriorBackend(Prior(alpha=1, beta=10))
+        prior_backend = StubPriorBackend(
+            Prior(alpha=1, beta=10, total_impressions_per_day=1_000_000)
+        )
         engagement_backend = StubEngagementBackend(
             {
                 "fresh1": (2, 4),
@@ -428,7 +432,9 @@ class TestThompsonSampling:
         )
         recs[0].isTimeSensitive = False
 
-        prior_backend = StubPriorBackend(Prior(alpha=1, beta=10))
+        prior_backend = StubPriorBackend(
+            Prior(alpha=1, beta=10, total_impressions_per_day=1_000_000)
+        )
         engagement_backend = StubEngagementBackend({"fresh": (0, 4)})  # no_opens = 4
         rescaler = CrawledContentRescaler()  # fresh_items_limit_prior_threshold_multiplier = 1
 
@@ -455,7 +461,9 @@ class TestThompsonSampling:
         )
         recs[0].isTimeSensitive = False
 
-        prior_backend = StubPriorBackend(Prior(alpha=1, beta=10))
+        prior_backend = StubPriorBackend(
+            Prior(alpha=1, beta=10, total_impressions_per_day=1_000_000)
+        )
         engagement_backend = StubEngagementBackend({"stale": (0, 12)})  # no_opens = 12
         rescaler = CrawledContentRescaler()
 
@@ -1340,7 +1348,9 @@ class TestContextualRanker:
         any errors and must fall back to Thompson sampling for every recommendation.
         """
         recs = generate_recommendations(item_ids=["a", "b"], time_sensitive_count=0)
-        prior_backend = StubPriorBackend(Prior(alpha=1, beta=10))
+        prior_backend = StubPriorBackend(
+            Prior(alpha=1, beta=10, total_impressions_per_day=1_000_000)
+        )
         engagement_backend = StubEngagementBackend({})
         ml_backend = StubMLRecsBackend(rankings=None)
 
@@ -1356,7 +1366,9 @@ class TestContextualRanker:
     def test_rank_items_falls_back_to_thompson_when_item_not_in_rankings(self):
         """When rankings exist but the item's corpusItemId is absent, fall back to Thompson sampling."""
         recs = generate_recommendations(item_ids=["a", "b"], time_sensitive_count=0)
-        prior_backend = StubPriorBackend(Prior(alpha=1, beta=10))
+        prior_backend = StubPriorBackend(
+            Prior(alpha=1, beta=10, total_impressions_per_day=1_000_000)
+        )
         engagement_backend = StubEngagementBackend({})
         # Rankings present but no data for the particular items.
         ml_backend = StubMLRecsBackend(
@@ -1373,7 +1385,9 @@ class TestContextualRanker:
     def test_rank_items_uses_ml_score_when_item_in_rankings(self, monkeypatch):
         """When rankings contain the item, the ML (normal-sampled) score is used."""
         recs = generate_recommendations(item_ids=["a"], time_sensitive_count=0)
-        prior_backend = StubPriorBackend(Prior(alpha=1, beta=10))
+        prior_backend = StubPriorBackend(
+            Prior(alpha=1, beta=10, total_impressions_per_day=1_000_000)
+        )
         engagement_backend = StubEngagementBackend({})
         ml_backend = StubMLRecsBackend(
             rankings=ContextualArticleRankings(
@@ -1397,7 +1411,9 @@ class TestContextualRanker:
             topics=[Topic.ARTS, Topic.TECHNOLOGY, Topic.SCIENCE],
             time_sensitive_count=0,
         )
-        prior_backend = StubPriorBackend(Prior(alpha=1, beta=10))
+        prior_backend = StubPriorBackend(
+            Prior(alpha=1, beta=10, total_impressions_per_day=1_000_000)
+        )
         engagement_backend = StubEngagementBackend({})
         A_RANK = 0.0020001
         ml_backend = StubMLRecsBackend(

--- a/tests/unit/curated_recommendations/test_sections.py
+++ b/tests/unit/curated_recommendations/test_sections.py
@@ -5,6 +5,7 @@ import random
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
+from merino.curated_recommendations.prior_backends.protocol import Prior
 import pytest
 from pydantic import HttpUrl
 
@@ -1111,8 +1112,8 @@ class TestGetTopStoryListWithPinnedFreshRescaler:
 
         Args:
             fresh_remaining_impressions: remaining_impressions for the fresh item.
-                Use a value > EST_TOP_STORY_TILE_IMP_PER_CYCLE * max_scale (~3.9M) to guarantee
-                the fresh item is always picked; use 0 to guarantee it is never picked.
+                Use a large value to guarantee the fresh item is always picked;
+                use 0 to guarantee it is never picked.
         """
         non_fresh = generate_recommendations(
             item_ids=["a", "b", "c", "d", "e", "f"],
@@ -1142,9 +1143,21 @@ class TestGetTopStoryListWithPinnedFreshRescaler:
             extra_count=0,
             extra_source_depth=0,
             rescaler=CrawledContentPinnedFreshRescaler(),
+            prior=Prior(alpha=0, beta=0, total_impressions_per_day=100_000_000),
         )
-
         assert result[4].corpusItemId == "fresh"
+
+    def test_fresh_story_placed_at_fixed_position_missing_priors(self):
+        """Fresh story should not appear because we have no prior data"""
+        result = get_top_story_list(
+            self._make_items(),
+            top_count=5,
+            extra_count=0,
+            extra_source_depth=0,
+            rescaler=CrawledContentPinnedFreshRescaler(),
+            prior=None,
+        )
+        assert result[4].corpusItemId != "fresh"
 
     def test_list_length_unchanged_after_insertion(self):
         """Inserting at the fixed position should not change the total list length."""
@@ -1154,6 +1167,7 @@ class TestGetTopStoryListWithPinnedFreshRescaler:
             extra_count=0,
             extra_source_depth=0,
             rescaler=CrawledContentPinnedFreshRescaler(),
+            prior=Prior(alpha=0, beta=0, total_impressions_per_day=100_000_000),
         )
 
         assert len(result) == 5
@@ -1166,6 +1180,7 @@ class TestGetTopStoryListWithPinnedFreshRescaler:
             extra_count=0,
             extra_source_depth=0,
             rescaler=CrawledContentPinnedFreshRescaler(),
+            prior=Prior(alpha=0, beta=0, total_impressions_per_day=100_000_000),
         )
 
         assert [rec.receivedRank for rec in result] == list(range(len(result)))
@@ -1182,6 +1197,7 @@ class TestGetTopStoryListWithPinnedFreshRescaler:
             extra_count=0,
             extra_source_depth=0,
             rescaler=CrawledContentPinnedFreshRescaler(),
+            prior=Prior(alpha=0, beta=0, total_impressions_per_day=100_000_000),
         )
 
         assert len(result) == 5

--- a/tests/unit/prior_backends/test_engagement_rescaler.py
+++ b/tests/unit/prior_backends/test_engagement_rescaler.py
@@ -8,7 +8,6 @@ from merino.curated_recommendations.corpus_backends.protocol import Topic
 from merino.curated_recommendations.prior_backends.engagment_rescaler import (
     BLOCKED_FROM_MOST_POPULAR_SCALER,
     LOCAL_RERANK_WEGHT,
-    EST_TOP_STORY_TILE_IMP_PER_CYCLE,
     US_UTC_RELATIVE_IMPRESSIONS_NORM,
     CrawledContentPinnedFreshRescaler,
     CrawledContentRescaler,
@@ -20,6 +19,7 @@ from merino.curated_recommendations.prior_backends.engagment_rescaler import (
     PESSIMISTIC_PRIOR_ALPHA_SCALE,
     PESSIMISTIC_PRIOR_ALPHA_SCALE_SUBTOPIC,
 )
+from merino.curated_recommendations.prior_backends.protocol import Prior
 from merino.curated_recommendations.protocol import ITEM_SUBTOPIC_FLAG
 
 SECTIONS_HOLDBACK_TOTAL_PERCENT = 0.1
@@ -55,7 +55,12 @@ class TestCrawledContentRescaler:
         rec.is_story_blocked_for_top_stories.return_value = False
         assert not self.rescaler.is_blocked_from_most_popular(rec)
 
-        assert self.rescaler.compute_estimated_fresh_per_cycle() >= 0
+        assert (
+            self.rescaler.compute_estimated_fresh_per_cycle(
+                Prior(alpha=0, beta=0, total_impressions_per_day=1_000_000)
+            )
+            >= 0
+        )
         assert self.rescaler.fresh_items_top_stories_fixed_position is None
 
     def test_rescale_with_subtopic_item(self):
@@ -134,16 +139,15 @@ class TestCrawledContentPinnedFreshRescaler:
     def test_basic_stuff(self):
         """Test detection of blocked from most popular"""
         assert self.rescaler.fresh_items_top_stories_fixed_position == 4
-        assert (
-            self.rescaler.fresh_items_top_stories_fixed_est_imp_per_cycle
-            == EST_TOP_STORY_TILE_IMP_PER_CYCLE
-        )
         assert len(US_UTC_RELATIVE_IMPRESSIONS_NORM) == 24
         # Sanity check computed target value for tile is in range
+        estimated_impression_per_tile_per_cycle = 126_000
         assert (
-            0.1 * EST_TOP_STORY_TILE_IMP_PER_CYCLE
-            < self.rescaler.compute_estimated_fresh_per_cycle()
-            < 2.5 * EST_TOP_STORY_TILE_IMP_PER_CYCLE
+            0.1 * estimated_impression_per_tile_per_cycle
+            < self.rescaler.compute_estimated_fresh_per_cycle(
+                Prior(alpha=0, beta=0, total_impressions_per_day=220_000_000)
+            )
+            < 2.5 * estimated_impression_per_tile_per_cycle
         )
 
 
@@ -302,8 +306,8 @@ class TestSchedulerHoldbackRescaler:
             """Test that fixed position setting is set correctly"""
             assert self.rescaler.fresh_items_top_stories_fixed_position == 2
             # 4 is the default
+            prior = Prior(alpha=0, beta=0, total_impressions_per_day=1_000_000)
             assert self.rescaler_inferred.fresh_items_top_stories_fixed_position == 4
-            assert (
-                self.rescaler.compute_estimated_fresh_per_cycle()
-                == self.rescaler_inferred.compute_estimated_fresh_per_cycle()
-            )
+            assert self.rescaler.compute_estimated_fresh_per_cycle(
+                prior
+            ) == self.rescaler_inferred.compute_estimated_fresh_per_cycle(prior)


### PR DESCRIPTION
## References
JIRA: https://mozilla-hub.atlassian.net/browse/AIMOD-137

Previously we had some hard coded values to limit exploration of fresh content within the Contextual ranker system.

Now we are pulling in daily estimated impressions along with the priors.   

With the 'fixed tile' restrictions we limit fresh content to content tile 4 (though it typically shows up in tiles 5-6) to throttle content and expose it to different users. We now have new prior data that has the total daily number of users. This can easily be extended to to other countries in the future. 

The 'fresh per tile per cycle' for the US was previously 125k and is now 104k with this dynamic code.

The hard coded beta value for contextual ranking was originally 12,000 for US and is now 15,840 when dynamically calculated. These could be adjusted down in the future by adjusting the 'fresh_items_limit_prior_threshold_multiplier' field in the rescaler constructor.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2297)
