### PR TITLE
[HNT-2182] feat: Add editorial sections experiment treatment branch

### DIFF
--- a/merino/curated_recommendations/protocol.py
+++ b/merino/curated_recommendations/protocol.py
@@ -107,6 +107,8 @@ class ExperimentName(str, Enum):
     CONTEXTUAL_AD_V2_RELEASE_EXPERIMENT = "new-tab-contextual-ad-updates-v2-release"
     NEW_TAB_CUSTOM_SECTIONS_EXPERIMENT = "new-tab-custom-sections"
     INFERRED_TIME_ZONE_EXPERIMENT = "new-tab-stories-time-zone-based-ranking"
+    # Experiment to measure the impact of editorial sections by hiding them in the treatment branch
+    EDITORIAL_SECTIONS_EXPERIMENT = "editorial-sections-experiment"
 
     # Experiment for doing local reranking of popular today via inferred interests
     INFERRED_LOCAL_EXPERIMENT = "new-tab-automated-personalization-local-ranking"
@@ -122,6 +124,13 @@ class DailyBriefingBranch(str, Enum):
     BRIEFING_WITH_POPULAR = "briefing-with-popular"
     # Show Daily Briefing (headlines) section WITHOUT Popular Today section
     BRIEFING_WITHOUT_POPULAR = "briefing-without-popular"
+
+
+class EditorialSectionsBranch(str, Enum):
+    """Treatment branches for the Editorial Sections experiment (HNT-2182)."""
+
+    # Remove editorial (manually curated) sections; keep ML sections + Popular Today.
+    NO_EDITORIAL_SECTIONS = "no-editorial-sections"
 
 
 # Maximum tileId that Firefox can support. Firefox uses Javascript to store this value. The max

--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -48,6 +48,7 @@ from merino.curated_recommendations.protocol import (
     CuratedRecommendation,
     Section,
     SectionConfiguration,
+    EditorialSectionsBranch,
     ExperimentName,
     DailyBriefingBranch,
     ProcessedInterests,
@@ -234,6 +235,7 @@ async def get_corpus_sections(
     surface_id: SurfaceId,
     min_feed_rank: int,
     include_subtopics: bool = False,
+    exclude_editorial_sections: bool = False,
 ) -> tuple[CorpusSection | None, dict[str, Section]]:
     """Fetch curated sections.
 
@@ -242,6 +244,7 @@ async def get_corpus_sections(
         surface_id: Identifier for which surface to fetch sections.
         min_feed_rank: Starting rank offset for assigning receivedFeedRank.
         include_subtopics: Whether to include subtopic sections.
+        exclude_editorial_sections: Whether to drop manually curated sections.
 
     Returns:
         A tuple of the raw daily-briefing CorpusSection (if present,
@@ -263,6 +266,13 @@ async def get_corpus_sections(
         remaining_raw,
         include_subtopics,
     )
+
+    if exclude_editorial_sections:
+        filtered_corpus_sections = {
+            sid: cs
+            for sid, cs in filtered_corpus_sections.items()
+            if cs.createSource != CreateSource.MANUAL
+        }
 
     # Process the sections using the shared logic
     corpus_sections = _process_corpus_sections(
@@ -402,6 +412,19 @@ def is_custom_sections_experiment(request: CuratedRecommendationsRequest) -> boo
     """Return True if custom sections should be included based on experiments."""
     return is_enrolled_in_experiment(
         request, ExperimentName.NEW_TAB_CUSTOM_SECTIONS_EXPERIMENT.value, "treatment"
+    )
+
+
+def should_exclude_editorial_sections(request: CuratedRecommendationsRequest) -> bool:
+    """Return True if editorial (manually curated) sections must be hidden (HNT-2182).
+
+    True only for the `no-editorial-sections` branch of the editorial sections experiment.
+    Popular Today and ML sections are unaffected.
+    """
+    return is_enrolled_in_experiment(
+        request,
+        ExperimentName.EDITORIAL_SECTIONS_EXPERIMENT.value,
+        EditorialSectionsBranch.NO_EDITORIAL_SECTIONS.value,
     )
 
 
@@ -812,6 +835,7 @@ async def get_sections(
         surface_id=surface_id,
         min_feed_rank=1,
         include_subtopics=include_subtopics,
+        exclude_editorial_sections=should_exclude_editorial_sections(request),
     )
 
     # Determine if we should include daily briefing based on experiment

--- a/tests/unit/curated_recommendations/test_sections.py
+++ b/tests/unit/curated_recommendations/test_sections.py
@@ -36,6 +36,7 @@ from merino.curated_recommendations.protocol import (
     ITEM_SUBTOPIC_FLAG,
     Section,
     SectionConfiguration,
+    EditorialSectionsBranch,
     ExperimentName,
     DailyBriefingBranch,
     CuratedRecommendation,
@@ -49,6 +50,7 @@ from merino.curated_recommendations.sections import (
     exclude_recommendations_from_blocked_sections,
     is_subtopics_experiment,
     is_daily_briefing_experiment,
+    should_exclude_editorial_sections,
     should_show_popular_today_with_daily_briefing,
     update_received_feed_rank,
     get_sections_with_enough_items,
@@ -414,6 +416,38 @@ class TestDailyBriefingExperiment:
         """Test that should_show_popular_today_with_daily_briefing returns True only for briefing-with-popular."""
         req = SimpleNamespace(experimentName=name, experimentBranch=branch, inferredInterests=None)
         assert should_show_popular_today_with_daily_briefing(req) is expected
+
+
+class TestEditorialSectionsExperiment:
+    """Tests covering should_exclude_editorial_sections (HNT-2182)."""
+
+    @pytest.mark.parametrize(
+        "name,branch,expected",
+        [
+            # Treatment branch hides editorial sections.
+            (
+                ExperimentName.EDITORIAL_SECTIONS_EXPERIMENT.value,
+                EditorialSectionsBranch.NO_EDITORIAL_SECTIONS.value,
+                True,
+            ),
+            # Forced-enrollment (optin-) variant also activates the treatment.
+            (
+                f"optin-{ExperimentName.EDITORIAL_SECTIONS_EXPERIMENT.value}",
+                EditorialSectionsBranch.NO_EDITORIAL_SECTIONS.value,
+                True,
+            ),
+            # Control branch keeps editorial sections.
+            (ExperimentName.EDITORIAL_SECTIONS_EXPERIMENT.value, "control", False),
+            # Unrelated experiment does nothing.
+            ("other-experiment", "treatment", False),
+            # No experiment does nothing.
+            (None, None, False),
+        ],
+    )
+    def test_should_exclude_editorial_sections(self, name, branch, expected):
+        """Editorial sections are only excluded on the no-editorial-sections branch."""
+        req = SimpleNamespace(experimentName=name, experimentBranch=branch, inferredInterests=None)
+        assert should_exclude_editorial_sections(req) is expected
 
 
 class TestFilterSectionsByExperiment:
@@ -1789,6 +1823,41 @@ class TestGetCorpusSections:
 
         # Should include both ML and MANUAL sections
         assert set(sections.keys()) == {"sports", "custom-section-1", "custom-section-2"}
+
+    @pytest.mark.asyncio
+    async def test_exclude_editorial_sections_drops_manual_only(
+        self, sections_backend_with_manual_sections
+    ):
+        """When exclude_editorial_sections is True, only MANUAL sections are removed."""
+        _, sections = await get_corpus_sections(
+            sections_backend=sections_backend_with_manual_sections,
+            surface_id=SurfaceId.NEW_TAB_EN_US,
+            min_feed_rank=0,
+            exclude_editorial_sections=True,
+        )
+
+        # Only the ML legacy-topic section ("sports") remains.
+        assert set(sections.keys()) == {"sports"}
+
+    @pytest.mark.asyncio
+    async def test_exclude_editorial_sections_preserves_daily_briefing(
+        self, sections_backend_with_daily_briefing
+    ):
+        """Daily briefing is split out before filtering and must survive the editorial filter."""
+        raw_briefing, sections = await get_corpus_sections(
+            sections_backend=sections_backend_with_daily_briefing,
+            surface_id=SurfaceId.NEW_TAB_EN_US,
+            min_feed_rank=1,
+            include_subtopics=True,
+            exclude_editorial_sections=True,
+        )
+
+        # Daily briefing is still returned raw (it bypasses the filter pipeline).
+        assert raw_briefing is not None
+        assert raw_briefing.externalId == DAILY_BRIEFING_SECTION_KEY
+        # ML sections (sports, headlines) remain.
+        assert "sports" in sections
+        assert HEADLINES_SECTION_KEY in sections
 
     @pytest.mark.asyncio
     async def test_resolves_5050_pair_before_mapping(


### PR DESCRIPTION
## References

JIRA: [HNT-2182](https://mozilla-hub.atlassian.net/browse/HNT-2182)
Experimenter: https://experimenter.services.mozilla.com/nimbus/editorial-sections-experiment

## Description

Hides editorial (manually curated) sections from users in the `no-editorial-sections` branch of [editorial-sections-experiment](https://experimenter.services.mozilla.com/nimbus/editorial-sections-experiment/update_overview/), so we can measure their impact on engagement vs. ML sections alone. Popular Today, Daily Briefing, and ML sections are unaffected.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[HNT-2182]: https://mozilla-hub.atlassian.net/browse/HNT-2182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ