### PR TITLE
[HNT-2620] feat(particle): orchestrate processing remote files

### DIFF
--- a/merino/providers/games/particle/backends/filemanager.py
+++ b/merino/providers/games/particle/backends/filemanager.py
@@ -33,24 +33,18 @@ class ParticleLocalFileManager:
             with open(self.static_manifest_schema_file_path, "r") as f:
                 manifest_schema: dict = json.load(f)
                 return manifest_schema
-        except OSError as os_error:
+        except OSError as os_ex:
             error_msg = f"Cannot open file '{self.static_manifest_schema_file_path}"
 
-            sentry_sdk.capture_message(
-                error_msg,
-                level="error",
-            )
+            sentry_sdk.capture_exception(os_ex)
 
-            raise ParticleFileManagerError(error_msg) from os_error
-        except JSONDecodeError as json_error:
+            raise ParticleFileManagerError(error_msg) from os_ex
+        except JSONDecodeError as json_ex:
             error_msg = f"Cannot decode JSON file '{self.static_manifest_schema_file_path}"
 
-            sentry_sdk.capture_message(
-                error_msg,
-                level="error",
-            )
+            sentry_sdk.capture_exception(json_ex)
 
-            raise ParticleFileManagerError(error_msg) from json_error
+            raise ParticleFileManagerError(error_msg) from json_ex
 
 
 class ParticleRemoteFileManager:
@@ -87,14 +81,11 @@ class ParticleRemoteFileManager:
                 return file_contents
 
             return None
-        except Exception as e:
-            error_msg = f"Error retrieving remote Particle manifest file. {e}"
+        except Exception as ex:
+            error_msg = f"Error retrieving remote Particle manifest file. {ex}"
 
             logger.error(error_msg)
 
-            sentry_sdk.capture_message(
-                error_msg,
-                level="error",
-            )
+            sentry_sdk.capture_exception(ex)
 
-            return None
+            raise ParticleFileManagerError(error_msg) from ex

--- a/merino/providers/games/particle/backends/particle.py
+++ b/merino/providers/games/particle/backends/particle.py
@@ -71,25 +71,23 @@ class ParticleBackend:
 
             logger.error(error_msg)
 
-            sentry_sdk.capture_message(
-                error_msg,
-                level="error",
-            )
+            sentry_sdk.capture_exception(ex)
 
         # if the manifest was retrieved and has a content property, we're good
         if manifest and manifest.content:
             # try to convert the contents of manifest.content to JSON
             try:
                 manifest_json = orjson.loads(manifest.content)
-            except ValueError:
+            except ValueError as ex:
                 error_msg = "JSON error when converting Particle response"
 
                 logger.error(error_msg)
 
-                sentry_sdk.capture_message(
-                    error_msg,
-                    level="error",
-                )
+                sentry_sdk.capture_exception(ex)
 
         # returning json or None
         return manifest_json
+
+    async def fetch_manifest_json_from_gcs(self) -> Json | None:
+        """Retrieve the manifest json last stored in GCS"""
+        return self.remote_file_manager.get_manifest_file()

--- a/merino/providers/games/particle/backends/particle.py
+++ b/merino/providers/games/particle/backends/particle.py
@@ -1,6 +1,7 @@
 """Particle game backend."""
 
 import aiodogstatsd
+import asyncio
 import logging
 import orjson
 import sentry_sdk
@@ -90,4 +91,4 @@ class ParticleBackend:
 
     async def fetch_manifest_json_from_gcs(self) -> Json | None:
         """Retrieve the manifest json last stored in GCS"""
-        return self.remote_file_manager.get_manifest_file()
+        return await asyncio.to_thread(self.remote_file_manager.get_manifest_file)

--- a/merino/providers/games/particle/backends/protocol.py
+++ b/merino/providers/games/particle/backends/protocol.py
@@ -30,3 +30,7 @@ class ParticleBackend(Protocol):
     async def fetch_manifest_json_from_remote(self) -> Json | None:
         """Retrieve the latest manifest JSON from Particle"""
         ...
+
+    async def fetch_manifest_json_from_gcs(self) -> Json | None:
+        """Retrieve the manifest json last stored in GCS"""
+        ...

--- a/merino/providers/games/particle/backends/utils.py
+++ b/merino/providers/games/particle/backends/utils.py
@@ -4,10 +4,13 @@ import logging
 
 from jsonschema import exceptions, validate
 from pydantic import Json
-import sentry_sdk
 
 
 logger = logging.getLogger(__name__)
+
+
+class ParticleManifestValidationError(Exception):
+    """Error validating the Particle manifest JSON."""
 
 
 def validate_manifest_schema_version(manifest_json: Json, manifest_schema_version: int) -> None:
@@ -26,11 +29,9 @@ def validate_manifest_schema_version(manifest_json: Json, manifest_schema_versio
 
         logger.error(error_msg)
 
-        ex = Exception(error_msg)
+        ex = ParticleManifestValidationError(error_msg)
 
-        sentry_sdk.capture_exception(ex)
-
-        raise Exception(ex)
+        raise ex
 
 
 def validate_manifest_against_schema(manifest_json: Json, manifest_schema: Json) -> None:
@@ -41,9 +42,7 @@ def validate_manifest_against_schema(manifest_json: Json, manifest_schema: Json)
     except exceptions.ValidationError as ex:
         logger.error(f"Schema validation failed for manifest JSON: {ex}")
 
-        sentry_sdk.capture_exception(ex)
-
-        raise ex
+        raise ParticleManifestValidationError(str(ex)) from ex
 
 
 def remote_manifest_runtime_is_updated(manifest_remote: Json, manifest_gcs: Json) -> bool:
@@ -51,7 +50,7 @@ def remote_manifest_runtime_is_updated(manifest_remote: Json, manifest_gcs: Json
     runtime_remote = manifest_remote["channels"]["runtime"]["version"]
     runtime_gcs = manifest_gcs["channels"]["runtime"]["version"]
 
-    return True if runtime_remote != runtime_gcs else False
+    return bool(runtime_remote != runtime_gcs)
 
 
 def remote_manifest_puzzle_is_updated(manifest_remote: Json, manifest_gcs: Json) -> bool:
@@ -59,11 +58,11 @@ def remote_manifest_puzzle_is_updated(manifest_remote: Json, manifest_gcs: Json)
     daily_remote = manifest_remote["channels"]["daily"]["version"]
     daily_gcs = manifest_gcs["channels"]["daily"]["version"]
 
-    return True if daily_remote != daily_gcs else False
+    return bool(daily_remote != daily_gcs)
 
 
 async def update_files_puzzle(manifest_remote: Json, manifest_gcs: Json | None) -> bool:
-    """Attempt to update the daily puzzle files"""
+    """Attempt to update the daily puzzle files - partial stub, async operations to come"""
     should_update_puzzle = (
         remote_manifest_puzzle_is_updated(manifest_remote, manifest_gcs) if manifest_gcs else True
     )
@@ -78,7 +77,7 @@ async def update_files_puzzle(manifest_remote: Json, manifest_gcs: Json | None) 
 
 
 async def update_files_runtime(manifest_remote: Json, manifest_gcs: Json | None) -> bool:
-    """Attempt to update the runtime files"""
+    """Attempt to update the runtime files - partial stub, async operations to come"""
     should_update_runtime = (
         remote_manifest_runtime_is_updated(manifest_remote, manifest_gcs) if manifest_gcs else True
     )

--- a/merino/providers/games/particle/backends/utils.py
+++ b/merino/providers/games/particle/backends/utils.py
@@ -4,6 +4,7 @@ import logging
 
 from jsonschema import exceptions, validate
 from pydantic import Json
+import sentry_sdk
 
 
 logger = logging.getLogger(__name__)
@@ -21,12 +22,15 @@ def validate_manifest_schema_version(manifest_json: Json, manifest_schema_versio
         schema_version = None
 
     if schema_version != manifest_schema_version:
-        logger.error(
-            f"Schema version mismatch when validating manifest JSON. Received {schema_version}, expected {manifest_schema_version}."
-        )
-        raise Exception(
-            f"Error validating Particle manifest schema version. Received {schema_version}, expected {manifest_schema_version}."
-        )
+        error_msg = f"Error validating Particle manifest schema version. Received {schema_version}, expected {manifest_schema_version}."
+
+        logger.error(error_msg)
+
+        ex = Exception(error_msg)
+
+        sentry_sdk.capture_exception(ex)
+
+        raise Exception(ex)
 
 
 def validate_manifest_against_schema(manifest_json: Json, manifest_schema: Json) -> None:
@@ -36,6 +40,9 @@ def validate_manifest_against_schema(manifest_json: Json, manifest_schema: Json)
         validate(instance=manifest_json, schema=manifest_schema)
     except exceptions.ValidationError as ex:
         logger.error(f"Schema validation failed for manifest JSON: {ex}")
+
+        sentry_sdk.capture_exception(ex)
+
         raise ex
 
 
@@ -47,9 +54,39 @@ def remote_manifest_runtime_is_updated(manifest_remote: Json, manifest_gcs: Json
     return True if runtime_remote != runtime_gcs else False
 
 
-def remote_manifest_daily_is_updated(manifest_remote: Json, manifest_gcs: Json) -> bool:
+def remote_manifest_puzzle_is_updated(manifest_remote: Json, manifest_gcs: Json) -> bool:
     """Determine if the JSON manifest from Particle has newer game files than the manifest we have stored in GCS"""
     daily_remote = manifest_remote["channels"]["daily"]["version"]
     daily_gcs = manifest_gcs["channels"]["daily"]["version"]
 
     return True if daily_remote != daily_gcs else False
+
+
+async def update_files_puzzle(manifest_remote: Json, manifest_gcs: Json | None) -> bool:
+    """Attempt to update the daily puzzle files"""
+    should_update_puzzle = (
+        remote_manifest_puzzle_is_updated(manifest_remote, manifest_gcs) if manifest_gcs else True
+    )
+
+    if should_update_puzzle:
+        # validate puzzle files SHAs and, if valid, attempt to upload to GCS
+        # if the above succeeds, return True, else False
+        return True
+    else:
+        # if the puzzle files don't need to be updated, return False
+        return False
+
+
+async def update_files_runtime(manifest_remote: Json, manifest_gcs: Json | None) -> bool:
+    """Attempt to update the runtime files"""
+    should_update_runtime = (
+        remote_manifest_runtime_is_updated(manifest_remote, manifest_gcs) if manifest_gcs else True
+    )
+
+    if should_update_runtime:
+        # validate runtime files SHAs and, if valid, attempt to upload to GCS
+        # if the above succeeds, return True, else False
+        return True
+    else:
+        # if the runtime files don't need to be updated, return False
+        return False

--- a/merino/providers/games/particle/provider.py
+++ b/merino/providers/games/particle/provider.py
@@ -3,19 +3,20 @@
 import aiodogstatsd
 import asyncio
 import logging
-import orjson
 import sentry_sdk
 import time
 
 from pydantic import Json
 from typing import Any
 
+from merino.providers.games.particle.backends.filemanager import ParticleFileManagerError
 from merino.providers.games.particle.backends.protocol import Particle, ParticleBackend
 from merino.providers.games.particle.backends.utils import (
     update_files_puzzle,
     update_files_runtime,
     validate_manifest_against_schema,
     validate_manifest_schema_version,
+    ParticleManifestValidationError,
 )
 from merino.utils import cron
 
@@ -75,10 +76,11 @@ class Provider:
         return (time.time() - self.last_successful_update_at) >= self.resync_interval_sec
 
     async def _fetch_game_data(self) -> None:
-        raw_manifest_json: Json | None = None
+        manifest_json: Json | None = None
 
         try:
-            raw_manifest_json = await self.backend.fetch_manifest_json_from_remote()
+            # if successful, returns Json
+            manifest_json = await self.backend.fetch_manifest_json_from_remote()
         except Exception as ex:
             logger.warning(
                 "Failed to fetch Particle game data from remote endpoint", extra={"error": str(ex)}
@@ -86,14 +88,12 @@ class Provider:
 
             sentry_sdk.capture_exception(ex)
 
-        if raw_manifest_json is None:
+        if manifest_json is None:
             logger.warning(
                 f"Particle game data fetch returned None - will retry on next cron tick ({self.cron_interval_sec} seconds)"
             )
         else:
-            particle_updated = await self.process_remote_particle_data(
-                orjson.loads(raw_manifest_json)
-            )
+            particle_updated = await self.process_remote_particle_data(manifest_json)
 
             # only update the last success time if we actually updated some files
             if particle_updated:
@@ -105,17 +105,30 @@ class Provider:
         """
         # ensure the remote schema is valid
         # this will raise if the schema is invalid
-        validate_manifest_against_schema(remote_manifest_json, self.manifest_schema)
+        try:
+            validate_manifest_against_schema(remote_manifest_json, self.manifest_schema)
+        except ParticleManifestValidationError as ex:
+            sentry_sdk.capture_exception(ex)
+            return False
 
-        # ensure the schema verison is as expected
-        # this will raise is the schema version doesn't match
-        validate_manifest_schema_version(remote_manifest_json, self.manifest_schema_version)
+        # ensure the schema version is as expected
+        # this will raise if the schema version doesn't match
+        try:
+            validate_manifest_schema_version(remote_manifest_json, self.manifest_schema_version)
+        except ParticleManifestValidationError as ex:
+            sentry_sdk.capture_exception(ex)
+            return False
 
         # get the manifest file we last stored in GCS to determine if the
         # remote version is newer.
         # returns None if no file is found in GCS, will raise if there's an
         # error retrieving from GCS.
-        gcs_manifest_json = await self.backend.fetch_manifest_json_from_gcs()
+        try:
+            gcs_manifest_json = await self.backend.fetch_manifest_json_from_gcs()
+        except ParticleFileManagerError:
+            # if an exception occurs retrieving from GCS, return early to
+            # ensure the next cron tick again attempts an update
+            return False
 
         # conditionally attempt to update file sets - daily puzzle and runtime
         puzzle_updated = await update_files_puzzle(
@@ -127,7 +140,7 @@ class Provider:
 
         # if either set of files (daily puzzle or runtime) were updated, we can
         # consider this update successful
-        return True if puzzle_updated or runtime_updated else False
+        return puzzle_updated or runtime_updated
 
     async def get_game_url(self) -> Particle | None:
         """Proxy get_game_url from Particle backend"""

--- a/merino/providers/games/particle/provider.py
+++ b/merino/providers/games/particle/provider.py
@@ -11,6 +11,12 @@ from pydantic import Json
 from typing import Any
 
 from merino.providers.games.particle.backends.protocol import Particle, ParticleBackend
+from merino.providers.games.particle.backends.utils import (
+    update_files_puzzle,
+    update_files_runtime,
+    validate_manifest_against_schema,
+    validate_manifest_schema_version,
+)
 from merino.utils import cron
 
 logger = logging.getLogger(__name__)
@@ -73,15 +79,12 @@ class Provider:
 
         try:
             raw_manifest_json = await self.backend.fetch_manifest_json_from_remote()
-        except Exception as e:
+        except Exception as ex:
             logger.warning(
-                "Failed to fetch Particle game data from remote endpoint", extra={"error": str(e)}
+                "Failed to fetch Particle game data from remote endpoint", extra={"error": str(ex)}
             )
 
-            sentry_sdk.capture_message(
-                f"Failed to fetch Particle game data from remote endpoint: {e}",
-                level="error",
-            )
+            sentry_sdk.capture_exception(ex)
 
         if raw_manifest_json is None:
             logger.warning(
@@ -96,12 +99,35 @@ class Provider:
             if particle_updated:
                 self.last_successful_update_at = time.time()
 
-    async def process_remote_particle_data(self, manifest_json: Json) -> bool:
+    async def process_remote_particle_data(self, remote_manifest_json: Json) -> bool:
         """Orchestration function to validate and upload new Particle game data files to GCS.
         Returns True only if some files (puzzle runtime and/or daily puzzle) were updated.
         """
-        # TODO in follow up PR
-        return True
+        # ensure the remote schema is valid
+        # this will raise if the schema is invalid
+        validate_manifest_against_schema(remote_manifest_json, self.manifest_schema)
+
+        # ensure the schema verison is as expected
+        # this will raise is the schema version doesn't match
+        validate_manifest_schema_version(remote_manifest_json, self.manifest_schema_version)
+
+        # get the manifest file we last stored in GCS to determine if the
+        # remote version is newer.
+        # returns None if no file is found in GCS, will raise if there's an
+        # error retrieving from GCS.
+        gcs_manifest_json = await self.backend.fetch_manifest_json_from_gcs()
+
+        # conditionally attempt to update file sets - daily puzzle and runtime
+        puzzle_updated = await update_files_puzzle(
+            manifest_remote=remote_manifest_json, manifest_gcs=gcs_manifest_json
+        )
+        runtime_updated = await update_files_runtime(
+            manifest_remote=remote_manifest_json, manifest_gcs=gcs_manifest_json
+        )
+
+        # if either set of files (daily puzzle or runtime) were updated, we can
+        # consider this update successful
+        return True if puzzle_updated or runtime_updated else False
 
     async def get_game_url(self) -> Particle | None:
         """Proxy get_game_url from Particle backend"""

--- a/tests/data/games/particle/manifest-validation-schema.json
+++ b/tests/data/games/particle/manifest-validation-schema.json
@@ -1,0 +1,125 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Client Runtime Manifest v1",
+  "type": "object",
+  "required": ["schemaVersion", "generatedAt", "compatibility", "channels"],
+  "properties": {
+    "schemaVersion": {
+      "const": 1
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "compatibility": {
+      "type": "object",
+      "required": ["engineApiVersion", "uiContractVersion"],
+      "properties": {
+        "engineApiVersion": {
+          "type": "string",
+          "minLength": 1
+        },
+        "uiContractVersion": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "channels": {
+      "type": "object",
+      "required": ["runtime", "daily"],
+      "properties": {
+        "runtime": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/channel"
+            },
+            {
+              "type": "object",
+              "required": ["entrypointUrl"],
+              "properties": {
+                "entrypointUrl": {
+                  "type": "string",
+                  "pattern": "^runtime/widget-[a-f0-9]{64}\\.html$"
+                }
+              }
+            }
+          ]
+        },
+        "daily": {
+          "$ref": "#/$defs/channel"
+        }
+      }
+    }
+  },
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "file": {
+      "type": "object",
+      "required": [
+        "path",
+        "url",
+        "size",
+        "sha256",
+        "contentType",
+        "cacheControl"
+      ],
+      "properties": {
+        "path": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^(?!/)(?!.*\\.\\.)[^\\\\]+$"
+        },
+        "url": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^(?!/)(?!.*\\.\\.)[^\\\\]+$"
+        },
+        "size": {
+          "type": "number",
+          "minimum": 0
+        },
+        "sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "contentType": {
+          "type": "string",
+          "minLength": 1
+        },
+        "cacheControl": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "channel": {
+      "type": "object",
+      "required": ["version", "digest", "publishedAt", "archive", "files"],
+      "properties": {
+        "version": {
+          "$ref": "#/$defs/sha256"
+        },
+        "digest": {
+          "$ref": "#/$defs/sha256"
+        },
+        "publishedAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "archive": {
+          "$ref": "#/$defs/file"
+        },
+        "files": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/file"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/integration/providers/games/particle/test_provider.py
+++ b/tests/integration/providers/games/particle/test_provider.py
@@ -1,0 +1,101 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Integration tests for the Particle Provider"""
+
+import json
+import pytest
+
+from httpx import AsyncClient, Request, Response
+from pytest_mock import MockerFixture
+from typing import cast
+from unittest.mock import patch, AsyncMock
+
+from merino.providers.games.particle.backends.particle import ParticleBackend
+from merino.providers.games.particle.provider import Provider
+
+
+@pytest.fixture(name="manifest_json_raw_str")
+def fixture_manifest_json_raw_str() -> str:
+    """Return Particle's manifest payload as a raw JSON string, mimicing actual HTTP response."""
+    with open("tests/data/games/particle/runtime-manifest.v1.json") as f:
+        return f.read()
+
+
+@pytest.fixture(name="manifest_validation_schema")
+def fixture_manifest_validation_schema():
+    """Load the JSON schema used to validate the manifest."""
+    with open("tests/data/games/particle/manifest-validation-schema.json") as f:
+        return json.load(f)
+
+
+@pytest.fixture(name="particle_backend")
+def fixture_particle_backend(
+    mocker: MockerFixture,
+    statsd_mock,
+) -> ParticleBackend:
+    """Create a particle backend with a mocked http_client intended to simulate fetching data from particle"""
+    return ParticleBackend(
+        gcs_uploader=mocker.MagicMock(),
+        http_client=mocker.AsyncMock(spec=AsyncClient),
+        manifest_gcs_file_name="runtime-manifest.v1.json",
+        metrics_client=statsd_mock,
+        particle_url_root="https://test.test/",
+        particle_url_path_manifest="manifest.json",
+        remote_file_manager=mocker.MagicMock(),
+    )
+
+
+@pytest.fixture(name="particle_provider")
+def fixture_particle_provider(
+    particle_backend, manifest_json_raw_str, manifest_validation_schema, statsd_mock
+):
+    """Create a particle provider with a custom happy path response on the backend's http_client"""
+    # customize response from the backend http client to mimic a successful
+    # response from particle
+    client_mock: AsyncMock = cast(AsyncMock, particle_backend.http_client)
+
+    client_mock.get.side_effect = [
+        Response(
+            status_code=200,
+            content=manifest_json_raw_str.encode("utf-8"),
+            headers={"content-type": "application/json"},
+            request=Request(
+                method="GET",
+                url=("https://test.test"),
+            ),
+        )
+    ]
+
+    return Provider(
+        backend=particle_backend,
+        cron_interval_sec=60,
+        manifest_schema=manifest_validation_schema,
+        manifest_schema_version=1,
+        metrics_client=statsd_mock,
+        name="particle",
+        resync_interval_sec=120,
+        enabled=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_game_data_successfully_processes_valid_remote_data(particle_provider) -> None:
+    """Test that fetching valid manifest data from particle succeeds"""
+    with patch.object(
+        particle_provider, "process_remote_particle_data", new=AsyncMock()
+    ) as mock_process_remote_data:
+        mock_process_remote_data.return_value = True
+
+        # verify last update is at the default value
+        assert particle_provider.last_successful_update_at == 0.0
+
+        await particle_provider._fetch_game_data()
+
+        # _fetch_game_data should have successfully run, updating the last update time
+        assert particle_provider.last_successful_update_at > 0.0
+
+        # a successful fetch should result in process_remote_particle_data
+        # being called
+        mock_process_remote_data.assert_awaited_once()

--- a/tests/unit/providers/games/particle/backends/test_filemanager.py
+++ b/tests/unit/providers/games/particle/backends/test_filemanager.py
@@ -173,5 +173,5 @@ def test_get_remote_file_error(
     particle_remote_filemanager.gcs_client = MagicMock()
     particle_remote_filemanager.gcs_client.get_file_by_name.side_effect = Exception("Test error")
 
-    result = particle_remote_filemanager.get_manifest_file()
-    assert result is None
+    with pytest.raises(ParticleFileManagerError):
+        particle_remote_filemanager.get_manifest_file()

--- a/tests/unit/providers/games/particle/backends/test_utils.py
+++ b/tests/unit/providers/games/particle/backends/test_utils.py
@@ -13,11 +13,14 @@ from jsonschema import exceptions
 from pydantic import Json
 from pytest import LogCaptureFixture
 from typing import Any
+from unittest.mock import patch
 
 from merino.configs import settings
 from merino.providers.games.particle.backends.utils import (
-    remote_manifest_daily_is_updated,
+    remote_manifest_puzzle_is_updated,
     remote_manifest_runtime_is_updated,
+    update_files_puzzle,
+    update_files_runtime,
     validate_manifest_schema_version,
     validate_manifest_against_schema,
 )
@@ -50,8 +53,26 @@ def invalid_manifest_data():
 @pytest.fixture()
 def manifest_schema_data():
     """Retrieve manifest schema JSON."""
-    with open("merino/data/providers/games/particle/runtime-manifest.v1.schema.json") as f:
+    with open("tests/data/games/particle/manifest-validation-schema.json") as f:
         return json.load(f)
+
+
+@pytest.fixture
+def mock_remote_manifest_puzzle_is_updated():
+    """Return mock remote_manifest_puzzle_is_updated function"""
+    with patch(
+        "merino.providers.games.particle.backends.utils.remote_manifest_puzzle_is_updated"
+    ) as mock_remote_manifest_puzzle_is_updated:
+        yield mock_remote_manifest_puzzle_is_updated
+
+
+@pytest.fixture
+def mock_remote_manifest_runtime_is_updated():
+    """Return mock remote_manifest_runtime_is_updated function"""
+    with patch(
+        "merino.providers.games.particle.backends.utils.remote_manifest_runtime_is_updated"
+    ) as mock_remote_manifest_runtime_is_updated:
+        yield mock_remote_manifest_runtime_is_updated
 
 
 # END FIXTURES
@@ -103,7 +124,7 @@ def test_validate_manifest_schema_version_raises_with_invalid_schema_version(
 
     # verify expected error was logged
     assert len(error_records) == 1
-    assert "Schema version mismatch when validating manifest JSON" in error_records[0].message
+    assert "Error validating Particle manifest schema version" in error_records[0].message
 
 
 def test_validate_manifest_schema_version_raises_with_no_schema_version_in_json(
@@ -126,7 +147,7 @@ def test_validate_manifest_schema_version_raises_with_no_schema_version_in_json(
     assert (
         "JSON key error retrieving 'schemaVersion' from manifest JSON." == error_records[0].message
     )
-    assert "Schema version mismatch when validating manifest JSON" in error_records[1].message
+    assert "Error validating Particle manifest schema version" in error_records[1].message
 
 
 # END validate_manifest_schema_version TESTS
@@ -183,11 +204,71 @@ def test_remote_manifest_daily_is_updated_was_updated(
     valid_manifest_data, valid_manifest_data_remote_updated
 ):
     """Test that comparing an old manifest to a new results in an updated signal"""
-    assert remote_manifest_daily_is_updated(
+    assert remote_manifest_puzzle_is_updated(
         valid_manifest_data_remote_updated, valid_manifest_data
     )
 
 
 def test_remote_manifest_daily_is_updated_was_not_updated(valid_manifest_data):
     """Test that comparing the same manifest results in a not updated signal"""
-    assert not remote_manifest_daily_is_updated(valid_manifest_data, valid_manifest_data)
+    assert not remote_manifest_puzzle_is_updated(valid_manifest_data, valid_manifest_data)
+
+
+# BEGIN update_files_puzzle TESTS
+@pytest.mark.asyncio
+async def test_update_files_puzzle_should_update_with_gcs_data(
+    valid_manifest_data, mock_remote_manifest_puzzle_is_updated
+):
+    """Test that puzzle files are updated if gcs data exists and versions mismatch"""
+    mock_remote_manifest_puzzle_is_updated.return_value = True
+
+    assert await update_files_puzzle(valid_manifest_data, valid_manifest_data)
+
+
+@pytest.mark.asyncio
+async def test_update_files_puzzle_should_not_update_with_gcs_data(
+    valid_manifest_data, mock_remote_manifest_puzzle_is_updated
+):
+    """Test that puzzle files are not updated if gcs data exists and versions match"""
+    mock_remote_manifest_puzzle_is_updated.return_value = False
+
+    assert not await update_files_puzzle(valid_manifest_data, valid_manifest_data)
+
+
+@pytest.mark.asyncio
+async def test_update_files_puzzle_should_update_without_gcs_data(valid_manifest_data):
+    """Test that puzzle files are updated if gcs data does not exist"""
+    assert await update_files_puzzle(valid_manifest_data, None)
+
+
+# END update_files_puzzle TESTS
+
+
+# BEGIN update_files_runtime TESTS
+@pytest.mark.asyncio
+async def test_update_files_runtime_should_update_with_gcs_data(
+    valid_manifest_data, mock_remote_manifest_runtime_is_updated
+):
+    """Test that runtime files are updated if gcs data exists and versions mismatch"""
+    mock_remote_manifest_runtime_is_updated.return_value = True
+
+    assert await update_files_runtime(valid_manifest_data, valid_manifest_data)
+
+
+@pytest.mark.asyncio
+async def test_update_files_runtime_should_not_update_with_gcs_data(
+    valid_manifest_data, mock_remote_manifest_runtime_is_updated
+):
+    """Test that runtime files are not updated if gcs data exists and versions match"""
+    mock_remote_manifest_runtime_is_updated.return_value = False
+
+    assert not await update_files_runtime(valid_manifest_data, valid_manifest_data)
+
+
+@pytest.mark.asyncio
+async def test_update_files_runtime_should_update_without_gcs_data(valid_manifest_data):
+    """Test that runtime files are updated if gcs data does not exist"""
+    assert await update_files_runtime(valid_manifest_data, None)
+
+
+# END update_files_runtime TESTS

--- a/tests/unit/providers/games/particle/backends/test_utils.py
+++ b/tests/unit/providers/games/particle/backends/test_utils.py
@@ -9,7 +9,6 @@ import logging
 import pytest
 
 from contextlib import nullcontext as does_not_raise
-from jsonschema import exceptions
 from pydantic import Json
 from pytest import LogCaptureFixture
 from typing import Any
@@ -17,6 +16,7 @@ from unittest.mock import patch
 
 from merino.configs import settings
 from merino.providers.games.particle.backends.utils import (
+    ParticleManifestValidationError,
     remote_manifest_puzzle_is_updated,
     remote_manifest_runtime_is_updated,
     update_files_puzzle,
@@ -131,7 +131,7 @@ def test_validate_manifest_schema_version_raises_with_no_schema_version_in_json(
     caplog: LogCaptureFixture, filter_caplog: Any
 ):
     """Verify missing schema version raises an exception."""
-    with pytest.raises(Exception):
+    with pytest.raises(ParticleManifestValidationError):
         validate_manifest_schema_version(
             json.loads('{"cremaVersion": 1}'), _manifest_schema_version
         )
@@ -169,7 +169,7 @@ def test_validate_manifest_against_schema_raises_with_invalid_json(
     filter_caplog: Any,
 ):
     """Verify expected error is raised if manifest JSON does not conform to the schema."""
-    with pytest.raises(exceptions.ValidationError):
+    with pytest.raises(ParticleManifestValidationError):
         validate_manifest_against_schema(invalid_manifest_data, manifest_schema_data)
 
     # get error records
@@ -200,7 +200,7 @@ def test_remote_manifest_runtime_is_updated_was_not_updated(valid_manifest_data)
     assert not remote_manifest_runtime_is_updated(valid_manifest_data, valid_manifest_data)
 
 
-def test_remote_manifest_daily_is_updated_was_updated(
+def test_remote_manifest_puzzle_is_updated_was_updated(
     valid_manifest_data, valid_manifest_data_remote_updated
 ):
     """Test that comparing an old manifest to a new results in an updated signal"""
@@ -209,7 +209,7 @@ def test_remote_manifest_daily_is_updated_was_updated(
     )
 
 
-def test_remote_manifest_daily_is_updated_was_not_updated(valid_manifest_data):
+def test_remote_manifest_puzzle_is_updated_was_not_updated(valid_manifest_data):
     """Test that comparing the same manifest results in a not updated signal"""
     assert not remote_manifest_puzzle_is_updated(valid_manifest_data, valid_manifest_data)
 

--- a/tests/unit/providers/games/particle/test_provider.py
+++ b/tests/unit/providers/games/particle/test_provider.py
@@ -5,6 +5,7 @@
 """Unit tests for the Particle games provider."""
 
 import asyncio
+import json
 import logging
 import pytest
 
@@ -31,6 +32,13 @@ def valid_manifest_data():
         return f.read()
 
 
+@pytest.fixture(name="manifest_validation_schema")
+def manifest_validation_schema():
+    """Load schema to validate manifest."""
+    with open("tests/data/games/particle/manifest-validation-schema.json") as f:
+        return json.load(f)
+
+
 @pytest.fixture(name="backend_mock")
 def fixture_backend_mock(mocker: MockerFixture):
     """Return a mock ParticleBackend."""
@@ -38,12 +46,14 @@ def fixture_backend_mock(mocker: MockerFixture):
 
 
 @pytest.fixture(name="provider")
-def fixture_provider(statsd_mock, backend_mock: ParticleBackend) -> Provider:
+def fixture_provider(
+    statsd_mock, backend_mock: ParticleBackend, manifest_validation_schema
+) -> Provider:
     """Return a Provider instance for testing."""
     return Provider(
         backend=backend_mock,
         cron_interval_sec=60,
-        manifest_schema="SomeJson",
+        manifest_schema=manifest_validation_schema,
         manifest_schema_version=1,
         metrics_client=statsd_mock,
         name="particle",
@@ -56,6 +66,51 @@ def fixture_provider(statsd_mock, backend_mock: ParticleBackend) -> Provider:
 def fixture_test_particle() -> Particle:
     """Return a test Particle instance."""
     return Particle(url=test_game_url)
+
+
+@pytest.fixture
+def mock_validate_schema():
+    """Return a mocked validate_manifest_against_schema function"""
+    with patch(
+        "merino.providers.games.particle.provider.validate_manifest_against_schema"
+    ) as mock_validate_schema:
+        yield mock_validate_schema
+
+
+@pytest.fixture
+def mock_validate_schema_version():
+    """Return a mocked validate_manifest_schema_version function"""
+    with patch(
+        "merino.providers.games.particle.provider.validate_manifest_schema_version"
+    ) as mock_validate_schema_version:
+        yield mock_validate_schema_version
+
+
+@pytest.fixture
+def mock_fetch_from_gcs(provider):
+    """Return a mocked fetch_manifest_json_from_gcs async function"""
+    with patch.object(
+        provider.backend, "fetch_manifest_json_from_gcs", new=AsyncMock()
+    ) as mock_fetch_from_gcs:
+        yield mock_fetch_from_gcs
+
+
+@pytest.fixture
+def mock_update_puzzle():
+    """Return a mocked update_files_puzzle async function"""
+    with patch(
+        "merino.providers.games.particle.provider.update_files_puzzle", new=AsyncMock()
+    ) as mock_update_puzzle:
+        yield mock_update_puzzle
+
+
+@pytest.fixture
+def mock_update_runtime():
+    """Return a mocked update_files_runtime async function"""
+    with patch(
+        "merino.providers.games.particle.provider.update_files_runtime", new=AsyncMock()
+    ) as mock_update_runtime:
+        yield mock_update_runtime
 
 
 def test_provider_name(provider: Provider) -> None:
@@ -229,6 +284,92 @@ async def test_fetch_game_data_remote_fetch_fails(
 
 
 @pytest.mark.asyncio
-async def test_process_remote_particle_data(provider, valid_manifest_data):
-    """Stub test for coverage - will be replaced when method body is implemented"""
+async def test_process_remote_particle_data_puzzle_and_runtime_updated(
+    provider,
+    valid_manifest_data,
+    mock_validate_schema,
+    mock_validate_schema_version,
+    mock_fetch_from_gcs,
+    mock_update_puzzle,
+    mock_update_runtime,
+):
+    """Assert process_remote_particle_data returns True and all expected functions are called when both puzzle and runtime files require updating"""
+    mock_update_puzzle.return_value = True
+    mock_update_runtime.return_value = True
+
     assert await provider.process_remote_particle_data(valid_manifest_data)
+
+    mock_validate_schema.assert_called_once()
+    mock_validate_schema_version.assert_called_once()
+    mock_fetch_from_gcs.assert_awaited_once()
+    mock_update_puzzle.assert_awaited_once()
+    mock_update_runtime.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_process_remote_particle_data_puzzle_updated(
+    provider,
+    valid_manifest_data,
+    mock_validate_schema,
+    mock_validate_schema_version,
+    mock_fetch_from_gcs,
+    mock_update_puzzle,
+    mock_update_runtime,
+):
+    """Assert process_remote_particle_data returns True and all expected functions are called when only puzzle files require updating"""
+    mock_update_puzzle.return_value = True
+    mock_update_runtime.return_value = False
+
+    assert await provider.process_remote_particle_data(valid_manifest_data)
+
+    mock_validate_schema.assert_called_once()
+    mock_validate_schema_version.assert_called_once()
+    mock_fetch_from_gcs.assert_awaited_once()
+    mock_update_puzzle.assert_awaited_once()
+    mock_update_runtime.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_process_remote_particle_data_runtime_updated(
+    provider,
+    valid_manifest_data,
+    mock_validate_schema,
+    mock_validate_schema_version,
+    mock_fetch_from_gcs,
+    mock_update_puzzle,
+    mock_update_runtime,
+):
+    """Assert process_remote_particle_data returns True and all expected functions are called when only runtime files require updating"""
+    mock_update_puzzle.return_value = False
+    mock_update_runtime.return_value = True
+
+    assert await provider.process_remote_particle_data(valid_manifest_data)
+
+    mock_validate_schema.assert_called_once()
+    mock_validate_schema_version.assert_called_once()
+    mock_fetch_from_gcs.assert_awaited_once()
+    mock_update_puzzle.assert_awaited_once()
+    mock_update_runtime.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_process_remote_particle_data_no_files_updated(
+    provider,
+    valid_manifest_data,
+    mock_validate_schema,
+    mock_validate_schema_version,
+    mock_fetch_from_gcs,
+    mock_update_puzzle,
+    mock_update_runtime,
+):
+    """Assert process_remote_particle_data returns False and all expected functions are called when no files require updating"""
+    mock_update_puzzle.return_value = False
+    mock_update_runtime.return_value = False
+
+    assert not await provider.process_remote_particle_data(valid_manifest_data)
+
+    mock_validate_schema.assert_called_once()
+    mock_validate_schema_version.assert_called_once()
+    mock_fetch_from_gcs.assert_awaited_once()
+    mock_update_puzzle.assert_awaited_once()
+    mock_update_runtime.assert_awaited_once()

--- a/tests/unit/providers/games/particle/test_provider.py
+++ b/tests/unit/providers/games/particle/test_provider.py
@@ -15,6 +15,7 @@ from pytest_mock import MockerFixture
 from tests.types import FilterCaplogFixture
 from unittest.mock import AsyncMock, patch
 
+from merino.providers.games.particle.backends.filemanager import ParticleFileManagerError
 from merino.providers.games.particle.backends.protocol import (
     Particle,
     ParticleBackend,
@@ -373,3 +374,25 @@ async def test_process_remote_particle_data_no_files_updated(
     mock_fetch_from_gcs.assert_awaited_once()
     mock_update_puzzle.assert_awaited_once()
     mock_update_runtime.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_process_remote_particle_data_gcs_fetch_raises(
+    provider,
+    valid_manifest_data,
+    mock_validate_schema,
+    mock_validate_schema_version,
+    mock_fetch_from_gcs,
+    mock_update_puzzle,
+    mock_update_runtime,
+):
+    """Assert process_remote_particle_data returns False and all expected functions are called when no files require updating"""
+    mock_fetch_from_gcs.side_effect = ParticleFileManagerError("GCS call failed")
+
+    assert not await provider.process_remote_particle_data(valid_manifest_data)
+
+    mock_validate_schema.assert_called_once()
+    mock_validate_schema_version.assert_called_once()
+    mock_fetch_from_gcs.assert_awaited_once()
+    mock_update_puzzle.assert_not_awaited()
+    mock_update_runtime.assert_not_awaited()


### PR DESCRIPTION
## References

JIRA: [HNT-2620](https://mozilla-hub.atlassian.net/browse/HNT-2620)

## Description

incremental update to lay out orchestration of processing remote particle files.

- update sentry calls to capture_exception

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2341)


[HNT-2620]: https://mozilla-hub.atlassian.net/browse/HNT-2620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ