### PR TITLE
[DISCO-4254] feat(wcs:query): update query string to use stage for tbd teams

### DIFF
--- a/merino/providers/suggest/sports/backends/sportsdata/common/tbd.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/tbd.py
@@ -1,0 +1,16 @@
+"""Predicate for the TBD placeholder team used in cached WCS events."""
+
+from typing import Any
+
+from merino.providers.suggest.sports.backends.sportsdata.common.wcs_elimination import (
+    TBD_TEAM_KEY,
+)
+
+
+def is_tbd_event_team(team: dict[str, Any]) -> bool:
+    """Return True for the compact placeholder team used in cached WCS events."""
+    try:
+        team_id = int(team.get("id", -1))
+    except TypeError, ValueError:
+        team_id = -1
+    return str(team.get("key", "")).upper() == TBD_TEAM_KEY and team_id == 0

--- a/merino/providers/suggest/sports/backends/sportsdata/protocol.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/protocol.py
@@ -15,6 +15,7 @@ from merino.providers.suggest.sports.backends.sportsdata.common.data import (
 from merino.providers.suggest.sports.backends.sportsdata.common.sports import (
     SPORT_CATEGORY_MAP,
 )
+from merino.providers.suggest.sports.backends.sportsdata.common.tbd import is_tbd_event_team
 from merino.utils.logos import get_logo_url, LogoCategory
 
 # Mapping of sport name from SportEventDetail
@@ -50,11 +51,24 @@ def build_query(event: dict[str, Any]) -> str:
         query_timezone: tzinfo = sportsdata_timezone_for_sport(event.get("sport", ""))
         date = event_date.astimezone(query_timezone).strftime("%d %B %Y")
     # catch pre-stored values
+    # Forked query string for WCS vs. other sports
     if event.get("sport", "").lower() == "fifa":
         sport_query_name = "World Cup 2026"
+        home_team = event.get("home_team")
+        away_team = event.get("away_team")
+        if (
+            home_team is None
+            or away_team is None
+            or is_tbd_event_team(home_team)
+            or is_tbd_event_team(away_team)
+        ):
+            return f"{event.get('stage', '')} {sport_query_name}"
+        # If it gets to this point these should be defined, but there is not
+        # type safety so we have to use fallbacks
+        return f"{event.get('home_team', {}).get('name', '')} vs {event.get('away_team', {}).get('name', '')} {sport_query_name}"
     else:
         sport_query_name = event.get("sport", "")
-    return f"""{sport_query_name} {event.get("home_team", {}).get("name", "")} vs {event.get("away_team", {}).get("name", "")} {date}"""
+        return f"""{sport_query_name} {event.get("home_team", {}).get("name", "")} vs {event.get("away_team", {}).get("name", "")} {date}"""
 
 
 class SportEventDetail(BaseModel):

--- a/merino/providers/wcs/protocol.py
+++ b/merino/providers/wcs/protocol.py
@@ -5,9 +5,7 @@ from typing import Any
 from pydantic import BaseModel, ConfigDict, Field, HttpUrl
 
 from merino.providers.suggest.sports.backends.sportsdata.common.data import Event, Team
-from merino.providers.suggest.sports.backends.sportsdata.common.wcs_elimination import (
-    TBD_TEAM_KEY,
-)
+from merino.providers.suggest.sports.backends.sportsdata.common.tbd import is_tbd_event_team
 from merino.providers.suggest.sports.backends.sportsdata.protocol import build_query
 from merino.providers.wcs.utils import get_team_colours
 from merino.utils.logos import LogoCategory, load_manifest
@@ -91,15 +89,6 @@ class TeamInfo(BaseModel):
         )
 
 
-def _is_tbd_event_team(team: dict[str, Any]) -> bool:
-    """Return True for the compact placeholder team used in cached WCS events."""
-    try:
-        team_id = int(team.get("id", -1))
-    except TypeError, ValueError:
-        team_id = -1
-    return str(team.get("key", "")).upper() == TBD_TEAM_KEY and team_id == 0
-
-
 class EventInfo(BaseModel):
     """A single match event."""
 
@@ -138,12 +127,12 @@ class EventInfo(BaseModel):
         """Build widget event info from a cached SportsData event."""
         home_team = (
             None
-            if _is_tbd_event_team(event.home_team)
+            if is_tbd_event_team(event.home_team)
             else TeamInfo.from_event_team(event.home_team, group=event.group)
         )
         away_team = (
             None
-            if _is_tbd_event_team(event.away_team)
+            if is_tbd_event_team(event.away_team)
             else TeamInfo.from_event_team(event.away_team, group=event.group)
         )
         updated = event.updated or event.date

--- a/tests/integration/api/v1/wcs/test_matches.py
+++ b/tests/integration/api/v1/wcs/test_matches.py
@@ -109,7 +109,7 @@ def test_matches_returns_nullable_tbd_sides(client: TestClient) -> None:
     assert body["current"][0]["home_team"] is None
     assert body["current"][0]["away_team"] is None
     assert body["current"][0]["stage"] == "Quarterfinals"
-    assert body["current"][0]["query"] == "World Cup 2026 TBD vs TBD 05 July 2026"
+    assert body["current"][0]["query"] == "Quarterfinals World Cup 2026"
 
 
 def test_invalid_date_returns_400(client: TestClient) -> None:

--- a/tests/unit/providers/suggest/sports/backends/test_sports_backend.py
+++ b/tests/unit/providers/suggest/sports/backends/test_sports_backend.py
@@ -420,19 +420,43 @@ def test_sport_event_detail_remap() -> None:  # WCS, Widget
 
     result = SportEventDetail.from_event_dict(event)
     assert result.sport == "World Cup"
-    assert result.query == "World Cup 2026 Home Team vs Away Team 01 October 2025"
+    assert result.query == "Home Team vs Away Team World Cup 2026"
 
 
-def test_build_query() -> None:
+@pytest.mark.parametrize(
+    "home_team_name,away_team_name,sport,stage,expected",
+    [
+        ("Home Team", "Away Team", "NFL", None, "NFL Home Team vs Away Team 01 October 2025"),
+        ("Switzerland", "Germany", "FIFA", "Group", "Switzerland vs Germany World Cup 2026"),
+        ("Japan", None, "FIFA", "Round of 16", "Round of 16 World Cup 2026"),
+        (None, None, "FIFA", "Round of 32", "Round of 32 World Cup 2026"),
+        ("South Korea", "TBD", "FIFA", "Semi-Finals", "Semi-Finals World Cup 2026"),
+        ("TBD", "TBD", "FIFA", "3rd Place", "3rd Place World Cup 2026"),
+    ],
+    ids=["NFL", "WCS", "WCS: None (one)", "WCS: None (both)", "WCS: TBD (one)", "WCS: TBD (both)"],
+)
+def test_build_query(home_team_name, away_team_name, sport, stage, expected) -> None:
     """build_query produces a 'sport away vs home date' string."""
     event: dict = {
-        "sport": "NFL",
+        "sport": sport,
         "date": "2025-10-01T16:00:00+00:00",
-        "home_team": {"name": "Home Team"},
-        "away_team": {"name": "Away Team"},
+        "home_team": {
+            "name": home_team_name,
+            "key": home_team_name,
+            "id": 0 if home_team_name == "TBD" else 123,
+        }
+        if home_team_name is not None
+        else None,
+        "away_team": {
+            "name": away_team_name,
+            "key": away_team_name,
+            "id": 0 if away_team_name == "TBD" else 345,
+        }
+        if away_team_name is not None
+        else None,
+        "stage": stage,
     }
-
-    assert build_query(event) == "NFL Home Team vs Away Team 01 October 2025"
+    assert build_query(event) == expected
 
 
 def test_build_query_uses_league_local_date() -> None:
@@ -463,19 +487,6 @@ def test_build_query_uses_source_day_for_scheduled_us_sports() -> None:
     assert build_query(event) == "NFL Fake Home vs Fake Away 26 October 2025"
 
 
-def test_build_query_uses_source_day_for_scheduled_world_cup() -> None:
-    """build_query uses the SportsData source day for WCS click-through queries."""
-    event: dict = {
-        "sport": "fifa",
-        "date": "2026-06-16T02:00:00+00:00",
-        "original_date": "2026-06-15T00:00:00",
-        "home_team": {"name": "IR Iran"},
-        "away_team": {"name": "New Zealand"},
-    }
-
-    assert build_query(event) == "World Cup 2026 IR Iran vs New Zealand 15 June 2026"
-
-
 def test_sport_summary_current_suppresses_previous_and_keeps_next() -> None:
     """SportSummary returns current and next events when both are available."""
 
@@ -501,19 +512,6 @@ def test_sport_summary_current_suppresses_previous_and_keeps_next() -> None:
     )
 
     assert [value.status_type for value in summary.values] == ["live", "scheduled"]
-
-
-def test_build_query_world_cup() -> None:
-    """build_query uses World Cup 2026 prefix for games"""
-    event: dict = {
-        "sport": "fifa",
-        "date": "2026-06-15T02:00:00+00:00",
-        "home_team": {"name": "Home Team"},
-        "away_team": {"name": "Away Team"},
-    }
-
-    assert build_query(event) == "World Cup 2026 Home Team vs Away Team 15 June 2026"
-    assert event["sport"] == "fifa"
 
 
 def test_sport_event_detail_icon_set_when_team_in_manifest(

--- a/tests/unit/providers/wcs/test_protocol.py
+++ b/tests/unit/providers/wcs/test_protocol.py
@@ -12,7 +12,8 @@ from merino.providers.suggest.sports.backends.sportsdata.common import GameStatu
 from merino.providers.suggest.sports.backends.sportsdata.common.wcs_elimination import (
     TBD_TEAM_KEY,
 )
-from merino.providers.wcs.protocol import EventInfo, TeamInfo, _is_tbd_event_team
+from merino.providers.suggest.sports.backends.sportsdata.common.tbd import is_tbd_event_team
+from merino.providers.wcs.protocol import EventInfo, TeamInfo
 from merino.utils.logos import LogoCategory, LogoManifest
 from tests.wcs.factories import event
 
@@ -20,7 +21,7 @@ MakeManifest = Callable[..., LogoManifest]
 
 
 def test_event_info_from_event_builds_world_cup_query() -> None:
-    """`query` uses the World Cup 2026 prefix and date string."""
+    """`query` uses the World Cup 2026 suffix without game date"""
     e = event(
         event_id=1,
         day_offset=0,
@@ -32,8 +33,7 @@ def test_event_info_from_event_builds_world_cup_query() -> None:
 
     info = EventInfo.from_event(e)
 
-    expected_date = e.date.strftime("%d %B %Y")
-    assert info.query == f"World Cup 2026 Brazil vs Argentina {expected_date}"
+    assert info.query == "Brazil vs Argentina World Cup 2026"
 
 
 def test_event_info_from_event_uses_source_day_for_world_cup_query() -> None:
@@ -51,7 +51,7 @@ def test_event_info_from_event_uses_source_day_for_world_cup_query() -> None:
     info = EventInfo.from_event(e)
 
     assert info.date == "2026-06-16T02:00:00+00:00"
-    assert info.query == "World Cup 2026 IR Iran vs New Zealand 15 June 2026"
+    assert info.query == "IR Iran vs New Zealand World Cup 2026"
 
 
 def test_team_info_icon_url_can_be_none_when_logo_is_missing(
@@ -83,7 +83,7 @@ def test_team_info_icon_url_uses_png_when_svg_is_missing(
 
 def test_is_tbd_event_team_ignores_malformed_placeholder_id() -> None:
     """A malformed placeholder id is not treated as an undecided bracket side."""
-    assert _is_tbd_event_team({"key": TBD_TEAM_KEY, "id": "bad"}) is False
+    assert is_tbd_event_team({"key": TBD_TEAM_KEY, "id": "bad"}) is False
 
 
 def test_event_info_from_event_builds_tbd_world_cup_query() -> None:
@@ -103,7 +103,7 @@ def test_event_info_from_event_builds_tbd_world_cup_query() -> None:
 
     assert info.home_team is None
     assert info.away_team is None
-    assert info.query == "World Cup 2026 TBD vs TBD 05 July 2026"
+    assert info.query == "Quarterfinals World Cup 2026"
 
 
 def test_event_info_from_event_serializes_one_tbd_side_as_null() -> None:
@@ -124,7 +124,7 @@ def test_event_info_from_event_serializes_one_tbd_side_as_null() -> None:
     assert info.home_team is not None
     assert info.home_team.name == "Sweden"
     assert info.away_team is None
-    assert info.query == "World Cup 2026 Sweden vs TBD 05 July 2026"
+    assert info.query == "Quarterfinals World Cup 2026"
 
 
 def test_event_info_from_event_includes_stage() -> None:

--- a/tests/unit/providers/wcs/test_provider.py
+++ b/tests/unit/providers/wcs/test_provider.py
@@ -177,7 +177,7 @@ async def test_matches_include_nullable_tbd_teams() -> None:
     assert event.home_team is None
     assert event.away_team is None
     assert event.stage == "Quarterfinals"
-    assert event.query == "World Cup 2026 TBD vs TBD 05 July 2026"
+    assert event.query == "Quarterfinals World Cup 2026"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## References

JIRA: [DISCO-4254]

## Description

Update query string to use stage for tbd teams, and remove game date from query

So "World Cup Mexico vs Japan 11 July 2026" becomes "Mexico vs Japan World Cup 2026"
and "World Cup TBD vs TBD 11 July 2026" becomes "Round of 32 World Cup 2026" (note -- this SERP will have dupes because it most likely applies to multiple games)

Move is_tbd_team method to own file to avoid
circular import issue with wcs provider and sports


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2344)


[DISCO-4254]: https://mozilla-hub.atlassian.net/browse/DISCO-4254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ