### PR TITLE
[DISCO-4238] Return correct group for teams from matches endpoint

### DIFF
--- a/merino/providers/wcs/protocol.py
+++ b/merino/providers/wcs/protocol.py
@@ -62,8 +62,18 @@ class TeamInfo(BaseModel):
         )
 
     @classmethod
-    def from_event_team(cls, team: dict[str, Any]) -> "TeamInfo":
-        """Build widget team info from the compact team dict stored on events."""
+    def from_event_team(
+        cls,
+        team: dict[str, Any],
+        *,
+        group: str | None = None,
+    ) -> "TeamInfo":
+        """Build widget team info from the compact team dict stored on events.
+
+        The `group` argument is plumbed in from the parent event because the
+        compact team dict does not carry a group of its own; the World Cup
+        group is a per-event attribute.
+        """
         key = str(team["key"])
         raw_icon_url = team.get("icon_url")
         return cls(
@@ -73,7 +83,7 @@ class TeamInfo(BaseModel):
             region=str(team.get("region") or team.get("country") or key),
             colors=get_team_colours(key),
             icon_url=HttpUrl(raw_icon_url) if raw_icon_url else _icon(key),
-            group=team.get("group"),
+            group=group,
             eliminated=bool(team.get("eliminated", False)),
         )
 
@@ -106,8 +116,8 @@ class EventInfo(BaseModel):
     @classmethod
     def from_event(cls, event: Event) -> "EventInfo":
         """Build widget event info from a cached SportsData event."""
-        home_team = TeamInfo.from_event_team(event.home_team)
-        away_team = TeamInfo.from_event_team(event.away_team)
+        home_team = TeamInfo.from_event_team(event.home_team, group=event.group)
+        away_team = TeamInfo.from_event_team(event.away_team, group=event.group)
         updated = event.updated or event.date
         return cls(
             date=event.date.isoformat(),

--- a/tests/unit/providers/wcs/test_protocol.py
+++ b/tests/unit/providers/wcs/test_protocol.py
@@ -78,6 +78,7 @@ def test_event_info_from_event_stage_defaults_to_none() -> None:
 
 
 def test_event_info_from_event_propagates_group_to_both_teams() -> None:
+    """The event-level group surfaces on both team info entries."""
     e = event(
         event_id=5,
         day_offset=0,

--- a/tests/unit/providers/wcs/test_protocol.py
+++ b/tests/unit/providers/wcs/test_protocol.py
@@ -75,3 +75,37 @@ def test_event_info_from_event_stage_defaults_to_none() -> None:
 
     info = EventInfo.from_event(e)
     assert info.stage is None
+
+
+def test_event_info_from_event_propagates_group_to_both_teams() -> None:
+    e = event(
+        event_id=5,
+        day_offset=0,
+        hour=14,
+        home=("BRA", "Brazil", 90000001),
+        away=("ARG", "Argentina", 90000002),
+        status=GameStatus.Scheduled,
+        group="Group A",
+    )
+
+    info = EventInfo.from_event(e)
+
+    assert info.home_team.group == "Group A"
+    assert info.away_team.group == "Group A"
+
+
+def test_event_info_from_event_group_defaults_to_none() -> None:
+    """Events without a cached group (e.g. knockout matches) emit `None`."""
+    e = event(
+        event_id=6,
+        day_offset=0,
+        hour=14,
+        home=("BRA", "Brazil", 90000001),
+        away=("ARG", "Argentina", 90000002),
+        status=GameStatus.Scheduled,
+    )
+
+    info = EventInfo.from_event(e)
+
+    assert info.home_team.group is None
+    assert info.away_team.group is None


### PR DESCRIPTION
## References

JIRA: [DISCO-TODO](https://mozilla-hub.atlassian.net/browse/DISCO-4238)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->
This PR:
- Retrieves group data from the event.
- Adds test that fails without the fix.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2331)
