### PR TITLE
DISCO-4235 TBD teams for WCS

### DIFF
--- a/merino/providers/suggest/sports/backends/sportsdata/common/sports.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/sports.py
@@ -33,6 +33,7 @@ from merino.providers.suggest.sports.backends.sportsdata.common.data import (
     sportsdata_day_slug,
 )
 from merino.providers.suggest.sports.backends.sportsdata.common.wcs_elimination import (
+    TBD_TEAM_KEY,
     eliminated_team_keys,
     eliminated_team_keys_cache_key,
     parse_eliminated_team_keys,
@@ -40,7 +41,6 @@ from merino.providers.suggest.sports.backends.sportsdata.common.wcs_elimination 
 )
 
 FORCE_IMPORT = ""
-_TBD_TEAM_KEY = "TBD"
 _SEASON_TYPE_POSTSEASON = 3
 
 # When creating a new sport class, add its entry to SPORT_CATEGORY_MAP below.
@@ -987,7 +987,7 @@ class WCS(Sport):
     ) -> tuple[dict[str, Any], str] | None:
         """Return compact team data and search terms for one placeholder row side."""
         if team_id is None:
-            return self._tbd_team_minimal(), _TBD_TEAM_KEY.lower()
+            return self._tbd_team_minimal(), TBD_TEAM_KEY.lower()
 
         team = self.teams.get(team_id)
         if team is None:
@@ -1004,7 +1004,7 @@ class WCS(Sport):
 
     def _tbd_team_minimal(self) -> dict[str, Any]:
         """Return the compact event-team shape for an unassigned WCS side."""
-        return {"key": _TBD_TEAM_KEY, "name": _TBD_TEAM_KEY, "colors": [], "id": 0}
+        return {"key": TBD_TEAM_KEY, "name": TBD_TEAM_KEY, "colors": [], "id": 0}
 
     async def get_team(self, id: int) -> Team | None:
         """Fetch a team from the thread locked source"""

--- a/merino/providers/suggest/sports/backends/sportsdata/common/sports.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/sports.py
@@ -18,7 +18,7 @@ from pydantic import ValidationError
 
 from merino.cache.redis import RedisAdapter
 from merino.cache.none import NoCacheAdapter
-from merino.providers.suggest.sports import LOGGING_TAG
+from merino.providers.suggest.sports import LOGGING_TAG, utc_time_from_now
 from merino.providers.suggest.sports.backends.sportsdata.common.error import SportsDataError
 from merino.providers.suggest.sports.backends import get_data
 from merino.providers.suggest.sports.backends.sportsdata.common import SportCategory
@@ -27,6 +27,7 @@ from merino.providers.suggest.sports.backends.sportsdata.common.data import (
     SportTerms,
     Team,
     Event,
+    SportsDataEventRow,
     SPORTSDATA_US_EASTERN,
     SPORTSDATA_UTC,
     sportsdata_day_slug,
@@ -39,6 +40,8 @@ from merino.providers.suggest.sports.backends.sportsdata.common.wcs_elimination 
 )
 
 FORCE_IMPORT = ""
+_TBD_TEAM_KEY = "TBD"
+_SEASON_TYPE_POSTSEASON = 3
 
 # When creating a new sport class, add its entry to SPORT_CATEGORY_MAP below.
 # The key must match the class name, as that is what is stored in the `Event.sport` field.
@@ -936,6 +939,72 @@ class WCS(Sport):
         team_data = super().team_minimal(team)
         team_data["name"] = team.name
         return team_data
+
+    def event_from_row(self, row: SportsDataEventRow) -> Event | None:
+        """Create a WCS event, preserving knockout placeholders with TBD teams."""
+        if self._is_knockout_placeholder_row(row):
+            return self._knockout_placeholder_event_from_row(row)
+        return super().event_from_row(row)
+
+    def _is_knockout_placeholder_row(self, row: SportsDataEventRow) -> bool:
+        """Return True when a knockout row has at least one unassigned team."""
+        return (
+            row.raw.get("SeasonType") == _SEASON_TYPE_POSTSEASON
+            and row.raw.get("Group") is None
+            and (row.home_team_id is None or row.away_team_id is None)
+        )
+
+    def _knockout_placeholder_event_from_row(self, row: SportsDataEventRow) -> Event | None:
+        """Create an Event for knockout rows whose teams are not fully known yet."""
+        if not self.row_in_event_window(row):
+            return None
+
+        home_side = self._event_team_or_tbd_for_row(row, row.home_team_id)
+        away_side = self._event_team_or_tbd_for_row(row, row.away_team_id)
+        if home_side is None or away_side is None:
+            return None
+        home_team, home_terms = home_side
+        away_team, away_terms = away_side
+
+        return Event(
+            sport=self.name,
+            id=row.game_id,
+            terms=" ".join(term for term in (home_terms, away_terms) if term).strip(),
+            date=row.kickoff,
+            original_date=row.original_date,
+            home_team=home_team,
+            away_team=away_team,
+            home_score=row.home_score,
+            away_score=row.away_score,
+            status=row.status,
+            expiry=utc_time_from_now(self.event_ttl),
+            updated=row.updated,
+            **self.event_details(row.raw),
+        )
+
+    def _event_team_or_tbd_for_row(
+        self, row: SportsDataEventRow, team_id: int | None
+    ) -> tuple[dict[str, Any], str] | None:
+        """Return compact team data and search terms for one placeholder row side."""
+        if team_id is None:
+            return self._tbd_team_minimal(), _TBD_TEAM_KEY.lower()
+
+        team = self.teams.get(team_id)
+        if team is None:
+            logger.warning(
+                "%s Could not find team info for '%s' vs '%s' for %s: %s",
+                LOGGING_TAG,
+                row.home_team_key,
+                row.away_team_key,
+                self.name,
+                row.raw,
+            )
+            return None
+        return self.team_minimal(team), team.terms
+
+    def _tbd_team_minimal(self) -> dict[str, Any]:
+        """Return the compact event-team shape for an unassigned WCS side."""
+        return {"key": _TBD_TEAM_KEY, "name": _TBD_TEAM_KEY, "colors": [], "id": 0}
 
     async def get_team(self, id: int) -> Team | None:
         """Fetch a team from the thread locked source"""

--- a/merino/providers/suggest/sports/backends/sportsdata/common/wcs_elimination.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/wcs_elimination.py
@@ -10,6 +10,7 @@ from merino.providers.suggest.sports.backends.sportsdata.common.data import Even
 
 _FIRST_KNOCKOUT_ADVANCER_COUNT = 32
 _ELIMINATED_TEAM_KEYS_META_KEY = "meta:eliminated_team_keys"
+_PLACEHOLDER_TEAM_KEYS = {"TBD"}
 
 
 def eliminated_team_keys_cache_key(cache_prefix: str) -> str:
@@ -101,14 +102,14 @@ def _active_path_team_keys(events: list[Event]) -> set[str]:
 
 
 def _event_team_keys(event: Event) -> set[str]:
-    """Return non-empty team keys from an event."""
+    """Return real, non-empty team keys from an event."""
     return {
         key
         for key in (
             event.home_team.get("key"),
             event.away_team.get("key"),
         )
-        if isinstance(key, str) and key
+        if isinstance(key, str) and key and key not in _PLACEHOLDER_TEAM_KEYS
     }
 
 

--- a/merino/providers/suggest/sports/backends/sportsdata/common/wcs_elimination.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/wcs_elimination.py
@@ -10,7 +10,8 @@ from merino.providers.suggest.sports.backends.sportsdata.common.data import Even
 
 _FIRST_KNOCKOUT_ADVANCER_COUNT = 32
 _ELIMINATED_TEAM_KEYS_META_KEY = "meta:eliminated_team_keys"
-_PLACEHOLDER_TEAM_KEYS = {"TBD"}
+TBD_TEAM_KEY = "TBD"
+_PLACEHOLDER_TEAM_KEYS = {TBD_TEAM_KEY}
 
 
 def eliminated_team_keys_cache_key(cache_prefix: str) -> str:

--- a/merino/providers/wcs/fake_live_data.py
+++ b/merino/providers/wcs/fake_live_data.py
@@ -20,6 +20,7 @@ class EventTemplate:
     away_key: str
     status_type: StatusType
     status: str
+    stage: str = "Group Stage"
     home_score: int | None = None
     away_score: int | None = None
     home_extra: int | None = None
@@ -39,6 +40,7 @@ _TEMPLATES: list[EventTemplate] = [
         away_key="ARG",
         status_type="past",
         status="Final",
+        stage="Round of 16",
         home_score=2,
         away_score=1,
         period="FT",
@@ -51,6 +53,7 @@ _TEMPLATES: list[EventTemplate] = [
         away_key="FRA",
         status_type="past",
         status="Final",
+        stage="Quarterfinals",
         home_score=1,
         away_score=1,
         home_extra=1,
@@ -226,6 +229,7 @@ _TEMPLATES: list[EventTemplate] = [
         away_key="BRA",
         status_type="past",
         status="Final",
+        stage="Final",
         home_score=1,
         away_score=1,
         home_extra=0,
@@ -241,6 +245,7 @@ _TEMPLATES: list[EventTemplate] = [
         away_key="ENG",
         status_type="past",
         status="Final",
+        stage="Third Place Playoff",
         home_score=0,
         away_score=0,
         home_extra=0,
@@ -333,14 +338,15 @@ def _event(
         global_event_id=global_event_id,
         home_team=_team(template.home_key),
         away_team=_team(template.away_key),
-        period=template.period or "",
+        period=template.period,
+        stage=template.stage,
         home_score=template.home_score,
         away_score=template.away_score,
         home_extra=template.home_extra,
         away_extra=template.away_extra,
         home_penalty=template.home_penalty,
         away_penalty=template.away_penalty,
-        clock=template.clock or "",
+        clock=template.clock,
         updated=int(event_dt.timestamp()) - 3600,
         status=template.status,
         status_type=template.status_type,

--- a/merino/providers/wcs/protocol.py
+++ b/merino/providers/wcs/protocol.py
@@ -5,6 +5,9 @@ from typing import Any
 from pydantic import BaseModel, ConfigDict, Field, HttpUrl
 
 from merino.providers.suggest.sports.backends.sportsdata.common.data import Event, Team
+from merino.providers.suggest.sports.backends.sportsdata.common.wcs_elimination import (
+    TBD_TEAM_KEY,
+)
 from merino.providers.suggest.sports.backends.sportsdata.protocol import build_query
 from merino.providers.wcs.utils import get_team_colours
 from merino.utils.logos import LogoCategory, load_manifest
@@ -14,7 +17,6 @@ from merino.utils.logos import LogoCategory, load_manifest
 # Pin WCS flag URLs to the production image bucket so stage and prod render the
 # same assets.
 _LOGO_HOST = "https://storage.googleapis.com/merino-images-prod"
-_TBD_TEAM_KEY = "TBD"
 
 
 def _icon(key: str) -> HttpUrl | None:
@@ -93,9 +95,9 @@ def _is_tbd_event_team(team: dict[str, Any]) -> bool:
     """Return True for the compact placeholder team used in cached WCS events."""
     try:
         team_id = int(team.get("id", -1))
-    except (TypeError, ValueError):
+    except TypeError, ValueError:
         team_id = -1
-    return str(team.get("key", "")).upper() == _TBD_TEAM_KEY and team_id == 0
+    return str(team.get("key", "")).upper() == TBD_TEAM_KEY and team_id == 0
 
 
 class EventInfo(BaseModel):

--- a/merino/providers/wcs/protocol.py
+++ b/merino/providers/wcs/protocol.py
@@ -14,6 +14,7 @@ from merino.utils.logos import LogoCategory, load_manifest
 # Pin WCS flag URLs to the production image bucket so stage and prod render the
 # same assets.
 _LOGO_HOST = "https://storage.googleapis.com/merino-images-prod"
+_TBD_TEAM_KEY = "TBD"
 
 
 def _icon(key: str) -> HttpUrl | None:
@@ -88,24 +89,41 @@ class TeamInfo(BaseModel):
         )
 
 
+def _is_tbd_event_team(team: dict[str, Any]) -> bool:
+    """Return True for the compact placeholder team used in cached WCS events."""
+    try:
+        team_id = int(team.get("id", -1))
+    except (TypeError, ValueError):
+        team_id = -1
+    return str(team.get("key", "")).upper() == _TBD_TEAM_KEY and team_id == 0
+
+
 class EventInfo(BaseModel):
     """A single match event."""
 
     date: str = Field(description="UTC ISO datetime for the start of the event.")
     global_event_id: int = Field(description="Stable identifier for this event.")
-    home_team: TeamInfo
-    away_team: TeamInfo
-    period: str = Field(description="Period descriptor: '1', '2', 'Extra', etc.")
+    home_team: TeamInfo | None = Field(
+        default=None,
+        description="Home team metadata, or null when the knockout side is not established.",
+    )
+    away_team: TeamInfo | None = Field(
+        default=None,
+        description="Away team metadata, or null when the knockout side is not established.",
+    )
+    period: str | None = Field(
+        default=None, description="Period descriptor: '1', '2', 'Extra', etc."
+    )
     home_score: int | None
     away_score: int | None
     home_extra: int | None
     away_extra: int | None
     home_penalty: int | None
     away_penalty: int | None
-    clock: str = Field(description="Elapsed minutes; extra time as '90+3'.")
+    clock: str | None = Field(default=None, description="Elapsed minutes; extra time as '90+3'.")
     updated: int = Field(description="UTC unix timestamp of the last record update.")
-    stage: str | None = Field(
-        default=None,
+    stage: str = Field(
+        default="",
         description="Tournament stage, e.g. 'Group Stage', 'Round of 32', 'Final'.",
     )
     status: str = Field(description="Game status: 'Scheduled', 'In Progress', 'Final', etc.")
@@ -116,24 +134,32 @@ class EventInfo(BaseModel):
     @classmethod
     def from_event(cls, event: Event) -> "EventInfo":
         """Build widget event info from a cached SportsData event."""
-        home_team = TeamInfo.from_event_team(event.home_team, group=event.group)
-        away_team = TeamInfo.from_event_team(event.away_team, group=event.group)
+        home_team = (
+            None
+            if _is_tbd_event_team(event.home_team)
+            else TeamInfo.from_event_team(event.home_team, group=event.group)
+        )
+        away_team = (
+            None
+            if _is_tbd_event_team(event.away_team)
+            else TeamInfo.from_event_team(event.away_team, group=event.group)
+        )
         updated = event.updated or event.date
         return cls(
             date=event.date.isoformat(),
             global_event_id=event.id,
             home_team=home_team,
             away_team=away_team,
-            period=event.period or "",
+            period=event.period,
             home_score=event.home_score,
             away_score=event.away_score,
             home_extra=event.home_extra,
             away_extra=event.away_extra,
             home_penalty=event.home_penalty,
             away_penalty=event.away_penalty,
-            clock=event.clock or "",
+            clock=event.clock,
             updated=int(updated.timestamp()),
-            stage=event.stage,
+            stage=event.stage or "",
             status=event.status.as_str(),
             status_type=event.status.as_ui_status(),
             query=build_query(event.model_dump(mode="json")),

--- a/merino/providers/wcs/provider.py
+++ b/merino/providers/wcs/provider.py
@@ -164,4 +164,7 @@ def _event_date(event: Event) -> date:
 
 def _has_team(event: EventInfo, team_keys: frozenset[str]) -> bool:
     """Return True if either side of `event` plays for one of `team_keys`."""
-    return event.home_team.key in team_keys or event.away_team.key in team_keys
+    return any(
+        team is not None and team.key in team_keys
+        for team in (event.home_team, event.away_team)
+    )

--- a/merino/providers/wcs/provider.py
+++ b/merino/providers/wcs/provider.py
@@ -165,6 +165,5 @@ def _event_date(event: Event) -> date:
 def _has_team(event: EventInfo, team_keys: frozenset[str]) -> bool:
     """Return True if either side of `event` plays for one of `team_keys`."""
     return any(
-        team is not None and team.key in team_keys
-        for team in (event.home_team, event.away_team)
+        team is not None and team.key in team_keys for team in (event.home_team, event.away_team)
     )

--- a/tests/integration/api/v1/wcs/test_live.py
+++ b/tests/integration/api/v1/wcs/test_live.py
@@ -36,6 +36,18 @@ def test_matches_sorted_ascending_by_date(client: TestClient) -> None:
     assert matches == sorted(matches, key=lambda e: e["date"])
 
 
+def test_event_contract_required_fields_are_non_null(client: TestClient) -> None:
+    """Live endpoint mock events include the required Mobile branch fields."""
+    matches = client.get(_PATH).json()["matches"]
+
+    assert matches
+    for event in matches:
+        assert event["date"] is not None
+        assert event["global_event_id"] is not None
+        assert event["status_type"] is not None
+        assert event["stage"] is not None
+
+
 def test_teams_filter(client: TestClient) -> None:
     """`teams` filter keeps only matches with that key on either side."""
     body = client.get(_PATH, params={"teams": "BRA"}).json()

--- a/tests/integration/api/v1/wcs/test_matches.py
+++ b/tests/integration/api/v1/wcs/test_matches.py
@@ -54,6 +54,19 @@ def test_matches_per_bucket(client: TestClient) -> None:
     assert all(e["status"] == "Scheduled" for e in body["next"])
 
 
+def test_event_contract_required_fields_are_non_null(client: TestClient) -> None:
+    """Event fields Mobile branches on are always present and non-null."""
+    body = client.get(_PATH, params={"date": _ANCHOR}).json()
+    events = body["previous"] + body["current"] + body["next"]
+
+    assert events
+    for event in events:
+        assert event["date"] is not None
+        assert event["global_event_id"] is not None
+        assert event["status_type"] is not None
+        assert event["stage"] is not None
+
+
 def test_limit_clamps_each_bucket(client: TestClient) -> None:
     """`limit` caps each bucket independently."""
     body = client.get(_PATH, params={"date": _ANCHOR, "limit": 1}).json()
@@ -72,8 +85,8 @@ def test_teams_filter(client: TestClient) -> None:
         assert "BRA" in {event["home_team"]["key"], event["away_team"]["key"]}
 
 
-def test_matches_returns_tbd_placeholders(client: TestClient) -> None:
-    """Knockout placeholders keep non-null team objects for the widget."""
+def test_matches_returns_nullable_tbd_sides(client: TestClient) -> None:
+    """Knockout placeholders serialize null team objects for Mobile."""
     app.dependency_overrides[get_wcs_provider] = lambda: build_provider(
         events=[
             build_event(
@@ -93,12 +106,8 @@ def test_matches_returns_tbd_placeholders(client: TestClient) -> None:
 
     body = client.get(_PATH, params={"date": "2026-07-05"}).json()
 
-    assert body["current"][0]["home_team"]["name"] == "TBD"
-    assert body["current"][0]["home_team"]["global_team_id"] == 0
-    assert body["current"][0]["home_team"]["icon_url"] is None
-    assert body["current"][0]["away_team"]["name"] == "TBD"
-    assert body["current"][0]["away_team"]["global_team_id"] == 0
-    assert body["current"][0]["away_team"]["icon_url"] is None
+    assert body["current"][0]["home_team"] is None
+    assert body["current"][0]["away_team"] is None
     assert body["current"][0]["stage"] == "Quarterfinals"
     assert body["current"][0]["query"] == "World Cup 2026 TBD vs TBD 05 July 2026"
 

--- a/tests/integration/api/v1/wcs/test_matches.py
+++ b/tests/integration/api/v1/wcs/test_matches.py
@@ -6,6 +6,11 @@
 
 from starlette.testclient import TestClient
 
+from merino.main import app
+from merino.providers.suggest.sports.backends.sportsdata.common import GameStatus
+from merino.providers.wcs import get_provider as get_wcs_provider
+from tests.wcs.factories import build_provider, event as build_event
+
 
 _PATH = "/api/v1/wcs/matches"
 # Pick an anchor inside the fake-data window so buckets are populated.
@@ -65,6 +70,37 @@ def test_teams_filter(client: TestClient) -> None:
     assert events
     for event in events:
         assert "BRA" in {event["home_team"]["key"], event["away_team"]["key"]}
+
+
+def test_matches_returns_tbd_placeholders(client: TestClient) -> None:
+    """Knockout placeholders keep non-null team objects for the widget."""
+    app.dependency_overrides[get_wcs_provider] = lambda: build_provider(
+        events=[
+            build_event(
+                90086997,
+                20,
+                20,
+                ("TBD", "TBD", 0),
+                ("TBD", "TBD", 0),
+                GameStatus.Scheduled,
+                original_date="2026-07-05T00:00:00",
+                stage="Quarterfinals",
+                round_id=1617,
+                season_type=3,
+            )
+        ]
+    )
+
+    body = client.get(_PATH, params={"date": "2026-07-05"}).json()
+
+    assert body["current"][0]["home_team"]["name"] == "TBD"
+    assert body["current"][0]["home_team"]["global_team_id"] == 0
+    assert body["current"][0]["home_team"]["icon_url"] is None
+    assert body["current"][0]["away_team"]["name"] == "TBD"
+    assert body["current"][0]["away_team"]["global_team_id"] == 0
+    assert body["current"][0]["away_team"]["icon_url"] is None
+    assert body["current"][0]["stage"] == "Quarterfinals"
+    assert body["current"][0]["query"] == "World Cup 2026 TBD vs TBD 05 July 2026"
 
 
 def test_invalid_date_returns_400(client: TestClient) -> None:

--- a/tests/unit/providers/suggest/sports/backends/common/test_sports.py
+++ b/tests/unit/providers/suggest/sports/backends/common/test_sports.py
@@ -2461,14 +2461,15 @@ async def test_wcs_sportsdata_schedule_and_games_by_date_payloads_match_expected
     """
     sport = WCS(settings=settings.providers.sports)
     sport.event_ttl = timedelta(weeks=8)
+    sport.rounds = {1615: "Group Stage", 1616: "Round of 32"}
     await sport.async_load_teams_from_source(wcs_static_teams_payload({"SWE", "TUN"}))
 
     sport.load_schedules_from_source(wcs_static_schedule_payload(), event_timezone=ZoneInfo("UTC"))
 
-    # Of the captured rows only SWE vs TUN has both teams loaded; placeholder
-    # rows (SeasonType=3 with null team ids) and partial-team games (e.g. SWE
-    # vs NLD) are dropped by the load filter.
-    assert set(sport.events) == {90086918}
+    # SWE vs TUN has both teams loaded. The knockout placeholder is also
+    # retained with TBD teams, while rows whose real teams are missing from the
+    # test team cache (e.g. SWE vs NLD) are still dropped.
+    assert set(sport.events) == {90086918, 90086979}
     event = sport.events[90086918]
     assert event.away_team["key"] == "TUN"
     assert event.away_team["name"] == "Tunisia"
@@ -2480,6 +2481,16 @@ async def test_wcs_sportsdata_schedule_and_games_by_date_payloads_match_expected
     assert event.season_type == 1
     assert event.group == "Group F"
     assert event.is_closed is False
+    assert event.stage == "Group Stage"
+
+    placeholder = sport.events[90086979]
+    assert placeholder.home_team == {"key": "TBD", "name": "TBD", "colors": [], "id": 0}
+    assert placeholder.away_team == {"key": "TBD", "name": "TBD", "colors": [], "id": 0}
+    assert placeholder.date == datetime(2026, 6, 28, 19, 0, tzinfo=timezone.utc)
+    assert placeholder.round_id == 1616
+    assert placeholder.season_type == 3
+    assert placeholder.group is None
+    assert placeholder.stage == "Round of 32"
 
     sport.load_scores_from_source(
         wcs_static_games_by_date_payload(), event_timezone=ZoneInfo("UTC")
@@ -2497,6 +2508,55 @@ async def test_wcs_sportsdata_schedule_and_games_by_date_payloads_match_expected
     assert event.winner is None
     assert event.is_closed is False
     assert event.updated == datetime(2026, 4, 29, 14, 26, 26, tzinfo=timezone.utc)
+
+
+@freezegun.freeze_time("2026-06-10T00:00:00", tz_offset=0)
+@pytest.mark.asyncio
+async def test_wcs_ingests_knockout_placeholder_with_one_known_team() -> None:
+    """A knockout row with one unassigned side keeps the known team and emits TBD."""
+    sport = WCS(settings=settings.providers.sports)
+    sport.event_ttl = timedelta(weeks=8)
+    sport.rounds = {1617: "Quarterfinals"}
+    await sport.async_load_teams_from_source(wcs_static_teams_payload({"SWE"}))
+
+    sport.load_schedules_from_source(
+        [
+            {
+                "GameId": 86997,
+                "RoundId": 1617,
+                "Season": 2026,
+                "SeasonType": 3,
+                "Group": None,
+                "AwayTeamId": None,
+                "HomeTeamId": 959,
+                "Day": "2026-07-05T00:00:00",
+                "DateTime": "2026-07-05T20:00:00",
+                "Status": "Scheduled",
+                "Period": "Regular",
+                "Clock": None,
+                "Winner": None,
+                "AwayTeamKey": None,
+                "AwayTeamName": None,
+                "AwayTeamScore": None,
+                "HomeTeamKey": "SWE",
+                "HomeTeamName": "Sweden",
+                "HomeTeamScore": None,
+                "Updated": "2025-12-06T20:35:30",
+                "UpdatedUtc": "2025-12-07T01:35:30",
+                "GlobalGameId": 90086997,
+                "GlobalAwayTeamId": None,
+                "GlobalHomeTeamId": 90000001,
+                "IsClosed": False,
+            }
+        ],
+        event_timezone=ZoneInfo("UTC"),
+    )
+
+    event = sport.events[90086997]
+    assert event.home_team["key"] == "SWE"
+    assert event.home_team["name"] == "Sweden"
+    assert event.away_team == {"key": "TBD", "name": "TBD", "colors": [], "id": 0}
+    assert event.stage == "Quarterfinals"
 
 
 @freezegun.freeze_time("2025-09-22T00:00:00", tz_offset=0)

--- a/tests/unit/providers/wcs/test_protocol.py
+++ b/tests/unit/providers/wcs/test_protocol.py
@@ -44,6 +44,30 @@ def test_event_info_from_event_uses_source_day_for_world_cup_query() -> None:
     assert info.query == "World Cup 2026 IR Iran vs New Zealand 15 June 2026"
 
 
+def test_event_info_from_event_builds_tbd_world_cup_query() -> None:
+    """Placeholder teams stay non-null and produce the expected click query."""
+    e = event(
+        event_id=5,
+        day_offset=20,
+        hour=20,
+        home=("TBD", "TBD", 0),
+        away=("TBD", "TBD", 0),
+        status=GameStatus.Scheduled,
+        original_date="2026-07-05T00:00:00",
+        stage="Quarterfinals",
+    )
+
+    info = EventInfo.from_event(e)
+
+    assert info.home_team.name == "TBD"
+    assert info.home_team.global_team_id == 0
+    assert info.home_team.icon_url is None
+    assert info.away_team.name == "TBD"
+    assert info.away_team.global_team_id == 0
+    assert info.away_team.icon_url is None
+    assert info.query == "World Cup 2026 TBD vs TBD 05 July 2026"
+
+
 def test_event_info_from_event_includes_stage() -> None:
     """Ensure stage is propagated from cache to response"""
     e = event(

--- a/tests/unit/providers/wcs/test_protocol.py
+++ b/tests/unit/providers/wcs/test_protocol.py
@@ -4,9 +4,19 @@
 
 """Unit tests for merino.providers.wcs.protocol."""
 
+from collections.abc import Callable
+
+from pytest_mock import MockerFixture
+
 from merino.providers.suggest.sports.backends.sportsdata.common import GameStatus
-from merino.providers.wcs.protocol import EventInfo
+from merino.providers.suggest.sports.backends.sportsdata.common.wcs_elimination import (
+    TBD_TEAM_KEY,
+)
+from merino.providers.wcs.protocol import EventInfo, TeamInfo, _is_tbd_event_team
+from merino.utils.logos import LogoCategory, LogoManifest
 from tests.wcs.factories import event
+
+MakeManifest = Callable[..., LogoManifest]
 
 
 def test_event_info_from_event_builds_world_cup_query() -> None:
@@ -42,6 +52,38 @@ def test_event_info_from_event_uses_source_day_for_world_cup_query() -> None:
 
     assert info.date == "2026-06-16T02:00:00+00:00"
     assert info.query == "World Cup 2026 IR Iran vs New Zealand 15 June 2026"
+
+
+def test_team_info_icon_url_can_be_none_when_logo_is_missing(
+    mocker: MockerFixture,
+    make_manifest: MakeManifest,
+) -> None:
+    """Teams without a manifest logo serialize icon_url=None."""
+    mocker.patch("merino.providers.wcs.protocol.load_manifest", return_value=make_manifest())
+
+    info = TeamInfo.from_event_team({"key": "ZZZ", "id": 1, "name": "Unknown"})
+
+    assert info.icon_url is None
+
+
+def test_team_info_icon_url_uses_png_when_svg_is_missing(
+    mocker: MockerFixture,
+    make_manifest: MakeManifest,
+) -> None:
+    """Manifest entries without SVGs fall back to their PNG URL."""
+    mocker.patch(
+        "merino.providers.wcs.protocol.load_manifest",
+        return_value=make_manifest((LogoCategory.Nations, "ZZZ")),
+    )
+
+    info = TeamInfo.from_event_team({"key": "ZZZ", "id": 1, "name": "Unknown"})
+
+    assert str(info.icon_url).endswith("/logos/nations/nations_zzz.png")
+
+
+def test_is_tbd_event_team_ignores_malformed_placeholder_id() -> None:
+    """A malformed placeholder id is not treated as an undecided bracket side."""
+    assert _is_tbd_event_team({"key": TBD_TEAM_KEY, "id": "bad"}) is False
 
 
 def test_event_info_from_event_builds_tbd_world_cup_query() -> None:

--- a/tests/unit/providers/wcs/test_protocol.py
+++ b/tests/unit/providers/wcs/test_protocol.py
@@ -45,7 +45,7 @@ def test_event_info_from_event_uses_source_day_for_world_cup_query() -> None:
 
 
 def test_event_info_from_event_builds_tbd_world_cup_query() -> None:
-    """Placeholder teams stay non-null and produce the expected click query."""
+    """Placeholder cache teams serialize as null while preserving the click query."""
     e = event(
         event_id=5,
         day_offset=20,
@@ -59,13 +59,30 @@ def test_event_info_from_event_builds_tbd_world_cup_query() -> None:
 
     info = EventInfo.from_event(e)
 
-    assert info.home_team.name == "TBD"
-    assert info.home_team.global_team_id == 0
-    assert info.home_team.icon_url is None
-    assert info.away_team.name == "TBD"
-    assert info.away_team.global_team_id == 0
-    assert info.away_team.icon_url is None
+    assert info.home_team is None
+    assert info.away_team is None
     assert info.query == "World Cup 2026 TBD vs TBD 05 July 2026"
+
+
+def test_event_info_from_event_serializes_one_tbd_side_as_null() -> None:
+    """A partially known bracket match keeps the real side and nulls the TBD side."""
+    e = event(
+        event_id=8,
+        day_offset=20,
+        hour=20,
+        home=("SWE", "Sweden", 90000001),
+        away=("TBD", "TBD", 0),
+        status=GameStatus.Scheduled,
+        original_date="2026-07-05T00:00:00",
+        stage="Quarterfinals",
+    )
+
+    info = EventInfo.from_event(e)
+
+    assert info.home_team is not None
+    assert info.home_team.name == "Sweden"
+    assert info.away_team is None
+    assert info.query == "World Cup 2026 Sweden vs TBD 05 July 2026"
 
 
 def test_event_info_from_event_includes_stage() -> None:
@@ -84,8 +101,8 @@ def test_event_info_from_event_includes_stage() -> None:
     assert info.stage == "Round of 32"
 
 
-def test_event_info_from_event_stage_defaults_to_none() -> None:
-    """An event with no cached stage serializes stage=None on the widget payload.
+def test_event_info_from_event_stage_defaults_to_empty_string() -> None:
+    """An event with no cached stage serializes a non-null stage value.
     This shouldn't happen with real data.
     """
     e = event(
@@ -98,7 +115,24 @@ def test_event_info_from_event_stage_defaults_to_none() -> None:
     )
 
     info = EventInfo.from_event(e)
-    assert info.stage is None
+    assert info.stage == ""
+
+
+def test_event_info_from_event_missing_period_and_clock_stay_null() -> None:
+    """Scheduled matches without period or clock metadata serialize nulls."""
+    e = event(
+        event_id=7,
+        day_offset=0,
+        hour=14,
+        home=("BRA", "Brazil", 90000001),
+        away=("ARG", "Argentina", 90000002),
+        status=GameStatus.Scheduled,
+    )
+
+    info = EventInfo.from_event(e)
+
+    assert info.period is None
+    assert info.clock is None
 
 
 def test_event_info_from_event_propagates_group_to_both_teams() -> None:
@@ -115,6 +149,8 @@ def test_event_info_from_event_propagates_group_to_both_teams() -> None:
 
     info = EventInfo.from_event(e)
 
+    assert info.home_team is not None
+    assert info.away_team is not None
     assert info.home_team.group == "Group A"
     assert info.away_team.group == "Group A"
 
@@ -132,5 +168,7 @@ def test_event_info_from_event_group_defaults_to_none() -> None:
 
     info = EventInfo.from_event(e)
 
+    assert info.home_team is not None
+    assert info.away_team is not None
     assert info.home_team.group is None
     assert info.away_team.group is None

--- a/tests/unit/providers/wcs/test_provider.py
+++ b/tests/unit/providers/wcs/test_provider.py
@@ -100,7 +100,9 @@ async def test_teams_filter_matches_either_side() -> None:
 
     assert events
     for event in events:
-        assert "BRA" in {event.home_team.key, event.away_team.key}
+        assert "BRA" in {
+            team.key for team in (event.home_team, event.away_team) if team is not None
+        }
 
 
 @pytest.mark.asyncio
@@ -139,8 +141,8 @@ async def test_public_sport_identifier_is_soccer() -> None:
 
 
 @pytest.mark.asyncio
-async def test_matches_include_tbd_placeholder_teams() -> None:
-    """The matches endpoint can return scheduled bracket placeholders."""
+async def test_matches_include_nullable_tbd_teams() -> None:
+    """The matches endpoint can return scheduled bracket slots with null teams."""
     placeholder = build_event(
         90086997,
         20,
@@ -162,12 +164,8 @@ async def test_matches_include_tbd_placeholder_teams() -> None:
 
     assert len(response.current) == 1
     event = response.current[0]
-    assert event.home_team.name == "TBD"
-    assert event.home_team.global_team_id == 0
-    assert event.home_team.icon_url is None
-    assert event.away_team.name == "TBD"
-    assert event.away_team.global_team_id == 0
-    assert event.away_team.icon_url is None
+    assert event.home_team is None
+    assert event.away_team is None
     assert event.stage == "Quarterfinals"
     assert event.query == "World Cup 2026 TBD vs TBD 05 July 2026"
 
@@ -176,8 +174,14 @@ async def test_matches_include_tbd_placeholder_teams() -> None:
 async def test_match_team_colors_are_normalized_to_hex() -> None:
     """Cached event team color names are replaced with WCS hex colors."""
     response = await build_provider().get_matches(ANCHOR, limit=None, team_keys=None)
-    event = next(event for event in response.previous if event.home_team.key == "BRA")
+    event = next(
+        event
+        for event in response.previous
+        if event.home_team is not None and event.home_team.key == "BRA"
+    )
 
+    assert event.home_team is not None
+    assert event.away_team is not None
     assert event.home_team.colors == ["#009C3B", "#FFDF00", "#002776"]
     assert event.away_team.colors == ["#74ACDF", "#FFFFFF", "#F6B40E"]
 
@@ -203,6 +207,7 @@ async def test_live_extra_time_match_shows_clock_in_extra_play() -> None:
 
     in_extra = [e for e in response.current if e.period == "ET"]
     assert len(in_extra) == 1
+    assert in_extra[0].clock is not None
     assert in_extra[0].clock.startswith("90+")
 
 
@@ -239,7 +244,9 @@ async def test_live_teams_filter_matches_either_side() -> None:
 
     assert response.matches
     for event in response.matches:
-        assert "BRA" in {event.home_team.key, event.away_team.key}
+        assert "BRA" in {
+            team.key for team in (event.home_team, event.away_team) if team is not None
+        }
 
 
 @pytest.mark.asyncio

--- a/tests/unit/providers/wcs/test_provider.py
+++ b/tests/unit/providers/wcs/test_provider.py
@@ -5,7 +5,7 @@
 """Unit tests for the WCS matches provider."""
 
 from collections import Counter
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from typing import Any
 
 import pytest
@@ -136,6 +136,40 @@ async def test_public_sport_identifier_is_soccer() -> None:
 
     assert events
     assert {event.sport for event in events} == {"soccer"}
+
+
+@pytest.mark.asyncio
+async def test_matches_include_tbd_placeholder_teams() -> None:
+    """The matches endpoint can return scheduled bracket placeholders."""
+    placeholder = build_event(
+        90086997,
+        20,
+        20,
+        ("TBD", "TBD", 0),
+        ("TBD", "TBD", 0),
+        GameStatus.Scheduled,
+        original_date="2026-07-05T00:00:00",
+        stage="Quarterfinals",
+        round_id=1617,
+        season_type=3,
+    )
+
+    response = await build_provider(events=[placeholder]).get_matches(
+        ANCHOR + timedelta(days=20),
+        limit=None,
+        team_keys=None,
+    )
+
+    assert len(response.current) == 1
+    event = response.current[0]
+    assert event.home_team.name == "TBD"
+    assert event.home_team.global_team_id == 0
+    assert event.home_team.icon_url is None
+    assert event.away_team.name == "TBD"
+    assert event.away_team.global_team_id == 0
+    assert event.away_team.icon_url is None
+    assert event.stage == "Quarterfinals"
+    assert event.query == "World Cup 2026 TBD vs TBD 05 July 2026"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## References

JIRA: [DISCO-4235](https://mozilla-hub.atlassian.net/browse/DISCO-4235)

## Description
World Cup knockout games appear on the SportsData feed before both teams are drawn, and Merino's base `event_from_row` drops any row missing a team `id`, so the widget never sees the bracket until matchups are
  finalized. 

This change overrides `event_from_row` on the `WCS` subclass to detect knockout placeholders (`SeasonType` ==
  `3`, `Group is None`, at least one null team id) and emit an `Event` whose unknown side carries `{"key": "TBD", "name": "TBD", "colors": [], "id": 0}` instead of being dropped, with `_event_team_keys` in `wcs_elimination` filtering TBD out so it never pollutes the eliminated-team set or the active-path calculation. 

The `/matches?date=...` endpoint is unchanged and `TeamInfo.from_event_team` handles the placeholder naturally, returning `icon_url: null` since TBD is absent from the logo manifest and emitting a click query of the form World Cup 2026 TBD vs TBD 05 July 2026.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2330)


[DISCO-4235]: https://mozilla-hub.atlassian.net/browse/DISCO-4235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ