### PR TITLE
AIMOD-1253: Content contexual ranking tweaks to allow fresh stories to become popular

### DIFF
--- a/merino/curated_recommendations/ml_backends/static_local_model.py
+++ b/merino/curated_recommendations/ml_backends/static_local_model.py
@@ -380,7 +380,7 @@ class SuperInferredModel(LocalModelBackend):
             if is_baysean_smoothing
             else None,
             day_time_weighting=DayTimeWeightingConfig(
-                days=[30],
+                days=[90],
                 relative_weight=[1],
             ),
             interest_vector={

--- a/merino/curated_recommendations/prior_backends/engagment_rescaler.py
+++ b/merino/curated_recommendations/prior_backends/engagment_rescaler.py
@@ -120,6 +120,7 @@ class CrawledContentPinnedFreshRescaler(CrawledContentRescaler):
             "fresh_items_top_stories_fixed_position", 4
         )  # Because there are 2 ads, typically 4 is position 6 (0 based)
         data.setdefault("fresh_items_top_stories_max_percentage", 0.03)
+        data.setdefault("fresh_items_limit_prior_threshold_multiplier", 0.7)
         super().__init__(**data)
 
     def compute_estimated_fresh_per_cycle(self, prior: Prior) -> int:

--- a/merino/curated_recommendations/rankers/contextual_ranker.py
+++ b/merino/curated_recommendations/rankers/contextual_ranker.py
@@ -112,7 +112,7 @@ class ContextualRanker(Ranker):
         rng = np.random.default_rng()
         for rec in recs:
             opens, no_opens, a_prior, b_prior, non_rescaled_b_prior = self.compute_interactions(
-                rec, rescaler, region
+                rec, rescaler, region, blend_region_with_global=False
             )
             is_fresh = False
             # add random value between 0 and 1 to break ties randomly

--- a/merino/curated_recommendations/rankers/interest_ranker.py
+++ b/merino/curated_recommendations/rankers/interest_ranker.py
@@ -107,7 +107,7 @@ class InterestRanker(Ranker):
 
         for r, rec in enumerate(recs):
             opens, no_opens, a_prior, b_prior, non_rescaled_b_prior = self.compute_interactions(
-                rec, rescaler, region
+                rec, rescaler, region, blend_region_with_global=False
             )
 
             # Two conditions must hold to use the LinTS score:

--- a/merino/curated_recommendations/rankers/ranker.py
+++ b/merino/curated_recommendations/rankers/ranker.py
@@ -49,6 +49,7 @@ class Ranker:
         rec: CuratedRecommendation,
         rescaler: EngagementRescaler | None = None,
         region: str | None = None,
+        blend_region_with_global=True,
     ) -> tuple[float, float, float, float, float]:
         """Compute opens, no_opens, a_prior, b_prior, non_rescaled_b_prior for a recommendation."""
         opens, no_opens = self.get_opens_no_opens(rec)
@@ -61,14 +62,11 @@ class Ranker:
 
         if region_no_opens and region_prior:
             # Weighted average of regional and global engagement
-            opens = region_opens * self.region_weight + opens * (1 - self.region_weight)
-            no_opens = region_no_opens * self.region_weight + no_opens * (1 - self.region_weight)
-            a_prior = (self.region_weight * region_prior.alpha) + (
-                (1 - self.region_weight) * a_prior
-            )
-            b_prior = (self.region_weight * region_prior.beta) + (
-                (1 - self.region_weight) * b_prior
-            )
+            region_weight = self.region_weight if blend_region_with_global else 1.0
+            opens = region_opens * region_weight + opens * (1 - region_weight)
+            no_opens = region_no_opens * region_weight + no_opens * (1 - region_weight)
+            a_prior = (region_weight * region_prior.alpha) + ((1 - region_weight) * a_prior)
+            b_prior = (region_weight * region_prior.beta) + ((1 - region_weight) * b_prior)
 
         if rescaler is not None:
             opens, no_opens = rescaler.rescale(rec, opens, no_opens)


### PR DESCRIPTION
## References

JIRA: https://mozilla-hub.atlassian.net/browse/AIMOD-1253

## Description

Research into an [engagement drop potential anomaly in March](https://docs.google.com/document/d/12v3NjOCZ5OtAS2TNLIHHgtToO0MroyGkCZGbKMbntKA/edit?tab=t.0#heading=h.f9a6w7ide9dc)  showed that getting fresh politics stories lots of impressions in Most Popular is important.

To that end, we want to throttle fresh stories via the contextual ranker less.

Also I’ve noticed in the contextual ranker that if any of the impressions show up in the ‘global’ bucket as well as the local one, then the ‘beta’ is much much higher (2-4x) causing the stories to not advance as quickly. To that end, I’m disabling US/Global blending in the Contextual ranker.



See this chart for details on our goal (larger lime is the goal) https://sql.telemetry.mozilla.org/queries/116824?p_end_date=2026-03-28&p_start_date=2026-03-25#286036

Also changing the inferred history window larger to 90 days

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2338)
