### PR TITLE
[HNT-2596] fix: Clean up IE sections experiment

### DIFF
--- a/merino/curated_recommendations/legacy/provider.py
+++ b/merino/curated_recommendations/legacy/provider.py
@@ -101,8 +101,9 @@ class LegacyCuratedRecommendationsProvider:
             SurfaceId.NEW_TAB_EN_US,
             SurfaceId.NEW_TAB_EN_GB,
             SurfaceId.NEW_TAB_EN_CA,
+            SurfaceId.NEW_TAB_EN_IE,
         ):
-            # US/GB/CA: fetch from sections backend instead of scheduler
+            # US/GB/CA/IE: fetch from sections backend instead of scheduler
             rescaler = CrawledContentRescaler()
             return await get_legacy_recommendations_from_sections(
                 sections_backend=curated_corpus_provider.sections_backend,

--- a/merino/curated_recommendations/legacy/provider.py
+++ b/merino/curated_recommendations/legacy/provider.py
@@ -17,7 +17,6 @@ from merino.curated_recommendations.legacy.protocol import (
     CuratedRecommendationsLegacyFx114Request,
     CuratedRecommendationsLegacyFx114Response,
 )
-from merino.curated_recommendations.corpus_backends.protocol import SurfaceId
 from merino.curated_recommendations.legacy.sections_adapter import (
     get_legacy_recommendations_from_sections,
 )
@@ -25,6 +24,7 @@ from merino.curated_recommendations.prior_backends.engagment_rescaler import (
     CrawledContentRescaler,
 )
 from merino.curated_recommendations.utils import (
+    ROLLED_OUT_SECTION_SURFACES,
     get_recommendation_surface_id,
     derive_region,
 )
@@ -97,13 +97,8 @@ class LegacyCuratedRecommendationsProvider:
         """Fetch base recommendations from sections backend (US/GB) or scheduler (other)."""
         surface_id = get_recommendation_surface_id(locale, region)
 
-        if surface_id in (
-            SurfaceId.NEW_TAB_EN_US,
-            SurfaceId.NEW_TAB_EN_GB,
-            SurfaceId.NEW_TAB_EN_CA,
-            SurfaceId.NEW_TAB_EN_IE,
-        ):
-            # US/GB/CA/IE: fetch from sections backend instead of scheduler
+        if surface_id in ROLLED_OUT_SECTION_SURFACES:
+            # Rolled-out section surfaces: fetch from sections backend instead of scheduler
             rescaler = CrawledContentRescaler()
             return await get_legacy_recommendations_from_sections(
                 sections_backend=curated_corpus_provider.sections_backend,

--- a/merino/curated_recommendations/prior_backends/engagment_rescaler.py
+++ b/merino/curated_recommendations/prior_backends/engagment_rescaler.py
@@ -141,25 +141,6 @@ class CrawledContentPinnedFreshRescaler(CrawledContentRescaler):
         return round(impressions_for_tile_for_period * scale)
 
 
-IE_EXPERIMENT_TREATMENT_PERCENT = 0.10
-
-
-class IECrawledContentRescaler(CrawledContentRescaler):
-    """Rescaler for IE experiment — scales engagement up by 1/0.10 = 10x
-    to compensate for only 10% of IE traffic generating engagement data.
-    """
-
-    def __init__(self, **data: Any):
-        super().__init__(**data)
-
-    def rescale(self, rec: CuratedRecommendation, opens: float, no_opens: float):
-        """Apply parent scaling (blocked-from-most-popular 5x), then divide by
-        treatment percentage to compensate for small experiment size.
-        """
-        opens, no_opens = super().rescale(rec, opens, no_opens)
-        return opens / IE_EXPERIMENT_TREATMENT_PERCENT, no_opens / IE_EXPERIMENT_TREATMENT_PERCENT
-
-
 DE_EXPERIMENT_TREATMENT_PERCENT = 0.10
 
 

--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -177,8 +177,9 @@ class CuratedRecommendationsProvider:
             SurfaceId.NEW_TAB_EN_US,
             SurfaceId.NEW_TAB_EN_GB,
             SurfaceId.NEW_TAB_EN_CA,
+            SurfaceId.NEW_TAB_EN_IE,
         ):
-            # US/GB/CA non-sections: fetch from sections backend instead of scheduler
+            # US/GB/CA/IE non-sections: fetch from sections backend instead of scheduler
             rescaler: EngagementRescaler | None = None
             rescaler = CrawledContentRescaler()
             general_feed = await get_legacy_recommendations_from_sections(

--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -43,6 +43,7 @@ from merino.curated_recommendations.prior_backends.engagment_rescaler import (
 )
 from merino.curated_recommendations.sections import get_sections
 from merino.curated_recommendations.utils import (
+    ROLLED_OUT_SECTION_SURFACES,
     get_recommendation_surface_id,
     get_millisecond_epoch_time,
     derive_region,
@@ -173,13 +174,8 @@ class CuratedRecommendationsProvider:
                 lints_interest_backend=self.lints_interest_backend,
                 region=derive_region(request.locale, request.region),
             )
-        elif surface_id in (
-            SurfaceId.NEW_TAB_EN_US,
-            SurfaceId.NEW_TAB_EN_GB,
-            SurfaceId.NEW_TAB_EN_CA,
-            SurfaceId.NEW_TAB_EN_IE,
-        ):
-            # US/GB/CA/IE non-sections: fetch from sections backend instead of scheduler
+        elif surface_id in ROLLED_OUT_SECTION_SURFACES:
+            # Rolled-out section surfaces: fetch from sections backend instead of scheduler
             rescaler: EngagementRescaler | None = None
             rescaler = CrawledContentRescaler()
             general_feed = await get_legacy_recommendations_from_sections(

--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -38,7 +38,6 @@ from merino.curated_recommendations.prior_backends.engagment_rescaler import (
     CrawledContentPinnedFreshRescaler,
     CrawledContentRescaler,
     DECrawledContentRescaler,
-    IECrawledContentRescaler,
     SchedulerHoldbackRescaler,
 )
 from merino.curated_recommendations.prior_backends.protocol import (
@@ -465,10 +464,8 @@ def get_ranking_rescaler_for_branch(
     if surface_id == SurfaceId.NEW_TAB_EN_GB:
         return CrawledContentRescaler()
 
-    if surface_id == SurfaceId.NEW_TAB_EN_IE and is_enrolled_in_experiment(
-        request, "sections-in-ie", "sections"
-    ):
-        return IECrawledContentRescaler()
+    if surface_id == SurfaceId.NEW_TAB_EN_IE:
+        return CrawledContentRescaler()
 
     if surface_id == SurfaceId.NEW_TAB_DE_DE and is_enrolled_in_experiment(
         request, "sections-in-germany", "sections"

--- a/merino/curated_recommendations/utils.py
+++ b/merino/curated_recommendations/utils.py
@@ -6,6 +6,18 @@ import time
 from merino.curated_recommendations.corpus_backends.protocol import SurfaceId
 from merino.curated_recommendations.protocol import CuratedRecommendationsRequest, Locale
 
+# Surfaces where sections have rolled out at 100%. Non-sections requests for these
+# surfaces are served from the sections backend (via the legacy adapter) instead of
+# the scheduled-surface backend.
+ROLLED_OUT_SECTION_SURFACES: frozenset[SurfaceId] = frozenset(
+    {
+        SurfaceId.NEW_TAB_EN_US,
+        SurfaceId.NEW_TAB_EN_GB,
+        SurfaceId.NEW_TAB_EN_CA,
+        SurfaceId.NEW_TAB_EN_IE,
+    }
+)
+
 
 def get_recommendation_surface_id(
     locale: Locale,

--- a/merino/curated_recommendations/utils.py
+++ b/merino/curated_recommendations/utils.py
@@ -41,19 +41,7 @@ def get_recommendation_surface_id(
         if derived_region == "CA":
             return SurfaceId.NEW_TAB_EN_CA
         elif derived_region == "IE":
-            # Ireland routing: Map to NEW_TAB_EN_IE only if:
-            # 1. Request includes 'sections' in feeds
-            # 2. User is in 'sections' branch of 'sections-in-ie' experiment
-            # Otherwise, default to NEW_TAB_EN_GB
-            if (
-                request is not None
-                and request.feeds is not None
-                and "sections" in request.feeds
-                and is_enrolled_in_experiment(request, "sections-in-ie", "sections")
-            ):
-                return SurfaceId.NEW_TAB_EN_IE
-            else:
-                return SurfaceId.NEW_TAB_EN_GB
+            return SurfaceId.NEW_TAB_EN_IE
         elif derived_region is None or derived_region == "US":
             return SurfaceId.NEW_TAB_EN_US
         elif derived_region == "GB":

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -652,8 +652,13 @@ class TestLegacyEndpoints:
             assert item["receivedRank"] == i
 
     @freezegun.freeze_time("2012-01-14 03:21:34", tz_offset=0)
-    @pytest.mark.parametrize("region", ["GB", "IE"])
-    def test_en_gb_non_sections_request(self, region: str, client: TestClient):
+    @pytest.mark.parametrize(
+        "region,expected_surface",
+        [("GB", SurfaceId.NEW_TAB_EN_GB), ("IE", SurfaceId.NEW_TAB_EN_IE)],
+    )
+    def test_en_gb_non_sections_request(
+        self, region: str, expected_surface: SurfaceId, client: TestClient
+    ):
         """Test en-GB non-sections request via main endpoint (backward-compatible path).
 
         GB/IE clients without feeds=["sections"] use get_legacy_recommendations_from_sections.
@@ -665,7 +670,7 @@ class TestLegacyEndpoints:
         data = response.json()
 
         assert response.status_code == 200
-        assert data["surfaceId"] == SurfaceId.NEW_TAB_EN_GB
+        assert data["surfaceId"] == expected_surface
 
         # Non-sections request returns data in data[], not feeds
         corpus_items = data["data"]
@@ -2775,10 +2780,13 @@ class TestSections:
             )
 
     @pytest.mark.parametrize(
-        "region",
-        ["GB", "IE"],
+        "region,expected_surface",
+        [
+            ("GB", SurfaceId.NEW_TAB_EN_GB.value),
+            ("IE", SurfaceId.NEW_TAB_EN_IE.value),
+        ],
     )
-    def test_uk_sections_enabled(self, region, client: TestClient):
+    def test_uk_sections_enabled(self, region, expected_surface, client: TestClient):
         """Test that UK/IE users with feeds=['sections'] get sections."""
         response = client.post(
             "/api/v1/curated-recommendations",
@@ -2791,7 +2799,7 @@ class TestSections:
         data = response.json()
 
         assert response.status_code == 200
-        assert data["surfaceId"] == SurfaceId.NEW_TAB_EN_GB.value
+        assert data["surfaceId"] == expected_surface
 
         # Should have feeds with sections
         assert data["feeds"] is not None

--- a/tests/unit/curated_recommendations/test_sections.py
+++ b/tests/unit/curated_recommendations/test_sections.py
@@ -28,7 +28,6 @@ from merino.curated_recommendations.prior_backends.engagment_rescaler import (
     CrawledContentPinnedFreshRescaler,
     CrawledContentRescaler,
     DECrawledContentRescaler,
-    IECrawledContentRescaler,
     SchedulerHoldbackRescaler,
 )
 from merino.curated_recommendations.protocol import (
@@ -473,23 +472,7 @@ class TestFilterSectionsByExperiment:
             (None, None, "IE", SurfaceId.NEW_TAB_EN_GB, CrawledContentRescaler),
             (None, None, "UK", SurfaceId.NEW_TAB_EN_GB, CrawledContentRescaler),
             (None, None, "ZZ", SurfaceId.NEW_TAB_EN_GB, CrawledContentRescaler),
-            # IE with sections branch gets IECrawledContentRescaler
-            (
-                "sections-in-ie",
-                "sections",
-                "IE",
-                SurfaceId.NEW_TAB_EN_IE,
-                IECrawledContentRescaler,
-            ),
-            # IE with wrong branch falls through to CrawledContentRescaler
-            (
-                "sections-in-ie",
-                "control",
-                "IE",
-                SurfaceId.NEW_TAB_EN_IE,
-                CrawledContentRescaler,
-            ),
-            # IE surface without experiment falls through to CrawledContentRescaler
+            # IE surface gets CrawledContentRescaler (no experiment gating)
             (None, None, "IE", SurfaceId.NEW_TAB_EN_IE, CrawledContentRescaler),
             # CA surface gets CrawledContentRescaler (no experiment gating)
             (None, None, "CA", SurfaceId.NEW_TAB_EN_CA, CrawledContentRescaler),

--- a/tests/unit/curated_recommendations/test_utils.py
+++ b/tests/unit/curated_recommendations/test_utils.py
@@ -125,9 +125,9 @@ class TestCuratedRecommendationsProviderGetRecommendationSurfaceId:
             ("en-CA", "GB", SurfaceId.NEW_TAB_EN_GB),
             ("en-GB", "GB", SurfaceId.NEW_TAB_EN_GB),
             ("en-US", "GB", SurfaceId.NEW_TAB_EN_GB),
-            ("en-CA", "IE", SurfaceId.NEW_TAB_EN_GB),
-            ("en-GB", "IE", SurfaceId.NEW_TAB_EN_GB),
-            ("en-US", "IE", SurfaceId.NEW_TAB_EN_GB),
+            ("en-CA", "IE", SurfaceId.NEW_TAB_EN_IE),
+            ("en-GB", "IE", SurfaceId.NEW_TAB_EN_IE),
+            ("en-US", "IE", SurfaceId.NEW_TAB_EN_IE),
             ("fr", "FR", SurfaceId.NEW_TAB_FR_FR),
             ("it", "IT", SurfaceId.NEW_TAB_IT_IT),
             ("es", "ES", SurfaceId.NEW_TAB_ES_ES),
@@ -141,7 +141,7 @@ class TestCuratedRecommendationsProviderGetRecommendationSurfaceId:
             ("en", "CA", SurfaceId.NEW_TAB_EN_CA),
             ("en", "US", SurfaceId.NEW_TAB_EN_US),
             ("en", "GB", SurfaceId.NEW_TAB_EN_GB),
-            ("en", "IE", SurfaceId.NEW_TAB_EN_GB),
+            ("en", "IE", SurfaceId.NEW_TAB_EN_IE),
             ("en", "IN", SurfaceId.NEW_TAB_EN_INTL),
             # The locale language primarily determines the market, even if it's not the most common language in the region.
             ("de", "US", SurfaceId.NEW_TAB_DE_DE),
@@ -152,15 +152,15 @@ class TestCuratedRecommendationsProviderGetRecommendationSurfaceId:
             # Extract region from locale, if it is not explicitly provided.
             ("en-US", None, SurfaceId.NEW_TAB_EN_US),
             ("en-GB", None, SurfaceId.NEW_TAB_EN_GB),
-            ("en-IE", None, SurfaceId.NEW_TAB_EN_GB),
+            ("en-IE", None, SurfaceId.NEW_TAB_EN_IE),
             # locale can vary in case.
             ("eN-US", None, SurfaceId.NEW_TAB_EN_US),
             ("En-GB", None, SurfaceId.NEW_TAB_EN_GB),
-            ("EN-ie", None, SurfaceId.NEW_TAB_EN_GB),
+            ("EN-ie", None, SurfaceId.NEW_TAB_EN_IE),
             ("en-cA", None, SurfaceId.NEW_TAB_EN_CA),
             # region can vary in case.
             ("en", "gB", SurfaceId.NEW_TAB_EN_GB),
-            ("en", "Ie", SurfaceId.NEW_TAB_EN_GB),
+            ("en", "Ie", SurfaceId.NEW_TAB_EN_IE),
             ("en", "in", SurfaceId.NEW_TAB_EN_INTL),
             # Default to international NewTab when region is unknown.
             ("en", "XX", SurfaceId.NEW_TAB_EN_US),
@@ -168,7 +168,7 @@ class TestCuratedRecommendationsProviderGetRecommendationSurfaceId:
             ("xx", "US", SurfaceId.NEW_TAB_EN_US),
             ("xx", "CA", SurfaceId.NEW_TAB_EN_CA),
             ("xx", "GB", SurfaceId.NEW_TAB_EN_GB),
-            ("xx", "IE", SurfaceId.NEW_TAB_EN_GB),
+            ("xx", "IE", SurfaceId.NEW_TAB_EN_IE),
             ("xx", "YY", SurfaceId.NEW_TAB_EN_US),
         ],
     )
@@ -179,97 +179,6 @@ class TestCuratedRecommendationsProviderGetRecommendationSurfaceId:
         ensure correct surface id is returned based on passed locale & region
         """
         assert get_recommendation_surface_id(locale, region) == recommendation_surface_id
-
-
-class TestGetRecommendationSurfaceIdWithExperiment:
-    """Unit tests for experiment-gated surface ID routing (IE)."""
-
-    @pytest.mark.parametrize(
-        "locale,region,exp_name,exp_branch,feeds,expected",
-        [
-            # --- IE experiment: sections-in-ie ---
-            # Treatment branch
-            (
-                Locale.EN_GB,
-                "IE",
-                "sections-in-ie",
-                "sections",
-                ["sections"],
-                SurfaceId.NEW_TAB_EN_IE,
-            ),
-            # Optin prefix
-            (
-                Locale.EN_GB,
-                "IE",
-                "optin-sections-in-ie",
-                "sections",
-                ["sections"],
-                SurfaceId.NEW_TAB_EN_IE,
-            ),
-            # Control branch falls back
-            (
-                Locale.EN_GB,
-                "IE",
-                "sections-in-ie",
-                "control",
-                ["sections"],
-                SurfaceId.NEW_TAB_EN_GB,
-            ),
-            # No sections feed falls back
-            (
-                Locale.EN_GB,
-                "IE",
-                "sections-in-ie",
-                "sections",
-                ["general"],
-                SurfaceId.NEW_TAB_EN_GB,
-            ),
-            # None feeds falls back
-            (Locale.EN_GB, "IE", "sections-in-ie", "sections", None, SurfaceId.NEW_TAB_EN_GB),
-            # Base en locale with IE region
-            (Locale.EN, "IE", "sections-in-ie", "sections", ["sections"], SurfaceId.NEW_TAB_EN_IE),
-            # GB region unaffected
-            (
-                Locale.EN_GB,
-                "GB",
-                "sections-in-ie",
-                "sections",
-                ["sections"],
-                SurfaceId.NEW_TAB_EN_GB,
-            ),
-        ],
-        ids=[
-            "ie-treatment",
-            "ie-optin",
-            "ie-control-fallback",
-            "ie-no-sections-feed",
-            "ie-none-feeds",
-            "ie-en-locale",
-            "ie-gb-unaffected",
-        ],
-    )
-    def test_experiment_gated_surface_id(
-        self, locale, region, exp_name, exp_branch, feeds, expected
-    ):
-        """Test that experiment-gated routing returns the correct surface ID."""
-        req = SimpleNamespace(
-            experimentName=exp_name,
-            experimentBranch=exp_branch,
-            feeds=feeds,
-        )
-        assert get_recommendation_surface_id(locale, region, request=req) == expected
-
-    @pytest.mark.parametrize(
-        "locale,region,expected",
-        [
-            (Locale.EN_CA, "CA", SurfaceId.NEW_TAB_EN_CA),
-            (Locale.EN_GB, "IE", SurfaceId.NEW_TAB_EN_GB),
-        ],
-        ids=["ca-no-request", "ie-no-request"],
-    )
-    def test_no_request_returns_fallback(self, locale, region, expected):
-        """Test that None request returns the expected surface."""
-        assert get_recommendation_surface_id(locale, region, request=None) == expected
 
 
 class TestIsEnrolledInExperiment:

--- a/tests/unit/prior_backends/test_engagement_rescaler.py
+++ b/tests/unit/prior_backends/test_engagement_rescaler.py
@@ -13,8 +13,6 @@ from merino.curated_recommendations.prior_backends.engagment_rescaler import (
     CrawledContentRescaler,
     DE_EXPERIMENT_TREATMENT_PERCENT,
     DECrawledContentRescaler,
-    IE_EXPERIMENT_TREATMENT_PERCENT,
-    IECrawledContentRescaler,
     SchedulerHoldbackRescaler,
     PESSIMISTIC_PRIOR_ALPHA_SCALE,
     PESSIMISTIC_PRIOR_ALPHA_SCALE_SUBTOPIC,
@@ -149,52 +147,6 @@ class TestCrawledContentPinnedFreshRescaler:
             )
             < 2.5 * estimated_impression_per_tile_per_cycle
         )
-
-
-class TestIECrawledContentRescaler:
-    """Test Rig for the IE experiment rescaler"""
-
-    def setup_method(self):
-        """Set up test"""
-        self.rescaler = IECrawledContentRescaler()
-
-    def test_rescale_regular_item(self):
-        """Test that regular items are scaled up by 1/0.10 = 10x for experiment size"""
-        rec = Mock()
-        rec.in_experiment.return_value = False
-        rec.is_story_blocked_for_top_stories.return_value = False
-
-        opens, no_opens = self.rescaler.rescale(rec, 100, 50)
-        assert opens == 100 / IE_EXPERIMENT_TREATMENT_PERCENT
-        assert no_opens == 50 / IE_EXPERIMENT_TREATMENT_PERCENT
-
-    def test_rescale_blocked_item(self):
-        """Test that blocked items get parent 5x scaling then 10x experiment scaling"""
-        rec = Mock()
-        rec.in_experiment.return_value = False
-        rec.topic = Topic.GAMING
-        rec.is_story_blocked_for_top_stories.return_value = True
-
-        opens, no_opens = self.rescaler.rescale(rec, 100, 50)
-        assert opens == 100 * BLOCKED_FROM_MOST_POPULAR_SCALER / IE_EXPERIMENT_TREATMENT_PERCENT
-        assert no_opens == 50 * BLOCKED_FROM_MOST_POPULAR_SCALER / IE_EXPERIMENT_TREATMENT_PERCENT
-
-    def test_rescale_prior_inherits_parent(self):
-        """Test that prior rescaling is inherited from CrawledContentRescaler"""
-        rec = Mock()
-        rec.in_experiment.return_value = True
-        rec.isTimeSensitive = False
-        rec.is_story_blocked_for_top_stories.return_value = False
-
-        alpha, beta = self.rescaler.rescale_prior(rec, 10, 20)
-        assert alpha == 10 * PESSIMISTIC_PRIOR_ALPHA_SCALE_SUBTOPIC
-        assert beta == 20
-
-    def test_fresh_items_settings_inherited(self):
-        """Test that fresh item settings are inherited from parent"""
-        assert self.rescaler.fresh_items_max == 0
-        assert self.rescaler.fresh_items_section_ranking_max_percentage > 0
-        assert self.rescaler.fresh_items_limit_prior_threshold_multiplier > 0
 
 
 class TestDECrawledContentRescaler:


### PR DESCRIPTION
## References

JIRA: [HNT-2596](https://mozilla-hub.atlassian.net/browse/HNT-2596), [HNT-2011](https://mozilla-hub.atlassian.net/browse/HNT-2011)
Rollout: [sections-in-ie-rollout](https://experimenter.services.mozilla.com/nimbus/sections-in-ie-rollout/summary/)

## Description

The `sections-in-ie` experiment was followed by a Nimbus rollout, but our rollouts set `merinoFeedExperiment: null` rather than re-asserting the experiment slug, so Merino's `is_enrolled_in_experiment("sections-in-ie", "sections")` check returned false for everyone in the rollout. IE users were silently falling through to `NEW_TAB_EN_GB`: they got GB-localized corpus content while ranking still used IE engagement, and telemetry logged `surface=EN_GB` with `country=IE`.

Removes the experiment gate so all IE requests route to `NEW_TAB_EN_IE`, and drops `IECrawledContentRescaler` along with its 10× inflation (no longer needed at 100% rollout). Mirrors the CA cleanup in #1309.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[HNT-2596]: https://mozilla-hub.atlassian.net/browse/HNT-2596


[HNT-2011]: https://mozilla-hub.atlassian.net/browse/HNT-2011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ