### PR TITLE
[DISCO-4236] fix: Remove redundant cache writes

### DIFF
--- a/merino/providers/suggest/sports/backends/sportsdata/common/sports.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/sports.py
@@ -859,7 +859,6 @@ class WCS(Sport):
             cache_dir=self.cache_dir,
             headers=self.api_headers(),
         )
-        self.rounds = {}
         for competition in response:
             match competition:
                 case {"Key": key, "Seasons": seasons} if key == self.name.upper():
@@ -876,10 +875,12 @@ class WCS(Sport):
                                     for r in rounds
                                     if r.get("RoundId") is not None and r.get("Name")
                                 }
-        await self.cache.set(
-            f"{self.cache_prefix}:rounds",
-            orjson.dumps(self.rounds, option=orjson.OPT_NON_STR_KEYS),
-        )
+                                await self.cache.set(
+                                    f"{self.cache_prefix}:rounds",
+                                    orjson.dumps(self.rounds, option=orjson.OPT_NON_STR_KEYS),
+                                )
+
+                                return
 
     async def get_season(self, client: AsyncClient) -> None:
         """Get the current season (which is just the current year)"""
@@ -956,7 +957,6 @@ class WCS(Sport):
             except SportsDataError:
                 pass  # pragma: no cover "skip error"
         self.refreshed = datetime.now(tz=timezone.utc)
-        await self.cache_teams()
         return self.teams
 
     async def update_teams(self, client: AsyncClient):

--- a/tests/unit/providers/suggest/sports/backends/common/test_sports.py
+++ b/tests/unit/providers/suggest/sports/backends/common/test_sports.py
@@ -2233,50 +2233,6 @@ async def test_wcs_load_rounds(mock_client: AsyncClient, mocker: MockerFixture) 
     )
 
 
-@freezegun.freeze_time("2030-06-10T00:00:00", tz_offset=0)
-@pytest.mark.asyncio
-async def test_wcs_load_rounds_no_matching_season(
-    mock_client: AsyncClient, mocker: MockerFixture
-) -> None:
-    """When no season matches, self.rounds stays empty and an empty mapping is cached."""
-    sport = WCS(settings=settings.providers.sports)
-    mocker.patch(
-        "merino.providers.suggest.sports.backends.sportsdata.common.sports.get_data",
-        side_effect=[wcs_competitions_payload()],
-    )
-    mock_cache = MagicMock(spec=RedisAdapter)
-    sport.cache = mock_cache
-
-    await sport.load_rounds(mock_client)
-
-    assert sport.rounds == {}
-    mock_cache.set.assert_called_once_with(
-        "sport:wcs:v1:rounds", orjson.dumps({}, option=orjson.OPT_NON_STR_KEYS)
-    )
-
-
-@freezegun.freeze_time("2026-06-10T00:00:00", tz_offset=0)
-@pytest.mark.asyncio
-async def test_wcs_load_rounds_no_matching_competition(
-    mock_client: AsyncClient, mocker: MockerFixture
-) -> None:
-    """Empty/non-matching /Competitions response yields an empty rounds map."""
-    sport = WCS(settings=settings.providers.sports)
-    mocker.patch(
-        "merino.providers.suggest.sports.backends.sportsdata.common.sports.get_data",
-        side_effect=[[{"Key": "OTHER", "Seasons": []}]],
-    )
-    mock_cache = MagicMock(spec=RedisAdapter)
-    sport.cache = mock_cache
-
-    await sport.load_rounds(mock_client)
-
-    assert sport.rounds == {}
-    mock_cache.set.assert_called_once_with(
-        "sport:wcs:v1:rounds", orjson.dumps({}, option=orjson.OPT_NON_STR_KEYS)
-    )
-
-
 def test_wcs_event_details_includes_stage_from_rounds() -> None:
     """event_details resolves the schedule's RoundId to a stage name via self.rounds."""
     sport = WCS(settings=settings.providers.sports)


### PR DESCRIPTION
## References

JIRA: [DISCO-4236](https://mozilla-hub.atlassian.net/browse/DISCO-4236)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2328)


[DISCO-4236]: https://mozilla-hub.atlassian.net/browse/DISCO-4236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ