### PR TITLE
[AIMOD-1220] Enable Inferred Interest Ranker in Prod

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -1265,8 +1265,8 @@ cron_interval_seconds = 600
 
 [default.contextual_interest]
 # MERINO__CONTEXTUAL_INTEREST__ENABLED
-# Disabled by default, enabled only in staging initially
-enabled = false
+# Enables the granular interest ranker for new tab recs
+enabled = true
 
 [default.contextual_interest.gcs]
 # MERINO__CONTEXTUAL_INTEREST__GCS__GCP_PROJECT

--- a/merino/configs/development.toml
+++ b/merino/configs/development.toml
@@ -82,3 +82,7 @@ gcs_bucket = "merino-images-local"
 # MERINO_IMAGE_GCS_V2__CDN_HOSTNAME
 # CDN hostname used for public URLs of stored images
 cdn_hostname = "localhost:4443"
+
+[development.contextual_interest]
+# disabled by default so we don't fetch artifacts locally
+enabled = false

--- a/merino/configs/development.toml
+++ b/merino/configs/development.toml
@@ -84,5 +84,5 @@ gcs_bucket = "merino-images-local"
 cdn_hostname = "localhost:4443"
 
 [development.contextual_interest]
-# disabled by default so we don't fetch artifacts locally
+# disabled in dev so we don't fetch artifacts locally
 enabled = false

--- a/merino/configs/production.toml
+++ b/merino/configs/production.toml
@@ -146,8 +146,7 @@ gcp_project = "moz-fx-merino-prod-5de4"
 # GCS bucket that contains cohort model data
 bucket_name = "merino-ml-data-prod"
 
-# contextual_interest.enabled stays false from default.toml and will
-# not load the LinTS-interest model by default
+# contextual_interest.enabled is true from default.toml
 [production.contextual_interest.gcs]
 # GCP project name where the GCS bucket lives.
 gcp_project = "moz-fx-merino-prod-5de4"


### PR DESCRIPTION
## References

JIRA: [AIMOD-1220](https://mozilla-hub.atlassian.net/browse/AIMOD-1220)

## Description
We tested the interest ranker in [staging](https://yardstick.mozilla.org/d/fa5cfb41-1ad8-4e7c-975a-44c41c6f6975/merino-application-and-infrastructure-gcp-v2?orgId=1&from=now-24h&to=now&timezone=browser&var-env=nonprod&var-app=merino&var-deployment=$__all&var-v2_datasource=edq6thuke248we&var-project_id=moz-fx-%28data%7Cweb%29services-%28high%7Clow%29-%28prod%7Cnonpro%28d%29%3F%29&var-namespace=merino-stage&refresh=1m) and got a 👍 from [Nan](https://mozilla.slack.com/archives/G01M6ALKVL4/p1778537866628869) for prod deployment.

Will monitor once released.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2309)


[AIMOD-1220]: https://mozilla-hub.atlassian.net/browse/AIMOD-1220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ