### PR TITLE
[HNT-2594] feat: add filemanager class for particle game

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -1140,9 +1140,9 @@ feed_url = "https://commons.wikimedia.org/w/api.php?action=featuredfeed&feed=pot
 # The type of this provider, should be `particle`.
 type = "particle"
 
-# MERINO_GAMES_PROVIDERS__PARTICLE__ENABLED_BY_DEFAULT
-# Whether or not this provider is enabled by default.
-enabled_by_default = false
+# MERINO_GAMES_PROVIDERS__PARTICLE__ENABLED
+# Whether or not this provider is enabled.
+enabled = false
 
 # MERINO_GAMES_PROVIDERS__PARTICLE__CACHE_TTL
 # The amount of time in seconds for the max-age Cache-control header.
@@ -1165,9 +1165,30 @@ url_path_manifest = "/runtime-manifest.v1.json"
 # Used to validate manifest JSON.
 manifest_schema_version = 1
 
+# MERINO_GAMES_PROVIDERS__PARTICLE__MANFIEST_SCHEMA_FILE_PATH
+# The path to the Particle schema validator file.
+# Used to validate the schema retrieved from the Particle endpoint.
+manifest_schema_file_path = "merino/data/providers/games/particle/runtime-manifest.v1.schema.json"
+
+# MERINO_GAMES_PROVIDERS__PARTICLE__MANIFEST_FILE_NAME
+# The name of the manifest file that we store in GCS.
+# Used to store and retrieve the manifest from GCS.
+manifest_gcs_file_name = "runtime-manifest.v1.json"
+
 # MERINO_GAMES_PROVIDERS__PARTICLE__CONNECT_TIMEOUT_SEC
 # Timeout in seconds for establishing a connection to Particle endpoint.
 connect_timeout_sec = 3.0
+
+# MERINO_GAMES_PROVIDERS__PARTICLE__CRON_INTERVAL_SEC
+# The cron tick interval to try to get Particle data from the remote endpoint.
+# This is the error retry interval, and should be less than the
+# resync_interval_sec value below to allow for retries.
+cron_interval_sec = 600 # ten minutes
+
+# MERINO_GAMES_PROVIDERS__PARTICLE__RESYNC_INTERVAL_SEC
+# Time between re-syncs of Particle game data, in seconds.
+# Particle updates their files daily.
+resync_interval_sec = 86400 # one day
 
 
 [default.curated_recommendations.gcs]

--- a/merino/providers/games/particle/backends/filemanager.py
+++ b/merino/providers/games/particle/backends/filemanager.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import sentry_sdk
 
 from json import JSONDecodeError
 from typing import Any
@@ -33,13 +34,23 @@ class ParticleLocalFileManager:
                 manifest_schema: dict = json.load(f)
                 return manifest_schema
         except OSError as os_error:
-            raise ParticleFileManagerError(
-                f"Cannot open file '{self.static_manifest_schema_file_path}"
-            ) from os_error
+            error_msg = f"Cannot open file '{self.static_manifest_schema_file_path}"
+
+            sentry_sdk.capture_message(
+                error_msg,
+                level="error",
+            )
+
+            raise ParticleFileManagerError(error_msg) from os_error
         except JSONDecodeError as json_error:
-            raise ParticleFileManagerError(
-                f"Cannot decode JSON file '{self.static_manifest_schema_file_path}"
-            ) from json_error
+            error_msg = f"Cannot decode JSON file '{self.static_manifest_schema_file_path}"
+
+            sentry_sdk.capture_message(
+                error_msg,
+                level="error",
+            )
+
+            raise ParticleFileManagerError(error_msg) from json_error
 
 
 class ParticleRemoteFileManager:
@@ -77,5 +88,13 @@ class ParticleRemoteFileManager:
 
             return None
         except Exception as e:
-            logger.error(f"Error with getting remote Particle manifest file. {e}")
+            error_msg = f"Error retrieving remote Particle manifest file. {e}"
+
+            logger.error(error_msg)
+
+            sentry_sdk.capture_message(
+                error_msg,
+                level="error",
+            )
+
             return None

--- a/merino/providers/games/particle/backends/filemanager.py
+++ b/merino/providers/games/particle/backends/filemanager.py
@@ -1,0 +1,81 @@
+"""File manager class for the Particle backend."""
+
+import json
+import logging
+
+from json import JSONDecodeError
+from typing import Any
+
+from merino.exceptions import FilemanagerError
+from merino.utils.gcs.gcs_uploader import GcsUploader
+
+logger = logging.getLogger(__name__)
+
+
+class ParticleFileManagerError(FilemanagerError):
+    """Error loading local Particle manifest schema validator file."""
+
+
+class ParticleLocalFileManager:
+    """File manager for processing local Particle data."""
+
+    # path to the local manifest schema file
+    static_manifest_schema_file_path: str
+
+    def __init__(self, static_manifest_schema_file_path: str) -> None:
+        self.static_manifest_schema_file_path = static_manifest_schema_file_path
+
+    def get_manifest_schema(self) -> dict[str, Any]:
+        """Read local manifest schema validator file."""
+        try:
+            """Retrieve manifest schema JSON when this module loads."""
+            with open(self.static_manifest_schema_file_path, "r") as f:
+                manifest_schema: dict = json.load(f)
+                return manifest_schema
+        except OSError as os_error:
+            raise ParticleFileManagerError(
+                f"Cannot open file '{self.static_manifest_schema_file_path}"
+            ) from os_error
+        except JSONDecodeError as json_error:
+            raise ParticleFileManagerError(
+                f"Cannot decode JSON file '{self.static_manifest_schema_file_path}"
+            ) from json_error
+
+
+class ParticleRemoteFileManager:
+    """Filemanager for processing remote (GCS) Particle data."""
+
+    gcs_client: GcsUploader
+    manifest_file_name: str
+
+    def __init__(
+        self,
+        gcs_client: GcsUploader,
+        manifest_file_name: str,
+    ) -> None:
+        """Initialize the remote filemanager."""
+        self.gcs_client = gcs_client
+        self.manifest_file_name = manifest_file_name
+
+    def get_manifest_file(self) -> dict[str, Any] | None:
+        """Read remote manifest file.
+
+        Raises:
+            ParticleFileManagerError: If the manifest file cannot be accessed.
+        Returns:
+            Dictionary containing manifest.
+        """
+        try:
+            blob = self.gcs_client.get_file_by_name(self.manifest_file_name)
+
+            if blob is not None:
+                blob_data = blob.download_as_text()
+                file_contents: dict = json.loads(blob_data)
+                logger.info("Successfully loaded remote Particle manifest file.")
+
+                return file_contents
+
+            return None
+        except Exception as e:
+            logger.error(f"Error with getting remote Particle manifest file. {e}")
+            return None

--- a/merino/utils/gcs/gcs_uploader.py
+++ b/merino/utils/gcs/gcs_uploader.py
@@ -106,10 +106,14 @@ class GcsUploader(BaseContentUploader):
         else:
             return str(blob.public_url)
 
-    def get_file_by_name(self, blob_name: str, blob_generation: int) -> Blob | None:
-        """Return blob from GCS if we have a new generation"""
-        bucket: Bucket = self.storage_client.get_bucket(self.bucket_name)
+    def get_file_by_name(self, blob_name: str, blob_generation: int = 0) -> Blob | None:
+        """Return blob from GCS. If blob_generation is passed (and is not 0), only returns the blob if the current generation does not match the passed version."""
         if blob_name:
+            bucket: Bucket = self.storage_client.get_bucket(self.bucket_name)
+            # if blob_generation is 0, a blob will only be returned if there is a live version
+            # https://docs.cloud.google.com/python/docs/reference/storage/latest/generation_metageneration#using-ifgenerationnotmatch
             most_recent = bucket.get_blob(blob_name, if_generation_not_match=blob_generation)
+
             return most_recent
+
         return None

--- a/tests/unit/providers/games/particle/backends/test_filemanager.py
+++ b/tests/unit/providers/games/particle/backends/test_filemanager.py
@@ -1,0 +1,177 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Unit tests for the Particle filemanager module."""
+
+import logging
+import os
+import pytest
+
+from google.auth.credentials import AnonymousCredentials
+from google.cloud.storage import Blob
+from json import JSONDecodeError
+from logging import LogRecord
+from pytest import LogCaptureFixture
+from pytest_mock import MockerFixture
+from tests.types import FilterCaplogFixture
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from merino.configs import settings
+from merino.providers.games.particle.backends.filemanager import (
+    ParticleFileManagerError,
+    ParticleLocalFileManager,
+    ParticleRemoteFileManager,
+)
+from merino.utils.gcs.gcs_uploader import GcsUploader
+
+
+@pytest.fixture(name="manifest_json")
+def fixture_manifest_json():
+    """Load manifest data from local file"""
+    with open("tests/data/games/particle/runtime-manifest.v1.json") as f:
+        return f.read()
+
+
+@pytest.fixture(name="manifest_gcs_blob_mock")
+def fixture_gcs_manifest_blob(mocker: MockerFixture, manifest_json: str) -> Any:
+    """Create a GCS Blob mock object for testing."""
+    mock_blob = mocker.MagicMock(spec=Blob)
+    mock_blob.name = "runtime-manifest.v1.json"
+    mock_blob.download_as_text.return_value = manifest_json
+
+    return mock_blob
+
+
+@pytest.fixture(name="particle_local_filemanager_parameters")
+def fixture_particle_local_filemanager_parameters() -> dict[str, Any]:
+    """Define ParticleLocalFileManager parameters for test."""
+    return {
+        "static_manifest_schema_file_path": settings.games_providers.particle.manifest_schema_file_path
+    }
+
+
+@pytest.fixture(name="particle_local_filemanager")
+def fixture_particle_local_filemanager(
+    particle_local_filemanager_parameters: dict[str, Any],
+) -> ParticleLocalFileManager:
+    """Create a ParticleLocalFileManager object for test."""
+    return ParticleLocalFileManager(**particle_local_filemanager_parameters)
+
+
+@pytest.fixture(name="gcs_uploader_mock")
+def fixture_gcs_uploader_mock(manifest_gcs_blob_mock) -> GcsUploader:
+    """Return a mock GcsUploader."""
+    mock = MagicMock(spec=GcsUploader)
+    mock.get_file_by_name.return_value = manifest_gcs_blob_mock
+
+    return mock
+
+
+@pytest.fixture(name="particle_remote_filemanager_parameters")
+def fixture_particle_remote_filemanager_parameters(gcs_uploader_mock) -> dict[str, Any]:
+    """Define ParticleRemoteFileManager parameters for test."""
+    return {"gcs_client": gcs_uploader_mock, "manifest_file_name": "test_file.json"}
+
+
+@pytest.fixture(name="particle_remote_filemanager")
+def fixture_particle_remote_filemanager(
+    particle_remote_filemanager_parameters: dict[str, Any],
+) -> ParticleRemoteFileManager:
+    """Create a ParticleRemoteFileManager object for test."""
+    with (
+        patch("google.auth.default") as mock_auth_default,
+    ):
+        creds = AnonymousCredentials()  # type: ignore
+        mock_auth_default.return_value = (creds, "test-project")
+        return ParticleRemoteFileManager(**particle_remote_filemanager_parameters)
+
+
+def test_local_file_exists() -> None:
+    """Test that the Particle manifest schema file exists locally"""
+    assert os.path.exists(settings.games_providers.particle.manifest_schema_file_path)
+
+
+def test_get_local_file(particle_local_filemanager: ParticleLocalFileManager) -> None:
+    """Test that the JSON file containing the manifest schema can be processed"""
+    schema = particle_local_filemanager.get_manifest_schema()
+    assert schema["title"] == "Client Runtime Manifest v1"
+    assert len(schema["properties"]["channels"]["properties"]) == 2
+
+
+def test_local_filemanager_get_file_json_decode_error(
+    particle_local_filemanager: ParticleLocalFileManager, mocker
+) -> None:
+    """Test that the read function fails, raising ParticleFileManagerError when a
+    JSONDecodeError is captured.
+    """
+    mocker.patch("json.load", side_effect=JSONDecodeError("test", "json", 1))
+    with pytest.raises(ParticleFileManagerError):
+        particle_local_filemanager.get_manifest_schema()
+
+
+def test_local_filemanager_get_file_os_error(
+    particle_local_filemanager: ParticleLocalFileManager, mocker
+) -> None:
+    """Test that the read function fails, raising ParticleFileManagerError when an
+    OSError is captured.
+    """
+    mocker.patch("json.load", side_effect=OSError("test", "json", 1))
+    with pytest.raises(ParticleFileManagerError):
+        particle_local_filemanager.get_manifest_schema()
+
+
+def test_local_filemanager_get_file_invalid_path() -> None:
+    """Test that read domain fails and raises ParticleFileManagerError
+    exception with invalid file path.
+    """
+    test_path = ParticleLocalFileManager("./wrongfile.json")
+    with pytest.raises(ParticleFileManagerError):
+        test_path.get_manifest_schema()
+
+
+def test_get_remote_file(
+    particle_remote_filemanager: ParticleRemoteFileManager,
+    caplog: LogCaptureFixture,
+    filter_caplog: FilterCaplogFixture,
+) -> None:
+    """Test that the Remote Filemanager get_manifest_file method returns manifest data."""
+    caplog.set_level(logging.INFO)
+
+    result = particle_remote_filemanager.get_manifest_file()
+
+    records: list[LogRecord] = filter_caplog(
+        caplog.records, "merino.providers.games.particle.backends.filemanager"
+    )
+
+    # verify basic contents of manifest json
+    assert isinstance(result, dict)
+    assert result["schemaVersion"]
+    assert len(result["channels"]) == 2
+
+    # verify logging
+    assert len(records) == 1
+    assert records[0].message.startswith("Successfully loaded remote Particle manifest file.")
+
+
+def test_get_remote_file_empty(
+    particle_remote_filemanager: ParticleRemoteFileManager,
+) -> None:
+    """Test that the RemoteFileManager returns None when the call to GCS returns None."""
+    particle_remote_filemanager.gcs_client = MagicMock()
+    particle_remote_filemanager.gcs_client.get_file_by_name.return_value = None
+
+    result = particle_remote_filemanager.get_manifest_file()
+    assert result is None
+
+
+def test_get_remote_file_error(
+    particle_remote_filemanager: ParticleRemoteFileManager,
+) -> None:
+    """Test that the RemoteFileManager returns None when the call to GCS fails."""
+    particle_remote_filemanager.gcs_client = MagicMock()
+    particle_remote_filemanager.gcs_client.get_file_by_name.side_effect = Exception("Test error")
+
+    result = particle_remote_filemanager.get_manifest_file()
+    assert result is None


### PR DESCRIPTION


## References

JIRA: [HNT-2594](https://mozilla-hub.atlassian.net/browse/HNT-2594)

## Description

adds a filemanager class to the particle provider for managing local and remote (GCS) files.

- small refactor on gcs_uploader class
- add particle settings

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2326)


[HNT-2594]: https://mozilla-hub.atlassian.net/browse/HNT-2594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ