### PR TITLE
DISCO-4208 Refactor SportsData date handling

### DIFF
--- a/merino/providers/suggest/sports/backends/sportsdata/common/data.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/data.py
@@ -6,6 +6,7 @@ import logging
 import os
 
 from abc import abstractmethod
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from enum import StrEnum
 from typing import Any
@@ -41,6 +42,32 @@ _TEAM_KEY_OVERRIDES: dict[tuple[str, str], str] = {
 
 # Global Logger
 logger = logging.getLogger(__name__)
+
+SPORTSDATA_UTC = ZoneInfo("UTC")
+SPORTSDATA_US_EASTERN = ZoneInfo("America/New_York")
+SPORTSDATA_LEAGUE_NA_SPORTS = {"MLB", "NBA", "NHL", "NFL"}
+
+
+def sportsdata_timezone_for_sport(sport: str) -> ZoneInfo:
+    """Return the timezone SportsData uses for a sport's day-based endpoints."""
+    if sport.upper() in SPORTSDATA_LEAGUE_NA_SPORTS:
+        return SPORTSDATA_US_EASTERN
+    return SPORTSDATA_UTC
+
+
+def sportsdata_day_slug(kickoff: datetime, event_timezone: ZoneInfo) -> str:
+    """Return the date path segment SportsData expects for a kickoff."""
+    if kickoff.tzinfo is None:
+        kickoff = kickoff.replace(tzinfo=timezone.utc)
+    return kickoff.astimezone(event_timezone).strftime("%Y-%b-%d").upper()
+
+
+def _parse_sportsdata_datetime(value: Any, source_timezone: ZoneInfo) -> datetime:
+    """Parse a SportsData timestamp and normalize it to UTC."""
+    parsed = datetime.fromisoformat(value)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=source_timezone)
+    return parsed.astimezone(timezone.utc)
 
 
 class Team(BaseModel):
@@ -270,6 +297,81 @@ SportNormalizedTerms: dict[SportTerms, str] = {
 }
 
 
+@dataclass(frozen=True)
+class SportsDataEventRow:
+    """Normalized fields from a SportsData schedule or score row."""
+
+    game_id: int
+    status: GameStatus
+    home_team_id: int | None
+    away_team_id: int | None
+    home_team_key: str | None
+    away_team_key: str | None
+    home_score: int | None
+    away_score: int | None
+    kickoff: datetime
+    original_date: str | None
+    updated: datetime | None
+    raw: dict[str, Any]
+
+    @classmethod
+    def from_event_description(
+        cls,
+        event_description: dict[str, Any],
+        normalized_terms: dict[SportTerms, str],
+        event_timezone: ZoneInfo,
+    ) -> "SportsDataEventRow":
+        """Normalize shared SportsData schedule and score fields."""
+        game_id = event_description.get(normalized_terms[SportTerms.GAME_ID])
+        if game_id is None:
+            raise SportsDataError(f"No game id found for event: {event_description}")
+
+        kickoff, original_date = cls._kickoff_at(event_description, event_timezone)
+        return cls(
+            game_id=game_id,
+            status=GameStatus.parse(event_description["Status"]),
+            home_team_id=event_description.get(normalized_terms[SportTerms.HOME_TEAM_ID]),
+            away_team_id=event_description.get(normalized_terms[SportTerms.AWAY_TEAM_ID]),
+            home_team_key=event_description.get(normalized_terms[SportTerms.HOME_TEAM_KEY]),
+            away_team_key=event_description.get(normalized_terms[SportTerms.AWAY_TEAM_KEY]),
+            home_score=event_description.get(normalized_terms[SportTerms.HOME_TEAM_SCORE]),
+            away_score=event_description.get(normalized_terms[SportTerms.AWAY_TEAM_SCORE]),
+            kickoff=kickoff,
+            original_date=original_date,
+            updated=cls._updated_at(event_description, event_timezone),
+            raw=event_description,
+        )
+
+    @staticmethod
+    def _kickoff_at(
+        event_description: dict[str, Any], event_timezone: ZoneInfo
+    ) -> tuple[datetime, str | None]:
+        """Return the event kickoff, preferring SportsData's UTC field."""
+        if event_description.get("DateTimeUTC"):
+            raw_utc_date = event_description["DateTimeUTC"]
+            return _parse_sportsdata_datetime(raw_utc_date, SPORTSDATA_UTC), raw_utc_date
+        if event_description.get("DateTime"):
+            raw_date = event_description["DateTime"]
+            return _parse_sportsdata_datetime(raw_date, event_timezone), raw_date
+        raise TypeError("SportsData event has no DateTimeUTC or DateTime")
+
+    @staticmethod
+    def _updated_at(
+        event_description: dict[str, Any], event_timezone: ZoneInfo
+    ) -> datetime | None:
+        """Return the SportsData row update timestamp as UTC."""
+        raw_updated_utc = event_description.get("UpdatedUtc") or event_description.get(
+            "UpdatedUTC"
+        )
+        if raw_updated_utc:
+            return _parse_sportsdata_datetime(raw_updated_utc, SPORTSDATA_UTC)
+
+        raw_updated = event_description.get("Updated") or event_description.get("LastUpdated")
+        if raw_updated:
+            return _parse_sportsdata_datetime(raw_updated, event_timezone)
+        return None
+
+
 class Sport:
     """Root Model for Sport data"""
 
@@ -372,143 +474,23 @@ class Sport:
         data: list[dict[str, Any]],
         event_timezone: ZoneInfo = ZoneInfo("UTC"),
     ) -> dict[int, "Event"]:
-        """Scan the list of Event scores for any event within the 'current' window.
-
-        This presumes that we are receiving data that complies with the SportsData.io
-        `ScoreBasic` data dictionary (See https://sportsdata.io/developers/data-dictionary/nfl#scorebasic)
-
-        If we ever have a different data provider, this will need to be moved to the
-        SportData provider class.
-
-        """
-        # Sample raw score (Each Sport will have slight variations.)
-        """
-        [
-            {'Quarter': None,
-             'TimeRemaining': None,
-             'QuarterDescription': '',
-             'GameEndDateTime': None,
-             'AwayScore': None,
-             'HomeScore': None,
-             'GameID': 19047,
-             'GlobalGameID': 19047,
-             'ScoreID': 19047,
-             'GameKey': '202510428',
-             'Season': 2025,
-             'SeasonType': 1,
-             'Status': 'Scheduled',
-             'Canceled': False,
-             'Date': '2025-09-28T09:30:00',
-             'Day': '2025-09-28T00:00:00',
-             'DateTime': '2025-09-28T09:30:00',
-             'DateTimeUTC': '2025-09-28T13:30:00',
-             'AwayTeam': 'MIN',
-             'HomeTeam': 'PIT',
-             'GlobalAwayTeamID': 20,
-             'GlobalHomeTeamID': 28,
-             'AwayTeamID': 20,
-             'HomeTeamID': 28,
-             'StadiumID': 90,
-             'Closed': False,
-             'LastUpdated': '2025-09-24T12:03:59',
-             'IsClosed': False,
-             'Week': 4},
-             ...
-             ]
-        """
-        start_window = datetime.now(tz=timezone.utc) - self.event_ttl
-        end_window = datetime.now(tz=timezone.utc) + self.event_ttl
+        """Scan score rows and update or create events in the interest window."""
         for event_description in data:
-            game_id = event_description[self.normalized_terms[SportTerms.GAME_ID]]
-            status = GameStatus.parse(event_description["Status"])
-            if status in [GameStatus.NotNecessary, GameStatus.Canceled]:
+            row = self.event_row_from_source(event_description, event_timezone)
+            if row is None or self.skip_event_row(row):
                 continue
-            # only update the scores.
-            if game_id in self.events:
-                event = self.events[game_id]
-                event.home_score = event_description.get(
-                    self.normalized_terms[SportTerms.HOME_TEAM_SCORE]
-                )
-                event.away_score = event_description.get(
-                    self.normalized_terms[SportTerms.AWAY_TEAM_SCORE]
-                )
-                event.status = status
-                event.updated = self.updated_at(event_description, event_timezone)
-                for field, value in self.event_details(event_description).items():
-                    # Skip Nones so a partial payload (e.g. pre-kickoff Clock) does not
-                    # clobber a value the schedule load already populated.
-                    if value is not None:
-                        setattr(event, field, value)
+
+            if row.game_id in self.events:
+                event = self.events[row.game_id]
+                self.apply_score_update(event, row)
             else:
                 # Some Sports may not pull Schedules first
-                home_id = event_description.get(self.normalized_terms[SportTerms.HOME_TEAM_ID])
-                away_id = event_description.get(self.normalized_terms[SportTerms.AWAY_TEAM_ID])
-                home_name = event_description.get(self.normalized_terms[SportTerms.HOME_TEAM_KEY])
-                away_name = event_description.get(self.normalized_terms[SportTerms.AWAY_TEAM_KEY])
                 logger.warning(
-                    f"{LOGGING_TAG} Adding game...{away_name} at {home_name} :: {status}"
+                    f"{LOGGING_TAG} Adding game...{row.away_team_key} at {row.home_team_key} :: {row.status}"
                 )
-                home_score = event_description.get(
-                    self.normalized_terms[SportTerms.HOME_TEAM_SCORE]
-                )
-                away_score = event_description.get(
-                    self.normalized_terms[SportTerms.AWAY_TEAM_SCORE]
-                )
-                if not home_id or not away_id:
-                    log = logger.debug if home_id is None and away_id is None else logger.warning
-                    log(
-                        f"{LOGGING_TAG} Could not find team id for '{home_name}' vs '{away_name}' for {self.name}: {event_description}"
-                    )
-                    continue
-                home_team = self.teams.get(home_id)
-                away_team = self.teams.get(away_id)
-                if not home_team or not away_team:
-                    logger.warning(
-                        f"{LOGGING_TAG} Could not find team info for '{home_name}' vs '{away_name}' for {self.name}: {event_description}"
-                    )
-                    continue
-
-                try:
-                    if "DateTimeUTC" in event_description:
-                        date = datetime.fromisoformat(event_description["DateTimeUTC"]).replace(
-                            tzinfo=timezone.utc
-                        )
-                    else:
-                        date = datetime.fromisoformat(event_description["DateTime"]).replace(
-                            tzinfo=event_timezone
-                        )
-                # There have been incidents where an event returns "None" as a date value.
-                # We should ignore that event, and allow processing to continue, but note
-                # the error in case we need to escalate the problem.
-                except TypeError:
-                    # It's possible to salvage this game by examining the other fields like "Day" or "Updated",
-                    # but if there's an error, it's probably wise to ignore this.
-                    logger.info(
-                        f"""{LOGGING_TAG}📈 sports.error.no_date ["sport" = "{self.name}"]"""
-                    )
-                    continue
-                # Ignore any events that are outside of the event interest window.
-                if not start_window <= date <= end_window:
-                    continue
-                updated = self.updated_at(event_description, event_timezone)
-                event = Event(
-                    sport=self.name,
-                    id=game_id,
-                    date=date,
-                    original_date=event_description.get(
-                        "DateTimeUTC", event_description.get("DateTime")
-                    ),
-                    terms=f"{home_team.terms} {away_team.terms}",
-                    home_team=self.team_minimal(home_team),
-                    away_team=self.team_minimal(away_team),
-                    home_score=home_score,
-                    away_score=away_score,
-                    status=status,
-                    expiry=utc_time_from_now(self.event_ttl),
-                    updated=updated,
-                    **self.event_details(event_description),
-                )
-            self.events[event.id] = event
+                new_event = self.event_from_row(row)
+                if new_event is not None:
+                    self.events[new_event.id] = new_event
 
         return self.events
 
@@ -519,125 +501,114 @@ class Sport:
     def load_schedules_from_source(
         self, data: list[dict[str, Any]], event_timezone: ZoneInfo = ZoneInfo("UTC")
     ) -> dict[int, "Event"]:
-        """Scan the list of Scheduled events, storing any in the current interest window.
-        (Note: this is very similar to `load_scores_from_source` with some minor
-        differences in the source data.)
+        """Scan schedule rows and store events in the interest window."""
+        for event_description in data:
+            row = self.event_row_from_source(event_description, event_timezone)
+            if row is None or self.skip_event_row(row):
+                continue
 
-        This presumes that we are receiving data that complies with the SportsData.io
-        `ScheduleBasic` Data dictionary (See https://sportsdata.io/developers/data-dictionary/nhl#schedulebasic)
+            event = self.event_from_row(row)
+            if event is not None:
+                self.events[event.id] = event
+        return self.events
 
-        """
-        # Sample raw event (Each Sport will have slight variations.)
-        """
-        [
-            {"GameID":23869,
-             "Season":2026,
-             "SeasonType":2,
-             "Status":"Final",
-             "Day":"2025-09-21T00:00:00",
-             "DateTime":"2025-09-21T21:30:00",
-             "Updated":"2025-09-29T04:10:57",
-             "IsClosed":true,
-             "AwayTeam":"UTA",
-             "HomeTeam":"COL",
-             "StadiumID":9,
-             "AwayTeamScore":2,
-             "HomeTeamScore":3,
-             "GlobalGameID":30023869,
-             "GlobalAwayTeamID":30000041,
-             "GlobalHomeTeamID":30000019,
-             "GameEndDateTime":"2025-09-22T00:10:17",
-             "NeutralVenue":false,
-             "DateTimeUTC":"2025-09-22T01:30:00",
-             "AwayTeamID":41,
-             "HomeTeamID":19,
-             "SeriesInfo":null
-             },
-             ...
-             ]
-        ]"""
+    def event_row_from_source(
+        self, event_description: dict[str, Any], event_timezone: ZoneInfo
+    ) -> SportsDataEventRow | None:
+        """Return a normalized event row or skip invalid SportsData input."""
+        try:
+            return SportsDataEventRow.from_event_description(
+                event_description=event_description,
+                normalized_terms=self.normalized_terms,
+                event_timezone=event_timezone,
+            )
+        except SportsDataError as ex:
+            self._log_invalid_event_row("sports.error.invalid_event", ex)
+        except (TypeError, ValueError) as ex:
+            self._log_invalid_event_row("sports.error.no_date", ex)
+        except KeyError as ex:
+            self._log_invalid_event_row("sports.error.invalid_event", ex)
+        return None
 
+    def _log_invalid_event_row(self, metric: str, error: BaseException) -> None:
+        """Log a skipped SportsData row with the closest known reason."""
+        logger.info(f"""{LOGGING_TAG}📈 {metric} ["sport" = "{self.name}"]""")
+        logger.debug(f"{LOGGING_TAG} {self.name} invalid event row skipped: {error}")
+
+    def skip_event_row(self, row: SportsDataEventRow) -> bool:
+        """Return whether an event row should not be considered for ingestion."""
+        return row.status in [GameStatus.NotNecessary, GameStatus.Canceled]
+
+    def event_from_row(self, row: SportsDataEventRow) -> Event | None:
+        """Create an Event from a normalized row when teams and dates are usable."""
+        if not self.row_in_event_window(row):
+            return None
+
+        teams = self.teams_for_row(row)
+        if teams is None:
+            return None
+        home_team, away_team = teams
+
+        return Event(
+            sport=self.name,
+            id=row.game_id,
+            terms=f"{home_team.terms} {away_team.terms}",
+            date=row.kickoff,
+            original_date=row.original_date,
+            home_team=self.team_minimal(home_team),
+            away_team=self.team_minimal(away_team),
+            home_score=row.home_score,
+            away_score=row.away_score,
+            status=row.status,
+            expiry=utc_time_from_now(self.event_ttl),
+            updated=row.updated,
+            **self.event_details(row.raw),
+        )
+
+    def row_in_event_window(self, row: SportsDataEventRow) -> bool:
+        """Return whether a row kickoff falls inside this sport's interest window."""
         start_window = datetime.now(tz=timezone.utc) - self.event_ttl
         end_window = datetime.now(tz=timezone.utc) + self.event_ttl
-        for event_description in data:
-            game_id = event_description[self.normalized_terms[SportTerms.GAME_ID]]
-            home_id = event_description.get(self.normalized_terms[SportTerms.HOME_TEAM_ID])
-            away_id = event_description.get(self.normalized_terms[SportTerms.AWAY_TEAM_ID])
-            home_score = event_description.get(self.normalized_terms[SportTerms.HOME_TEAM_SCORE])
-            away_score = event_description.get(self.normalized_terms[SportTerms.AWAY_TEAM_SCORE])
-            if not home_id or not away_id:
-                log = logger.debug if home_id is None and away_id is None else logger.warning
-                log(f"{LOGGING_TAG} Could not find team for event: {event_description}")
-                continue
-            home_team = self.teams.get(home_id)
-            away_team = self.teams.get(away_id)
-            if not home_team or not away_team:
-                logger.warning(
-                    f"{LOGGING_TAG} Could not find team info for event: {event_description}"
-                )
-                continue
+        return start_window <= row.kickoff <= end_window
 
-            status = GameStatus.parse(event_description["Status"])
-            # Ignore cancelled games.
-            if status == GameStatus.Canceled:
-                # Cancelled games have no UTC time stamp, so we can't know how recent they were.
-                continue
-            try:
-                if "DateTimeUTC" in event_description:
-                    date = datetime.fromisoformat(event_description["DateTimeUTC"]).replace(
-                        tzinfo=timezone.utc
-                    )
-                else:
-                    date = datetime.fromisoformat(event_description["DateTime"]).replace(
-                        tzinfo=event_timezone
-                    )
-            except TypeError as ex:
-                # It's possible to salvage this game by examining the other fields like "Day" or "Updated",
-                # but if there's an error, it's probably wise to ignore this.
-                logger.info(f"""{LOGGING_TAG}📈 sports.error.no_date ["sport" = "{self.name}"]""")
-                logger.debug(
-                    f"{LOGGING_TAG} {status} {self.name} Event {game_id} between {home_team.key} and {away_team.key} has no time, skipping [{ex}]"
-                )
-                continue
-            # Ignore any events that are outside of the event interest window.
-            if not start_window <= date <= end_window:
-                continue
-            terms = f"{home_team.terms} {away_team.terms}"
-            updated = self.updated_at(event_description, event_timezone)
-
-            event = Event(
-                sport=self.name,
-                id=game_id,
-                terms=terms,
-                date=date,
-                original_date=event_description.get(
-                    "DateTimeUTC", event_description.get("DateTime")
-                ),
-                home_team=self.team_minimal(home_team),
-                away_team=self.team_minimal(away_team),
-                home_score=home_score,
-                away_score=away_score,
-                status=GameStatus.parse(event_description["Status"]),
-                expiry=utc_time_from_now(self.event_ttl),
-                updated=updated,
-                **self.event_details(event_description),
+    def teams_for_row(self, row: SportsDataEventRow) -> tuple[Team, Team] | None:
+        """Return the home and away teams for a normalized SportsData row."""
+        if not row.home_team_id or not row.away_team_id:
+            log = (
+                logger.debug
+                if row.home_team_id is None and row.away_team_id is None
+                else logger.warning
             )
-            self.events[event.id] = event
-        return self.events
+            log(
+                f"{LOGGING_TAG} Could not find team id for '{row.home_team_key}' vs '{row.away_team_key}' for {self.name}: {row.raw}"
+            )
+            return None
+
+        home_team = self.teams.get(row.home_team_id)
+        away_team = self.teams.get(row.away_team_id)
+        if not home_team or not away_team:
+            logger.warning(
+                f"{LOGGING_TAG} Could not find team info for '{row.home_team_key}' vs '{row.away_team_key}' for {self.name}: {row.raw}"
+            )
+            return None
+        return home_team, away_team
+
+    def apply_score_update(self, event: Event, row: SportsDataEventRow) -> None:
+        """Apply score fields and source freshness from a normalized score row."""
+        event.home_score = row.home_score
+        event.away_score = row.away_score
+        event.status = row.status
+        event.updated = row.updated
+        for field, value in self.event_details(row.raw).items():
+            # Skip Nones so partial score payloads do not clobber schedule details.
+            if value is not None:
+                setattr(event, field, value)
 
     def updated_at(
         self, event_description: dict[str, Any], event_timezone: ZoneInfo
     ) -> datetime | None:
         """Return the event update timestamp, preferring the UTC field when available."""
-        if event_description.get("UpdatedUtc"):
-            return datetime.fromisoformat(event_description["UpdatedUtc"]).replace(
-                tzinfo=timezone.utc
-            )
-        if event_description.get("Updated"):
-            return datetime.fromisoformat(event_description["Updated"]).replace(
-                tzinfo=event_timezone
-            )
-        return None
+        return SportsDataEventRow._updated_at(event_description, event_timezone)
 
     def event_details(self, event_description: dict[str, Any]) -> dict[str, Any]:
         """Return optional fields to merge into an `Event`.

--- a/merino/providers/suggest/sports/backends/sportsdata/common/elastic.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/elastic.py
@@ -603,6 +603,74 @@ class SportsDataStore(ElasticDataStore):
                 return False
         return True
 
+    @staticmethod
+    def event_datetime(event: dict[str, Any], field: str, fallback: str = "date") -> datetime:
+        """Return an event datetime field, falling back to kickoff when absent."""
+        return datetime.fromisoformat(event.get(field) or event[fallback])
+
+    @classmethod
+    def choose_previous_event(
+        cls, selected_events: dict[str, dict[str, Any]], event: dict[str, Any]
+    ) -> None:
+        """Keep the latest final game by kickoff, using updated only as a tie-breaker."""
+        if "current" in selected_events:
+            return
+        if "previous" not in selected_events:
+            selected_events["previous"] = event
+            return
+
+        previous_event = selected_events["previous"]
+        previous_date = cls.event_datetime(previous_event, "date")
+        event_date = cls.event_datetime(event, "date")
+        previous_updated = cls.event_datetime(previous_event, "updated")
+        event_updated = cls.event_datetime(event, "updated")
+        if previous_date < event_date or (
+            previous_date == event_date and previous_updated < event_updated
+        ):
+            selected_events["previous"] = event
+
+    @classmethod
+    def choose_current_event(
+        cls, selected_events: dict[str, dict[str, Any]], event: dict[str, Any]
+    ) -> None:
+        """Keep the most recently updated in-progress game."""
+        selected_events.pop("previous", None)
+        if "current" not in selected_events:
+            selected_events["current"] = event
+            return
+
+        if cls.event_datetime(selected_events["current"], "updated") < cls.event_datetime(
+            event, "updated"
+        ):
+            selected_events["current"] = event
+
+    @classmethod
+    def choose_next_event(
+        cls, selected_events: dict[str, dict[str, Any]], event: dict[str, Any]
+    ) -> None:
+        """Keep the soonest scheduled game by kickoff."""
+        if "next" not in selected_events:
+            selected_events["next"] = event
+            return
+
+        if cls.event_datetime(selected_events["next"], "date") > cls.event_datetime(event, "date"):
+            selected_events["next"] = event
+
+    @classmethod
+    def choose_result_event(
+        cls,
+        selected_events: dict[str, dict[str, Any]],
+        event: dict[str, Any],
+        status: GameStatus,
+    ) -> None:
+        """Apply previous/current/next selection rules to a candidate event."""
+        if status.is_final():
+            cls.choose_previous_event(selected_events, event)
+        elif status.is_scheduled():
+            cls.choose_next_event(selected_events, event)
+        elif status.is_in_progress():
+            cls.choose_current_event(selected_events, event)
+
     async def search_events(
         self, q: str, language_code: str, mix_sports: bool = False
     ) -> dict[str, dict]:
@@ -653,9 +721,9 @@ class SportsDataStore(ElasticDataStore):
             raise BackendError(f"Elasticsearch error for {index_id}") from ex
         logger.debug(f"{LOGGING_TAG} found {res} for `{q}`")
         if res.get("hits", {}).get("total", {}).get("value", 0) > 0:
-            # filter sport for prev, current, next
+            # Select one previous/current/next event for each sport bucket.
             try:
-                filter: dict[str, dict] = {}
+                selected_events_by_sport: dict[str, dict[str, dict[str, Any]]] = {}
                 for doc in res["hits"]["hits"]:
                     # We previously stored events as strings. Handle the potential transition.
                     if isinstance(doc["_source"]["event"], str):
@@ -668,13 +736,8 @@ class SportsDataStore(ElasticDataStore):
                     if not event["date"]:
                         logger.info(f"{LOGGING_TAG}Event has no date, skipping")
                         continue
-                    event_date = datetime.fromisoformat(event["date"])
-                    if mix_sports:
-                        sport = "all"
-                    else:
-                        sport = event["sport"]
-                    if sport not in filter:
-                        filter[sport] = {}
+                    sport = "all" if mix_sports else event["sport"]
+                    selected_events = selected_events_by_sport.setdefault(sport, {})
 
                     # This may be a bit confusing.
                     # There are four "status" fields.
@@ -684,57 +747,10 @@ class SportsDataStore(ElasticDataStore):
                     # `status_type` (reported externally) is the simplified type requested by the UI team.
                     status = GameStatus.parse(event["status"])
                     event["event_status"] = status
-                    # Because we may be collecting "all" sports, we want to find the most recently
-                    # concluded game and the next scheduled game. As for current, we just grab the last
-                    # "inprogress" game that is reported.
-                    if status.is_final():
-                        if "previous" not in filter[sport] and "current" not in filter[sport]:
-                            filter[sport]["previous"] = event
-                            continue
-                        # get the most recently "finalized" game
-                        # This uses the "updated" time, which will be after the prior event's start time,
-                        # but could also potentially overlap with the current event's start time (for mixed
-                        # sport results). There is a risk that a much earlier game is updated long after the
-                        # the events closure or the next event's closure (e.g. there is a contested score
-                        # that is adjusted), but this should be an anomalous event.
-                        # Note, in spite of what test coverage says, this is being exercised by
-                        # `test_sports_search_event_hits` & `test_sports_search_event_hits_no_current`,
-                        if filter.get(sport, {}).get(  # pragma: no cover
-                            "previous", {}
-                        ).get("updated") and (
-                            datetime.fromisoformat(filter[sport]["previous"]["updated"])
-                            < datetime.fromisoformat(event.get("updated", event_date))
-                        ):
-                            # if "unittest" in sys.modules.keys():
-                            #    print("\n👀👀 LOOK AT ME! RUNNING IN UNIT TESTS! 👀👀")
-                            filter[sport]["previous"] = event
-                            continue
-                    # If only show the next upcoming game.
-                    if status.is_scheduled():
-                        # if there is no "next" game, or if the "next" game is later than this one,
-                        # display the most immediate upcoming event.
-                        if "next" not in filter[sport]:
-                            filter[sport]["next"] = event
-                            continue
-                        # Keep the soonest scheduled game. Hits arrive sorted by date desc,
-                        # so without this comparator the farthest-future game wins and
-                        # today's game is shadowed by next week's. (DISCO-4167)
-                        if datetime.fromisoformat(filter[sport]["next"]["date"]) > event_date:
-                            filter[sport]["next"] = event
-                    if status.is_in_progress():
-                        # remove the previous game info because we have a current one.
-                        if "previous" in filter[sport]:
-                            del filter[sport]["previous"]
-                        if "current" not in filter[sport]:
-                            filter[sport]["current"] = event
-                            continue
-                        if datetime.fromisoformat(
-                            filter[sport]["current"]["updated"]
-                        ) < datetime.fromisoformat(event["updated"]):
-                            filter[sport]["current"] = event
+                    self.choose_result_event(selected_events, event, status)
             except Exception as ex:
                 logger.error(f"{LOGGING_TAG} search_event: Unexpected error {ex}")
-            return filter
+            return selected_events_by_sport
         else:
             return {}
 

--- a/merino/providers/suggest/sports/backends/sportsdata/common/sports.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/sports.py
@@ -8,7 +8,6 @@ import logging
 import orjson
 from datetime import datetime, timedelta, timezone
 from typing import Any, cast
-from zoneinfo import ZoneInfo
 
 # We use this for each Sport subclass, so that there's some flexibility for what config
 # values are used and passed.
@@ -27,6 +26,9 @@ from merino.providers.suggest.sports.backends.sportsdata.common.data import (
     SportTerms,
     Team,
     Event,
+    SPORTSDATA_US_EASTERN,
+    SPORTSDATA_UTC,
+    sportsdata_day_slug,
 )
 
 FORCE_IMPORT = ""
@@ -175,7 +177,7 @@ class NFL(Sport):
         """Update the events for this sport in the elastic search database"""
         await self.get_season(client=client)
         logger.debug(f"{LOGGING_TAG} Getting Events for {self.name}")
-        local_timezone = ZoneInfo("America/New_York")
+        local_timezone = SPORTSDATA_US_EASTERN
         # get this week and next week
         if self.week is None:
             logger.debug(f"{LOGGING_TAG} No events (No week)")
@@ -285,7 +287,7 @@ class NHL(Sport):
         await self.get_season(client=client)
         logger.debug(f"{LOGGING_TAG} Getting {self.name} schedules")
         url = f"{self.base_url}/SchedulesBasic/{self.season}"
-        local_timezone = ZoneInfo("America/New_York")
+        local_timezone = SPORTSDATA_US_EASTERN
         response = await get_data(
             client=client,
             url=url,
@@ -294,11 +296,9 @@ class NHL(Sport):
             args={"key": self.api_key},
         )
         self.load_schedules_from_source(response, event_timezone=local_timezone)
-        date_list = []
+        date_list: set[str] = set()
         for _id, event in list(self.events.items()):
-            # sportsdata.io keys date-by-day endpoints on the league's local game day,
-            # not UTC. event.date is UTC, so a 10pm-ET game lives on the prior day's URL.
-            day = event.date.astimezone(local_timezone).strftime("%Y-%b-%d").upper()
+            day = sportsdata_day_slug(event.date, local_timezone)
             if not event.status.is_scheduled() and day not in date_list:
                 url = f"{self.base_url}/GamesByDate/{day}"
                 response = await get_data(
@@ -309,7 +309,7 @@ class NHL(Sport):
                     args={"key": self.api_key},
                 )
                 self.load_scores_from_source(response, event_timezone=local_timezone)
-            date_list.append(day)
+            date_list.add(day)
 
 
 class NBA(Sport):
@@ -395,7 +395,7 @@ class NBA(Sport):
                 f"{LOGGING_TAG} Skipping out of season {self.name}"
             )  # pragma: no cover "informational"
         logger.debug(f"{LOGGING_TAG} Getting {self.name} schedules")
-        local_timezone = ZoneInfo("America/New_York")
+        local_timezone = SPORTSDATA_US_EASTERN
         url = f"{self.base_url}/SchedulesBasic/{self.season}"
         response = await get_data(
             client=client,
@@ -405,13 +405,11 @@ class NBA(Sport):
             args={"key": self.api_key},
         )
         self.load_schedules_from_source(response, event_timezone=local_timezone)
-        date_list = []
+        date_list: set[str] = set()
         # update scores based on events:
         # Events may cross multiple days, so we should update those scores.
         for _id, event in list(self.events.items()):
-            # sportsdata.io keys date-by-day endpoints on the league's local game day,
-            # not UTC. event.date is UTC, so a 10pm-ET game lives on the prior day's URL.
-            day = event.date.astimezone(local_timezone).strftime("%Y-%b-%d").upper()
+            day = sportsdata_day_slug(event.date, local_timezone)
             if not event.status.is_scheduled() and day not in date_list:
                 url = f"{self.base_url}/ScoresBasic/{day}"
                 response = await get_data(
@@ -422,7 +420,7 @@ class NBA(Sport):
                     args={"key": self.api_key},
                 )
                 self.load_scores_from_source(response, event_timezone=local_timezone)
-                date_list.append(day)
+                date_list.add(day)
 
 
 class UCL(Sport):
@@ -518,7 +516,7 @@ class UCL(Sport):
         await self.get_season(client=client)
         logger.debug(f"{LOGGING_TAG} Getting {self.name} schedules")
         url = f"{self.base_url}/SchedulesBasic/{self.name}/{self.season}"
-        local_timezone = ZoneInfo("UTC")
+        local_timezone = SPORTSDATA_UTC
         response = await get_data(
             client=client,
             url=url,
@@ -527,11 +525,11 @@ class UCL(Sport):
             args={"key": self.api_key},
         )
         self.load_schedules_from_source(response, event_timezone=local_timezone)
-        date_list = []
+        date_list: set[str] = set()
         # update scores based on events:
         # Events may cross multiple days, so we should update those scores.
         for _id, event in list(self.events.items()):
-            day = event.date.strftime("%Y-%b-%d").upper()
+            day = sportsdata_day_slug(event.date, local_timezone)
             if not event.status.is_scheduled() and day not in date_list:
                 url = f"{self.base_url}/ScoresBasic/{self.name}/{day}"
                 response = await get_data(
@@ -542,7 +540,7 @@ class UCL(Sport):
                     args={"key": self.api_key},
                 )
                 self.load_scores_from_source(response, event_timezone=local_timezone)
-                date_list.append(day)
+                date_list.add(day)
 
 
 class MLB(Sport):
@@ -626,7 +624,7 @@ class MLB(Sport):
 
     async def update_events(self, client: AsyncClient):
         """Fetch the list of events for the sport. (5 min interval)"""
-        local_timezone = ZoneInfo("America/New_York")
+        local_timezone = SPORTSDATA_US_EASTERN
         logger.debug(f"{LOGGING_TAG} Getting {self.name} schedules")
         url = f"{self.base_url}/SchedulesBasic/{self.season}"
         response = await get_data(
@@ -637,13 +635,11 @@ class MLB(Sport):
             args={"key": self.api_key},
         )
         self.load_schedules_from_source(response, event_timezone=local_timezone)
-        date_list = []
+        date_list: set[str] = set()
         # update scores based on events
         # Events may cross multiple days, so we should update those scores.
         for _id, event in list(self.events.items()):
-            # sportsdata.io keys date-by-day endpoints on the league's local game day,
-            # not UTC. event.date is UTC, so a 10pm-ET game lives on the prior day's URL.
-            day = event.date.astimezone(local_timezone).strftime("%Y-%b-%d").upper()
+            day = sportsdata_day_slug(event.date, local_timezone)
             if not event.status.is_scheduled() and day not in date_list:
                 url = f"{self.base_url}/ScoresBasic/{day}"
                 response = await get_data(
@@ -654,7 +650,7 @@ class MLB(Sport):
                     args={"key": self.api_key},
                 )
                 self.load_scores_from_source(response, event_timezone=local_timezone)
-                date_list.append(day)
+                date_list.add(day)
 
 
 class WCS(Sport):
@@ -1002,7 +998,7 @@ class WCS(Sport):
         await self.get_season(client=client)
         logger.debug(f"{LOGGING_TAG} Getting {self.name} schedules")
         url = f"{self.base_url}/SchedulesBasic/{self.name}/{self.season}"
-        local_timezone = ZoneInfo("UTC")
+        local_timezone = SPORTSDATA_UTC
         response = await get_data(
             client=client,
             url=url,
@@ -1016,11 +1012,11 @@ class WCS(Sport):
         # Treat each WCS schedule refresh as authoritative so removed events are pruned.
         self.events = {}
         self.load_schedules_from_source(response, event_timezone=local_timezone)
-        date_list = []
+        date_list: set[str] = set()
         # update scores based on events:
         # Events may cross multiple days, so we should update those scores.
         for _id, event in list(self.events.items()):
-            day = event.date.strftime("%Y-%b-%d").upper()
+            day = sportsdata_day_slug(event.date, local_timezone)
             if not event.status.is_scheduled() and day not in date_list:
                 url = f"{self.base_url}/GamesByDate/{self.name}/{day}"
                 response = await get_data(
@@ -1034,7 +1030,7 @@ class WCS(Sport):
                     response,
                     event_timezone=local_timezone,
                 )
-                date_list.append(day)
+                date_list.add(day)
 
         await self.cache_events()
 

--- a/merino/providers/suggest/sports/backends/sportsdata/protocol.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/protocol.py
@@ -1,13 +1,16 @@
 """Protocol for sport suggestion backends."""
 
 from typing import Any, Optional, cast
-from datetime import datetime
+from datetime import datetime, timezone, tzinfo
 from pydantic import HttpUrl
 
 from merino.providers.suggest.base import BaseModel
 from merino.providers.suggest.sports.backends.sportsdata.common import (
     GameStatus,
     SportCategory,
+)
+from merino.providers.suggest.sports.backends.sportsdata.common.data import (
+    sportsdata_timezone_for_sport,
 )
 from merino.providers.suggest.sports.backends.sportsdata.common.sports import (
     SPORT_CATEGORY_MAP,
@@ -39,10 +42,14 @@ class SportTeamDetail(BaseModel):
 
 def build_query(event: dict[str, Any]) -> str:
     """Build the search query from the event information"""
-    date = datetime.fromisoformat(event["date"]).strftime("%d %B %Y")
+    event_date = datetime.fromisoformat(event["date"])
+    query_timezone: tzinfo = timezone.utc
+    event_status = event.get("event_status")
+    if not isinstance(event_status, GameStatus) or not event_status.is_scheduled():
+        query_timezone = sportsdata_timezone_for_sport(event.get("sport", ""))
+    date = event_date.astimezone(query_timezone).strftime("%d %B %Y")
     # catch pre-stored values
-    if event.get("sport") == "fifa":
-        event["sport"] = "World Cup"
+    if event.get("sport", "").lower() == "fifa":
         sport_query_name = "World Cup 2026"
     else:
         sport_query_name = event.get("sport", "")

--- a/tests/unit/providers/suggest/sports/backends/common/test_data.py
+++ b/tests/unit/providers/suggest/sports/backends/common/test_data.py
@@ -1,6 +1,6 @@
 """Unit Test for Sports Data models."""
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from zoneinfo import ZoneInfo
 
 import freezegun
@@ -12,6 +12,9 @@ from merino.providers.suggest.sports.backends.sportsdata.common.data import (
     Team,
     Sport,
     SportNormalizedTerms,
+    SportsDataEventRow,
+    SPORTSDATA_US_EASTERN,
+    sportsdata_day_slug,
 )
 from merino.providers.suggest.sports.backends.sportsdata.common.sports import (
     NFL,
@@ -274,6 +277,127 @@ def test_load_schedules_from_source_filters_and_populates(
         [mod_event], event_timezone=ZoneInfo("America/New_York")
     )
     assert len(mod_events) == 0
+
+
+def test_sportsdata_event_rows_keep_mlb_kickoff_and_freshness_separate() -> None:
+    """Late ET MLB games keep UTC kickoffs and independent source freshness."""
+    sport = MLB(settings=settings.providers.sports, name="", base_url="")
+    may_11_row = SportsDataEventRow.from_event_description(
+        {
+            "AwayTeamRuns": 9,
+            "HomeTeamRuns": 3,
+            "GameID": 77896,
+            "Status": "Final",
+            "DateTime": "2026-05-11T22:10:00",
+            "DateTimeUTC": "2026-05-12T02:10:00",
+            "AwayTeam": "SF",
+            "HomeTeam": "LAD",
+            "AwayTeamID": 15,
+            "HomeTeamID": 1,
+            "Updated": "2026-05-13T07:58:54",
+        },
+        normalized_terms=sport.normalized_terms,
+        event_timezone=SPORTSDATA_US_EASTERN,
+    )
+    may_12_row = SportsDataEventRow.from_event_description(
+        {
+            "AwayTeamRuns": 6,
+            "HomeTeamRuns": 2,
+            "GameID": 77908,
+            "Status": "Final",
+            "DateTime": "2026-05-12T22:10:00",
+            "DateTimeUTC": "2026-05-13T02:10:00",
+            "AwayTeam": "SF",
+            "HomeTeam": "LAD",
+            "AwayTeamID": 15,
+            "HomeTeamID": 1,
+            "Updated": "2026-05-13T07:31:32",
+        },
+        normalized_terms=sport.normalized_terms,
+        event_timezone=SPORTSDATA_US_EASTERN,
+    )
+
+    assert may_11_row.kickoff == datetime(2026, 5, 12, 2, 10, tzinfo=timezone.utc)
+    assert sportsdata_day_slug(may_11_row.kickoff, SPORTSDATA_US_EASTERN) == "2026-MAY-11"
+    assert may_11_row.away_score == 9
+    assert may_11_row.home_score == 3
+    assert may_11_row.updated == datetime(2026, 5, 13, 11, 58, 54, tzinfo=timezone.utc)
+
+    assert may_12_row.kickoff == datetime(2026, 5, 13, 2, 10, tzinfo=timezone.utc)
+    assert sportsdata_day_slug(may_12_row.kickoff, SPORTSDATA_US_EASTERN) == "2026-MAY-12"
+    assert may_12_row.away_score == 6
+    assert may_12_row.home_score == 2
+    assert may_12_row.updated == datetime(2026, 5, 13, 11, 31, 32, tzinfo=timezone.utc)
+
+    assert may_11_row.updated > may_12_row.updated
+    assert may_11_row.kickoff < may_12_row.kickoff
+
+
+def test_sportsdata_event_row_allows_missing_updated_time() -> None:
+    """SportsData rows may omit source freshness timestamps."""
+    sport = MLB(settings=settings.providers.sports, name="", base_url="")
+    row = SportsDataEventRow.from_event_description(
+        {
+            "AwayTeamRuns": 6,
+            "HomeTeamRuns": 2,
+            "GameID": 77908,
+            "Status": "Final",
+            "DateTime": "2026-05-12T22:10:00",
+            "DateTimeUTC": "2026-05-13T02:10:00",
+            "AwayTeam": "SF",
+            "HomeTeam": "LAD",
+            "AwayTeamID": 15,
+            "HomeTeamID": 1,
+        },
+        normalized_terms=sport.normalized_terms,
+        event_timezone=SPORTSDATA_US_EASTERN,
+    )
+
+    assert row.updated is None
+
+
+def test_event_row_from_source_logs_invalid_event_for_missing_game_id(caplog) -> None:
+    """Rows without SportsData game IDs are invalid events, not date failures."""
+    caplog.set_level("INFO")
+    sport = MLB(settings=settings.providers.sports, name="", base_url="")
+
+    row = sport.event_row_from_source(
+        {
+            "Status": "Final",
+            "DateTimeUTC": "2026-05-13T02:10:00",
+            "AwayTeam": "SF",
+            "HomeTeam": "LAD",
+            "AwayTeamID": 15,
+            "HomeTeamID": 1,
+        },
+        event_timezone=SPORTSDATA_US_EASTERN,
+    )
+
+    assert row is None
+    assert "sports.error.invalid_event" in caplog.text
+    assert "sports.error.no_date" not in caplog.text
+
+
+def test_event_row_from_source_logs_no_date_for_missing_kickoff(caplog) -> None:
+    """Rows without a usable kickoff timestamp remain date failures."""
+    caplog.set_level("INFO")
+    sport = MLB(settings=settings.providers.sports, name="", base_url="")
+
+    row = sport.event_row_from_source(
+        {
+            "GameID": 77908,
+            "Status": "Final",
+            "AwayTeam": "SF",
+            "HomeTeam": "LAD",
+            "AwayTeamID": 15,
+            "HomeTeamID": 1,
+        },
+        event_timezone=SPORTSDATA_US_EASTERN,
+    )
+
+    assert row is None
+    assert "sports.error.no_date" in caplog.text
+    assert "sports.error.invalid_event" not in caplog.text
 
 
 @freezegun.freeze_time("2025-09-22T00:00:00", tz_offset=0)

--- a/tests/unit/providers/suggest/sports/backends/common/test_elastic.py
+++ b/tests/unit/providers/suggest/sports/backends/common/test_elastic.py
@@ -511,6 +511,81 @@ async def test_sports_search_event_hits_no_current(
     assert result == expected_result
 
 
+@freezegun.freeze_time("2026-05-13T13:30:00Z")
+@pytest.mark.asyncio
+async def test_sports_search_previous_uses_game_date_over_late_update(
+    sport_data_store: SportsDataStore,
+    es_client: AsyncMock,
+) -> None:
+    """The previous result should be the latest game, not an older late-updated game."""
+    hits = [
+        {
+            "_score": 1.0,
+            "_source": {
+                "event": json.dumps(
+                    {
+                        "sport": "MLB",
+                        "id": 77908,
+                        "status": "Final",
+                        "label": "may-12-game",
+                        "date": "2026-05-13T02:10:00+00:00",
+                        "updated": "2026-05-13T11:31:32+00:00",
+                        "home_score": 2,
+                        "away_score": 6,
+                    }
+                )
+            },
+        },
+        {
+            "_score": 1.0,
+            "_source": {
+                "event": json.dumps(
+                    {
+                        "sport": "MLB",
+                        "id": 77896,
+                        "status": "Final",
+                        "label": "may-11-game",
+                        "date": "2026-05-12T02:10:00+00:00",
+                        "updated": "2026-05-13T11:58:54+00:00",
+                        "home_score": 3,
+                        "away_score": 9,
+                    }
+                )
+            },
+        },
+    ]
+    es_client.search.return_value = {"hits": {"total": {"value": 2}, "hits": hits}}
+
+    result = await sport_data_store.search_events(
+        q="los angeles",
+        language_code="en",
+        mix_sports=True,
+    )
+
+    assert result["all"]["previous"]["label"] == "may-12-game"
+    assert result["all"]["previous"]["home_score"] == 2
+    assert result["all"]["previous"]["away_score"] == 6
+
+
+def test_choose_previous_ignores_final_when_current_exists() -> None:
+    """Final events should not be selected when a current game already exists."""
+    selected_events = {
+        "current": {
+            "date": "2026-05-13T02:10:00+00:00",
+            "updated": "2026-05-13T11:31:32+00:00",
+        }
+    }
+    final_event = {
+        "date": "2026-05-13T01:10:00+00:00",
+        "updated": "2026-05-13T11:58:54+00:00",
+    }
+
+    SportsDataStore.choose_previous_event(selected_events, final_event)
+
+    assert "previous" not in selected_events
+    assert selected_events["current"]["date"] == "2026-05-13T02:10:00+00:00"
+
+
 @pytest.mark.asyncio
 async def test_search_event_bad_hit_data(
     sport_data_store: SportsDataStore,

--- a/tests/unit/providers/suggest/sports/backends/test_sports_backend.py
+++ b/tests/unit/providers/suggest/sports/backends/test_sports_backend.py
@@ -34,6 +34,7 @@ from merino.providers.suggest.sports.backends.sportsdata.common.elastic import (
 )
 from merino.providers.suggest.sports.backends.sportsdata.protocol import (
     SportEventDetail,
+    SportSummary,
     build_query,
 )
 from merino.utils.logos import Logo, LogoCategory, LogoManifest
@@ -396,7 +397,7 @@ def test_build_query() -> None:
     """build_query produces a 'sport away vs home date' string."""
     event: dict = {
         "sport": "NFL",
-        "date": "2025-10-01T00:00:00+00:00",
+        "date": "2025-10-01T16:00:00+00:00",
         "home_team": {"name": "Home Team"},
         "away_team": {"name": "Away Team"},
     }
@@ -404,17 +405,70 @@ def test_build_query() -> None:
     assert build_query(event) == "NFL Home Team vs Away Team 01 October 2025"
 
 
+def test_build_query_uses_league_local_date() -> None:
+    """build_query uses the SportsData league-local date for final US sports."""
+    event: dict = {
+        "sport": "MLB",
+        "event_status": GameStatus.Final,
+        "date": "2026-05-13T02:10:00+00:00",
+        "home_team": {"name": "Los Angeles Dodgers"},
+        "away_team": {"name": "San Francisco Giants"},
+    }
+
+    assert build_query(event) == "MLB Los Angeles Dodgers vs San Francisco Giants 12 May 2026"
+
+
+def test_build_query_keeps_scheduled_date_utc() -> None:
+    """build_query keeps the existing UTC date behavior for scheduled events."""
+    event: dict = {
+        "sport": "NFL",
+        "event_status": GameStatus.Scheduled,
+        "date": "2025-10-27T00:10:00+00:00",
+        "home_team": {"name": "Fake Home"},
+        "away_team": {"name": "Fake Away"},
+    }
+
+    assert build_query(event) == "NFL Fake Home vs Fake Away 27 October 2025"
+
+
+def test_sport_summary_current_suppresses_previous_and_keeps_next() -> None:
+    """SportSummary returns current and next events when both are available."""
+
+    def event(status: GameStatus, date: str) -> dict[str, Any]:
+        return {
+            "sport": "TEST",
+            "event_status": status,
+            "date": date,
+            "home_team": {"key": "HOM", "name": "Home Team", "colors": ["000000"]},
+            "away_team": {"key": "AWY", "name": "Away Team", "colors": ["FFFFFF"]},
+            "home_score": None,
+            "away_score": None,
+            "touched": "2026-05-13T00:00:00+00:00",
+        }
+
+    summary = SportSummary.from_events(
+        "all",
+        {
+            "previous": event(GameStatus.Final, "2026-05-12T02:10:00+00:00"),
+            "current": event(GameStatus.InProgress, "2026-05-13T02:10:00+00:00"),
+            "next": event(GameStatus.Scheduled, "2026-05-14T02:10:00+00:00"),
+        },
+    )
+
+    assert [value.status_type for value in summary.values] == ["live", "scheduled"]
+
+
 def test_build_query_world_cup() -> None:
     """build_query uses World Cup 2026 prefix for games"""
     event: dict = {
         "sport": "fifa",
-        "date": "2025-10-01T00:00:00+00:00",
+        "date": "2026-06-15T02:00:00+00:00",
         "home_team": {"name": "Home Team"},
         "away_team": {"name": "Away Team"},
     }
 
-    assert build_query(event) == "World Cup 2026 Home Team vs Away Team 01 October 2025"
-    assert event["sport"] == "World Cup"
+    assert build_query(event) == "World Cup 2026 Home Team vs Away Team 15 June 2026"
+    assert event["sport"] == "fifa"
 
 
 def test_sport_event_detail_icon_set_when_team_in_manifest(


### PR DESCRIPTION
## References

JIRA: [DISCO-4208](https://mozilla-hub.atlassian.net/browse/DISCO-4208)

## Description
Root cause: at fetch time, we were effectively treating SportsData’s `Updated` timestamp as the source of truth for which final game was the latest. That is not stable: `Updated` is provider freshness, not game recency.

For example:

- May 11 Giants @ Dodgers
  - `GameID`: `77896`
  - `DateTimeUTC`: `2026-05-12T02:10:00`
  - Score: `SF 9`, `LAD 3`
  - `Updated`: `2026-05-13T07:58:54`

- May 12 Giants @ Dodgers
  - `GameID`: `77908`
  - `DateTimeUTC`: `2026-05-13T02:10:00`
  - Score: `SF 6`, `LAD 2`
  - `Updated`: observed earlier as `2026-05-13T07:31:32`

Because the older May 11 row had the later `Updated` value at that moment, Merino selected the May 11 score as the previous game. The click-through/SERP then resolved to the May 12 game, so the scores did not match.

This change makes kickoff time the source of truth for final-game recency, uses league-local dates for SportsData day endpoints/query text, and treats `Updated` only as source freshness/tie-breaker data.

The fix separates these concepts:
- use kickoff time (`DateTimeUTC`) to choose latest previous game
- use league-local day (`Day` / local date) to fetch the right SportsData score endpoint
- treat `Updated` only as source freshness, and only as a tie-breaker for the same kickoff

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2316)


[DISCO-4208]: https://mozilla-hub.atlassian.net/browse/DISCO-4208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ