### PR TITLE
DISCO-4228 Respect date when clicking on sports result for click-through

### DIFF
--- a/merino/providers/suggest/sports/backends/sportsdata/common/data.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/data.py
@@ -349,12 +349,15 @@ class SportsDataEventRow:
         event_description: dict[str, Any], event_timezone: ZoneInfo
     ) -> tuple[datetime, str | None]:
         """Return the event kickoff, preferring SportsData's UTC field."""
+        source_day = event_description.get("Day")
         if event_description.get("DateTimeUTC"):
             raw_utc_date = event_description["DateTimeUTC"]
-            return _parse_sportsdata_datetime(raw_utc_date, SPORTSDATA_UTC), raw_utc_date
+            return _parse_sportsdata_datetime(
+                raw_utc_date, SPORTSDATA_UTC
+            ), source_day or raw_utc_date
         if event_description.get("DateTime"):
             raw_date = event_description["DateTime"]
-            return _parse_sportsdata_datetime(raw_date, event_timezone), raw_date
+            return _parse_sportsdata_datetime(raw_date, event_timezone), source_day or raw_date
         raise TypeError("SportsData event has no DateTimeUTC or DateTime")
 
     @staticmethod

--- a/merino/providers/suggest/sports/backends/sportsdata/protocol.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/protocol.py
@@ -1,7 +1,7 @@
 """Protocol for sport suggestion backends."""
 
 from typing import Any, Optional, cast
-from datetime import datetime, timezone, tzinfo
+from datetime import datetime, tzinfo
 from pydantic import HttpUrl
 
 from merino.providers.suggest.base import BaseModel
@@ -42,12 +42,13 @@ class SportTeamDetail(BaseModel):
 
 def build_query(event: dict[str, Any]) -> str:
     """Build the search query from the event information"""
-    event_date = datetime.fromisoformat(event["date"])
-    query_timezone: tzinfo = timezone.utc
-    event_status = event.get("event_status")
-    if not isinstance(event_status, GameStatus) or not event_status.is_scheduled():
-        query_timezone = sportsdata_timezone_for_sport(event.get("sport", ""))
-    date = event_date.astimezone(query_timezone).strftime("%d %B %Y")
+    source_day = event.get("original_date")
+    if source_day:
+        date = datetime.fromisoformat(source_day).strftime("%d %B %Y")
+    else:
+        event_date = datetime.fromisoformat(event["date"])
+        query_timezone: tzinfo = sportsdata_timezone_for_sport(event.get("sport", ""))
+        date = event_date.astimezone(query_timezone).strftime("%d %B %Y")
     # catch pre-stored values
     if event.get("sport", "").lower() == "fifa":
         sport_query_name = "World Cup 2026"

--- a/tests/integration/providers/suggest/sports/backends/test_sportsdata.py
+++ b/tests/integration/providers/suggest/sports/backends/test_sportsdata.py
@@ -113,7 +113,7 @@ def fixture_nfl() -> NFL:
         id=1,
         terms="fakehome fakeaway",
         date=FROZEN_TIME + timedelta(seconds=600),
-        original_date="2025-10-27",
+        original_date="2025-10-26",
         home_team=home,
         away_team=away,
         home_score=None,
@@ -151,7 +151,7 @@ async def test_sportsdata_na_query(sportsdata: SportsDataBackend, sports_league:
             SportEventDetail(
                 sport="NFL",
                 sport_category=SportCategory.Football,
-                query="NFL Fake Home vs Fake Away 27 October 2025",
+                query="NFL Fake Home vs Fake Away 26 October 2025",
                 date="2025-10-27T00:10:00+00:00",
                 home_team=SportTeamDetail(
                     key="HOM", name="Fake Home", colors=["000000", "FFFFFF"], score=None

--- a/tests/unit/providers/suggest/sports/backends/common/test_data.py
+++ b/tests/unit/providers/suggest/sports/backends/common/test_data.py
@@ -288,6 +288,7 @@ def test_sportsdata_event_rows_keep_mlb_kickoff_and_freshness_separate() -> None
             "HomeTeamRuns": 3,
             "GameID": 77896,
             "Status": "Final",
+            "Day": "2026-05-11T00:00:00",
             "DateTime": "2026-05-11T22:10:00",
             "DateTimeUTC": "2026-05-12T02:10:00",
             "AwayTeam": "SF",
@@ -305,6 +306,7 @@ def test_sportsdata_event_rows_keep_mlb_kickoff_and_freshness_separate() -> None
             "HomeTeamRuns": 2,
             "GameID": 77908,
             "Status": "Final",
+            "Day": "2026-05-12T00:00:00",
             "DateTime": "2026-05-12T22:10:00",
             "DateTimeUTC": "2026-05-13T02:10:00",
             "AwayTeam": "SF",
@@ -319,12 +321,14 @@ def test_sportsdata_event_rows_keep_mlb_kickoff_and_freshness_separate() -> None
 
     assert may_11_row.kickoff == datetime(2026, 5, 12, 2, 10, tzinfo=timezone.utc)
     assert sportsdata_day_slug(may_11_row.kickoff, SPORTSDATA_US_EASTERN) == "2026-MAY-11"
+    assert may_11_row.original_date == "2026-05-11T00:00:00"
     assert may_11_row.away_score == 9
     assert may_11_row.home_score == 3
     assert may_11_row.updated == datetime(2026, 5, 13, 11, 58, 54, tzinfo=timezone.utc)
 
     assert may_12_row.kickoff == datetime(2026, 5, 13, 2, 10, tzinfo=timezone.utc)
     assert sportsdata_day_slug(may_12_row.kickoff, SPORTSDATA_US_EASTERN) == "2026-MAY-12"
+    assert may_12_row.original_date == "2026-05-12T00:00:00"
     assert may_12_row.away_score == 6
     assert may_12_row.home_score == 2
     assert may_12_row.updated == datetime(2026, 5, 13, 11, 31, 32, tzinfo=timezone.utc)

--- a/tests/unit/providers/suggest/sports/backends/test_sports_backend.py
+++ b/tests/unit/providers/suggest/sports/backends/test_sports_backend.py
@@ -412,6 +412,7 @@ def test_build_query_uses_league_local_date() -> None:
         "sport": "MLB",
         "event_status": GameStatus.Final,
         "date": "2026-05-13T02:10:00+00:00",
+        "original_date": "2026-05-12T00:00:00",
         "home_team": {"name": "Los Angeles Dodgers"},
         "away_team": {"name": "San Francisco Giants"},
     }
@@ -419,17 +420,31 @@ def test_build_query_uses_league_local_date() -> None:
     assert build_query(event) == "MLB Los Angeles Dodgers vs San Francisco Giants 12 May 2026"
 
 
-def test_build_query_keeps_scheduled_date_utc() -> None:
-    """build_query keeps the existing UTC date behavior for scheduled events."""
+def test_build_query_uses_source_day_for_scheduled_us_sports() -> None:
+    """build_query uses the SportsData source day for scheduled US sports."""
     event: dict = {
         "sport": "NFL",
         "event_status": GameStatus.Scheduled,
         "date": "2025-10-27T00:10:00+00:00",
+        "original_date": "2025-10-26T00:00:00",
         "home_team": {"name": "Fake Home"},
         "away_team": {"name": "Fake Away"},
     }
 
-    assert build_query(event) == "NFL Fake Home vs Fake Away 27 October 2025"
+    assert build_query(event) == "NFL Fake Home vs Fake Away 26 October 2025"
+
+
+def test_build_query_uses_source_day_for_scheduled_world_cup() -> None:
+    """build_query uses the SportsData source day for WCS click-through queries."""
+    event: dict = {
+        "sport": "fifa",
+        "date": "2026-06-16T02:00:00+00:00",
+        "original_date": "2026-06-15T00:00:00",
+        "home_team": {"name": "IR Iran"},
+        "away_team": {"name": "New Zealand"},
+    }
+
+    assert build_query(event) == "World Cup 2026 IR Iran vs New Zealand 15 June 2026"
 
 
 def test_sport_summary_current_suppresses_previous_and_keeps_next() -> None:

--- a/tests/unit/providers/wcs/test_protocol.py
+++ b/tests/unit/providers/wcs/test_protocol.py
@@ -26,6 +26,24 @@ def test_event_info_from_event_builds_world_cup_query() -> None:
     assert info.query == f"World Cup 2026 Brazil vs Argentina {expected_date}"
 
 
+def test_event_info_from_event_uses_source_day_for_world_cup_query() -> None:
+    """`query` uses the SportsData source day rather than the UTC kickoff date."""
+    e = event(
+        event_id=4,
+        day_offset=1,
+        hour=2,
+        home=("IRN", "IR Iran", 90000003),
+        away=("NZL", "New Zealand", 90000004),
+        status=GameStatus.Scheduled,
+        original_date="2026-06-15T00:00:00",
+    )
+
+    info = EventInfo.from_event(e)
+
+    assert info.date == "2026-06-16T02:00:00+00:00"
+    assert info.query == "World Cup 2026 IR Iran vs New Zealand 15 June 2026"
+
+
 def test_event_info_from_event_includes_stage() -> None:
     """Ensure stage is propagated from cache to response"""
     e = event(

--- a/tests/wcs/factories.py
+++ b/tests/wcs/factories.py
@@ -63,6 +63,7 @@ def event(
     period: str | None = None,
     clock: str | None = None,
     stage: str | None = None,
+    original_date: str | None = None,
 ) -> Event:
     """Build a cached event model."""
     event_date = datetime.combine(ANCHOR + timedelta(days=day_offset), time(hour, tzinfo=UTC))
@@ -71,7 +72,7 @@ def event(
         id=event_id,
         terms=f"{home[1].lower()} {away[1].lower()}",
         date=event_date,
-        original_date=event_date.isoformat(),
+        original_date=original_date or event_date.isoformat(),
         home_team=team_dict(*home),
         away_team=team_dict(*away),
         home_score=home_score,


### PR DESCRIPTION
## References

JIRA: [DISCO-4228](https://mozilla-hub.atlassian.net/browse/DISCO-4228)

## Description
- Preserve SportsData’s source `Day` as `original_date` when normalizing event rows.
- Update `build_query()` to prefer `original_date` for the human search query date.
- Keep the public response schema unchanged.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2324)


[DISCO-4228]: https://mozilla-hub.atlassian.net/browse/DISCO-4228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ