### PR TITLE
feat: [DISCO-4163] Return live team data

### DIFF
--- a/merino/providers/suggest/sports/backends/sportsdata/common/sports.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/sports.py
@@ -869,7 +869,7 @@ class WCS(Sport):
         for team_data in data:
             try:
                 area = await self.get_country(team_data.get("AreaId"))
-                # TODO: get `eliminated` field from ??
+                # TODO: get `eliminated` field from ?? (team_data["Active"]?)
                 team = Team.from_data(
                     team_data=team_data,
                     term_filter=self.term_filter,

--- a/merino/providers/wcs/protocol.py
+++ b/merino/providers/wcs/protocol.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, HttpUrl
 
-from merino.providers.suggest.sports.backends.sportsdata.common.data import Event
+from merino.providers.suggest.sports.backends.sportsdata.common.data import Event, Team
 from merino.providers.suggest.sports.backends.sportsdata.protocol import build_query
 from merino.providers.wcs.utils import get_team_colours
 from merino.utils.logos import LogoCategory, load_manifest
@@ -38,6 +38,20 @@ class TeamInfo(BaseModel):
     eliminated: bool = Field(
         default=False, description="True once the team is out of the tournament."
     )
+
+    @classmethod
+    def from_team(cls, team:Team) -> "TeamInfo":
+        """Build a widget team from the full team record"""
+        return cls(
+            key = team.key,
+            global_team_id = team.id,
+            name = team.name,
+            region = team.country or "",
+            colors = team.colors,
+            icon_url = _icon(team.key),
+            # TODO: overwrite with team elimination status.
+            eliminated = False,
+        )
 
     @classmethod
     def from_event_team(cls, team: dict[str, Any]) -> "TeamInfo":

--- a/merino/providers/wcs/provider.py
+++ b/merino/providers/wcs/provider.py
@@ -8,6 +8,8 @@ from aiodogstatsd import Client
 
 from merino.exceptions import CacheAdapterError
 from merino.providers.suggest.sports.backends.sportsdata.common.data import Event
+from merino.providers.suggest.sports.backends.sportsdata.common.sports import WCS
+from merino.providers.wcs.protocol import TeamInfo
 from merino.providers.wcs.fake_data import get_all_teams
 from merino.providers.wcs.fake_live_data import build_live_events
 from merino.providers.wcs.protocol import (
@@ -36,7 +38,7 @@ class WcsSport(Protocol):
 class WcsProvider:
     """Serves match data for the World Cup Soccer endpoint."""
 
-    def __init__(self, sport: WcsSport, metrics_client: Client | None = None) -> None:
+    def __init__(self, sport: WCS, metrics_client: Client | None = None) -> None:
         """Create a WCS provider backed by the shared WCS sport cache."""
         self.sport = sport
         self.metrics_client = metrics_client or get_metrics_client()
@@ -96,9 +98,13 @@ class WcsProvider:
         ]
         return LiveMatchesResponse(matches=matches)
 
-    def get_teams(self) -> TeamsResponse:
+    async def get_teams(self) -> TeamsResponse:
         """Return all teams participating in the tournament."""
-        return TeamsResponse(teams=get_all_teams())
+        response = []
+        teams = await self.sport.get_all_teams()
+        for team in teams.values():
+            response.append(TeamInfo.from_team(team))
+        return TeamsResponse(teams=response)
 
     def _record_cache_error(self, endpoint: str, ex: CacheAdapterError) -> None:
         """Log and count cache read failures by endpoint."""

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -735,7 +735,7 @@ async def get_wcs_teams(
     provider: WcsProvider = Depends(get_wcs_provider),
 ) -> TeamsResponse:
     """Return all teams participating in the World Cup."""
-    return provider.get_teams()
+    return await provider.get_teams()
 
 
 def _parse_team_keys(teams: str | None) -> frozenset[str] | None:

--- a/tests/wcs/factories.py
+++ b/tests/wcs/factories.py
@@ -1,10 +1,10 @@
 """Shared WCS provider fixtures."""
 
-from datetime import UTC, date, datetime, time, timedelta
+from datetime import UTC, date, datetime, time, timedelta, timezone
 from typing import Any
 
 from merino.providers.suggest.sports.backends.sportsdata.common import GameStatus
-from merino.providers.suggest.sports.backends.sportsdata.common.data import Event
+from merino.providers.suggest.sports.backends.sportsdata.common.data import Event, Team
 from merino.providers.wcs.provider import WcsProvider
 
 ANCHOR = date(2026, 6, 15)
@@ -21,8 +21,9 @@ KNOWN_TEAMS = [
 class StubWcsSport:
     """Small WCS sport stand-in that behaves like the Redis-backed sport."""
 
-    def __init__(self, events: list[Event]) -> None:
+    def __init__(self, events: list[Event], teams: list[Team]) -> None:
         self.events = events
+        self.teams = teams
 
     async def get_events_by_date(
         self, start: datetime | None = None, end: datetime | None = None
@@ -86,7 +87,6 @@ def event(
         clock=clock,
     )
 
-
 def build_events() -> list[Event]:
     """Build the deterministic event set used by WCS provider tests."""
     bra, arg, ger, fra, eng, usa = [
@@ -139,14 +139,39 @@ def build_events() -> list[Event]:
         event(1007, 8, 19, fra, usa, GameStatus.Scheduled),
     ]
 
+def build_teams() -> list[Team]:
+    """Build dummy teams for testing"""
+    teams = []
+    iter = 900000
+    now = datetime.now(tz=timezone.utc)
+    for (key, name) in KNOWN_TEAMS:
+        teams.append(Team(
+            name=name,
+            aliases=[name],
+            terms=name,
+            fullname=name,
+            key=key,
+            locale=name,
+            id=iter,
+            colors=[],
+            updated=now,
+            expiry=now+timedelta(hours=1),
+            country=name,
+        ))
+        iter = iter+1
+    return teams
+
+
 
 def build_provider(
     events: list[Event] | None = None,
+    teams: list[Team] | None = None,
     metrics_client: Any | None = None,
 ) -> WcsProvider:
     """Build a WCS provider backed by deterministic stub data."""
     stub_events = build_events() if events is None else events
+    stub_teams = build_teams() if teams is None else teams
     return WcsProvider(
-        sport=StubWcsSport(stub_events),
+        sport=WCS(stub_events, stub_teams),
         metrics_client=metrics_client,
     )


### PR DESCRIPTION
## References

JIRA: [DISCO-4163](https://mozilla-hub.atlassian.net/browse/DISCO-4163)

## Description

Return cached team data. 
WIP: Need to fix up the provider stub testing. 

Closes DISCO-4163


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2314)


[DISCO-4163]: https://mozilla-hub.atlassian.net/browse/DISCO-4163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ