### PR TITLE
chore(wcs): update time window for wcs to +/- 10 days

### DIFF
--- a/merino/providers/wcs/provider.py
+++ b/merino/providers/wcs/provider.py
@@ -18,7 +18,7 @@ from merino.providers.wcs.protocol import (
 )
 from merino.utils.metrics import get_metrics_client
 
-_WINDOW = timedelta(days=7)
+_WINDOW = timedelta(days=10)
 _CACHE_ERROR_METRIC = "wcs.cache_error"
 logger = logging.getLogger(__name__)
 
@@ -47,7 +47,7 @@ class WcsProvider:
         limit: int | None,
         team_keys: frozenset[str] | None,
     ) -> MatchesResponse:
-        """Return matches in the +/- 7 day window around `target_date`.
+        """Return matches in a +/- _WINDOW day window around `target_date`.
 
         Events are bucketed into `previous`, `current`, and `next` relative to
         `target_date` and sorted ascending by event date. `limit` keeps the

--- a/tests/unit/providers/wcs/test_provider.py
+++ b/tests/unit/providers/wcs/test_provider.py
@@ -115,7 +115,8 @@ async def test_response_is_deterministic_for_same_anchor() -> None:
 @pytest.mark.asyncio
 async def test_six_records_two_per_status_type() -> None:
     """The stub set has at least two past, two live, and two scheduled matches
-    assuming a window >= 7 days."""
+    assuming a window >= 7 days.
+    """
     response = await build_provider().get_matches(ANCHOR, limit=None, team_keys=None)
 
     assert len(response.previous) >= 2

--- a/tests/unit/providers/wcs/test_provider.py
+++ b/tests/unit/providers/wcs/test_provider.py
@@ -14,7 +14,7 @@ from merino.configs import settings
 from merino.exceptions import CacheAdapterError
 from merino.providers import wcs as wcs_module
 from merino.providers.wcs.fake_live_data import build_live_events
-from merino.providers.wcs.provider import WcsProvider
+from merino.providers.wcs.provider import WcsProvider, _WINDOW
 from merino.providers.wcs.protocol import LiveMatchesResponse, TeamInfo, TeamsResponse
 from tests.wcs.factories import ANCHOR, build_provider
 
@@ -58,12 +58,12 @@ async def test_buckets_split_by_date() -> None:
 
 @pytest.mark.asyncio
 async def test_window_excludes_outside_range() -> None:
-    """No event lands more than 7 days from the anchor."""
+    """No event lands more than WINDOW days from the anchor."""
     response = await build_provider().get_matches(ANCHOR, limit=None, team_keys=None)
 
     for event in response.previous + response.current + response.next_:
         delta = abs((datetime.fromisoformat(event.date).date() - ANCHOR).days)
-        assert delta <= 7
+        assert delta <= _WINDOW.days
 
 
 @pytest.mark.asyncio
@@ -114,12 +114,13 @@ async def test_response_is_deterministic_for_same_anchor() -> None:
 
 @pytest.mark.asyncio
 async def test_six_records_two_per_status_type() -> None:
-    """The stub set has exactly two past, two live, and two scheduled matches."""
+    """The stub set has at least two past, two live, and two scheduled matches
+    assuming a window >= 7 days."""
     response = await build_provider().get_matches(ANCHOR, limit=None, team_keys=None)
 
-    assert len(response.previous) == 2
-    assert len(response.current) == 2
-    assert len(response.next_) == 2
+    assert len(response.previous) >= 2
+    assert len(response.current) >= 2
+    assert len(response.next_) >= 2
     assert all(e.status_type == "past" for e in response.previous)
     assert all(e.status_type == "live" for e in response.current)
     assert all(e.status_type == "scheduled" for e in response.next_)


### PR DESCRIPTION
## References


## Description
To coincide with the expected launch timing, update window to +/- 10 days so that games will show up on launch day (June 2). There aren't 100s of games so this doesn't increase the payload size that much.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2319)
