### PR TITLE
[DICSO-4203] feat(wcs): add tournament stage to widget response

### DIFF
--- a/merino/providers/suggest/sports/backends/sportsdata/common/data.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/data.py
@@ -191,6 +191,8 @@ class Event(BaseModel):
     away_penalty: int | None = None
     # Play time, with additions when provided by the feed.
     clock: str | None = None
+    # Optional stage, e.g. "Group", "Round of 32"
+    stage: str | None = None
 
     def key(self) -> str:
         """Generate semi-unique key for this event"""

--- a/merino/providers/suggest/sports/backends/sportsdata/common/sports.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/sports.py
@@ -822,7 +822,7 @@ class WCS(Sport):
         """
         # Sample Response
         """
-        {
+        [{
             "CompetitionId": 21,
             ...
             "Key": "FIFA",
@@ -852,21 +852,23 @@ class WCS(Sport):
             cache_dir=self.cache_dir,
             args={"key": self.api_key},
         )
-        competition = next(
-            (c for c in response if c.get("Key") == self.name.upper()),
-            None,
-        )
-        seasons: list[dict] = (competition or {}).get("Seasons") or []
-        season_data = next(
-            (s for s in seasons if str(s.get("Season")) == self.season),
-            None,
-        )
-        rounds: list[dict] = (season_data or {}).get("Rounds") or []
-        self.rounds = {
-            int(r["RoundId"]): r["Name"]
-            for r in rounds
-            if r.get("RoundId") is not None and r.get("Name")
-        }
+        self.rounds = {}
+        for competition in response:
+            match competition:
+                case {"Key": key, "Seasons": seasons} if key == self.name.upper():
+                    for season_data in seasons:
+                        match season_data:
+                            case {"Season": season, "Rounds": rounds} if (
+                                str(season) == self.season
+                            ):
+                                # Note: There should only be one match, which is
+                                # why we can set the rounds variable rather than
+                                # reduce/update dict
+                                self.rounds = {
+                                    int(r["RoundId"]): r["Name"]
+                                    for r in rounds
+                                    if r.get("RoundId") is not None and r.get("Name")
+                                }
         await self.cache.set(
             f"{self.cache_prefix}:rounds",
             orjson.dumps(self.rounds, option=orjson.OPT_NON_STR_KEYS),

--- a/merino/providers/suggest/sports/backends/sportsdata/common/sports.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/sports.py
@@ -668,6 +668,7 @@ class WCS(Sport):
     cache_prefix: str = "sport:wcs:v1"  # Unique prefix for Redis
     _lock: asyncio.Lock
     teams: dict[int, Team] = {}
+    rounds: dict[int, str] = {}
     refreshed: datetime = datetime.now(tz=timezone.utc)
 
     def __init__(
@@ -711,6 +712,7 @@ class WCS(Sport):
     def event_details(self, event_description: dict[str, Any]) -> dict[str, Any]:
         """Return soccer score details used by the WCS widget."""
         clock = event_description.get("ClockDisplay") or event_description.get("Clock")
+        round_id = event_description.get("RoundId")
         return {
             "period": event_description.get("Period"),
             "home_extra": event_description.get("HomeTeamScoreExtraTime"),
@@ -718,6 +720,7 @@ class WCS(Sport):
             "home_penalty": event_description.get("HomeTeamScorePenalty"),
             "away_penalty": event_description.get("AwayTeamScorePenalty"),
             "clock": str(clock) if clock is not None else None,
+            "stage": self.rounds.get(round_id) if round_id is not None else None,
         }
 
     # Note: this is covered by `test_wcs_init_cache` but I believe that the heavy use of Mocks
@@ -761,6 +764,7 @@ class WCS(Sport):
                 # We got the lock, we can initialize things.
                 # to initial stuff.
                 await self.load_areas(client)
+                await self.load_rounds(client)
                 await self.update_teams(client)
                 await self.cache_teams()
                 complete = int(datetime.now(tz=timezone.utc).timestamp())
@@ -810,6 +814,63 @@ class WCS(Sport):
             }
             # cache this for later, we're gonna need them for teams.
             await self.cache.hset(f"{self.cache_prefix}:area:{area['AreaId']}", country_data)
+
+    async def load_rounds(self, client) -> None:
+        """Fetch and load the round info to the cache
+        This is specifically to resolve the stage. We expect
+        this data to stay static throughout the tournament.
+        """
+        # Sample Response
+        """
+        {
+            "CompetitionId": 21,
+            ...
+            "Key": "FIFA",
+            "Seasons": [
+                {
+                    "SeasonId": 368,
+                    "CompetitionId": 21,
+                    "Season": 2026,
+                     ...
+                    "Rounds": [
+                        {
+                            "RoundId": 1615,
+                            "SeasonId": 368,
+                            "Season": 2026,
+                            "SeasonType": 1,
+                            "Name": "Group Stage",
+                           ...
+                        },
+        """
+        await self.get_season(client=client)
+        logging.info(f"{LOGGING_TAG} Pre Loading Rounds")
+        url = f"{self.base_url}/Competitions"
+        response = await get_data(
+            client=client,
+            url=url,
+            ttl=timedelta(weeks=25),
+            cache_dir=self.cache_dir,
+            args={"key": self.api_key},
+        )
+        competition = next(
+            (c for c in response if c.get("Key") == self.name.upper()),
+            None,
+        )
+        seasons: list[dict] = (competition or {}).get("Seasons") or []
+        season_data = next(
+            (s for s in seasons if str(s.get("Season")) == self.season),
+            None,
+        )
+        rounds: list[dict] = (season_data or {}).get("Rounds") or []
+        self.rounds = {
+            int(r["RoundId"]): r["Name"]
+            for r in rounds
+            if r.get("RoundId") is not None and r.get("Name")
+        }
+        await self.cache.set(
+            f"{self.cache_prefix}:rounds",
+            orjson.dumps(self.rounds, option=orjson.OPT_NON_STR_KEYS),
+        )
 
     async def get_season(self, client: AsyncClient) -> None:
         """Get the current season (which is just the current year)"""
@@ -1000,6 +1061,11 @@ class WCS(Sport):
     async def update_events(self, client: AsyncClient, allow_no_teams: bool = False):
         """Update schedules and game scores for this sport"""
         await self.get_season(client=client)
+        # Stage names are joined by Event.RoundId onto self.rounds
+        # Rounds are lazy loaded, so ensure we got them (otherwise
+        # stage will always default to None)
+        if not self.rounds:
+            await self.load_rounds(client=client)
         logger.debug(f"{LOGGING_TAG} Getting {self.name} schedules")
         url = f"{self.base_url}/SchedulesBasic/{self.name}/{self.season}"
         local_timezone = ZoneInfo("UTC")

--- a/merino/providers/wcs/protocol.py
+++ b/merino/providers/wcs/protocol.py
@@ -71,6 +71,10 @@ class EventInfo(BaseModel):
     away_penalty: int | None
     clock: str = Field(description="Elapsed minutes; extra time as '90+3'.")
     updated: int = Field(description="UTC unix timestamp of the last record update.")
+    stage: str | None = Field(
+        default=None,
+        description="Tournament stage, e.g. 'Group Stage', 'Round of 32', 'Final'.",
+    )
     status: str = Field(description="Game status: 'Scheduled', 'In Progress', 'Final', etc.")
     status_type: str = Field(description="UI status bucket, e.g. 'past', 'live', 'scheduled'.")
     query: str | None = Field(default=None, description="Optional click-through query.")
@@ -96,6 +100,7 @@ class EventInfo(BaseModel):
             away_penalty=event.away_penalty,
             clock=event.clock or "",
             updated=int(updated.timestamp()),
+            stage=event.stage,
             status=event.status.as_str(),
             status_type=event.status.as_ui_status(),
             query=build_query(event.model_dump(mode="json")),

--- a/tests/unit/providers/suggest/sports/backends/common/test_sports.py
+++ b/tests/unit/providers/suggest/sports/backends/common/test_sports.py
@@ -10,6 +10,7 @@ from typing import Any, cast
 from zoneinfo import ZoneInfo
 
 import freezegun
+import orjson
 import pytest
 from httpx import AsyncClient
 from pytest_mock import MockerFixture
@@ -2170,6 +2171,173 @@ async def test_wcs_load_areas(mock_client: AsyncClient, mocker: MockerFixture) -
     ]
 
 
+def wcs_competitions_payload() -> list[dict]:
+    """Return a trimmed SportsData Competitions response with relevant (World Cup) and irrelevant
+    competition and seasons.
+    """
+    return [
+        {
+            "Key": "FIFA",
+            "Seasons": [
+                {
+                    "Season": 2026,
+                    "Rounds": [
+                        {"RoundId": 1615, "Name": "Group Stage"},
+                        {"RoundId": 1616, "Name": "Round of 32"},
+                    ],
+                },
+                {
+                    "Season": 2018,
+                    "Rounds": [{"RoundId": 196, "Name": "Group Stage"}],
+                },
+            ],
+        },
+        {
+            "Key": "FAFFY",
+            "Seasons": [
+                {
+                    "Season": 2026,
+                    "Rounds": [{"RoundId": 999, "Name": "Sudden Death"}],
+                }
+            ],
+        },
+    ]
+
+
+@freezegun.freeze_time("2026-06-10T00:00:00", tz_offset=0)
+@pytest.mark.asyncio
+async def test_wcs_load_rounds(mock_client: AsyncClient, mocker: MockerFixture) -> None:
+    """load_rounds populates self.rounds and caches it for the current world cup."""
+    sport = WCS(settings=settings.providers.sports)
+    competitions = wcs_competitions_payload()
+    mocker.patch(
+        "merino.providers.suggest.sports.backends.sportsdata.common.sports.get_data",
+        side_effect=[competitions],
+    )
+    mock_cache = MagicMock(spec=RedisAdapter)
+    sport.cache = mock_cache
+
+    await sport.load_rounds(mock_client)
+
+    assert sport.rounds == {1615: "Group Stage", 1616: "Round of 32"}
+    mock_cache.set.assert_called_once_with(
+        "sport:wcs:v1:rounds",
+        orjson.dumps({1615: "Group Stage", 1616: "Round of 32"}, option=orjson.OPT_NON_STR_KEYS),
+    )
+
+
+@freezegun.freeze_time("2030-06-10T00:00:00", tz_offset=0)
+@pytest.mark.asyncio
+async def test_wcs_load_rounds_no_matching_season(
+    mock_client: AsyncClient, mocker: MockerFixture
+) -> None:
+    """When no season matches, self.rounds stays empty and an empty mapping is cached."""
+    sport = WCS(settings=settings.providers.sports)
+    mocker.patch(
+        "merino.providers.suggest.sports.backends.sportsdata.common.sports.get_data",
+        side_effect=[wcs_competitions_payload()],
+    )
+    mock_cache = MagicMock(spec=RedisAdapter)
+    sport.cache = mock_cache
+
+    await sport.load_rounds(mock_client)
+
+    assert sport.rounds == {}
+    mock_cache.set.assert_called_once_with(
+        "sport:wcs:v1:rounds", orjson.dumps({}, option=orjson.OPT_NON_STR_KEYS)
+    )
+
+
+@freezegun.freeze_time("2026-06-10T00:00:00", tz_offset=0)
+@pytest.mark.asyncio
+async def test_wcs_load_rounds_no_matching_competition(
+    mock_client: AsyncClient, mocker: MockerFixture
+) -> None:
+    """Empty/non-matching /Competitions response yields an empty rounds map."""
+    sport = WCS(settings=settings.providers.sports)
+    mocker.patch(
+        "merino.providers.suggest.sports.backends.sportsdata.common.sports.get_data",
+        side_effect=[[{"Key": "OTHER", "Seasons": []}]],
+    )
+    mock_cache = MagicMock(spec=RedisAdapter)
+    sport.cache = mock_cache
+
+    await sport.load_rounds(mock_client)
+
+    assert sport.rounds == {}
+    mock_cache.set.assert_called_once_with(
+        "sport:wcs:v1:rounds", orjson.dumps({}, option=orjson.OPT_NON_STR_KEYS)
+    )
+
+
+def test_wcs_event_details_includes_stage_from_rounds() -> None:
+    """event_details resolves the schedule's RoundId to a stage name via self.rounds."""
+    sport = WCS(settings=settings.providers.sports)
+    sport.rounds = {1615: "Group Stage", 1616: "Round of 32"}
+
+    details = sport.event_details({"RoundId": 1616, "Period": "Regular"})
+
+    assert details["stage"] == "Round of 32"
+
+
+def test_wcs_event_details_unknown_round_id_returns_none_stage() -> None:
+    """A RoundId not in the cached mapping resolves to stage=None."""
+    sport = WCS(settings=settings.providers.sports)
+    sport.rounds = {1615: "Group Stage"}
+
+    details = sport.event_details({"RoundId": 9999})
+
+    assert details["stage"] is None
+
+
+def test_wcs_event_details_missing_round_id_returns_none_stage() -> None:
+    """Schedule rows without a RoundId resolve to stage=None."""
+    sport = WCS(settings=settings.providers.sports)
+    sport.rounds = {1615: "Group Stage"}
+
+    details = sport.event_details({})
+
+    assert details["stage"] is None
+
+
+def test_wcs_event_details_no_rounds_returns_none_stage() -> None:
+    """If rounds can't be loaded or aren't found (default to empty dict)
+    stage returns none.
+    """
+    sport = WCS(settings=settings.providers.sports)
+    sport.rounds = {}
+
+    details = sport.event_details({})
+
+    assert details["stage"] is None
+
+
+@freezegun.freeze_time("2026-06-10T00:00:00", tz_offset=0)
+@pytest.mark.asyncio
+async def test_wcs_update_events_loads_rounds_when_empty(
+    mock_client: AsyncClient, mocker: MockerFixture
+) -> None:
+    """Ensure that lazily loaded rounds are fetched if they aren't
+    already loaded during update_events
+    """
+    sport = WCS(settings=settings.providers.sports)
+    await sport.async_load_teams_from_source(wcs_teams_payload())
+    sport.event_ttl = timedelta(weeks=8)
+
+    competitions = wcs_competitions_payload()
+    mocker.patch(
+        "merino.providers.suggest.sports.backends.sportsdata.common.sports.get_data",
+        side_effect=[competitions, wcs_schedule_payload(), wcs_score_payload()],
+    )
+    mock_cache = MagicMock(spec=RedisAdapter)
+    sport.cache = mock_cache
+
+    await sport.update_events(client=mock_client)
+
+    assert sport.rounds == {1615: "Group Stage", 1616: "Round of 32"}
+    assert sport.events[90011111].stage == "Group Stage"
+
+
 @freezegun.freeze_time("2025-09-22T00:00:00", tz_offset=0)
 @pytest.mark.asyncio
 async def test_wcs_update_events(
@@ -2182,6 +2350,8 @@ async def test_wcs_update_events(
     await sport.async_load_teams_from_source(teams_payload)
     sport.season = "2025"  # set by update_teams normally
     sport.event_ttl = timedelta(weeks=2)
+    # Preload rounds to avoid mocking external call
+    sport.rounds = {1615: "Group Stage"}
 
     schedules_payload = wcs_schedule_payload()
     scores_payload = wcs_score_payload()
@@ -2605,6 +2775,8 @@ async def test_wcs_update_events_prunes_previously_cached_events_removed_from_so
         updated=stale_date,
     )
     sport.events = {stale_event.id: stale_event}
+    # Preload rounds to avoid mocking external call
+    sport.rounds = {1615: "Group Stage"}
     mock_cache = MagicMock(spec=RedisAdapter)
     mock_cache.zrange.return_value = [b"sport:wcs:v1:event:999"]
     sport.cache = mock_cache
@@ -2645,6 +2817,8 @@ async def test_wcs_update_events_empty_schedule_preserves_existing_cache(
         updated=stale_date,
     )
     sport.events = {stale_event.id: stale_event}
+    # Preload rounds to avoid mocking external call
+    sport.rounds = {1615: "Group Stage"}
     mock_cache = MagicMock(spec=RedisAdapter)
     sport.cache = mock_cache
     mocker.patch(

--- a/tests/unit/providers/wcs/test_protocol.py
+++ b/tests/unit/providers/wcs/test_protocol.py
@@ -24,3 +24,36 @@ def test_event_info_from_event_builds_world_cup_query() -> None:
 
     expected_date = e.date.strftime("%d %B %Y")
     assert info.query == f"World Cup 2026 Brazil vs Argentina {expected_date}"
+
+
+def test_event_info_from_event_includes_stage() -> None:
+    """Ensure stage is propagated from cache to response"""
+    e = event(
+        event_id=2,
+        day_offset=0,
+        hour=14,
+        home=("BRA", "Brazil", 90000001),
+        away=("ARG", "Argentina", 90000002),
+        status=GameStatus.Scheduled,
+        stage="Round of 32",
+    )
+
+    info = EventInfo.from_event(e)
+    assert info.stage == "Round of 32"
+
+
+def test_event_info_from_event_stage_defaults_to_none() -> None:
+    """An event with no cached stage serializes stage=None on the widget payload.
+    This shouldn't happen with real data.
+    """
+    e = event(
+        event_id=3,
+        day_offset=0,
+        hour=14,
+        home=("BRA", "Brazil", 90000001),
+        away=("ARG", "Argentina", 90000002),
+        status=GameStatus.Scheduled,
+    )
+
+    info = EventInfo.from_event(e)
+    assert info.stage is None

--- a/tests/wcs/factories.py
+++ b/tests/wcs/factories.py
@@ -62,6 +62,7 @@ def event(
     away_penalty: int | None = None,
     period: str | None = None,
     clock: str | None = None,
+    stage: str | None = None,
 ) -> Event:
     """Build a cached event model."""
     event_date = datetime.combine(ANCHOR + timedelta(days=day_offset), time(hour, tzinfo=UTC))
@@ -84,6 +85,7 @@ def event(
         home_penalty=home_penalty,
         away_penalty=away_penalty,
         clock=clock,
+        stage=stage,
     )
 
 


### PR DESCRIPTION
## References

JIRA:  [DISCO-4203]

## Description
Add stage name to the /wcs/matches response. This is not available on the SchedulesBasic or Scores payload, but they do have the RoundId. The Competitions payload has a list of rounds, so I decided to use that in a similar way to how Areas is used. We expect this data to be essentially static since all the Rounds are already planned for the competition (even if we don't know what teams are playing).

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2318)


[DISCO-4203]: https://mozilla-hub.atlassian.net/browse/DISCO-4203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ