### PR TITLE
[DISCO-4117] chore: autoscale index replicas settings

### DIFF
--- a/merino/jobs/wikipedia_indexer/settings/v1.py
+++ b/merino/jobs/wikipedia_indexer/settings/v1.py
@@ -33,7 +33,7 @@ def get_suggest_mapping(analyzer_suffix: str) -> dict:
 FR_INDEX_SETTINGS: dict = {
     "refresh_interval": "-1",
     "number_of_shards": "1",  # <10gb
-    "index.auto_expand_replicas": "1-all",   # autoscale replicas so all nodes have a copy
+    "index.auto_expand_replicas": "1-all",  # autoscale replicas so all nodes have a copy
     "index.lifecycle.name": "frwiki_policy",
     "analysis": {
         "filter": {
@@ -112,7 +112,7 @@ FR_INDEX_SETTINGS: dict = {
 DE_INDEX_SETTINGS: dict = {
     "refresh_interval": "-1",
     "number_of_shards": "1",
-    "index.auto_expand_replicas": "1-all",   # autoscale replicas so all nodes have a copy
+    "index.auto_expand_replicas": "1-all",  # autoscale replicas so all nodes have a copy
     "index.lifecycle.name": "dewiki_policy",
     "analysis": {
         "filter": {
@@ -169,7 +169,7 @@ DE_INDEX_SETTINGS: dict = {
 EN_INDEX_SETTINGS: dict = {
     "refresh_interval": "-1",
     "number_of_shards": "1",
-    "index.auto_expand_replicas": "1-all",   # autoscale replicas so all nodes have a copy
+    "index.auto_expand_replicas": "1-all",  # autoscale replicas so all nodes have a copy
     "index.lifecycle.name": "enwiki_policy",
     "analysis": {
         "filter": {
@@ -266,7 +266,7 @@ EN_INDEX_SETTINGS: dict = {
 IT_INDEX_SETTINGS: dict = {
     "refresh_interval": "-1",
     "number_of_shards": "1",
-    "index.auto_expand_replicas": "1-all",   # autoscale replicas so all nodes have a copy
+    "index.auto_expand_replicas": "1-all",  # autoscale replicas so all nodes have a copy
     "index.lifecycle.name": "itwiki_policy",
     "analysis": {
         "filter": {
@@ -352,7 +352,7 @@ IT_INDEX_SETTINGS: dict = {
 PL_INDEX_SETTINGS: dict = {
     "refresh_interval": "-1",
     "number_of_shards": "1",
-    "index.auto_expand_replicas": "1-all",   # autoscale replicas so all nodes have a copy
+    "index.auto_expand_replicas": "1-all",  # autoscale replicas so all nodes have a copy
     "index.lifecycle.name": "plwiki_policy",
     "analysis": {
         "filter": {

--- a/merino/jobs/wikipedia_indexer/settings/v1.py
+++ b/merino/jobs/wikipedia_indexer/settings/v1.py
@@ -31,9 +31,9 @@ def get_suggest_mapping(analyzer_suffix: str) -> dict:
 
 
 FR_INDEX_SETTINGS: dict = {
-    "number_of_replicas": "1",
     "refresh_interval": "-1",
     "number_of_shards": "1",  # <10gb
+    "index.auto_expand_replicas": "1-all",   # autoscale replicas so all nodes have a copy
     "index.lifecycle.name": "frwiki_policy",
     "analysis": {
         "filter": {
@@ -110,9 +110,9 @@ FR_INDEX_SETTINGS: dict = {
 
 
 DE_INDEX_SETTINGS: dict = {
-    "number_of_replicas": "1",
     "refresh_interval": "-1",
     "number_of_shards": "1",
+    "index.auto_expand_replicas": "1-all",   # autoscale replicas so all nodes have a copy
     "index.lifecycle.name": "dewiki_policy",
     "analysis": {
         "filter": {
@@ -167,9 +167,9 @@ DE_INDEX_SETTINGS: dict = {
 }
 
 EN_INDEX_SETTINGS: dict = {
-    "number_of_replicas": "1",
     "refresh_interval": "-1",
     "number_of_shards": "1",
+    "index.auto_expand_replicas": "1-all",   # autoscale replicas so all nodes have a copy
     "index.lifecycle.name": "enwiki_policy",
     "analysis": {
         "filter": {
@@ -264,9 +264,9 @@ EN_INDEX_SETTINGS: dict = {
 
 
 IT_INDEX_SETTINGS: dict = {
-    "number_of_replicas": "1",
     "refresh_interval": "-1",
     "number_of_shards": "1",
+    "index.auto_expand_replicas": "1-all",   # autoscale replicas so all nodes have a copy
     "index.lifecycle.name": "itwiki_policy",
     "analysis": {
         "filter": {
@@ -350,9 +350,9 @@ IT_INDEX_SETTINGS: dict = {
 
 
 PL_INDEX_SETTINGS: dict = {
-    "number_of_replicas": "1",
     "refresh_interval": "-1",
     "number_of_shards": "1",
+    "index.auto_expand_replicas": "1-all",   # autoscale replicas so all nodes have a copy
     "index.lifecycle.name": "plwiki_policy",
     "analysis": {
         "filter": {

--- a/merino/providers/suggest/sports/backends/sportsdata/common/elastic.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/elastic.py
@@ -44,9 +44,9 @@ from merino.utils.metrics import ES_SEARCH_METRIC_NAME
 META_INDEX: str = "sports-meta"
 
 EN_INDEX_SETTINGS: dict = {
-    "number_of_replicas": "1",
     "refresh_interval": "-1",
     "number_of_shards": "2",
+    "index.auto_expand_replicas": "1-all",   # autoscale replicas so all nodes have a copy
     "index.lifecycle.name": "sports-en-policy",
     "analysis": {
         "filter": {

--- a/merino/providers/suggest/sports/backends/sportsdata/common/elastic.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/elastic.py
@@ -46,7 +46,7 @@ META_INDEX: str = "sports-meta"
 EN_INDEX_SETTINGS: dict = {
     "refresh_interval": "-1",
     "number_of_shards": "2",
-    "index.auto_expand_replicas": "1-all",   # autoscale replicas so all nodes have a copy
+    "index.auto_expand_replicas": "1-all",  # autoscale replicas so all nodes have a copy
     "index.lifecycle.name": "sports-en-policy",
     "analysis": {
         "filter": {


### PR DESCRIPTION

## References

JIRA: [DISCO-4117] (supporting)


## Description
Note: this will not do anything until the indices are rebuilt, and is mostly to prevent the explicit replica count from overriding index.auto_expand_replicas or erroring out if index.auto_expand_replicas is set. We can (or must, in the case of sports which doesn't auto-rebuild) update this mutable setting directly.

In the future, operational settings should be owned in terraform templates rather than app code.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-4117]: https://mozilla-hub.atlassian.net/browse/DISCO-4117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ