### PR TITLE
[DISCO-4201] fix(wcs): query string updates for world cup

### DIFF
--- a/merino/providers/suggest/sports/backends/sportsdata/protocol.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/protocol.py
@@ -46,7 +46,7 @@ def build_query(event: dict[str, Any]) -> str:
         sport_query_name = "World Cup 2026"
     else:
         sport_query_name = event.get("sport", "")
-    return f"""{sport_query_name} {event.get("away_team", {}).get("name", "")} vs {event.get("home_team", {}).get("name", "")} {date}"""
+    return f"""{sport_query_name} {event.get("home_team", {}).get("name", "")} vs {event.get("away_team", {}).get("name", "")} {date}"""
 
 
 class SportEventDetail(BaseModel):

--- a/merino/providers/suggest/sports/backends/sportsdata/protocol.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/protocol.py
@@ -39,11 +39,14 @@ class SportTeamDetail(BaseModel):
 
 def build_query(event: dict[str, Any]) -> str:
     """Build the search query from the event information"""
-    date = datetime.fromisoformat(event["date"]).strftime("%d %b %Y")
+    date = datetime.fromisoformat(event["date"]).strftime("%d %B %Y")
     # catch pre-stored values
     if event.get("sport") == "fifa":
         event["sport"] = "World Cup"
-    return f"""{event.get("sport")} {event.get("away_team", {}).get("name", "")} at {event.get("home_team", {}).get("name", "")} {date}"""
+        sport_query_name = "World Cup 2026"
+    else:
+        sport_query_name = event.get("sport", "")
+    return f"""{sport_query_name} {event.get("away_team", {}).get("name", "")} at {event.get("home_team", {}).get("name", "")} {date}"""
 
 
 class SportEventDetail(BaseModel):

--- a/merino/providers/suggest/sports/backends/sportsdata/protocol.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/protocol.py
@@ -46,7 +46,7 @@ def build_query(event: dict[str, Any]) -> str:
         sport_query_name = "World Cup 2026"
     else:
         sport_query_name = event.get("sport", "")
-    return f"""{sport_query_name} {event.get("away_team", {}).get("name", "")} at {event.get("home_team", {}).get("name", "")} {date}"""
+    return f"""{sport_query_name} {event.get("away_team", {}).get("name", "")} vs {event.get("home_team", {}).get("name", "")} {date}"""
 
 
 class SportEventDetail(BaseModel):

--- a/merino/providers/wcs/protocol.py
+++ b/merino/providers/wcs/protocol.py
@@ -5,6 +5,7 @@ from typing import Any
 from pydantic import BaseModel, ConfigDict, Field, HttpUrl
 
 from merino.providers.suggest.sports.backends.sportsdata.common.data import Event
+from merino.providers.suggest.sports.backends.sportsdata.protocol import build_query
 from merino.providers.wcs.utils import get_team_colours
 from merino.utils.logos import LogoCategory, load_manifest
 
@@ -97,7 +98,7 @@ class EventInfo(BaseModel):
             updated=int(updated.timestamp()),
             status=event.status.as_str(),
             status_type=event.status.as_ui_status(),
-            query=f"{home_team.name} vs {away_team.name}",
+            query=build_query(event.model_dump(mode="json")),
         )
 
 

--- a/tests/integration/providers/suggest/sports/backends/test_sportsdata.py
+++ b/tests/integration/providers/suggest/sports/backends/test_sportsdata.py
@@ -151,7 +151,7 @@ async def test_sportsdata_na_query(sportsdata: SportsDataBackend, sports_league:
             SportEventDetail(
                 sport="NFL",
                 sport_category=SportCategory.Football,
-                query="NFL Fake Away at Fake Home 27 Oct 2025",
+                query="NFL Fake Away at Fake Home 27 October 2025",
                 date="2025-10-27T00:10:00+00:00",
                 home_team=SportTeamDetail(
                     key="HOM", name="Fake Home", colors=["000000", "FFFFFF"], score=None

--- a/tests/integration/providers/suggest/sports/backends/test_sportsdata.py
+++ b/tests/integration/providers/suggest/sports/backends/test_sportsdata.py
@@ -151,7 +151,7 @@ async def test_sportsdata_na_query(sportsdata: SportsDataBackend, sports_league:
             SportEventDetail(
                 sport="NFL",
                 sport_category=SportCategory.Football,
-                query="NFL Fake Away at Fake Home 27 October 2025",
+                query="NFL Fake Away vs Fake Home 27 October 2025",
                 date="2025-10-27T00:10:00+00:00",
                 home_team=SportTeamDetail(
                     key="HOM", name="Fake Home", colors=["000000", "FFFFFF"], score=None

--- a/tests/integration/providers/suggest/sports/backends/test_sportsdata.py
+++ b/tests/integration/providers/suggest/sports/backends/test_sportsdata.py
@@ -151,7 +151,7 @@ async def test_sportsdata_na_query(sportsdata: SportsDataBackend, sports_league:
             SportEventDetail(
                 sport="NFL",
                 sport_category=SportCategory.Football,
-                query="NFL Fake Away vs Fake Home 27 October 2025",
+                query="NFL Fake Home vs Fake Away 27 October 2025",
                 date="2025-10-27T00:10:00+00:00",
                 home_team=SportTeamDetail(
                     key="HOM", name="Fake Home", colors=["000000", "FFFFFF"], score=None

--- a/tests/unit/providers/suggest/sports/backends/test_sports_backend.py
+++ b/tests/unit/providers/suggest/sports/backends/test_sports_backend.py
@@ -34,6 +34,7 @@ from merino.providers.suggest.sports.backends.sportsdata.common.elastic import (
 )
 from merino.providers.suggest.sports.backends.sportsdata.protocol import (
     SportEventDetail,
+    build_query,
 )
 from merino.utils.logos import Logo, LogoCategory, LogoManifest
 
@@ -388,6 +389,32 @@ def test_sport_event_detail_remap() -> None:  # WCS, Widget
 
     result = SportEventDetail.from_event_dict(event)
     assert result.sport == "World Cup"
+    assert result.query == "World Cup 2026 Away Team at Home Team 01 October 2025"
+
+
+def test_build_query() -> None:
+    """build_query produces a 'sport away at home date' string."""
+    event: dict = {
+        "sport": "NFL",
+        "date": "2025-10-01T00:00:00+00:00",
+        "home_team": {"name": "Home Team"},
+        "away_team": {"name": "Away Team"},
+    }
+
+    assert build_query(event) == "NFL Away Team at Home Team 01 October 2025"
+
+
+def test_build_query_world_cup() -> None:
+    """build_query uses World Cup 2026 prefix for games"""
+    event: dict = {
+        "sport": "fifa",
+        "date": "2025-10-01T00:00:00+00:00",
+        "home_team": {"name": "Home Team"},
+        "away_team": {"name": "Away Team"},
+    }
+
+    assert build_query(event) == "World Cup 2026 Away Team at Home Team 01 October 2025"
+    assert event["sport"] == "World Cup"
 
 
 def test_sport_event_detail_icon_set_when_team_in_manifest(

--- a/tests/unit/providers/suggest/sports/backends/test_sports_backend.py
+++ b/tests/unit/providers/suggest/sports/backends/test_sports_backend.py
@@ -389,7 +389,7 @@ def test_sport_event_detail_remap() -> None:  # WCS, Widget
 
     result = SportEventDetail.from_event_dict(event)
     assert result.sport == "World Cup"
-    assert result.query == "World Cup 2026 Away Team vs Home Team 01 October 2025"
+    assert result.query == "World Cup 2026 Home Team vs Away Team 01 October 2025"
 
 
 def test_build_query() -> None:
@@ -401,7 +401,7 @@ def test_build_query() -> None:
         "away_team": {"name": "Away Team"},
     }
 
-    assert build_query(event) == "NFL Away Team vs Home Team 01 October 2025"
+    assert build_query(event) == "NFL Home Team vs Away Team 01 October 2025"
 
 
 def test_build_query_world_cup() -> None:
@@ -413,7 +413,7 @@ def test_build_query_world_cup() -> None:
         "away_team": {"name": "Away Team"},
     }
 
-    assert build_query(event) == "World Cup 2026 Away Team vs Home Team 01 October 2025"
+    assert build_query(event) == "World Cup 2026 Home Team vs Away Team 01 October 2025"
     assert event["sport"] == "World Cup"
 
 

--- a/tests/unit/providers/suggest/sports/backends/test_sports_backend.py
+++ b/tests/unit/providers/suggest/sports/backends/test_sports_backend.py
@@ -389,11 +389,11 @@ def test_sport_event_detail_remap() -> None:  # WCS, Widget
 
     result = SportEventDetail.from_event_dict(event)
     assert result.sport == "World Cup"
-    assert result.query == "World Cup 2026 Away Team at Home Team 01 October 2025"
+    assert result.query == "World Cup 2026 Away Team vs Home Team 01 October 2025"
 
 
 def test_build_query() -> None:
-    """build_query produces a 'sport away at home date' string."""
+    """build_query produces a 'sport away vs home date' string."""
     event: dict = {
         "sport": "NFL",
         "date": "2025-10-01T00:00:00+00:00",
@@ -401,7 +401,7 @@ def test_build_query() -> None:
         "away_team": {"name": "Away Team"},
     }
 
-    assert build_query(event) == "NFL Away Team at Home Team 01 October 2025"
+    assert build_query(event) == "NFL Away Team vs Home Team 01 October 2025"
 
 
 def test_build_query_world_cup() -> None:
@@ -413,7 +413,7 @@ def test_build_query_world_cup() -> None:
         "away_team": {"name": "Away Team"},
     }
 
-    assert build_query(event) == "World Cup 2026 Away Team at Home Team 01 October 2025"
+    assert build_query(event) == "World Cup 2026 Away Team vs Home Team 01 October 2025"
     assert event["sport"] == "World Cup"
 
 

--- a/tests/unit/providers/wcs/test_protocol.py
+++ b/tests/unit/providers/wcs/test_protocol.py
@@ -23,4 +23,4 @@ def test_event_info_from_event_builds_world_cup_query() -> None:
     info = EventInfo.from_event(e)
 
     expected_date = e.date.strftime("%d %B %Y")
-    assert info.query == f"World Cup 2026 Argentina vs Brazil {expected_date}"
+    assert info.query == f"World Cup 2026 Brazil vs Argentina {expected_date}"

--- a/tests/unit/providers/wcs/test_protocol.py
+++ b/tests/unit/providers/wcs/test_protocol.py
@@ -1,0 +1,26 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Unit tests for merino.providers.wcs.protocol."""
+
+from merino.providers.suggest.sports.backends.sportsdata.common import GameStatus
+from merino.providers.wcs.protocol import EventInfo
+from tests.wcs.factories import event
+
+
+def test_event_info_from_event_builds_world_cup_query() -> None:
+    """`query` uses the World Cup 2026 prefix and date string."""
+    e = event(
+        event_id=1,
+        day_offset=0,
+        hour=14,
+        home=("BRA", "Brazil", 90000001),
+        away=("ARG", "Argentina", 90000002),
+        status=GameStatus.Scheduled,
+    )
+
+    info = EventInfo.from_event(e)
+
+    expected_date = e.date.strftime("%d %B %Y")
+    assert info.query == f"World Cup 2026 Argentina vs Brazil {expected_date}"


### PR DESCRIPTION
## References

JIRA: [DISCO-4201]

## Description
fix(wcs): query string updates for world cup

Use full month for dates instead of short name (this affects all sport responses)

Use 'World Cup 2026' as the prefix instead of just 'World Cup'

Use 'vs' instead of 'at' as the team separator

This is propagated to the /wcs/matches query response as well, so they are both unified. This is not yet in the /live endpoint because of the way the fake data is constructed, but when we use real data it should go through the EventInfo.from_event method and be propagated through


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-4021]: https://mozilla-hub.atlassian.net/browse/DISCO-4021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DISCO-4201]: https://mozilla-hub.atlassian.net/browse/DISCO-4201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ