### PR TITLE
fix: [DISCO-4239] Fix legacy ISO codes

### DIFF
--- a/merino/providers/suggest/sports/backends/sportsdata/common/sports.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/sports.py
@@ -688,6 +688,12 @@ class WCS(Sport):
         "CUW": "curacao",
     }
 
+    # Sportsdata.io returns the incorrect official ISO3 for the following countries.
+    ISO_alias = {
+        "CDR": "COD",
+        "CVI": "CPV",
+    }
+
     def __init__(
         self,
         settings: LazySettings,
@@ -920,6 +926,9 @@ class WCS(Sport):
             code = cached[b"code"].decode()
             if code in self.country_alias:
                 cached[b"aliases"] = self.country_alias[code].encode()
+            # Fix ISO3 codes.
+            if code in self.ISO_alias:
+                cached[b"code"] = self.ISO_alias[code].encode()
         return cached
 
     def team_minimal(self, team: Team) -> dict[str, Any]:
@@ -985,7 +994,7 @@ class WCS(Sport):
                     team.country = area.get(b"code", b"UNK").decode()  # pragma: no cover "widget"
                 # team.key is the authoritative ISO3 code after _TEAM_KEY_OVERRIDES;
                 # prefer for join key over AreaId. Since some teams (e.g. Curaçao)
-                # are returned with an AreaId that maps to ANOTher country's area
+                # are returned with an AreaId that maps to Another country's area
                 # (South Korea, in Curaçao's case 🤦)
                 alias = self.country_alias.get(team.key)
                 if alias:

--- a/tests/unit/providers/suggest/sports/backends/common/test_sports.py
+++ b/tests/unit/providers/suggest/sports/backends/common/test_sports.py
@@ -2976,6 +2976,24 @@ async def test_wcs_get_events_by_date_treats_naive_bounds_as_utc() -> None:
     )
 
 
+@pytest.mark.asyncio
+async def test_wcs_fix_country_codes() -> None:
+    """Test that we return corrected country codes"""
+    sport = WCS(settings=settings.providers.sports)
+    mock_cache = MagicMock(spec=RedisAdapter)
+    mock_cache.hgetall.side_effect = [
+        {b"name": "Cabo Verde".encode(), b"code": b"CVI"},
+        {b"name": "DR Congo".encode(), b"code": b"CDR"},
+    ]
+    sport.cache = mock_cache
+
+    # code doesn't really matter, but let's be consistent and pretend it does.
+    result = await sport.get_country(44)
+    assert cast(dict, result)[b"code"] == b"CPV"
+    result = await sport.get_country(53)
+    assert cast(dict, result)[b"code"] == b"COD"
+
+
 @freezegun.freeze_time("2025-09-22T00:00:00", tz_offset=0)
 @pytest.mark.asyncio
 async def test_weird_afc_update_events(


### PR DESCRIPTION
## References

JIRA: [DISCO-4239](https://mozilla-hub.atlassian.net/browse/DISCO-4239)

## Description
Replace legacy ISO3 codes for DR Congo and Cabo Verde


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2334)


[DISCO-4239]: https://mozilla-hub.atlassian.net/browse/DISCO-4239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ