### PR TITLE
[DISCO-4229] suggest turn off adm TS dry run for prod

### DIFF
--- a/merino/configs/production.toml
+++ b/merino/configs/production.toml
@@ -93,10 +93,10 @@ dummy_engaged_count = 1
 dummy_attempted_count = 1000
 
 # MERINO_PROVIDERS__ADM__THOMPSON__CHECK_CLIENT_VARIANTS
-check_client_variants = false
+check_client_variants = true
 
 # MERINO_PROVIDERS__ADM__THOMPSON__DRY_RUN
-dry_run = true
+dry_run = false
 
 [production.providers.top_picks]
 # MERINO_PROVIDERS__TOP_PICKS__DOMAIN_DATA_SOURCE


### PR DESCRIPTION
## References

JIRA: [DISCO-4229](https://mozilla-hub.atlassian.net/browse/DISCO-4229)

## Description
We want to turn off dry run for the experiment



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2332)


[DISCO-4229]: https://mozilla-hub.atlassian.net/browse/DISCO-4229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ