### PR TITLE
[DISCO-4250] Reduce Query Normalization Unit Test Runtime

### DIFF
--- a/tests/unit/query_normalization/conftest.py
+++ b/tests/unit/query_normalization/conftest.py
@@ -16,32 +16,35 @@ from merino.utils.query_processing.normalization.pipeline import (
 _DATA_DIR = Path(__file__).parent.parent.parent / "data" / "query_normalization"
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(scope="session", autouse=True)
 def _load_wordsegment() -> None:
-    """Ensure wordsegment tables are loaded for all tests."""
+    """Load wordsegment once; stub reloads since load() re-parses ~10MB each call."""
     wordsegment.load()
+    wordsegment.load = lambda: None  # type: ignore[assignment]
+    wordsegment._segmenter.load = lambda: None  # type: ignore[assignment]
+
+
+@pytest.fixture(scope="session", name="_canonical_base")
+def fixture_canonical_base() -> set[str]:
+    """Load the canonical set once per session. Treat as read-only."""
+    base: set[str] = set()
+    sports = json.loads((_DATA_DIR / "sports_teams.json").read_text())
+    base.update(sports)
+    fin = json.loads((_DATA_DIR / "finance_tickers.json").read_text())
+    base.update(fin.get("keyword_to_stock_ticker", {}).keys())
+    base.update(fin.get("keyword_to_etf_tickers", {}).keys())
+    return base
 
 
 @pytest.fixture(name="canonical")
-def fixture_canonical() -> set[str]:
-    """Build canonical set from test data."""
-    canonical: set[str] = set()
-
-    # Sports teams
-    sports = json.loads((_DATA_DIR / "sports_teams.json").read_text())
-    canonical.update(sports)
-
-    # Finance keywords
-    fin = json.loads((_DATA_DIR / "finance_tickers.json").read_text())
-    canonical.update(fin.get("keyword_to_stock_ticker", {}).keys())
-    canonical.update(fin.get("keyword_to_etf_tickers", {}).keys())
-
-    return canonical
+def fixture_canonical(_canonical_base: set[str]) -> set[str]:
+    """Return a fresh per-test copy of the canonical set (some tests mutate it)."""
+    return set(_canonical_base)
 
 
-@pytest.fixture(name="finance_bm25")
+@pytest.fixture(scope="session", name="finance_bm25")
 def fixture_finance_bm25() -> BM25Index:
-    """Build finance BM25 index from test data."""
+    """Build finance BM25 index once per session."""
     fin = json.loads((_DATA_DIR / "finance_tickers.json").read_text())
     keywords = list(
         {
@@ -52,9 +55,9 @@ def fixture_finance_bm25() -> BM25Index:
     return BM25Index(keywords)
 
 
-@pytest.fixture(name="prefix_index")
+@pytest.fixture(scope="session", name="prefix_index")
 def fixture_prefix_index() -> dict[str, tuple[str, int, int]]:
-    """Build prefix index from test word_freq.csv."""
+    """Build prefix index once per session."""
     vocab: dict[str, int] = {}
     with open(_DATA_DIR / "word_freq.csv") as f:
         reader = csv.DictReader(f)
@@ -63,15 +66,15 @@ def fixture_prefix_index() -> dict[str, tuple[str, int, int]]:
     return build_prefix_index(vocab)
 
 
-@pytest.fixture(name="pipeline")
+@pytest.fixture(scope="session", name="pipeline")
 def fixture_pipeline(
-    canonical: set[str],
+    _canonical_base: set[str],
     finance_bm25: BM25Index,
     prefix_index: dict[str, tuple[str, int, int]],
 ) -> NormalizePipeline:
-    """Build a NormalizePipeline from test data."""
+    """Build a NormalizePipeline once per session."""
     return NormalizePipeline(
-        canonical=canonical,
+        canonical=set(_canonical_base),
         finance_bm25=finance_bm25,
         canonical_prefix_index=prefix_index,
     )

--- a/tests/unit/query_normalization/conftest.py
+++ b/tests/unit/query_normalization/conftest.py
@@ -20,8 +20,8 @@ _DATA_DIR = Path(__file__).parent.parent.parent / "data" / "query_normalization"
 def _load_wordsegment() -> None:
     """Load wordsegment once; stub reloads since load() re-parses ~10MB each call."""
     wordsegment.load()
-    wordsegment.load = lambda: None  # type: ignore[assignment]
-    wordsegment._segmenter.load = lambda: None  # type: ignore[assignment]
+    wordsegment.load = lambda: None
+    wordsegment._segmenter.load = lambda: None
 
 
 @pytest.fixture(scope="session", name="_canonical_base")


### PR DESCRIPTION
## References

JIRA: [DISCO-4250](https://mozilla-hub.atlassian.net/browse/DISCO-4250)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->
- This reduces the runtime of the query normalization unit test from `~26s` to `~2.5s`
- The issue was the wordsegment `load()` function was getting called every time because it was function scoped (now session scoped)


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2346)


[DISCO-4250]: https://mozilla-hub.atlassian.net/browse/DISCO-4250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ