### PR TITLE
[DISCO-4255] fix(wcs): add timing logs and only wait 5s for ES conn to close

### DIFF
--- a/merino/jobs/sportsdata_jobs/__init__.py
+++ b/merino/jobs/sportsdata_jobs/__init__.py
@@ -24,7 +24,7 @@ import copy
 import logging
 import typer
 import sys
-from time import time
+from time import monotonic, time
 from datetime import datetime, timedelta, timezone
 from httpx import AsyncClient
 from dynaconf.base import LazySettings
@@ -383,7 +383,14 @@ def update_and_cache_wcs():
             connect_timeout=sports_settings.get("connect_timeout"),
             read_timeout=sports_settings.get("read_timeout"),
         )
-        asyncio.run(wcs_provider.update_and_cache_wcs())
+        started = monotonic()
+        try:
+            asyncio.run(wcs_provider.update_and_cache_wcs())
+        finally:
+            logger.info(
+                "update-and-cache-wcs finished",
+                extra={"elapsed_sec": monotonic() - started},
+            )
     else:
         logger.error("Sports provider unavailable.")
 

--- a/merino/jobs/sportsdata_jobs/__init__.py
+++ b/merino/jobs/sportsdata_jobs/__init__.py
@@ -362,7 +362,7 @@ def update():  # pragma: no cover
 
 
 @cli.command("update-widget")
-def update_widget():
+def update_widget():  # pragma: no cover
     """Update widget based info"""
     if provider:
         asyncio.run(provider.update_widget())
@@ -371,7 +371,7 @@ def update_widget():
 
 
 @cli.command("update-and-cache-wcs")
-def update_and_cache_wcs():
+def update_and_cache_wcs():  # pragma: no cover
     """Update Elasticsearch data and refresh the widget cache for WCS (only)."""
     if store and cache:
         wcs_only_settings = copy.copy(sports_settings)

--- a/merino/providers/suggest/sports/backends/sportsdata/common/elastic.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/elastic.py
@@ -1,5 +1,6 @@
 """Store and retrieve Sports information from ElasticSearch"""
 
+import asyncio
 import json
 import logging
 
@@ -7,6 +8,7 @@ import logging
 from abc import abstractmethod, ABC
 from aiodogstatsd import Client as StatsDClient
 from datetime import datetime, timezone
+from time import monotonic
 from typing import Any, Final
 
 
@@ -289,12 +291,30 @@ class ElasticDataStore(ABC):
             )
 
     async def shutdown(self) -> None:
-        """Politely close the data connection. Not strictly required, but python
-        may complain.
+        """Politely close the data connection. Force-abandon if it exceeds 5s.
+
+        Elasticsearch keepalive sockets to a silently-dropped peer can stall
+        ``close()`` for the Linux TCP retransmit ladder (~2-5 min). The
+        ``wait_for`` bound caps that at 5s so the cron exits promptly.
         """
-        logging.getLogger(__name__).info(f"{LOGGING_TAG} closing...")
+        logger = logging.getLogger(__name__)
+        logger.info(f"{LOGGING_TAG} closing...")
         if self.client:  # pragma: no cover  "test called, but Mock prevents coverage detection"
-            await self.client.close()
+            started = monotonic()
+            try:
+                await asyncio.wait_for(self.client.close(), timeout=5.0)
+            except asyncio.TimeoutError:
+                logger.warning(
+                    f"{LOGGING_TAG} close exceeded 5s timeout; abandoning client",
+                    extra={"elapsed_sec": monotonic() - started},
+                )
+            else:
+                logger.info(
+                    f"{LOGGING_TAG} close complete",
+                    extra={"elapsed_sec": monotonic() - started},
+                )
+            finally:
+                self.client = None
 
     @abstractmethod
     def build_event_mappings(self, language_code: str) -> dict[str, Any]:

--- a/merino/providers/suggest/sports/backends/sportsdata/common/elastic.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/elastic.py
@@ -313,8 +313,6 @@ class ElasticDataStore(ABC):
                     f"{LOGGING_TAG} close complete",
                     extra={"elapsed_sec": monotonic() - started},
                 )
-            finally:
-                self.client = None
 
     @abstractmethod
     def build_event_mappings(self, language_code: str) -> dict[str, Any]:


### PR DESCRIPTION
## References

JIRA: [DISCO-4255]

## Description
Jobs are occasionally running for 2-5 minutes, which may result in holding up the next cron job. From the logs the job completes in several seconds and shutdown is invoked, but the k8s cron job still hangs around. Hypothesis is that it's related to connection close; stop waiting after 5 seconds.

This adds some timing (just in the logs for debugging and can be removed later; we already capture the actual cron uptime in metrics) and abandons the shutdown request after 5 seconds.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2349)


[DISCO-4255]: https://mozilla-hub.atlassian.net/browse/DISCO-4255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ