### PR TITLE
DISCO-4163 enable live teams for wcs teams endpoint

### DIFF
--- a/merino/providers/suggest/sports/backends/sportsdata/common/data.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/data.py
@@ -220,6 +220,12 @@ class Event(BaseModel):
     clock: str | None = None
     # Optional stage, e.g. "Group", "Round of 32"
     stage: str | None = None
+    # Tournament metadata used by WCS widget team state.
+    round_id: int | None = None
+    season_type: int | None = None
+    group: str | None = None
+    winner: str | None = None
+    is_closed: bool | None = None
 
     def key(self) -> str:
         """Generate semi-unique key for this event"""
@@ -245,6 +251,12 @@ class Event(BaseModel):
             "home_penalty",
             "away_penalty",
             "clock",
+            "stage",
+            "round_id",
+            "season_type",
+            "group",
+            "winner",
+            "is_closed",
         )
         for field_name in optional_fields:
             value = getattr(self, field_name)

--- a/merino/providers/suggest/sports/backends/sportsdata/common/sports.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/sports.py
@@ -30,6 +30,12 @@ from merino.providers.suggest.sports.backends.sportsdata.common.data import (
     SPORTSDATA_UTC,
     sportsdata_day_slug,
 )
+from merino.providers.suggest.sports.backends.sportsdata.common.wcs_elimination import (
+    eliminated_team_keys,
+    eliminated_team_keys_cache_key,
+    parse_eliminated_team_keys,
+    serialize_eliminated_team_keys,
+)
 
 FORCE_IMPORT = ""
 
@@ -717,6 +723,11 @@ class WCS(Sport):
             "away_penalty": event_description.get("AwayTeamScorePenalty"),
             "clock": str(clock) if clock is not None else None,
             "stage": self.rounds.get(round_id) if round_id is not None else None,
+            "round_id": round_id,
+            "season_type": event_description.get("SeasonType"),
+            "group": event_description.get("Group"),
+            "winner": event_description.get("Winner"),
+            "is_closed": event_description.get("IsClosed"),
         }
 
     # Note: this is covered by `test_wcs_init_cache` but I believe that the heavy use of Mocks
@@ -928,7 +939,6 @@ class WCS(Sport):
         for team_data in data:
             try:
                 area = await self.get_country(team_data.get("AreaId"))
-                # TODO: get `eliminated` field from ??
                 team = Team.from_data(
                     team_data=team_data,
                     term_filter=self.term_filter,
@@ -1117,9 +1127,29 @@ class WCS(Sport):
                 calendar_key,
                 {event_key: int(event.date.timestamp())},
             )
-        await self.prune_stale_events(active_event_keys)
+        refresh_is_authoritative = await self.prune_stale_events(active_event_keys)
+        if refresh_is_authoritative:
+            await self.cache_eliminated_team_keys()
 
-    async def prune_stale_events(self, active_event_keys: set[str]) -> None:
+    async def cache_eliminated_team_keys(self) -> None:
+        """Write eliminated team keys computed from the latest event refresh."""
+        await self.cache.set(
+            eliminated_team_keys_cache_key(self.cache_prefix),
+            serialize_eliminated_team_keys(eliminated_team_keys(self.events.values())),
+        )
+
+    async def get_eliminated_team_keys(self) -> set[str]:
+        """Return cached WCS eliminated team keys."""
+        raw_keys = await self.cache.get(eliminated_team_keys_cache_key(self.cache_prefix))
+        try:
+            return parse_eliminated_team_keys(raw_keys)
+        except (orjson.JSONDecodeError, TypeError, ValueError) as ex:
+            logger.warning(
+                "%s Could not load cached WCS eliminated team keys: %s", LOGGING_TAG, ex
+            )
+            return set()
+
+    async def prune_stale_events(self, active_event_keys: set[str]) -> bool:
         """Remove cached event entries that no longer exist in the latest source data."""
         calendar_key = f"{self.cache_prefix}:calendar"
         indexed_event_keys = cast(
@@ -1133,7 +1163,7 @@ class WCS(Sport):
         )
         if indexed_event_keys and not active_event_keys:
             logger.warning(f"{LOGGING_TAG} Refusing to prune WCS events from an empty refresh")
-            return
+            return False
 
         # The schedule refresh is authoritative: any Redis event key missing from
         # this run points to a match removed or no longer returned by SportsData.
@@ -1146,9 +1176,10 @@ class WCS(Sport):
             if event_key not in active_event_keys
         ]
         if not stale_event_keys:
-            return
+            return True
         await self.cache.delete(*stale_event_keys)
         await self.cache.zrem(calendar_key, *stale_event_keys)
+        return True
 
     async def get_events_by_team(  # pragma: no cover "widget"
         self, team_key: str, start: datetime | None = None, end: datetime | None = None

--- a/merino/providers/suggest/sports/backends/sportsdata/common/wcs_elimination.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/wcs_elimination.py
@@ -1,0 +1,138 @@
+"""WCS tournament elimination helpers."""
+
+from collections.abc import Iterable
+import json
+from importlib.resources import files
+
+import orjson
+
+from merino.providers.suggest.sports.backends.sportsdata.common.data import Event
+
+_FIRST_KNOCKOUT_ADVANCER_COUNT = 32
+_ELIMINATED_TEAM_KEYS_META_KEY = "meta:eliminated_team_keys"
+
+
+def eliminated_team_keys_cache_key(cache_prefix: str) -> str:
+    """Return the Redis key used for cached eliminated WCS team keys."""
+    return f"{cache_prefix}:{_ELIMINATED_TEAM_KEYS_META_KEY}"
+
+
+def serialize_eliminated_team_keys(team_keys: Iterable[str]) -> bytes:
+    """Serialize eliminated team keys for Redis."""
+    return orjson.dumps(sorted(set(team_keys)))
+
+
+def parse_eliminated_team_keys(raw: bytes | str | None) -> set[str]:
+    """Parse cached eliminated team keys."""
+    if not raw:
+        return set()
+    payload = orjson.loads(raw)
+    if not isinstance(payload, list) or not all(isinstance(key, str) for key in payload):
+        raise ValueError("cached eliminated team keys must be a JSON list of strings")
+    return set(payload)
+
+
+def eliminated_team_keys(events: Iterable[Event]) -> set[str]:
+    """Return team keys eliminated according to cached WCS schedule state."""
+    event_list = list(events)
+    eliminated = _group_stage_eliminated_team_keys(event_list)
+
+    for event in event_list:
+        if not _is_completed_knockout_event(event):
+            continue
+        winner_key = _winner_key(event)
+        if winner_key is None:
+            continue
+        for team_key in _event_team_keys(event):
+            if team_key != winner_key:
+                eliminated.add(team_key)
+
+    eliminated.difference_update(_active_path_team_keys(event_list))
+    return eliminated
+
+
+def _group_stage_eliminated_team_keys(events: list[Event]) -> set[str]:
+    """Return group-stage non-advancers once the first knockout round is populated."""
+    first_knockout_round = _first_knockout_round_id(events)
+    if first_knockout_round is None:
+        return set()
+
+    advancing_keys = {
+        key
+        for event in events
+        if event.round_id == first_knockout_round
+        for key in _event_team_keys(event)
+    }
+    if len(advancing_keys) < _FIRST_KNOCKOUT_ADVANCER_COUNT:
+        return set()
+
+    return _roster_team_keys() - advancing_keys
+
+
+def _first_knockout_round_id(events: list[Event]) -> int | None:
+    """Return the first populated knockout round id from cached events."""
+    round_ids = [
+        event.round_id
+        for event in events
+        if _is_knockout_event(event) and event.round_id is not None and _event_team_keys(event)
+    ]
+    return min(round_ids) if round_ids else None
+
+
+def _is_completed_knockout_event(event: Event) -> bool:
+    """Return True when `event` can eliminate its loser."""
+    return _is_knockout_event(event) and (event.status.is_final() or bool(event.is_closed))
+
+
+def _is_knockout_event(event: Event) -> bool:
+    """Return True for WCS knockout-stage events."""
+    return event.season_type == 3 and event.group is None
+
+
+def _active_path_team_keys(events: list[Event]) -> set[str]:
+    """Return team keys with a scheduled or live knockout event still ahead."""
+    return {
+        key
+        for event in events
+        if _is_knockout_event(event)
+        and (event.status.is_scheduled() or event.status.is_in_progress())
+        for key in _event_team_keys(event)
+    }
+
+
+def _event_team_keys(event: Event) -> set[str]:
+    """Return non-empty team keys from an event."""
+    return {
+        key
+        for key in (
+            event.home_team.get("key"),
+            event.away_team.get("key"),
+        )
+        if isinstance(key, str) and key
+    }
+
+
+def _winner_key(event: Event) -> str | None:
+    """Return the winning team key only when SportsData declares one."""
+    winner = (event.winner or "").lower()
+    if winner == "hometeam":
+        return _team_key(event.home_team)
+    if winner == "awayteam":
+        return _team_key(event.away_team)
+    return None
+
+
+def _team_key(team: dict[str, object]) -> str | None:
+    """Return a team key from a compact event team dictionary."""
+    key = team.get("key")
+    return key if isinstance(key, str) and key else None
+
+
+def _roster_team_keys() -> set[str]:
+    """Return tournament roster team keys from static WCS metadata.
+
+    This is only used while materializing eliminated-team metadata during the WCS
+    cache refresh; endpoint requests read the cached metadata instead.
+    """
+    data = json.loads((files("merino.data") / "wcs_teams.json").read_text())
+    return {str(team["Key"]) for team in data}

--- a/merino/providers/wcs/fake_data.py
+++ b/merino/providers/wcs/fake_data.py
@@ -18,6 +18,7 @@ def _team_from_json(entry: dict[str, Any]) -> TeamInfo:
         region=key,
         colors=get_team_colours(key),
         icon_url=_icon(key),
+        group=str(entry["Group"]),
         eliminated=False,
     )
 
@@ -30,8 +31,14 @@ def _load_all_teams() -> list[TeamInfo]:
 
 
 _ALL_TEAMS: list[TeamInfo] = _load_all_teams()
+_TEAMS_BY_KEY: dict[str, TeamInfo] = {team.key: team for team in _ALL_TEAMS}
 
 
 def get_all_teams() -> list[TeamInfo]:
     """Return all tournament teams from the static teams list."""
     return _ALL_TEAMS
+
+
+def get_teams_by_key() -> dict[str, TeamInfo]:
+    """Return tournament team metadata keyed by WCS team key."""
+    return _TEAMS_BY_KEY

--- a/merino/providers/wcs/protocol.py
+++ b/merino/providers/wcs/protocol.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, HttpUrl
 
-from merino.providers.suggest.sports.backends.sportsdata.common.data import Event
+from merino.providers.suggest.sports.backends.sportsdata.common.data import Event, Team
 from merino.providers.suggest.sports.backends.sportsdata.protocol import build_query
 from merino.providers.wcs.utils import get_team_colours
 from merino.utils.logos import LogoCategory, load_manifest
@@ -35,9 +35,31 @@ class TeamInfo(BaseModel):
     region: str = Field(description="ISO3 region designation; may differ from `name`.")
     colors: list[str] = Field(description="Branding colors, primary first.")
     icon_url: HttpUrl | None = Field(default=None, description="Team flag URL, if available.")
+    group: str | None = Field(default=None, description="World Cup group name, if applicable.")
     eliminated: bool = Field(
         default=False, description="True once the team is out of the tournament."
     )
+
+    @classmethod
+    def from_team(
+        cls,
+        team: Team,
+        *,
+        group: str | None = None,
+        eliminated: bool = False,
+        region: str | None = None,
+    ) -> "TeamInfo":
+        """Build widget team info from a cached SportsData team."""
+        return cls(
+            key=team.key,
+            global_team_id=team.id,
+            name=team.name,
+            region=region or team.country or team.key,
+            colors=get_team_colours(team.key),
+            icon_url=_icon(team.key),
+            group=group,
+            eliminated=eliminated,
+        )
 
     @classmethod
     def from_event_team(cls, team: dict[str, Any]) -> "TeamInfo":
@@ -51,6 +73,7 @@ class TeamInfo(BaseModel):
             region=str(team.get("region") or team.get("country") or key),
             colors=get_team_colours(key),
             icon_url=HttpUrl(raw_icon_url) if raw_icon_url else _icon(key),
+            group=team.get("group"),
             eliminated=bool(team.get("eliminated", False)),
         )
 

--- a/merino/providers/wcs/provider.py
+++ b/merino/providers/wcs/provider.py
@@ -7,13 +7,14 @@ from typing import Protocol
 from aiodogstatsd import Client
 
 from merino.exceptions import CacheAdapterError
-from merino.providers.suggest.sports.backends.sportsdata.common.data import Event
+from merino.providers.suggest.sports.backends.sportsdata.common.data import Event, Team
 from merino.providers.wcs.fake_data import get_all_teams
 from merino.providers.wcs.fake_live_data import build_live_events
 from merino.providers.wcs.protocol import (
     EventInfo,
     LiveMatchesResponse,
     MatchesResponse,
+    TeamInfo,
     TeamsResponse,
 )
 from merino.utils.metrics import get_metrics_client
@@ -30,6 +31,14 @@ class WcsSport(Protocol):
         self, start: datetime | None = None, end: datetime | None = None
     ) -> list[Event]:
         """Return cached events within an optional inclusive datetime range."""
+        ...
+
+    async def get_all_teams(self) -> dict[int, Team]:
+        """Return all cached teams."""
+        ...
+
+    async def get_eliminated_team_keys(self) -> set[str]:
+        """Return cached eliminated team keys."""
         ...
 
 
@@ -96,9 +105,41 @@ class WcsProvider:
         ]
         return LiveMatchesResponse(matches=matches)
 
-    def get_teams(self) -> TeamsResponse:
-        """Return all teams participating in the tournament."""
-        return TeamsResponse(teams=get_all_teams())
+    async def get_teams(self) -> TeamsResponse:
+        """Return cache-backed teams participating in the tournament."""
+        try:
+            teams = await self.sport.get_all_teams()
+        except CacheAdapterError as ex:
+            self._record_cache_error("teams", ex)
+            return TeamsResponse(teams=[])
+
+        cached_by_key = {team.key: team for team in teams.values()}
+        if not cached_by_key:
+            return TeamsResponse(teams=[])
+
+        eliminated_keys = await self._get_eliminated_team_keys()
+        response: list[TeamInfo] = []
+        for roster_team in get_all_teams():
+            cached_team = cached_by_key.get(roster_team.key)
+            if cached_team is None:
+                continue
+            response.append(
+                TeamInfo.from_team(
+                    cached_team,
+                    group=roster_team.group,
+                    eliminated=cached_team.key in eliminated_keys,
+                    region=cached_team.country or roster_team.region,
+                )
+            )
+        return TeamsResponse(teams=response)
+
+    async def _get_eliminated_team_keys(self) -> set[str]:
+        """Return team keys that no longer have a tournament path."""
+        try:
+            return await self.sport.get_eliminated_team_keys()
+        except CacheAdapterError as ex:
+            self._record_cache_error("teams", ex)
+            return set()
 
     def _record_cache_error(self, endpoint: str, ex: CacheAdapterError) -> None:
         """Log and count cache read failures by endpoint."""

--- a/merino/web/api_v1_wcs.py
+++ b/merino/web/api_v1_wcs.py
@@ -72,7 +72,7 @@ async def get_wcs_teams(
     provider: WcsProvider = Depends(get_wcs_provider),
 ) -> TeamsResponse:
     """Return all teams participating in the World Cup."""
-    return provider.get_teams()
+    return await provider.get_teams()
 
 
 def _parse_team_keys(teams: str | None) -> frozenset[str] | None:

--- a/tests/integration/api/v1/wcs/test_teams.py
+++ b/tests/integration/api/v1/wcs/test_teams.py
@@ -21,7 +21,16 @@ def test_teams_endpoint_returns_correct_list_of_teams(client: TestClient) -> Non
     assert len(body["teams"]) == 48
 
     # assert all of the teams have the required keys.
-    required_keys = {"key", "global_team_id", "name", "region", "colors", "eliminated", "icon_url"}
+    required_keys = {
+        "key",
+        "global_team_id",
+        "name",
+        "region",
+        "colors",
+        "icon_url",
+        "group",
+        "eliminated",
+    }
     for team in body["teams"]:
         assert required_keys == set(team.keys())
 
@@ -33,6 +42,7 @@ def test_teams_endpoint_returns_correct_list_of_teams(client: TestClient) -> Non
     fra = next(t for t in body["teams"] if t["key"] == "FRA")
     assert len(fra["colors"]) == 3
     assert all(c.startswith("#") for c in fra["colors"])
+    assert fra["group"] == "Group I"
 
 
 def test_team_icons_are_svg_from_prod_logo_bucket(client: TestClient) -> None:

--- a/tests/unit/providers/suggest/sports/backends/common/test_sports.py
+++ b/tests/unit/providers/suggest/sports/backends/common/test_sports.py
@@ -23,6 +23,9 @@ from merino.providers.suggest.sports.backends.sportsdata.common.error import (
     SportsDataWarning,
 )
 from merino.providers.suggest.sports.backends.sportsdata.common import GameStatus
+from merino.providers.suggest.sports.backends.sportsdata.common.wcs_elimination import (
+    eliminated_team_keys_cache_key,
+)
 import merino.providers.suggest.sports.backends.sportsdata.common.sports as sports_module
 from merino.providers.suggest.sports.backends.sportsdata.common.sports import (
     NFL,
@@ -2408,6 +2411,11 @@ async def test_wcs_update_events(
     assert event.clock == "120"
     assert event.home_penalty == 5
     assert event.away_penalty == 4
+    assert event.round_id == 1708
+    assert event.season_type == 3
+    assert event.group == "Group A"
+    assert event.winner == "HomeTeam"
+    assert event.is_closed is True
     assert 2 == get_data.call_count
     for scall in get_data.call_args_list:
         assert scall.kwargs["url"] in [
@@ -2455,6 +2463,10 @@ async def test_wcs_sportsdata_schedule_and_games_by_date_payloads_match_expected
     assert event.home_team["name"] == "Sweden"
     assert event.date == datetime(2026, 6, 15, 2, 0, tzinfo=timezone.utc)
     assert event.period is None
+    assert event.round_id == 1615
+    assert event.season_type == 1
+    assert event.group == "Group F"
+    assert event.is_closed is False
 
     sport.load_scores_from_source(
         wcs_static_games_by_date_payload(), event_timezone=ZoneInfo("UTC")
@@ -2466,6 +2478,11 @@ async def test_wcs_sportsdata_schedule_and_games_by_date_payloads_match_expected
     assert event.clock is None
     assert event.home_score is None
     assert event.away_score is None
+    assert event.round_id == 1615
+    assert event.season_type == 1
+    assert event.group == "Group F"
+    assert event.winner is None
+    assert event.is_closed is False
     assert event.updated == datetime(2026, 4, 29, 14, 26, 26, tzinfo=timezone.utc)
 
 
@@ -2617,7 +2634,7 @@ async def test_team_cache_restore_skips_missing_and_invalid_entries() -> None:
 
 @pytest.mark.asyncio
 async def test_wcs_cache_events() -> None:
-    """Test WCS event caching writes event JSON and calendar entries."""
+    """Test WCS event caching writes event JSON, calendar entries, and eliminated metadata."""
     sport = WCS(settings=settings.providers.sports)
     now = datetime(2026, 6, 15, 12, tzinfo=timezone.utc)
     event = Event(
@@ -2635,6 +2652,10 @@ async def test_wcs_cache_events() -> None:
         updated=now,
         period="Regular",
         clock="90",
+        round_id=1617,
+        season_type=3,
+        winner="HomeTeam",
+        is_closed=True,
     )
     sport.events = {event.id: event}
     mock_cache = MagicMock(spec=RedisAdapter)
@@ -2643,13 +2664,57 @@ async def test_wcs_cache_events() -> None:
 
     await sport.cache_events()
 
-    mock_cache.set.assert_called_once()
-    assert mock_cache.set.call_args.args[0] == "sport:wcs:v1:event:123"
-    assert mock_cache.set.call_args.kwargs["ttl"] == sport.event_ttl
+    mock_cache.set.assert_any_call(
+        "sport:wcs:v1:event:123",
+        sport.event_as_serialized(event),
+        ttl=sport.event_ttl,
+    )
+    mock_cache.set.assert_any_call(
+        eliminated_team_keys_cache_key(sport.cache_prefix),
+        b'["AWY"]',
+    )
     mock_cache.zadd.assert_called_once_with(
         "sport:wcs:v1:calendar",
         {"sport:wcs:v1:event:123": int(now.timestamp())},
     )
+
+
+@pytest.mark.asyncio
+async def test_wcs_cache_events_does_not_replace_eliminated_metadata_on_empty_refresh() -> None:
+    """An empty non-authoritative refresh leaves cached eliminated-team metadata alone."""
+    sport = WCS(settings=settings.providers.sports)
+    mock_cache = MagicMock(spec=RedisAdapter)
+    mock_cache.zrange.return_value = [b"sport:wcs:v1:event:999"]
+    sport.cache = mock_cache
+
+    await sport.cache_events()
+
+    mock_cache.set.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_wcs_get_eliminated_team_keys_from_cache() -> None:
+    """WCS eliminated team metadata is restored from one Redis key."""
+    sport = WCS(settings=settings.providers.sports)
+    mock_cache = MagicMock(spec=RedisAdapter)
+    mock_cache.get.return_value = b'["AWY","HOM"]'
+    sport.cache = mock_cache
+
+    result = await sport.get_eliminated_team_keys()
+
+    assert result == {"AWY", "HOM"}
+    mock_cache.get.assert_called_once_with(eliminated_team_keys_cache_key(sport.cache_prefix))
+
+
+@pytest.mark.asyncio
+async def test_wcs_get_eliminated_team_keys_bad_cache_fails_open() -> None:
+    """Malformed eliminated-team metadata does not fail the teams endpoint."""
+    sport = WCS(settings=settings.providers.sports)
+    mock_cache = MagicMock(spec=RedisAdapter)
+    mock_cache.get.return_value = b"{bad-json"
+    sport.cache = mock_cache
+
+    assert await sport.get_eliminated_team_keys() == set()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/providers/wcs/test_provider.py
+++ b/tests/unit/providers/wcs/test_provider.py
@@ -13,10 +13,11 @@ import pytest
 from merino.configs import settings
 from merino.exceptions import CacheAdapterError
 from merino.providers import wcs as wcs_module
+from merino.providers.suggest.sports.backends.sportsdata.common import GameStatus
 from merino.providers.wcs.fake_live_data import build_live_events
 from merino.providers.wcs.provider import WcsProvider, _WINDOW
 from merino.providers.wcs.protocol import LiveMatchesResponse, TeamInfo, TeamsResponse
-from tests.wcs.factories import ANCHOR, build_provider
+from tests.wcs.factories import ANCHOR, build_provider, build_teams, event as build_event
 
 _LIVE_EVENT_COUNT = len(build_live_events(ANCHOR))
 
@@ -225,16 +226,221 @@ async def test_live_is_deterministic_within_same_utc_day() -> None:
 
 @pytest.mark.asyncio
 async def test_get_teams_count() -> None:
-    """The static tournament roster has exactly 48 teams, all TeamInfo instances."""
-    response = build_provider().get_teams()
+    """The cache-backed tournament roster has exactly 48 teams, all TeamInfo instances."""
+    response = await build_provider().get_teams()
     assert len(response.teams) == 48
     assert isinstance(response, TeamsResponse)
     assert all(isinstance(team, TeamInfo) for team in response.teams)
+    assert all(team.group for team in response.teams)
+
+
+@pytest.mark.asyncio
+async def test_teams_are_enriched_from_roster_metadata() -> None:
+    """Cached SportsData teams are filtered, ordered, and enriched from the tournament roster."""
+    teams = build_teams()
+    non_roster_team = teams[0].model_copy(
+        update={
+            "key": "ITA",
+            "id": 90000950,
+            "name": "Italy",
+            "country": None,
+            "colors": ["Blue", "White"],
+        }
+    )
+
+    response = await build_provider(teams=[non_roster_team, *reversed(teams)]).get_teams()
+
+    assert len(response.teams) == 48
+    assert [team.key for team in response.teams] == [team.key for team in build_teams()]
+    assert "ITA" not in {team.key for team in response.teams}
+    england = response.teams[0]
+    assert england.key == "ENG"
+    assert england.region == "ENG"
+    assert england.group == "Group L"
+    assert all(color.startswith("#") for color in england.colors)
+
+
+@pytest.mark.asyncio
+async def test_get_teams_uses_cached_eliminated_keys_without_calendar_scan(mocker) -> None:
+    """The teams endpoint reads materialized eliminated keys instead of all events."""
+    teams = build_teams()
+    sport = mocker.Mock()
+    sport.get_all_teams = mocker.AsyncMock(return_value={team.id: team for team in teams})
+    sport.get_eliminated_team_keys = mocker.AsyncMock(return_value={teams[0].key})
+    sport.get_events_by_date = mocker.AsyncMock()
+    provider = WcsProvider(sport=sport)
+
+    response = await provider.get_teams()
+
+    eliminated_by_key = {team.key: team.eliminated for team in response.teams}
+    assert eliminated_by_key[teams[0].key] is True
+    sport.get_eliminated_team_keys.assert_awaited_once()
+    sport.get_events_by_date.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_group_stage_elimination_waits_for_full_round_of_32() -> None:
+    """Group-stage teams stay active until all Round of 32 participants are populated."""
+    teams = build_teams()
+    partial_knockout_events = [
+        build_event(
+            9000 + index,
+            14,
+            index % 24,
+            (teams[index * 2].key, teams[index * 2].name, teams[index * 2].id),
+            (teams[(index * 2) + 1].key, teams[(index * 2) + 1].name, teams[(index * 2) + 1].id),
+            GameStatus.Scheduled,
+            round_id=1616,
+            season_type=3,
+        )
+        for index in range(15)
+    ]
+
+    response = await build_provider(events=partial_knockout_events).get_teams()
+
+    assert not any(team.eliminated for team in response.teams)
+
+
+@pytest.mark.asyncio
+async def test_group_stage_non_advancers_are_eliminated_after_round_of_32_populates() -> None:
+    """Roster teams missing from the populated Round of 32 are eliminated."""
+    teams = build_teams()
+    round_of_32_events = [
+        build_event(
+            9100 + index,
+            14,
+            index % 24,
+            (teams[index * 2].key, teams[index * 2].name, teams[index * 2].id),
+            (teams[(index * 2) + 1].key, teams[(index * 2) + 1].name, teams[(index * 2) + 1].id),
+            GameStatus.Scheduled,
+            round_id=1616,
+            season_type=3,
+        )
+        for index in range(16)
+    ]
+
+    response = await build_provider(events=round_of_32_events).get_teams()
+    eliminated_by_key = {team.key: team.eliminated for team in response.teams}
+
+    assert not any(eliminated_by_key[team.key] for team in teams[:32])
+    assert all(eliminated_by_key[team.key] for team in teams[32:])
+
+
+@pytest.mark.asyncio
+async def test_knockout_loser_is_eliminated_from_winner_field() -> None:
+    """A completed knockout game with HomeTeam as Winner eliminates the away side."""
+    home, away = build_teams()[:2]
+    knockout_event = build_event(
+        9200,
+        20,
+        18,
+        (home.key, home.name, home.id),
+        (away.key, away.name, away.id),
+        GameStatus.Final,
+        home_score=2,
+        away_score=1,
+        round_id=1617,
+        season_type=3,
+        winner="HomeTeam",
+        is_closed=True,
+    )
+
+    response = await build_provider(events=[knockout_event]).get_teams()
+    eliminated_by_key = {team.key: team.eliminated for team in response.teams}
+
+    assert eliminated_by_key[home.key] is False
+    assert eliminated_by_key[away.key] is True
+
+
+@pytest.mark.asyncio
+async def test_knockout_home_team_is_eliminated_from_away_winner_field() -> None:
+    """A completed knockout game with AwayTeam as Winner eliminates the home side."""
+    home, away = build_teams()[:2]
+    knockout_event = build_event(
+        9201,
+        20,
+        18,
+        (home.key, home.name, home.id),
+        (away.key, away.name, away.id),
+        GameStatus.Final,
+        round_id=1617,
+        season_type=3,
+        winner="AwayTeam",
+        is_closed=True,
+    )
+
+    response = await build_provider(events=[knockout_event]).get_teams()
+    eliminated_by_key = {team.key: team.eliminated for team in response.teams}
+
+    assert eliminated_by_key[home.key] is True
+    assert eliminated_by_key[away.key] is False
+
+
+@pytest.mark.asyncio
+async def test_knockout_loser_is_not_inferred_from_penalties_without_winner() -> None:
+    """A completed knockout game without `Winner` does not infer elimination from scores."""
+    home, away = build_teams()[:2]
+    knockout_event = build_event(
+        9202,
+        20,
+        18,
+        (home.key, home.name, home.id),
+        (away.key, away.name, away.id),
+        GameStatus.Final,
+        home_score=1,
+        away_score=1,
+        home_penalty=4,
+        away_penalty=5,
+        round_id=1617,
+        season_type=3,
+        is_closed=True,
+    )
+
+    response = await build_provider(events=[knockout_event]).get_teams()
+    eliminated_by_key = {team.key: team.eliminated for team in response.teams}
+
+    assert eliminated_by_key[home.key] is False
+    assert eliminated_by_key[away.key] is False
+
+
+@pytest.mark.asyncio
+async def test_scheduled_knockout_path_keeps_team_active() -> None:
+    """A later scheduled knockout event overrides group-stage non-advancer elimination."""
+    teams = build_teams()
+    round_of_32_events = [
+        build_event(
+            9300 + index,
+            14,
+            index % 24,
+            (teams[index * 2].key, teams[index * 2].name, teams[index * 2].id),
+            (teams[(index * 2) + 1].key, teams[(index * 2) + 1].name, teams[(index * 2) + 1].id),
+            GameStatus.Scheduled,
+            round_id=1616,
+            season_type=3,
+        )
+        for index in range(16)
+    ]
+    later_advancer = teams[40]
+    later_knockout_event = build_event(
+        9400,
+        20,
+        18,
+        (later_advancer.key, later_advancer.name, later_advancer.id),
+        (teams[41].key, teams[41].name, teams[41].id),
+        GameStatus.Scheduled,
+        round_id=1617,
+        season_type=3,
+    )
+
+    response = await build_provider(events=[*round_of_32_events, later_knockout_event]).get_teams()
+    eliminated_by_key = {team.key: team.eliminated for team in response.teams}
+
+    assert eliminated_by_key[later_advancer.key] is False
 
 
 @pytest.mark.asyncio
 async def test_empty_cache_returns_empty_payloads() -> None:
-    """An empty WCS event cache returns empty matches while live/teams stay static."""
+    """An empty WCS event cache returns empty matches while cached teams are served."""
     provider = build_provider(events=[])
 
     matches = await provider.get_matches(ANCHOR, limit=None, team_keys=None)
@@ -244,7 +450,13 @@ async def test_empty_cache_returns_empty_payloads() -> None:
         "next": [],
     }
     assert len((await provider.get_live_matches(team_keys=None)).matches) == _LIVE_EVENT_COUNT
-    assert len(provider.get_teams().teams) == 48
+    assert len((await provider.get_teams()).teams) == 48
+
+
+@pytest.mark.asyncio
+async def test_empty_team_cache_returns_empty_teams() -> None:
+    """An empty WCS team cache returns an empty teams envelope."""
+    assert (await build_provider(teams=[]).get_teams()).teams == []
 
 
 @pytest.mark.asyncio
@@ -252,6 +464,8 @@ async def test_cache_error_returns_empty_payloads(mocker) -> None:
     """A transient WCS cache read failure returns empty cache-backed envelopes."""
     sport = mocker.Mock()
     sport.get_events_by_date = mocker.AsyncMock(side_effect=CacheAdapterError("redis down"))
+    sport.get_all_teams = mocker.AsyncMock(side_effect=CacheAdapterError("redis down"))
+    sport.get_eliminated_team_keys = mocker.AsyncMock(side_effect=CacheAdapterError("redis down"))
     metrics_client = mocker.Mock()
     provider = WcsProvider(sport=sport, metrics_client=metrics_client)
 
@@ -262,5 +476,22 @@ async def test_cache_error_returns_empty_payloads(mocker) -> None:
         "next": [],
     }
     assert len((await provider.get_live_matches(team_keys=None)).matches) == _LIVE_EVENT_COUNT
-    assert len(provider.get_teams().teams) == 48
+    assert (await provider.get_teams()).teams == []
     metrics_client.increment.assert_any_call("wcs.cache_error", tags={"endpoint": "matches"})
+    metrics_client.increment.assert_any_call("wcs.cache_error", tags={"endpoint": "teams"})
+
+
+@pytest.mark.asyncio
+async def test_team_elimination_cache_error_leaves_teams_uneliminated(mocker) -> None:
+    """A WCS elimination-cache error does not hide cache-backed team rows."""
+    sport = mocker.Mock()
+    sport.get_all_teams = mocker.AsyncMock(return_value={team.id: team for team in build_teams()})
+    sport.get_eliminated_team_keys = mocker.AsyncMock(side_effect=CacheAdapterError("redis down"))
+    metrics_client = mocker.Mock()
+    provider = WcsProvider(sport=sport, metrics_client=metrics_client)
+
+    response = await provider.get_teams()
+
+    assert len(response.teams) == 48
+    assert not any(team.eliminated for team in response.teams)
+    metrics_client.increment.assert_called_once_with("wcs.cache_error", tags={"endpoint": "teams"})

--- a/tests/wcs/factories.py
+++ b/tests/wcs/factories.py
@@ -4,10 +4,15 @@ from datetime import UTC, date, datetime, time, timedelta
 from typing import Any
 
 from merino.providers.suggest.sports.backends.sportsdata.common import GameStatus
-from merino.providers.suggest.sports.backends.sportsdata.common.data import Event
+from merino.providers.suggest.sports.backends.sportsdata.common.data import Event, Team
+from merino.providers.suggest.sports.backends.sportsdata.common.wcs_elimination import (
+    eliminated_team_keys,
+)
+from merino.providers.wcs.fake_data import get_all_teams
 from merino.providers.wcs.provider import WcsProvider
 
 ANCHOR = date(2026, 6, 15)
+TEST_NOW = datetime(2026, 5, 13, 12, tzinfo=UTC)
 KNOWN_TEAMS = [
     ("BRA", "Brazil"),
     ("ARG", "Argentina"),
@@ -21,8 +26,19 @@ KNOWN_TEAMS = [
 class StubWcsSport:
     """Small WCS sport stand-in that behaves like the Redis-backed sport."""
 
-    def __init__(self, events: list[Event]) -> None:
+    def __init__(
+        self,
+        events: list[Event],
+        teams: list[Team],
+        cached_eliminated_team_keys: set[str] | None = None,
+    ) -> None:
         self.events = events
+        self.teams = teams
+        self.cached_eliminated_team_keys = (
+            eliminated_team_keys(events)
+            if cached_eliminated_team_keys is None
+            else cached_eliminated_team_keys
+        )
 
     async def get_events_by_date(
         self, start: datetime | None = None, end: datetime | None = None
@@ -33,6 +49,14 @@ class StubWcsSport:
             for event in self.events
             if (start is None or event.date >= start) and (end is None or event.date <= end)
         ]
+
+    async def get_all_teams(self) -> dict[int, Team]:
+        """Return cached teams by global team ID."""
+        return {team.id: team for team in self.teams}
+
+    async def get_eliminated_team_keys(self) -> set[str]:
+        """Return cached eliminated WCS team keys."""
+        return self.cached_eliminated_team_keys
 
 
 def team_dict(key: str, name: str, team_id: int) -> dict[str, Any]:
@@ -64,6 +88,11 @@ def event(
     clock: str | None = None,
     stage: str | None = None,
     original_date: str | None = None,
+    round_id: int | None = None,
+    season_type: int | None = None,
+    group: str | None = None,
+    winner: str | None = None,
+    is_closed: bool | None = None,
 ) -> Event:
     """Build a cached event model."""
     event_date = datetime.combine(ANCHOR + timedelta(days=day_offset), time(hour, tzinfo=UTC))
@@ -87,6 +116,11 @@ def event(
         away_penalty=away_penalty,
         clock=clock,
         stage=stage,
+        round_id=round_id,
+        season_type=season_type,
+        group=group,
+        winner=winner,
+        is_closed=is_closed,
     )
 
 
@@ -143,13 +177,38 @@ def build_events() -> list[Event]:
     ]
 
 
+def build_teams() -> list[Team]:
+    """Build deterministic cached teams from the tournament roster."""
+    teams = []
+    for roster_team in get_all_teams():
+        teams.append(
+            Team(
+                name=roster_team.name,
+                aliases=[roster_team.name],
+                terms=roster_team.name.lower(),
+                fullname=roster_team.name,
+                key=roster_team.key,
+                locale=roster_team.region,
+                id=roster_team.global_team_id,
+                colors=[],
+                updated=TEST_NOW,
+                expiry=TEST_NOW + timedelta(days=90),
+                country=roster_team.region,
+            )
+        )
+    return teams
+
+
 def build_provider(
     events: list[Event] | None = None,
+    teams: list[Team] | None = None,
     metrics_client: Any | None = None,
+    eliminated_team_keys: set[str] | None = None,
 ) -> WcsProvider:
     """Build a WCS provider backed by deterministic stub data."""
     stub_events = build_events() if events is None else events
+    stub_teams = build_teams() if teams is None else teams
     return WcsProvider(
-        sport=StubWcsSport(stub_events),
+        sport=StubWcsSport(stub_events, stub_teams, eliminated_team_keys),
         metrics_client=metrics_client,
     )


### PR DESCRIPTION
## References

JIRA: [DISCO-4163](https://mozilla-hub.atlassian.net/browse/DISCO-4163)

## Description
This updates the WCS teams endpoint to build from cached SportsData teams and schedule data while preserving our static grouping, region, color, and icon metadata. Elimination is derived from knockout fixtures and explicit winner data instead of SportsData’s `active` flag. 


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2322)


[DISCO-4163]: https://mozilla-hub.atlassian.net/browse/DISCO-4163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ