### PR TITLE
DISCO-4079 return real live matches for /live endpoint

### DIFF
--- a/merino/configs/__init__.py
+++ b/merino/configs/__init__.py
@@ -159,6 +159,7 @@ _validators = [
     Validator("providers.sports.max_suggestions", is_type_of=int, gte=1, required=True),
     Validator("providers.sports.event_ttl_weeks", is_type_of=int, gte=1, required=False),
     Validator("providers.sports.intent_words", is_type_of=list),
+    Validator("providers.wcs.live_data_enabled", is_type_of=bool),
     # TODO: Break these out into a generic "elastic search" set?
     Validator("providers.sports.es.dsn", is_type_of=str, required=True),
     Validator("providers.sports.es.api_key", is_type_of=str, required=True),

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -400,6 +400,11 @@ providers = ["sports", "polygon"]
 # GCS bucket for remote data files (used when data_source = "remote").
 gcs_bucket = ""
 
+# Sections under `[*.providers.<name>]` are loaded by the suggest provider
+# manager only when they expose a `type` field. Sibling subsystem configs can
+# share this namespace without `type` and initialize themselves elsewhere, as
+# `[*.providers.wcs]` does for the World Cup widget API.
+
 [default.providers.accuweather]
 # MERINO_PROVIDERS__ACCUWEATHER__TYPE
 # The type of this provider, should be `accuweather`.

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -516,6 +516,12 @@ cache_dir="/tmp"
 # base_url.nfl="https://api.sportsdata.io/v3/nfl/scores/json"
 # base_url.ucl="https://api.sportsdata.io/v4/soccer/scores/json"
 
+[default.providers.wcs]
+# MERINO_PROVIDERS__WCS__LIVE_DATA_ENABLED
+# Keep the /wcs/live mock response by default. DISCO-4231 can flip this to
+# serve Redis-backed in-progress matches after launch approval.
+live_data_enabled = false
+
 
 [default.manifest]
 # MERINO_PROVIDERS__MANIFEST__CRON_INTERVAL_SEC

--- a/merino/providers/suggest/manager.py
+++ b/merino/providers/suggest/manager.py
@@ -424,7 +424,12 @@ def load_providers(disabled_providers_list: list[str]) -> dict[str, BaseProvider
     """
     providers: dict[str, BaseProvider] = {}
     for provider_id, setting in settings.providers.items():
-        # Do not initialize provider if disabled in config.
+        # Skip sibling subsystems that share the settings.providers namespace
+        # but are not suggest providers (e.g. wcs). The contract is that a
+        # suggest provider entry exposes a `type` field; anything else here
+        # belongs to another subsystem (WCS, etc.) and initializes itself.
+        if "type" not in setting:
+            continue
         if provider_id.lower() not in disabled_providers_list:
             providers[provider_id] = _create_provider(provider_id, setting)
     return providers

--- a/merino/providers/suggest/manager.py
+++ b/merino/providers/suggest/manager.py
@@ -426,8 +426,9 @@ def load_providers(disabled_providers_list: list[str]) -> dict[str, BaseProvider
     for provider_id, setting in settings.providers.items():
         # Skip sibling subsystems that share the settings.providers namespace
         # but are not suggest providers (e.g. wcs). The contract is that a
-        # suggest provider entry exposes a `type` field; anything else here
-        # belongs to another subsystem (WCS, etc.) and initializes itself.
+        # suggest provider entry exposes a `type` field. This is documented in
+        # default.toml near the providers section; anything else here belongs
+        # to another subsystem (WCS, etc.) and initializes itself.
         if "type" not in setting:
             continue
         if provider_id.lower() not in disabled_providers_list:

--- a/merino/providers/suggest/sports/backends/sportsdata/common/sports.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/sports.py
@@ -7,8 +7,10 @@ import asyncio
 import logging
 import orjson
 import json
-from datetime import datetime, timedelta, timezone
+from collections.abc import Iterable
+from datetime import date, datetime, timedelta, timezone
 from typing import Any, cast
+from zoneinfo import ZoneInfo
 
 # We use this for each Sport subclass, so that there's some flexibility for what config
 # values are used and passed.
@@ -42,6 +44,8 @@ from merino.providers.suggest.sports.backends.sportsdata.common.wcs_elimination 
 
 FORCE_IMPORT = ""
 _SEASON_TYPE_POSTSEASON = 3
+_WCS_LIVE_REFRESH_WINDOW_DAYS = 1
+_WCS_GAMES_BY_DATE_TTL = timedelta(minutes=2)
 
 # When creating a new sport class, add its entry to SPORT_CATEGORY_MAP below.
 # The key must match the class name, as that is what is stored in the `Event.sport` field.
@@ -1207,27 +1211,49 @@ class WCS(Sport):
         # Treat each WCS schedule refresh as authoritative so removed events are pruned.
         self.events = {}
         self.load_schedules_from_source(response, event_timezone=local_timezone)
-        date_list: set[str] = set()
-        # update scores based on events:
-        # Events may cross multiple days, so we should update those scores.
-        for _id, event in list(self.events.items()):
-            day = sportsdata_day_slug(event.date, local_timezone)
-            if not event.status.is_scheduled() and day not in date_list:
-                url = f"{self.base_url}/GamesByDate/{self.name}/{day}"
-                response = await get_data(
-                    client=client,
-                    url=url,
-                    ttl=timedelta(minutes=5),
-                    cache_dir=self.cache_dir,
-                    headers=self.api_headers(),
-                )
-                self.load_scores_from_source(
-                    response,
-                    event_timezone=local_timezone,
-                )
-                date_list.add(day)
+        for day in self._games_by_date_slugs_to_refresh(
+            self.events.values(), event_timezone=local_timezone
+        ):
+            url = f"{self.base_url}/GamesByDate/{self.name}/{day}"
+            response = await get_data(
+                client=client,
+                url=url,
+                ttl=_WCS_GAMES_BY_DATE_TTL,
+                cache_dir=self.cache_dir,
+                headers=self.api_headers(),
+            )
+            self.load_scores_from_source(
+                response,
+                event_timezone=local_timezone,
+            )
 
         await self.cache_events()
+
+    def _games_by_date_slugs_to_refresh(
+        self, events: Iterable[Event], event_timezone: ZoneInfo
+    ) -> list[str]:
+        """Return SportsData day slugs that need detailed score refreshes.
+
+        Live freshness should not depend on `/SchedulesBasic` first changing a
+        match to `InProgress`. Refresh event days in the active UTC window
+        unconditionally, and keep refreshing days whose schedule rows already
+        report final/live/non-scheduled statuses.
+        """
+        today = datetime.now(tz=timezone.utc).astimezone(event_timezone).date()
+        window_start = today - timedelta(days=_WCS_LIVE_REFRESH_WINDOW_DAYS)
+        window_end = today + timedelta(days=_WCS_LIVE_REFRESH_WINDOW_DAYS)
+        days: dict[date, str] = {}
+
+        for event in events:
+            event_date = event.date
+            if event_date.tzinfo is None:
+                event_date = event_date.replace(tzinfo=timezone.utc)
+            event_day = event_date.astimezone(event_timezone).date()
+            in_active_window = window_start <= event_day <= window_end
+            if in_active_window or not event.status.is_scheduled():
+                days[event_day] = sportsdata_day_slug(event_date, event_timezone)
+
+        return [days[day] for day in sorted(days)]
 
     async def cache_events(self) -> None:
         """Write event data to Redis and index events by kickoff time."""

--- a/merino/providers/wcs/__init__.py
+++ b/merino/providers/wcs/__init__.py
@@ -29,7 +29,10 @@ def _build_provider() -> WcsProvider:
     """Build the singleton WCS API provider."""
     global _sport
     _sport = WCS(settings.providers.sports, cache=_cache())
-    return WcsProvider(sport=_sport)
+    return WcsProvider(
+        sport=_sport,
+        live_data_enabled=settings.providers.wcs.live_data_enabled,
+    )
 
 
 async def init_provider() -> None:

--- a/merino/providers/wcs/protocol.py
+++ b/merino/providers/wcs/protocol.py
@@ -86,7 +86,7 @@ class TeamInfo(BaseModel):
             region=str(team.get("region") or team.get("country") or key),
             colors=get_team_colours(key),
             icon_url=HttpUrl(raw_icon_url) if raw_icon_url else _icon(key),
-            group=group,
+            group=team.get("group") or group,
             eliminated=bool(team.get("eliminated", False)),
         )
 
@@ -185,7 +185,7 @@ class MatchesResponse(BaseModel):
 class LiveMatchesResponse(BaseModel):
     """Response payload for `GET /api/v1/wcs/live`.
 
-    Holds mocked live-endpoint events, sorted by `date` ascending.
+    Holds currently live events, sorted by `date` ascending.
     """
 
     matches: list[EventInfo]

--- a/merino/providers/wcs/provider.py
+++ b/merino/providers/wcs/provider.py
@@ -20,6 +20,8 @@ from merino.providers.wcs.protocol import (
 from merino.utils.metrics import get_metrics_client
 
 _WINDOW = timedelta(days=10)
+_LIVE_MATCH_LOOKBACK = timedelta(hours=6)
+_LIVE_MATCH_LOOKAHEAD = timedelta(hours=2)
 _CACHE_ERROR_METRIC = "wcs.cache_error"
 logger = logging.getLogger(__name__)
 
@@ -45,10 +47,16 @@ class WcsSport(Protocol):
 class WcsProvider:
     """Serves match data for the World Cup Soccer endpoint."""
 
-    def __init__(self, sport: WcsSport, metrics_client: Client | None = None) -> None:
+    def __init__(
+        self,
+        sport: WcsSport,
+        metrics_client: Client | None = None,
+        live_data_enabled: bool = False,
+    ) -> None:
         """Create a WCS provider backed by the shared WCS sport cache."""
         self.sport = sport
         self.metrics_client = metrics_client or get_metrics_client()
+        self.live_data_enabled = live_data_enabled
 
     async def get_matches(
         self,
@@ -94,16 +102,37 @@ class WcsProvider:
         return MatchesResponse(previous=previous, current=current, next_=next_)
 
     async def get_live_matches(self, team_keys: frozenset[str] | None) -> LiveMatchesResponse:
-        """Return fake live-endpoint events, sorted ascending by `date`.
+        """Return live-endpoint events, sorted ascending by `date`.
 
+        The Redis-backed path is gated so we can switch it on via an ENV
         `team_keys` restricts results to matches with that team on either side.
         """
-        matches = [
-            event
-            for event in sorted(build_live_events(datetime.now(UTC).date()), key=lambda e: e.date)
-            if team_keys is None or _has_team(event, team_keys)
-        ]
-        return LiveMatchesResponse(matches=matches)
+        if not self.live_data_enabled:
+            matches = [
+                event
+                for event in build_live_events(datetime.now(UTC).date())
+                if team_keys is None or _has_team(event, team_keys)
+            ]
+            return LiveMatchesResponse(matches=matches)
+
+        now = datetime.now(UTC)
+        window_start = now - _LIVE_MATCH_LOOKBACK
+        window_end = now + _LIVE_MATCH_LOOKAHEAD
+        try:
+            events = await self.sport.get_events_by_date(start=window_start, end=window_end)
+        except CacheAdapterError as ex:
+            self._record_cache_error("live", ex)
+            return LiveMatchesResponse(matches=[])
+
+        live_events: list[EventInfo] = []
+        for event in sorted(events, key=lambda e: e.date):
+            if not event.status.is_in_progress():
+                continue
+            event_info = EventInfo.from_event(event)
+            if team_keys is not None and not _has_team(event_info, team_keys):
+                continue
+            live_events.append(event_info)
+        return LiveMatchesResponse(matches=live_events)
 
     async def get_teams(self) -> TeamsResponse:
         """Return cache-backed teams participating in the tournament."""

--- a/merino/providers/wcs/provider.py
+++ b/merino/providers/wcs/provider.py
@@ -5,6 +5,7 @@ import logging
 from typing import Protocol
 
 from aiodogstatsd import Client
+import sentry_sdk
 
 from merino.exceptions import CacheAdapterError
 from merino.providers.suggest.sports.backends.sportsdata.common.data import Event, Team
@@ -87,14 +88,13 @@ class WcsProvider:
         for event in sorted(events, key=lambda e: e.date):
             event_info = EventInfo.from_event(event)
             event_date = _event_date(event)
-            if team_keys is not None and not _has_team(event_info, team_keys):
-                continue
-            if event_date < target_day:
-                previous.append(event_info)
-            elif event_date == target_day:
-                current.append(event_info)
-            else:
-                next_.append(event_info)
+            if _matches_team_filter(event_info, team_keys):
+                if event_date < target_day:
+                    previous.append(event_info)
+                elif event_date == target_day:
+                    current.append(event_info)
+                else:
+                    next_.append(event_info)
 
         if limit is not None:
             previous, current, next_ = previous[-limit:], current[:limit], next_[:limit]
@@ -104,14 +104,14 @@ class WcsProvider:
     async def get_live_matches(self, team_keys: frozenset[str] | None) -> LiveMatchesResponse:
         """Return live-endpoint events, sorted ascending by `date`.
 
-        The Redis-backed path is gated so we can switch it on via an ENV
+        The Redis-backed path is gated so we can switch it on via config.
         `team_keys` restricts results to matches with that team on either side.
         """
         if not self.live_data_enabled:
             matches = [
                 event
                 for event in build_live_events(datetime.now(UTC).date())
-                if team_keys is None or _has_team(event, team_keys)
+                if _matches_team_filter(event, team_keys)
             ]
             return LiveMatchesResponse(matches=matches)
 
@@ -129,9 +129,8 @@ class WcsProvider:
             if not event.status.is_in_progress():
                 continue
             event_info = EventInfo.from_event(event)
-            if team_keys is not None and not _has_team(event_info, team_keys):
-                continue
-            live_events.append(event_info)
+            if _matches_team_filter(event_info, team_keys):
+                live_events.append(event_info)
         return LiveMatchesResponse(matches=live_events)
 
     async def get_teams(self) -> TeamsResponse:
@@ -174,6 +173,7 @@ class WcsProvider:
         """Log and count cache read failures by endpoint."""
         logger.warning("WCS cache read failed while fetching %s: %s", endpoint, ex)
         self.metrics_client.increment(_CACHE_ERROR_METRIC, tags={"endpoint": endpoint})
+        sentry_sdk.capture_exception(ex)
 
 
 def _target_day(target_date: date) -> date:
@@ -196,3 +196,8 @@ def _has_team(event: EventInfo, team_keys: frozenset[str]) -> bool:
     return any(
         team is not None and team.key in team_keys for team in (event.home_team, event.away_team)
     )
+
+
+def _matches_team_filter(event: EventInfo, team_keys: frozenset[str] | None) -> bool:
+    """Return True when no filter is set or either side matches the requested teams."""
+    return team_keys is None or _has_team(event, team_keys)

--- a/merino/web/api_v1_wcs.py
+++ b/merino/web/api_v1_wcs.py
@@ -45,7 +45,7 @@ async def get_wcs_matches(
 @router.get(
     "/wcs/live",
     tags=["wcs"],
-    summary="Mocked World Cup Soccer events for the live endpoint",
+    summary="Currently live World Cup Soccer matches",
     response_model=LiveMatchesResponse,
 )
 async def get_wcs_live(
@@ -55,10 +55,7 @@ async def get_wcs_live(
     ] = None,
     provider: WcsProvider = Depends(get_wcs_provider),
 ) -> LiveMatchesResponse:
-    """Return mocked live-endpoint events, sorted ascending by date.
-
-    Anchored to fake test data until real live data lands.
-    """
+    """Return in-progress matches sorted ascending by date."""
     return await provider.get_live_matches(_parse_team_keys(teams))
 
 

--- a/tests/integration/api/v1/wcs/test_live.py
+++ b/tests/integration/api/v1/wcs/test_live.py
@@ -4,14 +4,25 @@
 
 """Integration tests for `GET /api/v1/wcs/live`."""
 
+from collections.abc import Iterator
+
+import freezegun
+import pytest
 from starlette.testclient import TestClient
 
 
 _PATH = "/api/v1/wcs/live"
 
 
+@pytest.fixture(autouse=True)
+def _freeze_live_now() -> Iterator[None]:
+    """Keep deterministic fixture events inside the live Redis query window."""
+    with freezegun.freeze_time("2026-06-15T16:00:00Z"):
+        yield
+
+
 def test_returns_matches_envelope(client: TestClient) -> None:
-    """Response is `{"matches": [...]}` with the mocked live-endpoint events."""
+    """Response is `{"matches": [...]}` with in-progress cached events."""
     response = client.get(_PATH)
     assert response.status_code == 200
 
@@ -19,19 +30,12 @@ def test_returns_matches_envelope(client: TestClient) -> None:
     assert set(body.keys()) == {"matches"}
     assert isinstance(body["matches"], list)
     assert body["matches"]
-    assert {e["status_type"] for e in body["matches"]} == {
-        "live",
-        "past",
-        "scheduled",
-        "unknown",
-    }
-    assert {"Awarded", "Canceled", "Postponed", "Suspended"}.issubset(
-        {event["status"] for event in body["matches"]}
-    )
+    assert {e["status_type"] for e in body["matches"]} == {"live"}
+    assert {event["status"] for event in body["matches"]} == {"In Progress"}
 
 
 def test_matches_sorted_ascending_by_date(client: TestClient) -> None:
-    """Matches come back ordered by event start time."""
+    """Live matches come back ordered by event start time."""
     matches = client.get(_PATH).json()["matches"]
     assert matches == sorted(matches, key=lambda e: e["date"])
 

--- a/tests/unit/providers/suggest/sports/backends/common/test_sports.py
+++ b/tests/unit/providers/suggest/sports/backends/common/test_sports.py
@@ -2394,6 +2394,85 @@ async def test_wcs_update_events(
         ]
 
 
+@pytest.mark.parametrize(
+    (
+        "schedule_overrides",
+        "score_overrides",
+        "expected_games_by_date_url",
+        "expected_status",
+    ),
+    [
+        pytest.param(
+            {},
+            {
+                "Status": "InProgress",
+                "Period": "1",
+                "ClockDisplay": "16",
+                "HomeTeamScore": 1,
+                "AwayTeamScore": 0,
+                "UpdatedUtc": "2026-06-11T19:16:00",
+            },
+            "https://api.sportsdata.io/v4/soccer/scores/json/GamesByDate/fifa/2026-JUN-11",
+            GameStatus.InProgress,
+            id="scheduled-active-window",
+        ),
+        pytest.param(
+            {
+                "DateTime": "2026-06-20T19:00:00",
+                "Day": "2026-06-20T00:00:00",
+                "Status": "Final",
+                "HomeTeamScore": 2,
+                "AwayTeamScore": 1,
+                "UpdatedUtc": "2026-06-20T21:00:00",
+            },
+            {},
+            "https://api.sportsdata.io/v4/soccer/scores/json/GamesByDate/fifa/2026-JUN-20",
+            GameStatus.Final,
+            id="non-scheduled-outside-active-window",
+        ),
+    ],
+)
+@freezegun.freeze_time("2026-06-11T12:00:00", tz_offset=0)
+@pytest.mark.asyncio
+async def test_wcs_update_events_fetches_games_by_date_for_live_relevant_days(
+    mock_client: AsyncClient,
+    mocker: MockerFixture,
+    schedule_overrides: dict[str, Any],
+    score_overrides: dict[str, Any],
+    expected_games_by_date_url: str,
+    expected_status: GameStatus,
+) -> None:
+    """Refresh active-window days and any day already reported non-scheduled."""
+    sport = WCS(settings=settings.providers.sports)
+    await sport.async_load_teams_from_source(wcs_teams_payload())
+    sport.event_ttl = timedelta(weeks=8)
+    sport.rounds = {1615: "Group Stage"}
+
+    schedule_row = {**wcs_schedule_payload()[0], **schedule_overrides}
+    schedules_payload = [schedule_row]
+    scores_payload = [{**schedule_row, **score_overrides}]
+    get_data = mocker.patch(
+        "merino.providers.suggest.sports.backends.sportsdata.common.sports.get_data",
+        side_effect=[schedules_payload, scores_payload],
+    )
+
+    await sport.update_events(client=mock_client)
+
+    event = sport.events[90011111]
+    assert event.status == expected_status
+    assert [call.kwargs["url"] for call in get_data.call_args_list] == [
+        "https://api.sportsdata.io/v4/soccer/scores/json/SchedulesBasic/fifa/2026",
+        expected_games_by_date_url,
+    ]
+    assert get_data.call_args_list[1].kwargs["ttl"] == timedelta(minutes=2)
+
+    if expected_status == GameStatus.InProgress:
+        assert event.period == "1"
+        assert event.clock == "16"
+        assert event.home_score == 1
+        assert event.away_score == 0
+
+
 @pytest.mark.asyncio
 async def test_wcs_national_teams_use_country_name_for_event_display() -> None:
     """WCS team full names are federation names, not widget display names."""

--- a/tests/unit/providers/wcs/test_provider.py
+++ b/tests/unit/providers/wcs/test_provider.py
@@ -214,6 +214,8 @@ async def test_match_team_group_comes_from_cached_event_group() -> None:
     )
     event = response.current[0]
 
+    assert event.home_team is not None
+    assert event.away_team is not None
     assert event.home_team.group == "Group C"
     assert event.away_team.group == "Group C"
 
@@ -574,6 +576,7 @@ async def test_cache_error_returns_empty_payloads(mocker) -> None:
     sport.get_all_teams = mocker.AsyncMock(side_effect=CacheAdapterError("redis down"))
     sport.get_eliminated_team_keys = mocker.AsyncMock(side_effect=CacheAdapterError("redis down"))
     metrics_client = mocker.Mock()
+    sentry_capture = mocker.patch("merino.providers.wcs.provider.sentry_sdk.capture_exception")
     provider = WcsProvider(sport=sport, metrics_client=metrics_client, live_data_enabled=True)
 
     matches = await provider.get_matches(ANCHOR, limit=None, team_keys=None)
@@ -588,6 +591,7 @@ async def test_cache_error_returns_empty_payloads(mocker) -> None:
     metrics_client.increment.assert_any_call("wcs.cache_error", tags={"endpoint": "matches"})
     metrics_client.increment.assert_any_call("wcs.cache_error", tags={"endpoint": "live"})
     metrics_client.increment.assert_any_call("wcs.cache_error", tags={"endpoint": "teams"})
+    assert sentry_capture.call_count == 3
 
 
 @pytest.mark.asyncio
@@ -597,6 +601,7 @@ async def test_team_elimination_cache_error_leaves_teams_uneliminated(mocker) ->
     sport.get_all_teams = mocker.AsyncMock(return_value={team.id: team for team in build_teams()})
     sport.get_eliminated_team_keys = mocker.AsyncMock(side_effect=CacheAdapterError("redis down"))
     metrics_client = mocker.Mock()
+    sentry_capture = mocker.patch("merino.providers.wcs.provider.sentry_sdk.capture_exception")
     provider = WcsProvider(sport=sport, metrics_client=metrics_client)
 
     response = await provider.get_teams()
@@ -604,3 +609,4 @@ async def test_team_elimination_cache_error_leaves_teams_uneliminated(mocker) ->
     assert len(response.teams) == 48
     assert not any(team.eliminated for team in response.teams)
     metrics_client.increment.assert_called_once_with("wcs.cache_error", tags={"endpoint": "teams"})
+    sentry_capture.assert_called_once()

--- a/tests/unit/providers/wcs/test_provider.py
+++ b/tests/unit/providers/wcs/test_provider.py
@@ -4,10 +4,10 @@
 
 """Unit tests for the WCS matches provider."""
 
-from collections import Counter
-from datetime import date, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from typing import Any
 
+import freezegun
 import pytest
 
 from merino.configs import settings
@@ -15,11 +15,21 @@ from merino.exceptions import CacheAdapterError
 from merino.providers import wcs as wcs_module
 from merino.providers.suggest.sports.backends.sportsdata.common import GameStatus
 from merino.providers.wcs.fake_live_data import build_live_events
-from merino.providers.wcs.provider import WcsProvider, _WINDOW
-from merino.providers.wcs.protocol import LiveMatchesResponse, TeamInfo, TeamsResponse
-from tests.wcs.factories import ANCHOR, build_provider, build_teams, event as build_event
-
-_LIVE_EVENT_COUNT = len(build_live_events(ANCHOR))
+from merino.providers.wcs.provider import (
+    WcsProvider,
+    _LIVE_MATCH_LOOKAHEAD,
+    _LIVE_MATCH_LOOKBACK,
+    _WINDOW,
+)
+from merino.providers.wcs.protocol import TeamInfo, TeamsResponse
+from tests.wcs.factories import (
+    ANCHOR,
+    StubWcsSport,
+    build_events,
+    build_provider,
+    build_teams,
+    event as build_event,
+)
 
 
 def test_cache_uses_wcs_redis_settings(mocker) -> None:
@@ -187,6 +197,28 @@ async def test_match_team_colors_are_normalized_to_hex() -> None:
 
 
 @pytest.mark.asyncio
+async def test_match_team_group_comes_from_cached_event_group() -> None:
+    """The matches endpoint maps the cached event group onto both teams."""
+    grouped_event = build_event(
+        1010,
+        0,
+        14,
+        ("BRA", "Brazil", 90000001),
+        ("ARG", "Argentina", 90000002),
+        GameStatus.Scheduled,
+        group="Group C",
+    )
+
+    response = await build_provider(events=[grouped_event]).get_matches(
+        ANCHOR, limit=None, team_keys=None
+    )
+    event = response.current[0]
+
+    assert event.home_team.group == "Group C"
+    assert event.away_team.group == "Group C"
+
+
+@pytest.mark.asyncio
 async def test_extra_and_penalty_populated_on_one_finalized_match() -> None:
     """Exactly one finalized match exposes extra-time and penalty-shootout values."""
     response = await build_provider().get_matches(ANCHOR, limit=None, team_keys=None)
@@ -212,32 +244,64 @@ async def test_live_extra_time_match_shows_clock_in_extra_play() -> None:
 
 
 @pytest.mark.asyncio
-async def test_live_returns_expanded_fake_events() -> None:
-    """`get_live_matches` returns the expanded fake live-endpoint event set."""
-    response = await build_provider(events=[]).get_live_matches(team_keys=None)
+@freezegun.freeze_time("2026-06-15T16:00:00Z")
+async def test_live_returns_mock_events_when_live_data_disabled() -> None:
+    """With live_data_enabled=False, /wcs/live serves build_live_events output."""
+    response = await build_provider(live_data_enabled=False).get_live_matches(team_keys=None)
 
-    assert len(response.matches) == _LIVE_EVENT_COUNT
-    assert Counter(e.status_type for e in response.matches) == Counter(
-        {
-            "past": 5,
-            "live": 11,
-            "scheduled": 3,
-            "unknown": 1,
-        }
-    )
-    assert {"Awarded", "Canceled", "Postponed", "Suspended"}.issubset(
-        {event.status for event in response.matches}
+    assert response.matches == build_live_events(date.today())
+
+
+@pytest.mark.asyncio
+async def test_live_mock_path_does_not_touch_redis(mocker) -> None:
+    """Disabled live-data must not hit the cache at all."""
+    sport = mocker.Mock()
+    sport.get_events_by_date = mocker.AsyncMock()
+
+    await WcsProvider(sport=sport, live_data_enabled=False).get_live_matches(team_keys=None)
+
+    sport.get_events_by_date.assert_not_called()
+
+
+@pytest.mark.asyncio
+@freezegun.freeze_time("2026-06-15T16:00:00Z")
+async def test_live_returns_only_in_progress_cached_events() -> None:
+    """`get_live_matches` reads Redis-backed events and keeps live matches only."""
+    response = await build_provider().get_live_matches(team_keys=None)
+
+    assert len(response.matches) == 2
+    assert {event.global_event_id for event in response.matches} == {1003, 1004}
+    assert {event.status for event in response.matches} == {"In Progress"}
+    assert {event.status_type for event in response.matches} == {"live"}
+
+
+@freezegun.freeze_time("2026-06-15T15:00:00Z")
+@pytest.mark.asyncio
+async def test_live_reads_bounded_cache_window(mocker) -> None:
+    """The Redis path only reads events near now, not the whole tournament calendar."""
+    sport = mocker.Mock(wraps=StubWcsSport(build_events(), build_teams()))
+    sport.get_events_by_date = mocker.AsyncMock(return_value=build_events())
+    provider = WcsProvider(sport=sport, live_data_enabled=True)
+
+    await provider.get_live_matches(team_keys=None)
+
+    now = datetime(2026, 6, 15, 15, tzinfo=UTC)
+    sport.get_events_by_date.assert_awaited_once_with(
+        start=now - _LIVE_MATCH_LOOKBACK,
+        end=now + _LIVE_MATCH_LOOKAHEAD,
     )
 
 
 @pytest.mark.asyncio
+@freezegun.freeze_time("2026-06-15T16:00:00Z")
 async def test_live_matches_sorted_ascending_by_date() -> None:
     """Live events are sorted ascending by `date`."""
-    matches: LiveMatchesResponse = await build_provider().get_live_matches(team_keys=None)
-    assert matches.matches == sorted(matches.matches, key=lambda e: e.date)
+    response = await build_provider().get_live_matches(team_keys=None)
+    assert response.matches == sorted(response.matches, key=lambda e: e.date)
 
 
 @pytest.mark.asyncio
+@freezegun.freeze_time("2026-06-15T16:00:00Z")
 async def test_live_teams_filter_matches_either_side() -> None:
     """Filter retains live events where either side plays for the listed team."""
     response = await build_provider().get_live_matches(team_keys=frozenset({"BRA"}))
@@ -250,6 +314,7 @@ async def test_live_teams_filter_matches_either_side() -> None:
 
 
 @pytest.mark.asyncio
+@freezegun.freeze_time("2026-06-15T16:00:00Z")
 async def test_live_unknown_team_returns_empty() -> None:
     """No match for the filter yields an empty list, not an error."""
     response = await build_provider().get_live_matches(team_keys=frozenset({"ZZZ"}))
@@ -257,9 +322,10 @@ async def test_live_unknown_team_returns_empty() -> None:
 
 
 @pytest.mark.asyncio
-async def test_live_is_deterministic_within_same_utc_day() -> None:
-    """Two calls in the same UTC day produce identical payloads."""
-    provider = build_provider(events=[])
+@freezegun.freeze_time("2026-06-15T16:00:00Z")
+async def test_live_is_deterministic_for_same_cached_events() -> None:
+    """Two calls against unchanged cached events produce identical payloads."""
+    provider = build_provider()
     a = await provider.get_live_matches(team_keys=None)
     b = await provider.get_live_matches(team_keys=None)
     assert a.model_dump() == b.model_dump()
@@ -490,7 +556,7 @@ async def test_empty_cache_returns_empty_payloads() -> None:
         "current": [],
         "next": [],
     }
-    assert len((await provider.get_live_matches(team_keys=None)).matches) == _LIVE_EVENT_COUNT
+    assert (await provider.get_live_matches(team_keys=None)).matches == []
     assert len((await provider.get_teams()).teams) == 48
 
 
@@ -508,7 +574,7 @@ async def test_cache_error_returns_empty_payloads(mocker) -> None:
     sport.get_all_teams = mocker.AsyncMock(side_effect=CacheAdapterError("redis down"))
     sport.get_eliminated_team_keys = mocker.AsyncMock(side_effect=CacheAdapterError("redis down"))
     metrics_client = mocker.Mock()
-    provider = WcsProvider(sport=sport, metrics_client=metrics_client)
+    provider = WcsProvider(sport=sport, metrics_client=metrics_client, live_data_enabled=True)
 
     matches = await provider.get_matches(ANCHOR, limit=None, team_keys=None)
     assert matches.model_dump(by_alias=True) == {
@@ -516,9 +582,11 @@ async def test_cache_error_returns_empty_payloads(mocker) -> None:
         "current": [],
         "next": [],
     }
-    assert len((await provider.get_live_matches(team_keys=None)).matches) == _LIVE_EVENT_COUNT
+    live = await provider.get_live_matches(team_keys=None)
+    assert live.matches == []
     assert (await provider.get_teams()).teams == []
     metrics_client.increment.assert_any_call("wcs.cache_error", tags={"endpoint": "matches"})
+    metrics_client.increment.assert_any_call("wcs.cache_error", tags={"endpoint": "live"})
     metrics_client.increment.assert_any_call("wcs.cache_error", tags={"endpoint": "teams"})
 
 

--- a/tests/wcs/factories.py
+++ b/tests/wcs/factories.py
@@ -204,6 +204,7 @@ def build_provider(
     teams: list[Team] | None = None,
     metrics_client: Any | None = None,
     eliminated_team_keys: set[str] | None = None,
+    live_data_enabled: bool = True,
 ) -> WcsProvider:
     """Build a WCS provider backed by deterministic stub data."""
     stub_events = build_events() if events is None else events
@@ -211,4 +212,5 @@ def build_provider(
     return WcsProvider(
         sport=StubWcsSport(stub_events, stub_teams, eliminated_team_keys),
         metrics_client=metrics_client,
+        live_data_enabled=live_data_enabled,
     )


### PR DESCRIPTION
## References

JIRA: [DISCO-4079](https://mozilla-hub.atlassian.net/browse/DISCO-4079)

## Description
This PR wires `/api/v1/wcs/live` to the Redis-backed WCS event cache while leaving the mock response in place as the production default. 

On the cron side, WCS.update_events now refreshes `GamesByDate/fifa/<day>` for any event whose day falls inside the active UTC window (today plus or minus one day) instead of only when `SchedulesBasic` already reports a non-scheduled status, with the TTL on that call lowered to two minutes so live status, score, and clock land within one cron tick. 

The endpoint reads a window of cached events, filters by `event.status.is_in_progress()`, and returns a new `{"current": [EventInfo, ...]}` response, with the Redis path gated behind `providers.wcs.live_data_enabled` so we can flip the cutover via config without a code change.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2329)


[DISCO-4079]: https://mozilla-hub.atlassian.net/browse/DISCO-4079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ