### PR TITLE
DISCO-4181 Add REGULAR, WIDGET and ALL mode to Merino

### DIFF
--- a/merino/configs/__init__.py
+++ b/merino/configs/__init__.py
@@ -5,7 +5,15 @@ from functools import partial, update_wrapper
 from dynaconf import Dynaconf, Validator
 
 # Validators for Merino settings.
+_RUNTIME_MODE_VALUES = ["ALL", "REGULAR", "WIDGET"]
+
 _validators = [
+    Validator(
+        "runtime.mode",
+        is_type_of=str,
+        is_in=_RUNTIME_MODE_VALUES,
+        default="ALL",
+    ),
     Validator(
         "runtime.disabled_providers",
         is_type_of=list,

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -28,6 +28,12 @@ suggest_supported_languages = ["en", "fr", "de", "it", "pl"]
 
 
 [default.runtime]
+# MERINO_RUNTIME__MODE
+# Boot-time feature profile.
+# Allowed values: ALL, REGULAR, WIDGET.
+# Use REGULAR for the main Suggest API, WIDGET for the WCS widget API, and ALL for both.
+mode = "ALL"
+
 # MERINO_RUNTIME__QUERY_TIMEOUT_SEC
 # A float timeout (in seconds) for all queries issued in "web/api_v1.py".
 # Indicates the maximum waiting period for queries issued within handler of the `suggest` endpoint.

--- a/merino/main.py
+++ b/merino/main.py
@@ -1,7 +1,9 @@
 """App startup point"""
 
+import inspect
 import logging
 
+from collections.abc import Callable
 from contextlib import asynccontextmanager
 
 from asgi_correlation_id import CorrelationIdMiddleware
@@ -11,14 +13,18 @@ from fastapi.responses import JSONResponse
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 
-from merino import curated_recommendations, governance
-from merino.providers import rss
 from merino.configs.app_configs.config_logging import configure_logging
 from merino.configs.app_configs.config_sentry import configure_sentry
-from merino.providers import games, manifest, suggest, wcs
+from merino.runtime import (
+    RuntimeFeature,
+    RuntimeMode,
+    coerce_runtime_mode,
+    get_runtime_mode,
+    mode_enables,
+)
 from merino.utils.metrics import configure_metrics, get_metrics_client
 from merino.middleware import featureflags, geolocation, logging as mw_logging, metrics, user_agent
-from merino.web import api_v1, dockerflow
+from merino.web import dockerflow
 
 tags_metadata = [
     {
@@ -34,8 +40,11 @@ tags_metadata = [
         "description": "World Cup Soccer match data for the New Tab widget.",
     },
 ]
+_REGULAR_API_TAG_NAMES = frozenset({"suggest", "providers"})
+_WCS_API_TAG_NAMES = frozenset({"wcs"})
 
 logger = logging.getLogger(__name__)
+CleanupCallback = Callable[[], object]
 
 
 @asynccontextmanager
@@ -43,35 +52,15 @@ async def lifespan(app: FastAPI):
     """Set up various configurations at startup and handle shutdown clean up.
     See lifespan events in fastAPI docs https://fastapi.tiangolo.com/advanced/events/
     """
-    # Setup methods run before `yield` and cleanup methods after.
-    # Load sentry and logging, init providers.
-    configure_logging()
-    configure_sentry()
-    await configure_metrics()
-    await suggest.init_providers()
-    await manifest.init_provider()
-    await rss.init_providers()
-    curated_recommendations.init_provider()
-    await games.init_providers()
-    await wcs.init_provider()
-    governance.start()
-    yield
-    governance.shutdown()
-    # Shut down providers and clean up.
-    await wcs.shutdown_provider()
-    await rss.shutdown_providers()
-    await suggest.shutdown_providers()
-    await get_metrics_client().close()
+    async with create_lifespan(get_runtime_mode())(app):
+        yield
 
 
-app = FastAPI(openapi_tags=tags_metadata, lifespan=lifespan, default_response_class=JSONResponse)
-
-
-@app.exception_handler(RequestValidationError)
-async def validation_exception_handler(
-    request: Request, exc: RequestValidationError
-) -> JSONResponse:
+async def validation_exception_handler(request: Request, exc: Exception) -> JSONResponse:
     """Use HTTP status code: 400 for all invalid requests."""
+    if not isinstance(exc, RequestValidationError):
+        raise exc
+
     # `exe.errors()` is intentionally omitted in the log to avoid log excessively
     # large error messages.
     logger.warning(f"HTTP 400: request validation error for path: {request.url.path}")
@@ -81,24 +70,146 @@ async def validation_exception_handler(
     )
 
 
-# Note: the order of the following middleware registration matters.
-# Specifically, `LoggingMiddleware` should be added after `CorrelationIdMiddleware` and
-# `GeolocationMiddleware`.
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["*"],
-    allow_credentials=False,
-    allow_methods=["GET", "OPTIONS", "HEAD"],
-)
-app.add_middleware(metrics.MetricsMiddleware)
-app.add_middleware(CorrelationIdMiddleware)
-app.add_middleware(featureflags.FeatureFlagsMiddleware)
-app.add_middleware(geolocation.GeolocationMiddleware)
-app.add_middleware(user_agent.UserAgentMiddleware)
-app.add_middleware(mw_logging.LoggingMiddleware)
+def create_lifespan(mode: RuntimeMode | str):
+    """Build startup and shutdown work for a runtime mode.
 
-app.include_router(dockerflow.router)
-app.include_router(api_v1.router, prefix="/api/v1")
+    To wire a new service into the main app:
+    add a RuntimeFeature, opt it into the right RuntimeMode values, start it here,
+    include its router in _include_routers, and add its OpenAPI tag metadata.
+    Dockerflow stays enabled for every mode.
+    """
+    runtime_mode = coerce_runtime_mode(mode)
+
+    @asynccontextmanager
+    async def runtime_lifespan(app: FastAPI):
+        cleanup_callbacks: list[CleanupCallback] = []
+        try:
+            configure_logging()
+            configure_sentry()
+            await configure_metrics()
+            cleanup_callbacks.append(_close_metrics_client)
+
+            if mode_enables(runtime_mode, RuntimeFeature.REGULAR_API):
+                await _start_regular_services(cleanup_callbacks)
+
+            if mode_enables(runtime_mode, RuntimeFeature.WCS_API):
+                await _start_wcs_services(cleanup_callbacks)
+
+            if mode_enables(runtime_mode, RuntimeFeature.REGULAR_API):
+                _start_governance(cleanup_callbacks)
+
+            yield
+        finally:
+            await _run_cleanup_callbacks(cleanup_callbacks)
+
+    return runtime_lifespan
+
+
+async def _start_regular_services(cleanup_callbacks: list[CleanupCallback]) -> None:
+    """Initialize regular Merino services and register cleanup callbacks."""
+    from merino import curated_recommendations
+    from merino.providers import games, manifest, rss, suggest
+
+    await suggest.init_providers()
+    cleanup_callbacks.append(suggest.shutdown_providers)
+
+    await manifest.init_provider()
+
+    await rss.init_providers()
+    cleanup_callbacks.append(rss.shutdown_providers)
+
+    curated_recommendations.init_provider()
+    await games.init_providers()
+
+
+async def _start_wcs_services(cleanup_callbacks: list[CleanupCallback]) -> None:
+    """Initialize World Cup widget services and register cleanup callbacks."""
+    from merino.providers import wcs
+
+    await wcs.init_provider()
+    cleanup_callbacks.append(wcs.shutdown_provider)
+
+
+def _start_governance(cleanup_callbacks: list[CleanupCallback]) -> None:
+    """Start regular service governance and register cleanup."""
+    from merino import governance
+
+    governance.start()
+    cleanup_callbacks.append(governance.shutdown)
+
+
+async def _run_cleanup_callbacks(cleanup_callbacks: list[CleanupCallback]) -> None:
+    """Run cleanup callbacks in reverse startup order."""
+    for cleanup in reversed(cleanup_callbacks):
+        result = cleanup()
+        if inspect.isawaitable(result):
+            await result
+
+
+async def _close_metrics_client() -> None:
+    """Close the shared metrics client."""
+    await get_metrics_client().close()
+
+
+def create_app(mode: RuntimeMode | str | None = None) -> FastAPI:
+    """Create the FastAPI application for a runtime mode."""
+    runtime_mode = get_runtime_mode() if mode is None else coerce_runtime_mode(mode)
+    app = FastAPI(
+        openapi_tags=_get_tags_metadata(runtime_mode),
+        lifespan=create_lifespan(runtime_mode),
+        default_response_class=JSONResponse,
+    )
+    app.add_exception_handler(RequestValidationError, validation_exception_handler)
+    _add_middleware(app)
+    _include_routers(app, runtime_mode)
+    return app
+
+
+def _get_tags_metadata(mode: RuntimeMode) -> list[dict[str, str]]:
+    """Return OpenAPI tag metadata for enabled feature groups."""
+    enabled_tag_names: set[str] = set()
+
+    if mode_enables(mode, RuntimeFeature.REGULAR_API):
+        enabled_tag_names.update(_REGULAR_API_TAG_NAMES)
+
+    if mode_enables(mode, RuntimeFeature.WCS_API):
+        enabled_tag_names.update(_WCS_API_TAG_NAMES)
+
+    return [tag for tag in tags_metadata if tag["name"] in enabled_tag_names]
+
+
+def _add_middleware(app: FastAPI) -> None:
+    """Register the historical app-wide middleware stack for every runtime mode."""
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_credentials=False,
+        allow_methods=["GET", "OPTIONS", "HEAD"],
+    )
+    app.add_middleware(metrics.MetricsMiddleware)
+    app.add_middleware(CorrelationIdMiddleware)
+    app.add_middleware(featureflags.FeatureFlagsMiddleware)
+    app.add_middleware(geolocation.GeolocationMiddleware)
+    app.add_middleware(user_agent.UserAgentMiddleware)
+    app.add_middleware(mw_logging.LoggingMiddleware)
+
+
+def _include_routers(app: FastAPI, mode: RuntimeMode) -> None:
+    """Include routers enabled for a runtime mode."""
+    app.include_router(dockerflow.router)
+
+    if mode_enables(mode, RuntimeFeature.REGULAR_API):
+        from merino.web import api_v1
+
+        app.include_router(api_v1.router, prefix="/api/v1")
+
+    if mode_enables(mode, RuntimeFeature.WCS_API):
+        from merino.web import api_v1_wcs
+
+        app.include_router(api_v1_wcs.router, prefix="/api/v1")
+
+
+app = create_app()
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/merino/providers/suggest/__init__.py
+++ b/merino/providers/suggest/__init__.py
@@ -1,14 +1,14 @@
 """Initialize all Providers."""
 
+from __future__ import annotations
+
 import asyncio
 import logging
 from timeit import default_timer as timer
 
-from merino.utils import metrics
-from merino.configs import settings
 from merino.providers.suggest.base import BaseProvider
 from merino.providers.suggest.manager import load_providers
-from merino.utils.query_processing.normalization import init_pipeline
+from merino.utils import metrics
 
 providers: dict[str, BaseProvider] = {}
 default_providers: list[BaseProvider] = []
@@ -21,6 +21,9 @@ async def init_providers() -> None:
 
     This should only be called once at the startup of application.
     """
+    from merino.configs import settings
+    from merino.utils.query_processing.normalization import init_pipeline
+
     start = timer()
     # register providers
     providers.update(load_providers(disabled_providers_list=settings.runtime.disabled_providers))

--- a/merino/runtime.py
+++ b/merino/runtime.py
@@ -1,0 +1,56 @@
+"""Runtime mode helpers for selecting Merino feature groups."""
+
+from enum import StrEnum
+
+
+class RuntimeFeature(StrEnum):
+    """Feature groups controlled by the runtime mode."""
+
+    REGULAR_API = "regular_api"
+    WCS_API = "wcs_api"
+
+
+class RuntimeMode(StrEnum):
+    """Boot-time runtime profiles for Merino."""
+
+    ALL = "ALL"
+    REGULAR = "REGULAR"
+    WIDGET = "WIDGET"
+
+
+_ALLOWED_RUNTIME_MODES = ", ".join(mode.value for mode in RuntimeMode)
+
+_RUNTIME_MODE_FEATURES: dict[RuntimeMode, frozenset[RuntimeFeature]] = {
+    RuntimeMode.ALL: frozenset({RuntimeFeature.REGULAR_API, RuntimeFeature.WCS_API}),
+    RuntimeMode.REGULAR: frozenset({RuntimeFeature.REGULAR_API}),
+    RuntimeMode.WIDGET: frozenset({RuntimeFeature.WCS_API}),
+}
+
+
+def coerce_runtime_mode(value: RuntimeMode | str | None) -> RuntimeMode:
+    """Return a runtime mode for a config or test value."""
+    if isinstance(value, RuntimeMode):
+        return value
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"runtime mode must be set to one of: {_ALLOWED_RUNTIME_MODES}")
+    try:
+        return RuntimeMode(value)
+    except ValueError as exc:
+        raise ValueError(f"runtime mode must be one of: {_ALLOWED_RUNTIME_MODES}") from exc
+
+
+def get_runtime_mode() -> RuntimeMode:
+    """Return the runtime mode configured for this process."""
+    from merino.configs import settings
+
+    return coerce_runtime_mode(settings.runtime.mode)
+
+
+def mode_features(mode: RuntimeMode | str | None) -> frozenset[RuntimeFeature]:
+    """Return the feature groups enabled for a runtime mode."""
+    return _RUNTIME_MODE_FEATURES[coerce_runtime_mode(mode)]
+
+
+def mode_enables(mode: RuntimeMode | str | None, feature: RuntimeFeature) -> bool:
+    """Return whether a runtime mode enables a feature group."""
+    return feature in mode_features(mode)

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -2,8 +2,6 @@
 
 import logging
 from asyncio import Task
-from datetime import UTC, datetime
-from datetime import date as Date
 from functools import partial
 from itertools import chain
 from typing import Annotated, Literal
@@ -76,9 +74,6 @@ from merino.utils.query_processing.normalization.pipeline import tier_a
 from merino.providers.games import get_particle_provider
 from merino.providers.games.particle.backends.protocol import Particle
 from merino.providers.games.particle.provider import Provider as ParticleProvider
-from merino.providers.wcs import get_provider as get_wcs_provider
-from merino.providers.wcs.protocol import LiveMatchesResponse, MatchesResponse, TeamsResponse
-from merino.providers.wcs.provider import WcsProvider
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -674,73 +669,3 @@ async def get_game_particle(
         content=jsonable_encoder(particle_data),
         headers={"Cache-Control": (f"private, max-age={_games_particle_ttl}")},
     )
-
-
-@router.get(
-    "/wcs/matches",
-    tags=["wcs"],
-    summary="World Cup Soccer matches in the +/- 7 day window around `date`",
-    response_model=MatchesResponse,
-    response_model_by_alias=True,
-)
-async def get_wcs_matches(
-    date: Annotated[
-        Date | None, Query(description="RFC date YYYY-MM-DD; defaults to today UTC.")
-    ] = None,
-    limit: Annotated[int | None, Query(ge=1, le=100)] = None,
-    teams: Annotated[
-        str | None,
-        Query(description="Comma-separated 3-letter team keys, e.g. 'BRA,ARG'."),
-    ] = None,
-    provider: WcsProvider = Depends(get_wcs_provider),
-) -> MatchesResponse:
-    """Return matches grouped into `previous`, `current`, and `next`.
-
-    The window is `+/- 7 days` around `date`. `current` holds matches on `date`,
-    `previous` is older, `next` is newer. Each bucket is sorted ascending by
-    event date.
-    """
-    target_date = date or datetime.now(UTC).date()
-    team_keys = _parse_team_keys(teams)
-    return await provider.get_matches(target_date, limit, team_keys)
-
-
-@router.get(
-    "/wcs/live",
-    tags=["wcs"],
-    summary="Mocked World Cup Soccer events for the live endpoint",
-    response_model=LiveMatchesResponse,
-)
-async def get_wcs_live(
-    teams: Annotated[
-        str | None,
-        Query(description="Comma-separated 3-letter team keys, e.g. 'BRA,ARG'."),
-    ] = None,
-    provider: WcsProvider = Depends(get_wcs_provider),
-) -> LiveMatchesResponse:
-    """Return mocked live-endpoint events, sorted ascending by date.
-
-    Anchored to fake test data until real live data lands.
-    """
-    return await provider.get_live_matches(_parse_team_keys(teams))
-
-
-@router.get(
-    "/wcs/teams",
-    tags=["wcs"],
-    summary="All World Cup Soccer teams",
-    response_model=TeamsResponse,
-)
-async def get_wcs_teams(
-    provider: WcsProvider = Depends(get_wcs_provider),
-) -> TeamsResponse:
-    """Return all teams participating in the World Cup."""
-    return provider.get_teams()
-
-
-def _parse_team_keys(teams: str | None) -> frozenset[str] | None:
-    """Parse a comma-separated list of team keys into an upper-case frozen set."""
-    if not teams:
-        return None
-    keys = frozenset(t.strip().upper() for t in teams.split(",") if t.strip())
-    return keys or None

--- a/merino/web/api_v1_wcs.py
+++ b/merino/web/api_v1_wcs.py
@@ -1,0 +1,83 @@
+"""Merino V1 World Cup Soccer API."""
+
+from datetime import UTC, datetime
+from datetime import date as Date
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Query
+
+from merino.providers.wcs import get_provider as get_wcs_provider
+from merino.providers.wcs.protocol import LiveMatchesResponse, MatchesResponse, TeamsResponse
+from merino.providers.wcs.provider import WcsProvider
+
+router = APIRouter()
+
+
+@router.get(
+    "/wcs/matches",
+    tags=["wcs"],
+    summary="World Cup Soccer matches in the +/- 7 day window around `date`",
+    response_model=MatchesResponse,
+    response_model_by_alias=True,
+)
+async def get_wcs_matches(
+    date: Annotated[
+        Date | None, Query(description="RFC date YYYY-MM-DD; defaults to today UTC.")
+    ] = None,
+    limit: Annotated[int | None, Query(ge=1, le=100)] = None,
+    teams: Annotated[
+        str | None,
+        Query(description="Comma-separated 3-letter team keys, e.g. 'BRA,ARG'."),
+    ] = None,
+    provider: WcsProvider = Depends(get_wcs_provider),
+) -> MatchesResponse:
+    """Return matches grouped into `previous`, `current`, and `next`.
+
+    The window is `+/- 7 days` around `date`. `current` holds matches on `date`,
+    `previous` is older, `next` is newer. Each bucket is sorted ascending by
+    event date.
+    """
+    target_date = date or datetime.now(UTC).date()
+    team_keys = _parse_team_keys(teams)
+    return await provider.get_matches(target_date, limit, team_keys)
+
+
+@router.get(
+    "/wcs/live",
+    tags=["wcs"],
+    summary="Mocked World Cup Soccer events for the live endpoint",
+    response_model=LiveMatchesResponse,
+)
+async def get_wcs_live(
+    teams: Annotated[
+        str | None,
+        Query(description="Comma-separated 3-letter team keys, e.g. 'BRA,ARG'."),
+    ] = None,
+    provider: WcsProvider = Depends(get_wcs_provider),
+) -> LiveMatchesResponse:
+    """Return mocked live-endpoint events, sorted ascending by date.
+
+    Anchored to fake test data until real live data lands.
+    """
+    return await provider.get_live_matches(_parse_team_keys(teams))
+
+
+@router.get(
+    "/wcs/teams",
+    tags=["wcs"],
+    summary="All World Cup Soccer teams",
+    response_model=TeamsResponse,
+)
+async def get_wcs_teams(
+    provider: WcsProvider = Depends(get_wcs_provider),
+) -> TeamsResponse:
+    """Return all teams participating in the World Cup."""
+    return provider.get_teams()
+
+
+def _parse_team_keys(teams: str | None) -> frozenset[str] | None:
+    """Parse a comma-separated list of team keys into an upper-case frozen set."""
+    if not teams:
+        return None
+    keys = frozenset(t.strip().upper() for t in teams.split(",") if t.strip())
+    return keys or None

--- a/tests/unit/test_runtime_modes.py
+++ b/tests/unit/test_runtime_modes.py
@@ -1,0 +1,360 @@
+"""Tests for Merino runtime modes."""
+
+from collections.abc import Callable
+import json
+import os
+from pathlib import Path
+
+# subprocess is used only for fixed-argv fresh interpreter checks.
+import subprocess  # nosec B404
+import sys
+
+import pytest
+from fastapi import FastAPI
+from pytest_mock import MockerFixture
+from starlette.testclient import TestClient
+
+from merino.main import create_app
+from merino.providers.wcs import get_provider as get_wcs_provider
+from merino.runtime import RuntimeFeature, RuntimeMode, coerce_runtime_mode, mode_enables
+from tests.wcs.factories import build_provider
+
+
+def _route_paths(app: FastAPI) -> set[str]:
+    """Return the registered paths for a FastAPI app."""
+    paths: set[str] = set()
+    for route in app.routes:
+        path = getattr(route, "path", None)
+        if isinstance(path, str):
+            paths.add(path)
+    return paths
+
+
+def test_runtime_mode_predicates() -> None:
+    """Runtime modes enable the intended feature groups."""
+    assert mode_enables(RuntimeMode.ALL, RuntimeFeature.REGULAR_API)
+    assert mode_enables(RuntimeMode.ALL, RuntimeFeature.WCS_API)
+
+    assert mode_enables(RuntimeMode.REGULAR, RuntimeFeature.REGULAR_API)
+    assert not mode_enables(RuntimeMode.REGULAR, RuntimeFeature.WCS_API)
+
+    assert mode_enables(RuntimeMode.WIDGET, RuntimeFeature.WCS_API)
+    assert not mode_enables(RuntimeMode.WIDGET, RuntimeFeature.REGULAR_API)
+
+
+def test_runtime_mode_coercion_rejects_unknown_mode() -> None:
+    """Unknown runtime mode values fail fast."""
+    assert coerce_runtime_mode(RuntimeMode.WIDGET) is RuntimeMode.WIDGET
+    assert coerce_runtime_mode("WIDGET") is RuntimeMode.WIDGET
+
+    for value in ("unknown", "widget", "", None):
+        with pytest.raises(ValueError, match="runtime mode must"):
+            coerce_runtime_mode(value)
+
+
+def test_invalid_configured_runtime_mode_fails_startup() -> None:
+    """Invalid configured runtime mode values fail config validation."""
+    env = os.environ.copy()
+    env["MERINO_RUNTIME__MODE"] = "bogus"
+    # Fixed argv, shell=False, no untrusted input.
+    result = subprocess.run(  # nosec B603
+        [sys.executable, "-c", "import merino.main"],
+        cwd=Path(__file__).parents[2],
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "runtime.mode" in result.stderr
+    assert "ALL" in result.stderr
+    assert "REGULAR" in result.stderr
+    assert "WIDGET" in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected_paths", "unexpected_paths"),
+    [
+        (
+            RuntimeMode.ALL,
+            {"/__heartbeat__", "/api/v1/suggest", "/api/v1/wcs/matches"},
+            set(),
+        ),
+        (
+            RuntimeMode.REGULAR,
+            {"/__heartbeat__", "/api/v1/suggest"},
+            {"/api/v1/wcs/matches"},
+        ),
+        (
+            RuntimeMode.WIDGET,
+            {"/__heartbeat__", "/api/v1/wcs/matches"},
+            {"/api/v1/suggest"},
+        ),
+    ],
+)
+def test_create_app_registers_routes_by_mode(
+    mode: RuntimeMode, expected_paths: set[str], unexpected_paths: set[str]
+) -> None:
+    """The app factory includes only the routers enabled by the runtime mode."""
+    paths = _route_paths(create_app(mode))
+
+    assert expected_paths <= paths
+    assert not unexpected_paths & paths
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected_tags"),
+    [
+        (RuntimeMode.ALL, ["suggest", "providers", "wcs"]),
+        (RuntimeMode.REGULAR, ["suggest", "providers"]),
+        (RuntimeMode.WIDGET, ["wcs"]),
+    ],
+)
+def test_create_app_registers_openapi_tags_by_mode(
+    mode: RuntimeMode, expected_tags: list[str]
+) -> None:
+    """The app factory exposes only OpenAPI tags for enabled feature groups."""
+    tags = [tag["name"] for tag in create_app(mode).openapi_tags or []]
+
+    assert tags == expected_tags
+
+
+@pytest.mark.parametrize("mode", [RuntimeMode.ALL, RuntimeMode.REGULAR, RuntimeMode.WIDGET])
+def test_create_app_registers_same_middleware_by_mode(mode: RuntimeMode) -> None:
+    """Runtime modes keep the existing middleware stack unchanged."""
+    middleware_names = [
+        getattr(middleware.cls, "__name__", repr(middleware.cls))
+        for middleware in create_app(mode).user_middleware
+    ]
+
+    assert middleware_names == [
+        "LoggingMiddleware",
+        "UserAgentMiddleware",
+        "GeolocationMiddleware",
+        "FeatureFlagsMiddleware",
+        "CorrelationIdMiddleware",
+        "MetricsMiddleware",
+        "CORSMiddleware",
+    ]
+
+
+def test_widget_mode_serves_wcs_and_dockerflow_only() -> None:
+    """Widget mode serves WCS and Dockerflow while regular API routes 404."""
+    app = create_app(RuntimeMode.WIDGET)
+    provider = build_provider()
+    app.dependency_overrides[get_wcs_provider] = lambda: provider
+
+    client = TestClient(app)
+
+    assert client.get("/__heartbeat__").status_code == 200
+    assert client.get("/api/v1/suggest", params={"q": "firefox"}).status_code == 404
+    assert client.get("/api/v1/wcs/matches", params={"date": "2026-06-15"}).status_code == 200
+
+
+def test_widget_mode_does_not_import_regular_routes() -> None:
+    """Widget mode avoids regular-only router imports."""
+    script = """
+import json
+import sys
+
+import merino.main
+
+regular_route_modules = [
+    "merino.web.api_v1",
+]
+api_paths = sorted(
+    route.path
+    for route in merino.main.app.routes
+    if hasattr(route, "path") and route.path.startswith("/api/v1")
+)
+print(
+    json.dumps(
+        {
+            "regular_route_modules": {
+                module_name: module_name in sys.modules for module_name in regular_route_modules
+            },
+            "api_paths": api_paths,
+        },
+        sort_keys=True,
+    )
+)
+"""
+    env = os.environ.copy()
+    env["MERINO_RUNTIME__MODE"] = RuntimeMode.WIDGET.value
+    # Fixed argv, shell=False, no untrusted input.
+    result = subprocess.run(  # nosec B603
+        [sys.executable, "-c", script],
+        cwd=Path(__file__).parents[2],
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    output = json.loads(result.stdout.splitlines()[-1])
+    assert output["regular_route_modules"] == {
+        "merino.web.api_v1": False,
+    }
+    assert output["api_paths"] == [
+        "/api/v1/wcs/live",
+        "/api/v1/wcs/matches",
+        "/api/v1/wcs/teams",
+    ]
+
+
+def test_regular_mode_serves_regular_api_without_wcs(mocker: MockerFixture) -> None:
+    """Regular mode serves regular API routes while WCS routes 404."""
+    import merino.main as main
+    from merino.providers.suggest import get_providers as get_suggest_providers
+    from tests.integration.api.v1.fake_providers import FakeProviderFactory
+
+    async def configure_metrics() -> None:
+        pass
+
+    async def close_metrics_client() -> None:
+        pass
+
+    async def start_regular(cleanup_callbacks) -> None:
+        pass
+
+    async def start_wcs(cleanup_callbacks) -> None:
+        raise AssertionError("WCS services should not start in REGULAR mode")
+
+    def start_governance(cleanup_callbacks) -> None:
+        pass
+
+    async def get_fake_providers():
+        provider = FakeProviderFactory.nonsponsored(enabled_by_default=True)
+        return {"non-sponsored": provider}, [provider]
+
+    mocker.patch.object(main, "configure_logging")
+    mocker.patch.object(main, "configure_sentry")
+    mocker.patch.object(main, "configure_metrics", side_effect=configure_metrics)
+    mocker.patch.object(main, "_close_metrics_client", side_effect=close_metrics_client)
+    regular_start = mocker.patch.object(main, "_start_regular_services", side_effect=start_regular)
+    wcs_start = mocker.patch.object(main, "_start_wcs_services", side_effect=start_wcs)
+    governance_start = mocker.patch.object(main, "_start_governance", side_effect=start_governance)
+
+    app = create_app(RuntimeMode.REGULAR)
+    app.dependency_overrides[get_suggest_providers] = get_fake_providers
+
+    with TestClient(app) as client:
+        assert client.get("/__heartbeat__").status_code == 200
+        response = client.get("/api/v1/suggest", params={"q": "nonsponsored"})
+        assert response.status_code == 200
+        assert response.json()["suggestions"][0]["full_keyword"] == "nonsponsored"
+        assert client.get("/api/v1/wcs/matches", params={"date": "2026-06-15"}).status_code == 404
+
+    regular_start.assert_awaited_once()
+    wcs_start.assert_not_awaited()
+    governance_start.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_callbacks_ignore_non_awaitable_return_values() -> None:
+    """Cleanup callbacks may return incidental values."""
+    import merino.main as main
+
+    events: list[str] = []
+
+    def cleanup() -> object:
+        events.append("cleanup")
+        return object()
+
+    await main._run_cleanup_callbacks([cleanup])
+
+    assert events == ["cleanup"]
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected_events"),
+    [
+        (
+            RuntimeMode.ALL,
+            [
+                "logging_start",
+                "sentry_start",
+                "metrics_start",
+                "regular_start",
+                "wcs_start",
+                "governance_start",
+                "governance_shutdown",
+                "wcs_shutdown",
+                "regular_shutdown",
+                "metrics_shutdown",
+            ],
+        ),
+        (
+            RuntimeMode.REGULAR,
+            [
+                "logging_start",
+                "sentry_start",
+                "metrics_start",
+                "regular_start",
+                "governance_start",
+                "governance_shutdown",
+                "regular_shutdown",
+                "metrics_shutdown",
+            ],
+        ),
+        (
+            RuntimeMode.WIDGET,
+            [
+                "logging_start",
+                "sentry_start",
+                "metrics_start",
+                "wcs_start",
+                "wcs_shutdown",
+                "metrics_shutdown",
+            ],
+        ),
+    ],
+)
+def test_lifespan_starts_and_stops_services_by_mode(
+    mocker: MockerFixture,
+    mode: RuntimeMode,
+    expected_events: list[str],
+) -> None:
+    """The lifespan initializes and cleans up only services enabled for the mode."""
+    import merino.main as main
+
+    events: list[str] = []
+
+    def record(event: str) -> Callable[[], None]:
+        def _record() -> None:
+            events.append(event)
+
+        return _record
+
+    async def configure_metrics() -> None:
+        events.append("metrics_start")
+
+    async def close_metrics_client() -> None:
+        events.append("metrics_shutdown")
+
+    async def start_regular(cleanup_callbacks) -> None:
+        events.append("regular_start")
+        cleanup_callbacks.append(record("regular_shutdown"))
+
+    async def start_wcs(cleanup_callbacks) -> None:
+        events.append("wcs_start")
+        cleanup_callbacks.append(record("wcs_shutdown"))
+
+    def start_governance(cleanup_callbacks) -> None:
+        events.append("governance_start")
+        cleanup_callbacks.append(record("governance_shutdown"))
+
+    mocker.patch.object(main, "configure_logging", side_effect=record("logging_start"))
+    mocker.patch.object(main, "configure_sentry", side_effect=record("sentry_start"))
+    mocker.patch.object(main, "configure_metrics", side_effect=configure_metrics)
+    mocker.patch.object(main, "_close_metrics_client", side_effect=close_metrics_client)
+    mocker.patch.object(main, "_start_regular_services", side_effect=start_regular)
+    mocker.patch.object(main, "_start_wcs_services", side_effect=start_wcs)
+    mocker.patch.object(main, "_start_governance", side_effect=start_governance)
+
+    with TestClient(create_app(mode)):
+        pass
+
+    assert events == expected_events


### PR DESCRIPTION
## References

JIRA: [DISCO-4181](https://mozilla-hub.atlassian.net/browse/DISCO-4181)

## Description
Implements boot-time runtime profiles for Merino with `ALL`, `REGULAR`, and `WIDGET` modes. The app now builds routers, middleware, and lifespan startup from the selected mode, keeping WCS isolated from regular API routes, regular provider initialization, cron work, and regular-only import-time resources. WCS routes are split into their own FastAPI router module while regular routes keep their existing paths and behavior.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-4181]: https://mozilla-hub.atlassian.net/browse/DISCO-4181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ