### PR TITLE
[AIMOD-1222] Fix Section Rankings for Interest Ranker

### DIFF
--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -1034,7 +1034,9 @@ async def get_sections(
         ranker,
         personal_interests,
         engagement_rescaler=rescaler,
-        do_section_personalization_reranking=not use_contexual_ranker,  # Contextual ranker already re-ranks all sections
+        do_section_personalization_reranking=not (
+            use_contexual_ranker or use_interest_ranker
+        ),  # Contextual + Interest rankers already re-rank sections
         include_daily_briefing_section=include_daily_briefing_section,
     )
 

--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -1036,7 +1036,7 @@ async def get_sections(
         engagement_rescaler=rescaler,
         do_section_personalization_reranking=not (
             use_contexual_ranker or use_interest_ranker
-        ),  # Contextual + Interest rankers already re-rank sections
+        ),  # Contextual + Interest rankers already re-rank sections implicitly
         include_daily_briefing_section=include_daily_briefing_section,
     )
 


### PR DESCRIPTION
## References

JIRA: [AIMOD-1222](https://mozilla-hub.atlassian.net/browse/AIMOD-1222)

## Description
Contextual Cohort model doesn't do greedy section ranking but this was inadvertently turned on for the interest ranker. Update so we have apples-to-apples comparison.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2317)


[AIMOD-1222]: https://mozilla-hub.atlassian.net/browse/AIMOD-1222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ