### PR TITLE
DISCO-4195 Use team hex colours for events endpoint

### DIFF
--- a/merino/providers/wcs/protocol.py
+++ b/merino/providers/wcs/protocol.py
@@ -5,6 +5,7 @@ from typing import Any
 from pydantic import BaseModel, ConfigDict, Field, HttpUrl
 
 from merino.providers.suggest.sports.backends.sportsdata.common.data import Event
+from merino.providers.wcs.utils import get_team_colours
 from merino.utils.logos import LogoCategory, load_manifest
 
 
@@ -43,7 +44,7 @@ class TeamInfo(BaseModel):
             global_team_id=int(team["id"]),
             name=str(team["name"]),
             region=str(team.get("region") or team.get("country") or key),
-            colors=[str(color) for color in team["colors"] if color],
+            colors=get_team_colours(key),
             icon_url=HttpUrl(raw_icon_url) if raw_icon_url else _icon(key),
             eliminated=bool(team.get("eliminated", False)),
         )

--- a/tests/unit/providers/wcs/test_provider.py
+++ b/tests/unit/providers/wcs/test_provider.py
@@ -136,6 +136,16 @@ async def test_public_sport_identifier_is_soccer() -> None:
 
 
 @pytest.mark.asyncio
+async def test_match_team_colors_are_normalized_to_hex() -> None:
+    """Cached event team color names are replaced with WCS hex colors."""
+    response = await build_provider().get_matches(ANCHOR, limit=None, team_keys=None)
+    event = next(event for event in response.previous if event.home_team.key == "BRA")
+
+    assert event.home_team.colors == ["#009C3B", "#FFDF00", "#002776"]
+    assert event.away_team.colors == ["#74ACDF", "#FFFFFF", "#F6B40E"]
+
+
+@pytest.mark.asyncio
 async def test_extra_and_penalty_populated_on_one_finalized_match() -> None:
     """Exactly one finalized match exposes extra-time and penalty-shootout values."""
     response = await build_provider().get_matches(ANCHOR, limit=None, team_keys=None)


### PR DESCRIPTION
## References

JIRA: [DISCO-4195](https://mozilla-hub.atlassian.net/browse/DISCO-4195DO)


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2304)


[DISCO-4195]: https://mozilla-hub.atlassian.net/browse/DISCO-4195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ