### PR TITLE
DISCO-4183 Add mocked data for live wcs events

### DIFF
--- a/merino/providers/wcs/fake_live_data.py
+++ b/merino/providers/wcs/fake_live_data.py
@@ -7,15 +7,7 @@ from typing import Literal
 from merino.providers.wcs.fake_data import get_all_teams
 from merino.providers.wcs.protocol import EventInfo, TeamInfo
 
-type StatusType = Literal[
-    "past",
-    "live",
-    "scheduled",
-    "interrupted",
-    "postponed",
-    "canceled",
-    "awarded",
-]
+type StatusType = Literal["past", "live", "scheduled", "unknown"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -264,7 +256,7 @@ _TEMPLATES: list[EventTemplate] = [
         hour=22,
         home_key="USA",
         away_key="ARG",
-        status_type="interrupted",
+        status_type="live",
         status="Suspended",
         home_score=1,
         away_score=0,
@@ -277,7 +269,7 @@ _TEMPLATES: list[EventTemplate] = [
         hour=12,
         home_key="ENG",
         away_key="GER",
-        status_type="postponed",
+        status_type="scheduled",
         status="Postponed",
     ),
     # Canceled match
@@ -286,7 +278,7 @@ _TEMPLATES: list[EventTemplate] = [
         hour=13,
         home_key="FRA",
         away_key="BRA",
-        status_type="canceled",
+        status_type="unknown",
         status="Canceled",
     ),
     # Awarded / forfeit match
@@ -295,7 +287,7 @@ _TEMPLATES: list[EventTemplate] = [
         hour=13,
         home_key="USA",
         away_key="ENG",
-        status_type="awarded",
+        status_type="past",
         status="Awarded",
         home_score=3,
         away_score=0,

--- a/merino/providers/wcs/fake_live_data.py
+++ b/merino/providers/wcs/fake_live_data.py
@@ -1,100 +1,363 @@
-"""Static live match templates for the WCS live endpoint."""
+"""Static match templates for the WCS live endpoint."""
 
-from datetime import UTC, date, datetime, time
+from dataclasses import dataclass
+from datetime import UTC, date, datetime, time, timedelta
+from typing import Literal
 
-from pydantic import HttpUrl
-
+from merino.providers.wcs.fake_data import get_all_teams
 from merino.providers.wcs.protocol import EventInfo, TeamInfo
-from merino.providers.wcs.utils import get_team_colours
-from merino.utils.logos import LogoCategory, load_manifest
 
-_LOGO_HOST = "https://storage.googleapis.com/merino-images-prod"
-
-
-def _icon(key: str) -> HttpUrl | None:
-    """Return the nations flag URL for `key`, if it exists in the logo manifest."""
-    entry = load_manifest().get(LogoCategory.Nations, key)
-    return HttpUrl(f"{_LOGO_HOST}/{entry.url}") if entry else None
-
-
-def _team(key: str, global_team_id: int, name: str) -> TeamInfo:
-    return TeamInfo(
-        key=key,
-        global_team_id=global_team_id,
-        name=name,
-        region=key,
-        colors=get_team_colours(key),
-        icon_url=_icon(key),
-        eliminated=False,
-    )
+type StatusType = Literal[
+    "past",
+    "live",
+    "scheduled",
+    "interrupted",
+    "postponed",
+    "canceled",
+    "awarded",
+]
 
 
+@dataclass(frozen=True, slots=True)
+class EventTemplate:
+    """Template row for a fake WCS live-endpoint event."""
+
+    day_offset: int
+    hour: int
+    home_key: str
+    away_key: str
+    status_type: StatusType
+    status: str
+    home_score: int | None = None
+    away_score: int | None = None
+    home_extra: int | None = None
+    away_extra: int | None = None
+    home_penalty: int | None = None
+    away_penalty: int | None = None
+    period: str | None = None
+    clock: str | None = None
+
+
+_TEMPLATES: list[EventTemplate] = [
+    # Existing finals / scheduled / live
+    EventTemplate(
+        day_offset=-1,
+        hour=14,
+        home_key="BRA",
+        away_key="ARG",
+        status_type="past",
+        status="Final",
+        home_score=2,
+        away_score=1,
+        period="FT",
+        clock="90",
+    ),
+    EventTemplate(
+        day_offset=-1,
+        hour=18,
+        home_key="GER",
+        away_key="FRA",
+        status_type="past",
+        status="Final",
+        home_score=1,
+        away_score=1,
+        home_extra=1,
+        away_extra=1,
+        home_penalty=5,
+        away_penalty=4,
+        period="FT(P)",
+        clock="120",
+    ),
+    EventTemplate(
+        day_offset=0,
+        hour=14,
+        home_key="ENG",
+        away_key="USA",
+        status_type="live",
+        status="In Progress",
+        home_score=1,
+        away_score=0,
+        period="2",
+        clock="67",
+    ),
+    EventTemplate(
+        day_offset=0,
+        hour=17,
+        home_key="BRA",
+        away_key="GER",
+        status_type="live",
+        status="In Progress",
+        home_score=2,
+        away_score=2,
+        period="ET",
+        clock="90+15",
+    ),
+    EventTemplate(
+        day_offset=1,
+        hour=15,
+        home_key="ARG",
+        away_key="ENG",
+        status_type="scheduled",
+        status="Scheduled",
+        period="1",
+        clock="0",
+    ),
+    EventTemplate(
+        day_offset=1,
+        hour=19,
+        home_key="FRA",
+        away_key="USA",
+        status_type="scheduled",
+        status="Scheduled",
+        period="1",
+        clock="0",
+    ),
+    # First half live - scoreless
+    EventTemplate(
+        day_offset=0,
+        hour=10,
+        home_key="BRA",
+        away_key="USA",
+        status_type="live",
+        status="In Progress",
+        home_score=0,
+        away_score=0,
+        period="1",
+        clock="12",
+    ),
+    # First half live - away team leading
+    EventTemplate(
+        day_offset=0,
+        hour=11,
+        home_key="ARG",
+        away_key="FRA",
+        status_type="live",
+        status="In Progress",
+        home_score=0,
+        away_score=1,
+        period="1",
+        clock="38",
+    ),
+    # Halftime / break
+    EventTemplate(
+        day_offset=0,
+        hour=12,
+        home_key="GER",
+        away_key="ENG",
+        status_type="live",
+        status="Break",
+        home_score=1,
+        away_score=1,
+        period="HT",
+        clock="45",
+    ),
+    # Second half stoppage time
+    EventTemplate(
+        day_offset=0,
+        hour=13,
+        home_key="USA",
+        away_key="BRA",
+        status_type="live",
+        status="In Progress",
+        home_score=2,
+        away_score=2,
+        period="2",
+        clock="90+3",
+    ),
+    # Extra time first half
+    EventTemplate(
+        day_offset=0,
+        hour=15,
+        home_key="FRA",
+        away_key="GER",
+        status_type="live",
+        status="In Progress",
+        home_score=1,
+        away_score=1,
+        home_extra=0,
+        away_extra=0,
+        period="ET1",
+        clock="98",
+    ),
+    # Extra time halftime
+    EventTemplate(
+        day_offset=0,
+        hour=16,
+        home_key="ENG",
+        away_key="ARG",
+        status_type="live",
+        status="Break",
+        home_score=1,
+        away_score=1,
+        home_extra=0,
+        away_extra=0,
+        period="ETHT",
+        clock="105",
+    ),
+    # Extra time second half
+    EventTemplate(
+        day_offset=0,
+        hour=17,
+        home_key="BRA",
+        away_key="FRA",
+        status_type="live",
+        status="In Progress",
+        home_score=1,
+        away_score=1,
+        home_extra=1,
+        away_extra=0,
+        period="ET2",
+        clock="117",
+    ),
+    # Penalty shootout live
+    EventTemplate(
+        day_offset=0,
+        hour=18,
+        home_key="GER",
+        away_key="USA",
+        status_type="live",
+        status="In Progress",
+        home_score=2,
+        away_score=2,
+        home_extra=0,
+        away_extra=0,
+        home_penalty=2,
+        away_penalty=1,
+        period="P",
+        clock="120",
+    ),
+    # Final after extra time
+    EventTemplate(
+        day_offset=-1,
+        hour=20,
+        home_key="ARG",
+        away_key="BRA",
+        status_type="past",
+        status="Final",
+        home_score=1,
+        away_score=1,
+        home_extra=0,
+        away_extra=1,
+        period="AET",
+        clock="120",
+    ),
+    # Final after penalties (alternate outcome)
+    EventTemplate(
+        day_offset=-1,
+        hour=21,
+        home_key="FRA",
+        away_key="ENG",
+        status_type="past",
+        status="Final",
+        home_score=0,
+        away_score=0,
+        home_extra=0,
+        away_extra=0,
+        home_penalty=3,
+        away_penalty=4,
+        period="FT(P)",
+        clock="120",
+    ),
+    # Suspended live match
+    EventTemplate(
+        day_offset=0,
+        hour=22,
+        home_key="USA",
+        away_key="ARG",
+        status_type="interrupted",
+        status="Suspended",
+        home_score=1,
+        away_score=0,
+        period="2",
+        clock="63",
+    ),
+    # Postponed match
+    EventTemplate(
+        day_offset=1,
+        hour=12,
+        home_key="ENG",
+        away_key="GER",
+        status_type="postponed",
+        status="Postponed",
+    ),
+    # Canceled match
+    EventTemplate(
+        day_offset=1,
+        hour=13,
+        home_key="FRA",
+        away_key="BRA",
+        status_type="canceled",
+        status="Canceled",
+    ),
+    # Awarded / forfeit match
+    EventTemplate(
+        day_offset=-1,
+        hour=13,
+        home_key="USA",
+        away_key="ENG",
+        status_type="awarded",
+        status="Awarded",
+        home_score=3,
+        away_score=0,
+        period="FT",
+        clock="90",
+    ),
+]
+
+_TEAM_KEYS = {template.home_key for template in _TEMPLATES} | {
+    template.away_key for template in _TEMPLATES
+}
+# TeamInfo objects come from fake_data.py, including the pinned flag icon URLs used by /wcs/teams.
 _TEAMS: dict[str, TeamInfo] = {
-    t.key: t
-    for t in [
-        _team("BRA", 90000001, "Brazil"),
-        _team("GER", 90000003, "Germany"),
-        _team("ENG", 90000005, "England"),
-        _team("USA", 90000006, "United States"),
-    ]
+    team.key: team for team in get_all_teams() if team.key in _TEAM_KEYS
 }
 
 
 def build_live_events(anchor: date) -> list[EventInfo]:
-    """Build fake live events anchored to `anchor`."""
-    return [
+    """Build fake live-endpoint events anchored to `anchor`."""
+    events = [
         _event(
             anchor=anchor,
-            hour=14,
-            home_key="ENG",
-            away_key="USA",
-            home_score=1,
-            away_score=0,
-            period="2",
-            clock="67",
-            global_event_id=1002,
-        ),
-        _event(
-            anchor=anchor,
-            hour=17,
-            home_key="BRA",
-            away_key="GER",
-            home_score=2,
-            away_score=2,
-            period="ET",
-            clock="90+15",
-            global_event_id=1003,
-        ),
+            template=template,
+            global_event_id=global_event_id,
+        )
+        for global_event_id, template in enumerate(_TEMPLATES, start=1001)
     ]
+    return sorted(events, key=lambda event: event.date)
 
 
 def _event(
     *,
     anchor: date,
-    hour: int,
-    home_key: str,
-    away_key: str,
-    home_score: int,
-    away_score: int,
-    period: str,
-    clock: str,
+    template: EventTemplate,
     global_event_id: int,
 ) -> EventInfo:
-    event_dt = datetime.combine(anchor, time(hour, tzinfo=UTC))
+    event_dt = datetime.combine(
+        anchor + timedelta(days=template.day_offset),
+        time(template.hour, tzinfo=UTC),
+    )
     return EventInfo(
         date=event_dt.isoformat(),
         global_event_id=global_event_id,
-        home_team=_TEAMS[home_key],
-        away_team=_TEAMS[away_key],
-        period=period,
-        home_score=home_score,
-        away_score=away_score,
-        home_extra=None,
-        away_extra=None,
-        home_penalty=None,
-        away_penalty=None,
-        clock=clock,
+        home_team=_team(template.home_key),
+        away_team=_team(template.away_key),
+        period=template.period or "",
+        home_score=template.home_score,
+        away_score=template.away_score,
+        home_extra=template.home_extra,
+        away_extra=template.away_extra,
+        home_penalty=template.home_penalty,
+        away_penalty=template.away_penalty,
+        clock=template.clock or "",
         updated=int(event_dt.timestamp()) - 3600,
-        status="In Progress",
-        status_type="live",
+        status=template.status,
+        status_type=template.status_type,
     )
+
+
+def _team(key: str) -> TeamInfo:
+    """Return WCS team metadata for `key`."""
+    try:
+        return _TEAMS[key]
+    except KeyError as ex:
+        raise ValueError(f"Missing WCS team data for {key}") from ex

--- a/merino/providers/wcs/protocol.py
+++ b/merino/providers/wcs/protocol.py
@@ -66,7 +66,7 @@ class EventInfo(BaseModel):
     clock: str = Field(description="Elapsed minutes; extra time as '90+3'.")
     updated: int = Field(description="UTC unix timestamp of the last record update.")
     status: str = Field(description="Game status: 'Scheduled', 'In Progress', 'Final', etc.")
-    status_type: str = Field(description="Simplified status: 'past' | 'live' | 'scheduled'.")
+    status_type: str = Field(description="UI status bucket, e.g. 'past', 'live', 'scheduled'.")
     query: str | None = Field(default=None, description="Optional click-through query.")
     sport: str = Field(default="soccer", description="Sport identifier.")
 
@@ -113,7 +113,7 @@ class MatchesResponse(BaseModel):
 class LiveMatchesResponse(BaseModel):
     """Response payload for `GET /api/v1/wcs/live`.
 
-    Holds events with `status_type == "live"`, sorted by `date` ascending.
+    Holds mocked live-endpoint events, sorted by `date` ascending.
     """
 
     matches: list[EventInfo]

--- a/merino/providers/wcs/provider.py
+++ b/merino/providers/wcs/provider.py
@@ -85,7 +85,7 @@ class WcsProvider:
         return MatchesResponse(previous=previous, current=current, next_=next_)
 
     async def get_live_matches(self, team_keys: frozenset[str] | None) -> LiveMatchesResponse:
-        """Return fake events currently in progress, sorted ascending by `date`.
+        """Return fake live-endpoint events, sorted ascending by `date`.
 
         `team_keys` restricts results to matches with that team on either side.
         """

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -708,7 +708,7 @@ async def get_wcs_matches(
 @router.get(
     "/wcs/live",
     tags=["wcs"],
-    summary="World Cup Soccer matches currently in progress",
+    summary="Mocked World Cup Soccer events for the live endpoint",
     response_model=LiveMatchesResponse,
 )
 async def get_wcs_live(
@@ -718,7 +718,7 @@ async def get_wcs_live(
     ] = None,
     provider: WcsProvider = Depends(get_wcs_provider),
 ) -> LiveMatchesResponse:
-    """Return matches with `status_type == "live"`, sorted ascending by date.
+    """Return mocked live-endpoint events, sorted ascending by date.
 
     Anchored to fake test data until real live data lands.
     """

--- a/tests/integration/api/v1/wcs/test_live.py
+++ b/tests/integration/api/v1/wcs/test_live.py
@@ -20,14 +20,14 @@ def test_returns_matches_envelope(client: TestClient) -> None:
     assert isinstance(body["matches"], list)
     assert body["matches"]
     assert {e["status_type"] for e in body["matches"]} == {
-        "awarded",
-        "canceled",
-        "interrupted",
         "live",
         "past",
-        "postponed",
         "scheduled",
+        "unknown",
     }
+    assert {"Awarded", "Canceled", "Postponed", "Suspended"}.issubset(
+        {event["status"] for event in body["matches"]}
+    )
 
 
 def test_matches_sorted_ascending_by_date(client: TestClient) -> None:

--- a/tests/integration/api/v1/wcs/test_live.py
+++ b/tests/integration/api/v1/wcs/test_live.py
@@ -11,7 +11,7 @@ _PATH = "/api/v1/wcs/live"
 
 
 def test_returns_matches_envelope(client: TestClient) -> None:
-    """Response is `{"matches": [...]}` with a list of in-progress events."""
+    """Response is `{"matches": [...]}` with the mocked live-endpoint events."""
     response = client.get(_PATH)
     assert response.status_code == 200
 
@@ -19,7 +19,15 @@ def test_returns_matches_envelope(client: TestClient) -> None:
     assert set(body.keys()) == {"matches"}
     assert isinstance(body["matches"], list)
     assert body["matches"]
-    assert all(e["status_type"] == "live" for e in body["matches"])
+    assert {e["status_type"] for e in body["matches"]} == {
+        "awarded",
+        "canceled",
+        "interrupted",
+        "live",
+        "past",
+        "postponed",
+        "scheduled",
+    }
 
 
 def test_matches_sorted_ascending_by_date(client: TestClient) -> None:

--- a/tests/unit/providers/wcs/test_provider.py
+++ b/tests/unit/providers/wcs/test_provider.py
@@ -167,14 +167,14 @@ async def test_live_returns_expanded_fake_events() -> None:
     assert len(response.matches) == _LIVE_EVENT_COUNT
     assert Counter(e.status_type for e in response.matches) == Counter(
         {
-            "past": 4,
-            "live": 10,
-            "scheduled": 2,
-            "interrupted": 1,
-            "postponed": 1,
-            "canceled": 1,
-            "awarded": 1,
+            "past": 5,
+            "live": 11,
+            "scheduled": 3,
+            "unknown": 1,
         }
+    )
+    assert {"Awarded", "Canceled", "Postponed", "Suspended"}.issubset(
+        {event.status for event in response.matches}
     )
 
 

--- a/tests/unit/providers/wcs/test_provider.py
+++ b/tests/unit/providers/wcs/test_provider.py
@@ -4,6 +4,7 @@
 
 """Unit tests for the WCS matches provider."""
 
+from collections import Counter
 from datetime import date, datetime
 from typing import Any
 
@@ -12,9 +13,12 @@ import pytest
 from merino.configs import settings
 from merino.exceptions import CacheAdapterError
 from merino.providers import wcs as wcs_module
+from merino.providers.wcs.fake_live_data import build_live_events
 from merino.providers.wcs.provider import WcsProvider
 from merino.providers.wcs.protocol import LiveMatchesResponse, TeamInfo, TeamsResponse
 from tests.wcs.factories import ANCHOR, build_provider
+
+_LIVE_EVENT_COUNT = len(build_live_events(ANCHOR))
 
 
 def test_cache_uses_wcs_redis_settings(mocker) -> None:
@@ -156,12 +160,22 @@ async def test_live_extra_time_match_shows_clock_in_extra_play() -> None:
 
 
 @pytest.mark.asyncio
-async def test_live_returns_only_in_progress_events() -> None:
-    """`get_live_matches` returns the two fake live events."""
+async def test_live_returns_expanded_fake_events() -> None:
+    """`get_live_matches` returns the expanded fake live-endpoint event set."""
     response = await build_provider(events=[]).get_live_matches(team_keys=None)
 
-    assert len(response.matches) == 2
-    assert all(e.status_type == "live" for e in response.matches)
+    assert len(response.matches) == _LIVE_EVENT_COUNT
+    assert Counter(e.status_type for e in response.matches) == Counter(
+        {
+            "past": 4,
+            "live": 10,
+            "scheduled": 2,
+            "interrupted": 1,
+            "postponed": 1,
+            "canceled": 1,
+            "awarded": 1,
+        }
+    )
 
 
 @pytest.mark.asyncio
@@ -217,7 +231,7 @@ async def test_empty_cache_returns_empty_payloads() -> None:
         "current": [],
         "next": [],
     }
-    assert len((await provider.get_live_matches(team_keys=None)).matches) == 2
+    assert len((await provider.get_live_matches(team_keys=None)).matches) == _LIVE_EVENT_COUNT
     assert len(provider.get_teams().teams) == 48
 
 
@@ -235,6 +249,6 @@ async def test_cache_error_returns_empty_payloads(mocker) -> None:
         "current": [],
         "next": [],
     }
-    assert len((await provider.get_live_matches(team_keys=None)).matches) == 2
+    assert len((await provider.get_live_matches(team_keys=None)).matches) == _LIVE_EVENT_COUNT
     assert len(provider.get_teams().teams) == 48
     metrics_client.increment.assert_any_call("wcs.cache_error", tags={"endpoint": "matches"})


### PR DESCRIPTION
## References

JIRA: [DISCO-4183](https://mozilla-hub.atlassian.net/browse/DISCO-4183)

## Description
Add more mocked events for UI to design against. 


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2302)


[DISCO-4183]: https://mozilla-hub.atlassian.net/browse/DISCO-4183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ