### PR TITLE
[DISCO-4252] Sort teams by name in ascending order

### DIFF
--- a/merino/providers/wcs/provider.py
+++ b/merino/providers/wcs/provider.py
@@ -159,7 +159,7 @@ class WcsProvider:
                     region=cached_team.country or roster_team.region,
                 )
             )
-        # return teams sorted by name in A - Z format.
+        # return teams sorted by name in A - Z order.
         return TeamsResponse(teams=sorted(response, key=lambda t: t.name))
 
     async def _get_eliminated_team_keys(self) -> set[str]:

--- a/merino/providers/wcs/provider.py
+++ b/merino/providers/wcs/provider.py
@@ -159,7 +159,8 @@ class WcsProvider:
                     region=cached_team.country or roster_team.region,
                 )
             )
-        return TeamsResponse(teams=response)
+        # return teams sorted by name in A - Z format.
+        return TeamsResponse(teams=sorted(response, key=lambda t: t.name))
 
     async def _get_eliminated_team_keys(self) -> set[str]:
         """Return team keys that no longer have a tournament path."""

--- a/tests/unit/providers/wcs/test_provider.py
+++ b/tests/unit/providers/wcs/test_provider.py
@@ -345,7 +345,7 @@ async def test_get_teams_count() -> None:
 
 @pytest.mark.asyncio
 async def test_teams_are_enriched_from_roster_metadata() -> None:
-    """Cached SportsData teams are filtered, ordered, and enriched from the tournament roster."""
+    """Cached SportsData teams are filtered, sorted A-Z by name, and enriched from the tournament roster."""
     teams = build_teams()
     non_roster_team = teams[0].model_copy(
         update={
@@ -362,11 +362,10 @@ async def test_teams_are_enriched_from_roster_metadata() -> None:
     assert len(response.teams) == 48
     assert [team.key for team in response.teams] == [team.key for team in build_teams()]
     assert "ITA" not in {team.key for team in response.teams}
-    england = response.teams[0]
-    assert england.key == "ENG"
-    assert england.region == "ENG"
-    assert england.group == "Group L"
-    assert all(color.startswith("#") for color in england.colors)
+    algeria = response.teams[0]
+    assert algeria.key == "ALG"
+    assert algeria.region == "ALG"
+    assert all(color.startswith("#") for color in algeria.colors)
 
 
 @pytest.mark.asyncio

--- a/tests/wcs/factories.py
+++ b/tests/wcs/factories.py
@@ -196,7 +196,7 @@ def build_teams() -> list[Team]:
                 country=roster_team.region,
             )
         )
-    return teams
+    return sorted(teams, key=lambda t: t.name)
 
 
 def build_provider(


### PR DESCRIPTION
## References

JIRA: [DISCO-4252](https://mozilla-hub.atlassian.net/browse/DISCO-4252)

## Description
Return `/teams` response in A - Z sorted order by team name.



## PR Review Checklist
- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2339)


[DISCO-4252]: https://mozilla-hub.atlassian.net/browse/DISCO-4252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ