### PR TITLE
[DISCO-4189] fix(sports:logos): fix logo mapping for world cup

### DIFF
--- a/merino/providers/suggest/sports/backends/sportsdata/protocol.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/protocol.py
@@ -14,6 +14,18 @@ from merino.providers.suggest.sports.backends.sportsdata.common.sports import (
 )
 from merino.utils.logos import get_logo_url, LogoCategory
 
+# Mapping of sport name from SportEventDetail
+# (e.g. "NFL", "NHL", "NBA", etc.) to the logo category
+# In order to onboard a new logo category (e.g. new sport)
+# You must update this mapping
+SportLogoCategoryMap: dict[str, LogoCategory] = {
+    "nfl": LogoCategory.NFL,
+    "nhl": LogoCategory.NHL,
+    "nba": LogoCategory.NBA,
+    "mlb": LogoCategory.MLB,
+    "fifa": LogoCategory.Nations,
+}
+
 
 class SportTeamDetail(BaseModel):
     """Data about the specific Sport team."""
@@ -52,7 +64,7 @@ class SportEventDetail(BaseModel):
         """
         status: GameStatus = event["event_status"]
         try:
-            category = LogoCategory(event["sport"].lower())
+            category = LogoCategory(SportLogoCategoryMap.get(event["sport"].lower(), "").lower())
         except ValueError:
             # No logos for this sport; leave icons as None
             category = None

--- a/tests/unit/providers/suggest/sports/backends/test_sports_backend.py
+++ b/tests/unit/providers/suggest/sports/backends/test_sports_backend.py
@@ -430,6 +430,35 @@ def test_sport_event_detail_icon_none_for_unknown_sport() -> None:
     assert result.away_team.icon is None
 
 
+def test_sport_event_detail_icon_set_for_fifa_uses_nations_logos(
+    mocker: MockerFixture, make_manifest
+) -> None:
+    """FIFA events resolve to LogoCategory.Nations via SportLogoCategoryMap."""
+    mocker.patch(
+        "merino.utils.logos.load_manifest",
+        return_value=make_manifest(
+            (LogoCategory.Nations, "usa"),
+            (LogoCategory.Nations, "can"),
+        ),
+    )
+
+    event = {
+        "date": "2026-06-15T00:00:00+00:00",
+        "sport": "FIFA",
+        "event_status": GameStatus.Scheduled,
+        "home_team": {"key": "USA", "name": "United States", "colors": ["B22234"]},
+        "away_team": {"key": "CAN", "name": "Canada", "colors": ["FF0000"]},
+        "home_score": None,
+        "away_score": None,
+        "touched": "2026-06-15T00:00:00+00:00",
+    }
+    result = SportEventDetail.from_event_dict(event)
+
+    host = f"https://{settings.image_gcs_v2.cdn_hostname}"
+    assert str(result.home_team.icon) == f"{host}/logos/nations/nations_usa.png"
+    assert str(result.away_team.icon) == f"{host}/logos/nations/nations_can.png"
+
+
 def test_sport_event_detail_icon_none_when_team_not_in_manifest() -> None:
     """Icons are None when the team key is absent from the manifest."""
     event = {


### PR DESCRIPTION


## References

JIRA: [DISCO-4189]

## Description
Previously the categories assumed the sport name from sportsdata response, but fifa has a different mapping. Did not change the logo name per request to limit use of fifa.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-4189]: https://mozilla-hub.atlassian.net/browse/DISCO-4189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ