### PR TITLE
AIMOD-1260 Fall back to Country ranking for non-interest cohorts in Canada Experiment

### DIFF
--- a/merino/curated_recommendations/ml_backends/gcs_interest_cohort_model.py
+++ b/merino/curated_recommendations/ml_backends/gcs_interest_cohort_model.py
@@ -128,9 +128,15 @@ class GcsInterestCohortModel(CohortModelBackend):
         We special case small country model because model is so simple
         """
         if model_id == SMALL_POPULATION_MODEL_ID:
-            return SMALL_POPULATION_MODEL_COHORT_LOOKUP.get(
+            cohort = SMALL_POPULATION_MODEL_COHORT_LOOKUP.get(
                 interests[:SMALL_POPULATION_MAX_CHARS], NO_CLICKS_COHORT_ID
             )
+
+            # Note this is a special case. No interest east cost is underperforming
+            # because it includes a lot of browsers with no clicks. Default to country
+            # cohort
+            if cohort == "4" and interests[:2] == "01":
+                return NO_CLICKS_COHORT_ID
 
         if self._model_id != model_id or self._model_id is None:
             return None

--- a/merino/curated_recommendations/ml_backends/gcs_interest_cohort_model.py
+++ b/merino/curated_recommendations/ml_backends/gcs_interest_cohort_model.py
@@ -20,6 +20,8 @@ DEFAULT_TARGET_COHORTS = 10
 DO_EMPTY_COHORT_FOR_NO_CLICKS = True
 NO_CLICKS_COHORT_ID = "-1"
 
+SMALL_POPULATION_EAST_COAST_TIME_ZONE = "01"
+
 SMALL_POPULATION_MAX_CHARS = 4
 SMALL_POPULATION_MODEL_COHORT_LOOKUP = {
     "0101": "1",
@@ -131,12 +133,12 @@ class GcsInterestCohortModel(CohortModelBackend):
             cohort = SMALL_POPULATION_MODEL_COHORT_LOOKUP.get(
                 interests[:SMALL_POPULATION_MAX_CHARS], NO_CLICKS_COHORT_ID
             )
-
             # Note this is a special case. No interest east cost is underperforming
             # because it includes a lot of browsers with no clicks. Default to country
             # cohort
-            if cohort == "4" and interests[:2] == "01":
-                return NO_CLICKS_COHORT_ID
+            if cohort == "4" and interests[:2] == SMALL_POPULATION_EAST_COAST_TIME_ZONE:
+                cohort = NO_CLICKS_COHORT_ID
+            return cohort
 
         if self._model_id != model_id or self._model_id is None:
             return None

--- a/tests/integration/api/v1/curated_recommendations/ml_backends/test_gcs_interest_cohort_model.py
+++ b/tests/integration/api/v1/curated_recommendations/ml_backends/test_gcs_interest_cohort_model.py
@@ -166,6 +166,20 @@ async def test_small_population_model(
         )
         == "4"
     )
+    assert (
+        model_provider.get_cohort_for_interests(
+            model_id=SMALL_POPULATION_MODEL_ID, interests="101010"
+        )
+        == "4"
+    )
+    # Special case - No interest, East coast time zone (last 2 chars) falls back
+    # to country model.
+    assert (
+        model_provider.get_cohort_for_interests(
+            model_id=SMALL_POPULATION_MODEL_ID, interests="101001"
+        )
+        == NO_CLICKS_COHORT_ID
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/integration/api/v1/curated_recommendations/ml_backends/test_gcs_interest_cohort_model.py
+++ b/tests/integration/api/v1/curated_recommendations/ml_backends/test_gcs_interest_cohort_model.py
@@ -162,6 +162,12 @@ async def test_small_population_model(
     )
     assert (
         model_provider.get_cohort_for_interests(
+            model_id=SMALL_POPULATION_MODEL_ID, interests="011001"
+        )
+        == "2"
+    )
+    assert (
+        model_provider.get_cohort_for_interests(
             model_id=SMALL_POPULATION_MODEL_ID, interests="1010"
         )
         == "4"


### PR DESCRIPTION
## References
https://mozilla-hub.atlassian.net/browse/AIMOD-1260

## Description
Inferred in Canada is mostly failing in the no-interest cohort for the eastern time zone. This cohort has the lowest interaction rates and performs better using thompson sampling data.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2343)
