### PR TITLE
[HNT-2611] feat(particle): set up cron to retrieve remote manifest file

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -338,11 +338,6 @@ gcs_bucket = ""
 # CDN hostname used for public URL
 cdn_hostname = ""
 
-# MERINO_GAMES_PARTICLE_GCS__ENABLED
-# Whether to enable fetching from GCS.
-# Set to `true` in production and `false` in staging or development.
-gcs_enabled = true
-
 [default.engagement]
 # MERINO_ENGAGEMENT__GCS_STORAGE_BUCKET
 gcs_storage_bucket = ""
@@ -1141,7 +1136,7 @@ feed_url = "https://commons.wikimedia.org/w/api.php?action=featuredfeed&feed=pot
 type = "particle"
 
 # MERINO_GAMES_PROVIDERS__PARTICLE__ENABLED
-# Whether or not this provider is enabled.
+# Whether or not the provider's cron runs to regularly update game files.
 enabled = false
 
 # MERINO_GAMES_PROVIDERS__PARTICLE__CACHE_TTL

--- a/merino/providers/games/__init__.py
+++ b/merino/providers/games/__init__.py
@@ -1,7 +1,12 @@
 """Initialize game providers."""
 
-from merino.configs import settings
+import pathlib
 
+from merino.configs import settings
+from merino.providers.games.particle.backends.filemanager import (
+    ParticleLocalFileManager,
+    ParticleRemoteFileManager,
+)
 from merino.providers.games.particle.backends.particle import ParticleBackend
 from merino.providers.games.particle.provider import Provider
 
@@ -9,13 +14,24 @@ from merino.utils.gcs.gcs_uploader import GcsUploader
 from merino.utils.http_client import create_http_client
 from merino.utils.metrics import get_metrics_client
 
+# get the application working directory to retrieve local manifest schema file
+_app_root_dir: str = str(pathlib.Path.cwd())
+
 _particle_provider: Provider | None = None
 
 # Module-level variables as looking up from settings each time is expensive.
 _connect_timeout = settings.games_providers.particle.connect_timeout_sec
+_cron_interval_sec = settings.games_providers.particle.cron_interval_sec
+_enabled = settings.games_providers.particle.enabled
 _gcs_project = settings.games_particle_gcs.gcs_project
 _gcs_bucket = settings.games_particle_gcs.gcs_bucket
 _gcs_cdn_hostname = settings.games_particle_gcs.cdn_hostname
+_manifest_gcs_file_name = settings.games_providers.particle.manifest_gcs_file_name
+_manifest_schema_file_path = (
+    f"{_app_root_dir}/{settings.games_providers.particle.manifest_schema_file_path}"
+)
+_manifest_schema_version = settings.games_providers.particle.manifest_schema_version
+_resync_interval_sec = settings.games_providers.particle.resync_interval_sec
 _url_root = settings.games_providers.particle.url_root
 _url_path_manifest = settings.games_providers.particle.url_path_manifest
 
@@ -34,16 +50,31 @@ async def init_providers() -> None:
 
     metrics_client = get_metrics_client()
 
+    # manages retrieving local manifest schema validation file
+    local_file_manager = ParticleLocalFileManager(_manifest_schema_file_path)
+
+    # manages particle files in gcs
+    remote_file_manager = ParticleRemoteFileManager(gcs_uploader, _manifest_gcs_file_name)
+
     particle_backend = ParticleBackend(
         gcs_uploader=gcs_uploader,
         http_client=http_client,
+        manifest_gcs_file_name=_manifest_gcs_file_name,
         metrics_client=metrics_client,
         particle_url_root=_url_root,
         particle_url_path_manifest=_url_path_manifest,
+        remote_file_manager=remote_file_manager,
     )
 
     _particle_provider = Provider(
-        backend=particle_backend, metrics_client=metrics_client, name="Particle Provider"
+        backend=particle_backend,
+        cron_interval_sec=_cron_interval_sec,
+        manifest_schema=local_file_manager.get_manifest_schema(),
+        manifest_schema_version=_manifest_schema_version,
+        metrics_client=metrics_client,
+        name="Particle Provider",
+        resync_interval_sec=_resync_interval_sec,
+        enabled=_enabled,
     )
 
     await _particle_provider.initialize()

--- a/merino/providers/games/particle/backends/particle.py
+++ b/merino/providers/games/particle/backends/particle.py
@@ -3,12 +3,14 @@
 import aiodogstatsd
 import logging
 import orjson
+import sentry_sdk
 
 from httpx import AsyncClient, HTTPError, Response
 from pydantic import Json
 
 from merino.configs import settings
 from merino.providers.games.particle.backends.protocol import Particle
+from merino.providers.games.particle.backends.filemanager import ParticleRemoteFileManager
 from merino.utils.gcs.gcs_uploader import GcsUploader
 
 logger = logging.getLogger(__name__)
@@ -23,16 +25,22 @@ class ParticleBackend:
     gcs_uploader: GcsUploader
     http_client: AsyncClient
     metrics_client: aiodogstatsd.Client
+    # remote endpoint
     particle_url_root: str
+    # path to the manifest on the remote endpoint
     particle_url_path_manifest: str
+    # manages files stored in GCS
+    remote_file_manager: ParticleRemoteFileManager
 
     def __init__(
         self,
         gcs_uploader: GcsUploader,
         http_client: AsyncClient,
+        manifest_gcs_file_name: str,
         metrics_client: aiodogstatsd.Client,
         particle_url_root: str,
         particle_url_path_manifest: str,
+        remote_file_manager: ParticleRemoteFileManager,
     ) -> None:
         """Initialize the Polygon backend."""
         self.gcs_uploader = gcs_uploader
@@ -40,12 +48,13 @@ class ParticleBackend:
         self.metrics_client = metrics_client
         self.particle_url_root = particle_url_root
         self.particle_url_path_manifest = particle_url_path_manifest
+        self.remote_file_manager = remote_file_manager
 
     async def get_game_url(self) -> Particle | None:
         """Return the public URL for the Particle game"""
         return Particle(url=_game_url)
 
-    async def _fetch_manifest_json(self) -> Json | None:
+    async def fetch_manifest_json_from_remote(self) -> Json | None:
         """Retrieve the latest manifest JSON from Particle"""
         manifest: Response | None = None
         manifest_json: Json | None = None
@@ -58,7 +67,14 @@ class ParticleBackend:
 
             manifest.raise_for_status()
         except HTTPError as ex:
-            logger.error(f"HTTP error when fetching Particle manifest: {ex}")
+            error_msg = f"HTTP error when fetching Particle manifest: {ex}"
+
+            logger.error(error_msg)
+
+            sentry_sdk.capture_message(
+                error_msg,
+                level="error",
+            )
 
         # if the manifest was retrieved and has a content property, we're good
         if manifest and manifest.content:
@@ -66,7 +82,14 @@ class ParticleBackend:
             try:
                 manifest_json = orjson.loads(manifest.content)
             except ValueError:
-                logger.error("JSON error when converting Particle response")
+                error_msg = "JSON error when converting Particle response"
+
+                logger.error(error_msg)
+
+                sentry_sdk.capture_message(
+                    error_msg,
+                    level="error",
+                )
 
         # returning json or None
         return manifest_json

--- a/merino/providers/games/particle/backends/protocol.py
+++ b/merino/providers/games/particle/backends/protocol.py
@@ -1,6 +1,6 @@
 """Protocol for Particle provider backend."""
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, Json
 
 from typing import Protocol
 
@@ -25,4 +25,8 @@ class ParticleBackend(Protocol):
         Returns:
             A Particle instance if data is available/valid, otherwise None.
         """
+        ...
+
+    async def fetch_manifest_json_from_remote(self) -> Json | None:
+        """Retrieve the latest manifest JSON from Particle"""
         ...

--- a/merino/providers/games/particle/backends/utils.py
+++ b/merino/providers/games/particle/backends/utils.py
@@ -5,14 +5,11 @@ import logging
 from jsonschema import exceptions, validate
 from pydantic import Json
 
-from merino.configs import settings
 
 logger = logging.getLogger(__name__)
 
-_manifest_schema_version = settings.games_providers.particle.manifest_schema_version
 
-
-def validate_manifest_schema_version(manifest_json: Json) -> None:
+def validate_manifest_schema_version(manifest_json: Json, manifest_schema_version: int) -> None:
     """Validate schema version exists in the JSON and is of the expected value."""
     try:
         schema_version = manifest_json["schemaVersion"]
@@ -23,12 +20,12 @@ def validate_manifest_schema_version(manifest_json: Json) -> None:
         logger.error("JSON error retrieving 'schemaVersion' from manifest JSON.")
         schema_version = None
 
-    if schema_version != _manifest_schema_version:
+    if schema_version != manifest_schema_version:
         logger.error(
-            f"Schema version mismatch when validating manifest JSON. Received {schema_version}, expected {_manifest_schema_version}."
+            f"Schema version mismatch when validating manifest JSON. Received {schema_version}, expected {manifest_schema_version}."
         )
         raise Exception(
-            f"Error validating Particle manifest schema version. Received {schema_version}, expected {_manifest_schema_version}."
+            f"Error validating Particle manifest schema version. Received {schema_version}, expected {manifest_schema_version}."
         )
 
 
@@ -40,3 +37,19 @@ def validate_manifest_against_schema(manifest_json: Json, manifest_schema: Json)
     except exceptions.ValidationError as ex:
         logger.error(f"Schema validation failed for manifest JSON: {ex}")
         raise ex
+
+
+def remote_manifest_runtime_is_updated(manifest_remote: Json, manifest_gcs: Json) -> bool:
+    """Determine if the JSON manifest from Particle has newer runtime files than the manifest we have stored in GCS"""
+    runtime_remote = manifest_remote["channels"]["runtime"]["version"]
+    runtime_gcs = manifest_gcs["channels"]["runtime"]["version"]
+
+    return True if runtime_remote != runtime_gcs else False
+
+
+def remote_manifest_daily_is_updated(manifest_remote: Json, manifest_gcs: Json) -> bool:
+    """Determine if the JSON manifest from Particle has newer game files than the manifest we have stored in GCS"""
+    daily_remote = manifest_remote["channels"]["daily"]["version"]
+    daily_gcs = manifest_gcs["channels"]["daily"]["version"]
+
+    return True if daily_remote != daily_gcs else False

--- a/merino/providers/games/particle/provider.py
+++ b/merino/providers/games/particle/provider.py
@@ -1,11 +1,17 @@
 """Particle integration."""
 
+import aiodogstatsd
+import asyncio
 import logging
+import orjson
+import sentry_sdk
+import time
+
+from pydantic import Json
 from typing import Any
 
-import aiodogstatsd
-
 from merino.providers.games.particle.backends.protocol import Particle, ParticleBackend
+from merino.utils import cron
 
 logger = logging.getLogger(__name__)
 
@@ -14,24 +20,88 @@ class Provider:
     """Particle provider for games."""
 
     backend: ParticleBackend
+    cron_interval_sec: float
+    last_successful_update_at: float
+    manifest_schema: Json
+    manifest_schema_version: int
     metrics_client: aiodogstatsd.Client
+    cron_task: asyncio.Task
+    resync_interval_sec: float
 
     def __init__(
         self,
         backend: ParticleBackend,
+        cron_interval_sec: float,
+        manifest_schema: Json,
+        manifest_schema_version: int,
         metrics_client: aiodogstatsd.Client,
         name: str,
-        enabled_by_default: bool = False,
+        resync_interval_sec: float,
+        enabled: bool = False,
         **kwargs: Any,
     ) -> None:
         self.backend = backend
+        self.cron_interval_sec = cron_interval_sec
+        self.last_successful_update_at = 0.0
+        self.manifest_schema = manifest_schema
+        self.manifest_schema_version = manifest_schema_version
         self.metrics_client = metrics_client
         self.name = name
-        self._enabled_by_default = enabled_by_default
+        self.resync_interval_sec = resync_interval_sec
+        self._enabled = enabled
         super().__init__(**kwargs)
 
     async def initialize(self) -> None:
         """Initialize the provider."""
+        if self._enabled:
+            # create a cron job to update particle game files
+            cron_job = cron.Job(
+                name="update_particle_game_data",
+                interval=self.cron_interval_sec,
+                condition=self._should_fetch_data,
+                task=self._fetch_game_data,
+            )
+
+            self.cron_task = asyncio.create_task(cron_job())
+
+    def _should_fetch_data(self) -> bool:
+        """Check if we should fetch Particle game data from the internet."""
+        return (time.time() - self.last_successful_update_at) >= self.resync_interval_sec
+
+    async def _fetch_game_data(self) -> None:
+        raw_manifest_json: Json | None = None
+
+        try:
+            raw_manifest_json = await self.backend.fetch_manifest_json_from_remote()
+        except Exception as e:
+            logger.warning(
+                "Failed to fetch Particle game data from remote endpoint", extra={"error": str(e)}
+            )
+
+            sentry_sdk.capture_message(
+                f"Failed to fetch Particle game data from remote endpoint: {e}",
+                level="error",
+            )
+
+        if raw_manifest_json is None:
+            logger.warning(
+                f"Particle game data fetch returned None - will retry on next cron tick ({self.cron_interval_sec} seconds)"
+            )
+        else:
+            particle_updated = await self.process_remote_particle_data(
+                orjson.loads(raw_manifest_json)
+            )
+
+            # only update the last success time if we actually updated some files
+            if particle_updated:
+                self.last_successful_update_at = time.time()
+
+    async def process_remote_particle_data(self, manifest_json: Json) -> bool:
+        """Orchestration function to validate and upload new Particle game data files to GCS.
+        Returns True only if some files (puzzle runtime and/or daily puzzle) were updated.
+        """
+        # TODO in follow up PR
+        return True
 
     async def get_game_url(self) -> Particle | None:
         """Proxy get_game_url from Particle backend"""

--- a/merino/providers/suggest/top_picks/backends/filemanager.py
+++ b/merino/providers/suggest/top_picks/backends/filemanager.py
@@ -60,7 +60,7 @@ class TopPicksLocalFilemanager:
 
 
 class TopPicksRemoteFilemanager:
-    """Filemanager for processing local Top Picks data."""
+    """Filemanager for processing remote Top Picks data."""
 
     gcs_client: GcsUploader
     blob_generation: int

--- a/tests/data/games/particle/runtime-manifest-remote-updated.v1.json
+++ b/tests/data/games/particle/runtime-manifest-remote-updated.v1.json
@@ -1,0 +1,113 @@
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-05-14T10:01:54.835Z",
+  "compatibility": {
+    "engineApiVersion": "1.0.0",
+    "uiContractVersion": "1"
+  },
+  "channels": {
+    "runtime": {
+      "version": "726e19990e3f3bdd1ff5eef99962222dd3858a5ec94d47a74e85643856ff881f",
+      "digest": "bc0f42a40c2be586b6113658c270832ac189200f5aaf09485aeaaf464d06dae2",
+      "publishedAt": "2026-05-14T10:01:54.835Z",
+      "entrypointUrl": "runtime/widget-726e19990e3f3bdd1ff5eef99962222dd3858a5ec94d47a74e85643856ff881f.html",
+      "archive": {
+        "path": "archives/runtime-726e19990e3f3bdd1ff5eef99962222dd3858a5ec94d47a74e85643856ff881f.zip",
+        "url": "archives/runtime-726e19990e3f3bdd1ff5eef99962222dd3858a5ec94d47a74e85643856ff881f.zip",
+        "size": 906328,
+        "sha256": "d9ebe8e7cec5d2f0b3dc83491e8b0afe50b6a1e3f240df3ab9ce1a900c7b589c",
+        "contentType": "application/zip",
+        "cacheControl": "public,max-age=31536000,immutable"
+      },
+      "files": [
+        {
+          "path": "assets/crossword_engine_bindings_wasm_bg-D5i4ARx9.wasm",
+          "url": "assets/crossword_engine_bindings_wasm_bg-D5i4ARx9.wasm",
+          "size": 595442,
+          "sha256": "f90205cdb42d75d046d8c7280c8ea2e0599503674c239008c4a3f9927acaa941",
+          "contentType": "application/wasm",
+          "cacheControl": "public,max-age=31536000,immutable"
+        },
+        {
+          "path": "assets/index-B9cVDaXk.js",
+          "url": "assets/index-B9cVDaXk.js",
+          "size": 259024,
+          "sha256": "0d157771bd9e1fe65a7935b4542d488d3cb00143d9f1e7bd3bbbc43de9d33719",
+          "contentType": "text/javascript; charset=utf-8",
+          "cacheControl": "public,max-age=31536000,immutable"
+        },
+        {
+          "path": "assets/index-Cp8XEDMr.css",
+          "url": "assets/index-Cp8XEDMr.css",
+          "size": 45121,
+          "sha256": "8abb60109b1118658bac1c3905134f439566ed82f632a2ab6a10bb4bf3c3463c",
+          "contentType": "text/css; charset=utf-8",
+          "cacheControl": "public,max-age=31536000,immutable"
+        },
+        {
+          "path": "assets/particle-logo-white-DKZgcqee.svg",
+          "url": "assets/particle-logo-white-DKZgcqee.svg",
+          "size": 5474,
+          "sha256": "23af9901c3da519f49f2abb170cd91d50ada69aee08ebfbe18894bb16d4ec260",
+          "contentType": "image/svg+xml",
+          "cacheControl": "public,max-age=31536000,immutable"
+        },
+        {
+          "path": "runtime/widget-726e19990e3f3bdd1ff5eef99962222dd3858a5ec94d47a74e85643856ff881f.html",
+          "url": "runtime/widget-726e19990e3f3bdd1ff5eef99962222dd3858a5ec94d47a74e85643856ff881f.html",
+          "size": 413,
+          "sha256": "46cdfe8f8b080a42a9d84d168deb14bb26367567d02488d781cf2af20e52b5a5",
+          "contentType": "text/html; charset=utf-8",
+          "cacheControl": "public,max-age=31536000,immutable"
+        }
+      ]
+    },
+    "daily": {
+      "version": "9c8d1e92dd9646ffbc832beea50d82f01bb64a0a53dd0c256ff56b5665878b31",
+      "digest": "9c8d1e92dd9646ffbc832beea50d82f01bb64a0a53dd0c256ff56b5665878b31",
+      "publishedAt": "2026-05-14T10:01:54.835Z",
+      "archive": {
+        "path": "archives/daily-9c8d1e92dd9646ffbc832beea50d82f01bb64a0a53dd0c256ff56b5665878b31.zip",
+        "url": "archives/daily-9c8d1e92dd9646ffbc832beea50d82f01bb64a0a53dd0c256ff56b5665878b31.zip",
+        "size": 1735954,
+        "sha256": "707708cc31a3a202de364eabe49b499a90f97ba5c8a74f19274b96ad82812d7d",
+        "contentType": "application/zip",
+        "cacheControl": "public,max-age=31536000,immutable"
+      },
+      "files": [
+        {
+          "path": "assets/cluster-images/36e111bda22a4fa113397920a88ed3aa0897368d225056519a3963576b399674.jpg",
+          "url": "assets/cluster-images/36e111bda22a4fa113397920a88ed3aa0897368d225056519a3963576b399674.jpg",
+          "size": 1157454,
+          "sha256": "7a574ef48aac42ef92504e90e3c0412a0022ad6d5db59c665107cd80cc50ea42",
+          "contentType": "image/jpeg",
+          "cacheControl": "public,max-age=31536000,immutable"
+        },
+        {
+          "path": "assets/cluster-images/46ca27bf5f0b5fd7fa8f81fe26493002a1869f336da55a300923ff68d79dba17.jpg",
+          "url": "assets/cluster-images/46ca27bf5f0b5fd7fa8f81fe26493002a1869f336da55a300923ff68d79dba17.jpg",
+          "size": 557829,
+          "sha256": "8b56a7c79db217c3c39fb4047d3dbf7a46635ba7f8f9f82f2edceeaddac524b4",
+          "contentType": "image/jpeg",
+          "cacheControl": "public,max-age=31536000,immutable"
+        },
+        {
+          "path": "generated/cluster-images.manifest.v1.json",
+          "url": "generated/cluster-images.manifest.v1.json",
+          "size": 1479,
+          "sha256": "9822bcfef030647156cb6db6b1c7dc28ea673893b905f2236b404cf3e298d17c",
+          "contentType": "application/json; charset=utf-8",
+          "cacheControl": "public,max-age=60,must-revalidate"
+        },
+        {
+          "path": "generated/daily-puzzle.v1.json",
+          "url": "generated/daily-puzzle.v1.json",
+          "size": 18364,
+          "sha256": "9b924daa284e4b3b87bac6ed6d6e3d005f4930951d61eb8e1bbcf9c23e7e171b",
+          "contentType": "application/json; charset=utf-8",
+          "cacheControl": "public,max-age=60,must-revalidate"
+        }
+      ]
+    }
+  }
+}

--- a/tests/unit/providers/games/particle/backends/test_particle_backend.py
+++ b/tests/unit/providers/games/particle/backends/test_particle_backend.py
@@ -15,6 +15,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 from merino.configs import settings
 from merino.utils.gcs.gcs_uploader import GcsUploader
+from merino.providers.games.particle.backends.filemanager import ParticleRemoteFileManager
 from merino.providers.games.particle.backends.particle import ParticleBackend
 
 _game_url = settings.games_providers.particle.game_url
@@ -38,17 +39,36 @@ def fixture_gcs_uploader_mock() -> GcsUploader:
     return MagicMock(spec=GcsUploader)
 
 
+@pytest.fixture(name="particle_remote_filemanager_parameters")
+def fixture_particle_remote_filemanager_parameters(gcs_uploader_mock) -> dict[str, Any]:
+    """Define ParticleRemoteFileManager parameters for test."""
+    return {"gcs_client": gcs_uploader_mock, "manifest_file_name": "test_file.json"}
+
+
+@pytest.fixture(name="particle_remote_filemanager")
+def fixture_particle_remote_filemanager(
+    particle_remote_filemanager_parameters: dict[str, Any],
+) -> ParticleRemoteFileManager:
+    """Create a ParticleRemoteFileManager object for test."""
+    return ParticleRemoteFileManager(**particle_remote_filemanager_parameters)
+
+
 @pytest.fixture(name="backend")
 def fixture_backend(
-    gcs_uploader_mock: GcsUploader, mocker: MockerFixture, statsd_mock
+    gcs_uploader_mock: GcsUploader,
+    mocker: MockerFixture,
+    statsd_mock,
+    particle_remote_filemanager: ParticleRemoteFileManager,
 ) -> ParticleBackend:
-    """Return a WikimediaPotdBackend instance for testing."""
+    """Return a ParticleBackend instance for testing."""
     return ParticleBackend(
         gcs_uploader=gcs_uploader_mock,
         http_client=mocker.AsyncMock(spec=AsyncClient),
+        manifest_gcs_file_name="test.json",
         metrics_client=statsd_mock,
         particle_url_root=PARTICLE_URL_ROOT,
         particle_url_path_manifest=PARTICLE_URL_PATH_MANIFEST,
+        remote_file_manager=particle_remote_filemanager,
     )
 
 
@@ -81,7 +101,7 @@ async def test_fetch_manifest_json_returns_json(
         request=Request(method="GET", url=PARTICLE_URL_ROOT),
     )
 
-    result = await backend._fetch_manifest_json()
+    result = await backend.fetch_manifest_json_from_remote()
 
     # result should be a python object (result of json.loads)
     assert isinstance(result, object)
@@ -102,7 +122,7 @@ async def test_fetch_manifest_json_returns_none_for_invalid_json(
 
     caplog.set_level(logging.ERROR)
 
-    result = await backend._fetch_manifest_json()
+    result = await backend.fetch_manifest_json_from_remote()
 
     # get error records
     error_records = filter_caplog(
@@ -128,7 +148,7 @@ async def test_fetch_manifest_json_returns_none_for_http_error(
 
     caplog.set_level(logging.ERROR)
 
-    result = await backend._fetch_manifest_json()
+    result = await backend.fetch_manifest_json_from_remote()
 
     # get error records
     error_records = filter_caplog(

--- a/tests/unit/providers/games/particle/backends/test_utils.py
+++ b/tests/unit/providers/games/particle/backends/test_utils.py
@@ -14,10 +14,15 @@ from pydantic import Json
 from pytest import LogCaptureFixture
 from typing import Any
 
+from merino.configs import settings
 from merino.providers.games.particle.backends.utils import (
+    remote_manifest_daily_is_updated,
+    remote_manifest_runtime_is_updated,
     validate_manifest_schema_version,
     validate_manifest_against_schema,
 )
+
+_manifest_schema_version = settings.games_providers.particle.manifest_schema_version
 
 
 # BEGIN FIXTURES
@@ -25,6 +30,13 @@ from merino.providers.games.particle.backends.utils import (
 def valid_manifest_data():
     """Load mock response data from the Particle manifest endpoint."""
     with open("tests/data/games/particle/runtime-manifest.v1.json") as f:
+        return json.load(f)
+
+
+@pytest.fixture()
+def valid_manifest_data_remote_updated():
+    """Load mock response data from the Particle manifest endpoint."""
+    with open("tests/data/games/particle/runtime-manifest-remote-updated.v1.json") as f:
         return json.load(f)
 
 
@@ -49,7 +61,7 @@ def manifest_schema_data():
 def test_validate_manifest_schema_version_does_not_raise_with_valid_json(valid_manifest_data):
     """Verify valid JSON results in no exception raised."""
     with does_not_raise():
-        validate_manifest_schema_version(valid_manifest_data)
+        validate_manifest_schema_version(valid_manifest_data, _manifest_schema_version)
 
 
 def test_validate_manifest_schema_version_raises_with_invalid_json(
@@ -59,7 +71,7 @@ def test_validate_manifest_schema_version_raises_with_invalid_json(
     caplog.set_level(logging.ERROR)
 
     with pytest.raises(Exception):
-        validate_manifest_schema_version("Not valid JSON")
+        validate_manifest_schema_version("Not valid JSON", _manifest_schema_version)
 
         # get error records
         error_records = filter_caplog(
@@ -79,7 +91,9 @@ def test_validate_manifest_schema_version_raises_with_invalid_schema_version(
 ):
     """Verify invalid schema version raises an exception."""
     with pytest.raises(Exception):
-        validate_manifest_schema_version(json.loads('{"schemaVersion": 2}'))
+        validate_manifest_schema_version(
+            json.loads('{"schemaVersion": 2}'), _manifest_schema_version
+        )
 
     # get error records
     error_records = filter_caplog(
@@ -97,7 +111,9 @@ def test_validate_manifest_schema_version_raises_with_no_schema_version_in_json(
 ):
     """Verify missing schema version raises an exception."""
     with pytest.raises(Exception):
-        validate_manifest_schema_version(json.loads('{"cremaVersion": 1}'))
+        validate_manifest_schema_version(
+            json.loads('{"cremaVersion": 1}'), _manifest_schema_version
+        )
 
     # get error records
     error_records = filter_caplog(
@@ -147,3 +163,31 @@ def test_validate_manifest_against_schema_raises_with_invalid_json(
 
 
 # END validate_manifest_against_schema TESTS
+
+
+def test_remote_manifest_runtime_is_updated_was_updated(
+    valid_manifest_data, valid_manifest_data_remote_updated
+):
+    """Test that comparing an old manifest to a new results in an updated signal"""
+    assert remote_manifest_runtime_is_updated(
+        valid_manifest_data_remote_updated, valid_manifest_data
+    )
+
+
+def test_remote_manifest_runtime_is_updated_was_not_updated(valid_manifest_data):
+    """Test that comparing the same manifest results in a not updated signal"""
+    assert not remote_manifest_runtime_is_updated(valid_manifest_data, valid_manifest_data)
+
+
+def test_remote_manifest_daily_is_updated_was_updated(
+    valid_manifest_data, valid_manifest_data_remote_updated
+):
+    """Test that comparing an old manifest to a new results in an updated signal"""
+    assert remote_manifest_daily_is_updated(
+        valid_manifest_data_remote_updated, valid_manifest_data
+    )
+
+
+def test_remote_manifest_daily_is_updated_was_not_updated(valid_manifest_data):
+    """Test that comparing the same manifest results in a not updated signal"""
+    assert not remote_manifest_daily_is_updated(valid_manifest_data, valid_manifest_data)

--- a/tests/unit/providers/games/particle/test_provider.py
+++ b/tests/unit/providers/games/particle/test_provider.py
@@ -4,8 +4,15 @@
 
 """Unit tests for the Particle games provider."""
 
+import asyncio
+import logging
 import pytest
+
+from logging import LogRecord
+from pytest import LogCaptureFixture
 from pytest_mock import MockerFixture
+from tests.types import FilterCaplogFixture
+from unittest.mock import AsyncMock, patch
 
 from merino.providers.games.particle.backends.protocol import (
     Particle,
@@ -15,6 +22,13 @@ from merino.providers.games.particle.provider import Provider
 
 
 test_game_url = "https://test.test"
+
+
+@pytest.fixture()
+def valid_manifest_data():
+    """Load mock response data from the Particle manifest endpoint."""
+    with open("tests/data/games/particle/runtime-manifest.v1.json") as f:
+        return f.read()
 
 
 @pytest.fixture(name="backend_mock")
@@ -28,9 +42,13 @@ def fixture_provider(statsd_mock, backend_mock: ParticleBackend) -> Provider:
     """Return a Provider instance for testing."""
     return Provider(
         backend=backend_mock,
+        cron_interval_sec=60,
+        manifest_schema="SomeJson",
+        manifest_schema_version=1,
         metrics_client=statsd_mock,
         name="particle",
-        enabled_by_default=False,
+        resync_interval_sec=120,
+        enabled=False,
     )
 
 
@@ -47,7 +65,7 @@ def test_provider_name(provider: Provider) -> None:
 
 def test_provider_enabled_by_default(provider: Provider) -> None:
     """Test that enabled_by_default is set correctly."""
-    assert provider._enabled_by_default is False
+    assert provider._enabled is False
 
 
 @pytest.mark.asyncio
@@ -79,3 +97,138 @@ async def test_get_game_url_returns_correct_particle(
 
     assert particle is not None
     assert particle.url == test_game_url
+
+
+@pytest.mark.asyncio
+async def test_initialize_runs_cron_when_provider_enabled(provider):
+    """Initialize should call _fetch_game_data and create cron job when provider is enabled."""
+    with (
+        patch.object(provider, "_enabled", True),
+        patch("asyncio.create_task", wraps=asyncio.create_task) as mock_create_task,
+        patch("merino.providers.games.particle.provider.cron.Job") as mock_cron_job,
+    ):
+        mock_job_instance = AsyncMock(name="mock_cron_job")
+        mock_cron_job.return_value = mock_job_instance
+
+        await provider.initialize()
+
+        mock_cron_job.assert_called_once_with(
+            name="update_particle_game_data",
+            interval=provider.cron_interval_sec,
+            condition=provider._should_fetch_data,
+            task=provider._fetch_game_data,
+        )
+
+        mock_create_task.assert_called_once()
+        args, _ = mock_create_task.call_args
+        called_arg = args[0]
+        assert asyncio.iscoroutine(called_arg)
+        assert hasattr(provider, "cron_task")
+
+
+def test_should_fetch_data_returns_true_when_interval_satsified(provider):
+    """_should_fetch_data should return True if the time interval condition is satisfied"""
+    with (
+        patch("merino.providers.games.particle.provider.time.time", side_effect=[100]),
+        patch.object(provider, "resync_interval_sec", 50),
+        patch.object(provider, "last_successful_update_at", 50),
+    ):
+        assert provider._should_fetch_data() is True
+
+
+def test_should_fetch_data_returns_false_when_interval_not_satsified(provider):
+    """_should_fetch_data should return False if the time interval condition is not satisfied"""
+    with (
+        patch("merino.providers.games.particle.provider.time.time", side_effect=[100]),
+        patch.object(provider, "resync_interval_sec", 60),
+        patch.object(provider, "last_successful_update_at", 50),
+    ):
+        assert provider._should_fetch_data() is False
+
+
+@pytest.mark.asyncio
+async def test_fetch_game_data_happy_path(provider, valid_manifest_data):
+    """Test that _fetch_game_data retrieves remote json and updates as expected"""
+    with (
+        patch.object(
+            provider.backend, "fetch_manifest_json_from_remote", new=AsyncMock()
+        ) as mock_fetch_manifest,
+        patch.object(provider, "process_remote_particle_data") as mock_process_data,
+        patch("merino.providers.games.particle.provider.time.time", side_effect=[100]),
+    ):
+        mock_fetch_manifest.return_value = valid_manifest_data
+        mock_process_data.return_value = True
+
+        await provider._fetch_game_data()
+
+        mock_fetch_manifest.assert_awaited_once()
+        mock_process_data.assert_called_once()
+        assert provider.last_successful_update_at == 100
+
+
+@pytest.mark.asyncio
+async def test_fetch_game_data_processing_remote_data_fails(provider, valid_manifest_data):
+    """Test that _fetch_game_data retrieves remote json but processing the json fails"""
+    with (
+        patch.object(
+            provider.backend, "fetch_manifest_json_from_remote", new=AsyncMock()
+        ) as mock_fetch_manifest,
+        patch.object(provider, "process_remote_particle_data") as mock_process_data,
+        patch.object(provider, "last_successful_update_at", 0.0),
+        patch("merino.providers.games.particle.provider.time.time", side_effect=[100]),
+    ):
+        mock_fetch_manifest.return_value = valid_manifest_data
+        mock_process_data.return_value = False
+
+        await provider._fetch_game_data()
+
+        mock_fetch_manifest.assert_awaited_once()
+        mock_process_data.assert_called_once()
+        assert provider.last_successful_update_at == 0.0
+
+
+@pytest.mark.asyncio
+async def test_fetch_game_data_remote_fetch_fails(
+    provider,
+    caplog: LogCaptureFixture,
+    filter_caplog: FilterCaplogFixture,
+):
+    """Test that _fetch_game_data logs as expected if the remote fetch fails"""
+    with (
+        patch.object(
+            provider.backend, "fetch_manifest_json_from_remote", new=AsyncMock()
+        ) as mock_fetch_manifest,
+        patch.object(provider, "process_remote_particle_data") as mock_process_data,
+        patch.object(provider, "last_successful_update_at", 0.0),
+        patch("merino.providers.games.particle.provider.time.time", side_effect=[100]),
+    ):
+        caplog.set_level(logging.INFO)
+
+        mock_fetch_manifest.side_effect = Exception("kaboom!")
+
+        await provider._fetch_game_data()
+
+        mock_fetch_manifest.assert_awaited_once()
+        mock_process_data.assert_not_awaited()
+
+        # ensure the last_successful_update_at value was not updated
+        assert provider.last_successful_update_at == 0.0
+
+        records: list[LogRecord] = filter_caplog(
+            caplog.records, "merino.providers.games.particle.provider"
+        )
+
+        # verify logging
+        assert len(records) == 2
+        assert records[0].message.startswith(
+            "Failed to fetch Particle game data from remote endpoint"
+        )
+        assert records[1].message.startswith(
+            "Particle game data fetch returned None - will retry on next cron tick"
+        )
+
+
+@pytest.mark.asyncio
+async def test_process_remote_particle_data(provider, valid_manifest_data):
+    """Stub test for coverage - will be replaced when method body is implemented"""
+    assert await provider.process_remote_particle_data(valid_manifest_data)

--- a/tests/unit/providers/games/test_init.py
+++ b/tests/unit/providers/games/test_init.py
@@ -23,12 +23,15 @@ async def test_init_providers() -> None:
         patch("merino.providers.games._gcs_project", "mock_gcs_project"),
         patch("merino.providers.games._gcs_bucket", "mock_gcs_bucket"),
         patch("merino.providers.games._gcs_cdn_hostname", "mock_cdn_hostname"),
+        patch("merino.providers.games._manifest_gcs_file_name", "mock_manifest_gcs_file_name"),
         patch("merino.providers.games._url_root", "mock_url_root"),
         patch("merino.providers.games._url_path_manifest", "mock_url_path_manifest"),
         patch("merino.providers.games.GcsUploader") as mock_gcs_uploader,
         patch("merino.providers.games.create_http_client") as mock_create_http_client,
         patch("merino.providers.games.get_metrics_client") as mock_get_metrics_client,
         patch("merino.providers.games.ParticleBackend") as mock_particle_backend,
+        patch("merino.providers.games.ParticleLocalFileManager") as mock_local_file_manager,
+        patch("merino.providers.games.ParticleRemoteFileManager") as mock_remote_file_manager,
     ):
         mock_gcs_uploader_instance = Mock(name="mock_gcs_uploader")
         mock_gcs_uploader.return_value = mock_gcs_uploader_instance
@@ -41,6 +44,12 @@ async def test_init_providers() -> None:
 
         mock_particle_backend_instance = Mock(name="mock_particle_backend")
         mock_particle_backend.return_value = mock_particle_backend_instance
+
+        mock_local_filemanager_instance = Mock(name="mock_local_file_manager")
+        mock_local_file_manager.return_value = mock_local_filemanager_instance
+
+        mock_remote_filemanager_instance = Mock(name="mock_remote_file_manager")
+        mock_remote_file_manager.return_value = mock_remote_filemanager_instance
 
         await init_providers()
 
@@ -57,13 +66,16 @@ async def test_init_providers() -> None:
         )
         mock_create_http_client.assert_called_once_with(connect_timeout="mock_connect_timeout")
         mock_get_metrics_client.assert_called_once()
+        mock_local_file_manager.assert_called_once()
 
         mock_particle_backend.assert_called_once_with(
             gcs_uploader=mock_gcs_uploader_instance,
             http_client=mock_http_client_instance,
+            manifest_gcs_file_name="mock_manifest_gcs_file_name",
             metrics_client=mock_metrics_client_instance,
             particle_url_root="mock_url_root",
             particle_url_path_manifest="mock_url_path_manifest",
+            remote_file_manager=mock_remote_filemanager_instance,
         )
 
 


### PR DESCRIPTION
## References

JIRA: [HNT-2611](https://mozilla-hub.atlassian.net/browse/HNT-2611)

## Description

set up cron to retrieve and potentially update particle game files.

- add sentry logging for remote file retrieval errors
- prep particle backend to perform game file update routine

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2335)


[HNT-2611]: https://mozilla-hub.atlassian.net/browse/HNT-2611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ