### PR TITLE
DISCO-4194 Fix bug to compare against timezone aware datestring from …

### DIFF
--- a/merino/providers/suggest/sports/backends/sportsdata/common/sports.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/sports.py
@@ -933,7 +933,7 @@ class WCS(Sport):
         # TODO: Team cache TTL should probably be a setting
         if not last_update or (
             last_update
-            and datetime.fromtimestamp(int.from_bytes(last_update))
+            and datetime.fromtimestamp(int.from_bytes(last_update), tz=timezone.utc)
             < datetime.now(tz=timezone.utc) - timedelta(hours=12)
         ):
             now = datetime.now(tz=timezone.utc)

--- a/tests/unit/providers/suggest/sports/backends/common/test_sports.py
+++ b/tests/unit/providers/suggest/sports/backends/common/test_sports.py
@@ -2381,6 +2381,35 @@ async def test_team_cache_restore(mock_client: AsyncClient) -> None:
 
 
 @pytest.mark.asyncio
+async def test_wcs_cache_teams_accepts_cached_refresh_timestamp() -> None:
+    """A cached refresh timestamp is compared as a timezone-aware datetime."""
+    sport = WCS(settings=settings.providers.sports)
+    now = datetime.now(tz=timezone.utc)
+    sport.teams = {
+        1: Team(
+            terms="",
+            fullname="Home",
+            name="Home",
+            key="HOM",
+            id=1,
+            aliases=["Home"],
+            colors=["white"],
+            updated=now,
+            expiry=now + timedelta(seconds=10),
+            locale=None,
+            country="ENG",
+        ),
+    }
+    mock_cache = MagicMock(spec=RedisAdapter)
+    mock_cache.get.return_value = int((now - timedelta(hours=13)).timestamp()).to_bytes(8)
+    sport.cache = mock_cache
+
+    await sport.cache_teams()
+
+    mock_cache.setnx.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_team_cache_restore_skips_missing_and_invalid_entries() -> None:
     """A partial or corrupt team cache does not fail the whole WCS teams response."""
     sport = WCS(settings=settings.providers.sports)


### PR DESCRIPTION
## References

JIRA: [DISCO-4194](https://mozilla-hub.atlassian.net/browse/DISCO-4194)

## Description
Fixes a WCS ETL crash when `cache_teams()` compares the cached Redis `team_refresh` timestamp against the current UTC time.

`team_refresh` is stored as raw bytes containing a Unix timestamp. On read, we decoded those bytes with:

`datetime.fromtimestamp(int.from_bytes(last_update))`

Without a `tz` argument, `datetime.fromtimestamp(...)` returns an offset-naive datetime. The code then compared that value with `datetime.now(tz=timezone.utc)`, which is offset-aware, raising:

`TypeError: can't compare offset-naive and offset-aware datetimes`


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2303)


[DISCO-4194]: https://mozilla-hub.atlassian.net/browse/DISCO-4194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ