### PR TITLE
DISCO-4135: Adding load tests for wcs endpoints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,11 @@ load-tests:  ##  Run local execution of (Locust) load tests
 	docker compose \
       -f $(LOAD_TEST_DIR)/docker-compose.yml \
       -p merino-py-load-tests \
-      up --scale locust_worker=1
+      build locust_master
+	docker compose \
+      -f $(LOAD_TEST_DIR)/docker-compose.yml \
+      -p merino-py-load-tests \
+      up --force-recreate --no-build --scale locust_worker=1
 
 .PHONY: load-tests-clean
 load-tests-clean:  ##  Stop and remove containers and networks for load tests

--- a/docs/testing/load-tests.md
+++ b/docs/testing/load-tests.md
@@ -31,11 +31,17 @@ The following environment variables as well as
 `tests\load\docker-compose.yml`.
 Make sure any required API key is added but then not checked into source control.
 
-**WARNING**: if the `WIKIPEDIA__ES_API_KEY` is missing, the load tests will not execute.
+**WARNING**: if the `WIKIPEDIA__ES_API_KEY` is missing, the `MerinoUser` load tests will
+not execute. `WcsUser` runs do not require the Suggest bootstrap variables.
 
 | Environment Variable                             | Node(s)         | Description                                                                               |
 |--------------------------------------------------|-----------------|-------------------------------------------------------------------------------------------|
 | LOAD_TESTS__LOGGING_LEVEL                        | master & worker | Level for the logger in the load tests as an int (`10` for `DEBUG`, `20` for `INFO` etc.) |
+| LOAD_TESTS__WCS__HOST                            | master & worker | Default host for WCS-only load tests. Defaults to `https://merino.services.allizom.org`    |
+| LOAD_TESTS__WCS__DESKTOP_WEIGHT                  | master & worker | Relative weight for Firefox desktop User-Agent headers in WCS requests. Defaults to `1`    |
+| LOAD_TESTS__WCS__MOBILE_WEIGHT                   | master & worker | Relative weight for Firefox mobile User-Agent headers in WCS requests. Defaults to `1`     |
+| LOAD_TESTS__WCS__DATES                           | master & worker | Optional comma-separated WCS match dates. Defaults to local WCS schedule data              |
+| LOAD_TESTS__WCS__TEAM_KEYS                       | master & worker | Optional comma-separated WCS team keys. Defaults to local WCS team data                    |
 | MERINO_REMOTE_SETTINGS__SERVER                   | master & worker | Server URL of the Kinto instance containing suggestions                                   |
 | MERINO_REMOTE_SETTINGS__BUCKET                   | master & worker | Kinto bucket with the suggestions                                                         |
 | MERINO_REMOTE_SETTINGS__COLLECTION               | master & worker | Kinto collection with the suggestions                                                     |

--- a/tests/load/Dockerfile
+++ b/tests/load/Dockerfile
@@ -37,6 +37,9 @@ ENV PATH="${PYTHON_VENV}/bin:${PATH}"
 # Add locust as a non-root user
 RUN useradd --create-home locust
 WORKDIR /home/locust
+RUN ln -s /app/dev dev && \
+    ln -s /app/merino merino && \
+    ln -s /app/merino-common merino-common
 
 COPY ./tests/load/common ./tests/load/common
 COPY ./tests/load/data ./tests/load/data

--- a/tests/load/common/client_info.py
+++ b/tests/load/common/client_info.py
@@ -8,10 +8,16 @@
 
 # Examples for supported User-Agent header values
 DESKTOP_FIREFOX: list[str] = [
-    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:10.0) Gecko/20100101 Firefox/90.0"
-    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:10.0) Gecko/20100101 Firefox/91.0"
-    "Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0"
-    "Mozilla/5.0 (X11; Linux x86_64; rv:90.0) Gecko/20100101 Firefox/91.0"
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:10.0) Gecko/20100101 Firefox/90.0",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:10.0) Gecko/20100101 Firefox/91.0",
+    "Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0",
+    "Mozilla/5.0 (X11; Linux x86_64; rv:90.0) Gecko/20100101 Firefox/91.0",
+]
+
+MOBILE_FIREFOX: list[str] = [
+    "Mozilla/5.0 (Android 14; Mobile; rv:124.0) Gecko/124.0 Firefox/124.0",
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) "
+    "AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/124.0 Mobile/15E148 Safari/605.1.15",
 ]
 
 # Examples for supported Accept-Language header values

--- a/tests/load/docker-compose.yml
+++ b/tests/load/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   locust_master:
     image: locust

--- a/tests/load/locustfiles/locustfile.py
+++ b/tests/load/locustfiles/locustfile.py
@@ -13,18 +13,25 @@ import os
 import socket
 import struct
 from collections import defaultdict
+from importlib import resources
 from itertools import chain
 from random import choice, randint, sample
-from typing import Any
+from typing import Any, cast
 
 import faker
 from elasticsearch import ApiError, Elasticsearch, ElasticsearchWarning, TransportError
 from locust import HttpUser, events, task
 from locust.exception import StopUser
 from locust.runners import MasterRunner
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
+from merino.configs import settings
 from merino.curated_recommendations.corpus_backends.protocol import Topic
+from merino.curated_recommendations.protocol import (
+    CuratedRecommendationsRequest,
+    CuratedRecommendationsResponse,
+    Locale,
+)
 from merino.providers.manifest.backends.protocol import ManifestData
 from merino.providers.suggest.adm.backends.protocol import SegmentType
 from merino.providers.suggest.adm.backends.remotesettings import (
@@ -37,18 +44,13 @@ from merino.providers.suggest.top_picks.backends.top_picks import (
     TopPicksBackend,
     TopPicksError,
 )
+from merino.providers.wcs.protocol import LiveMatchesResponse, MatchesResponse, TeamsResponse
 from merino.utils.blocklists import TOP_PICKS_BLOCKLIST
+from merino.utils.http_client import create_http_client
+from merino.utils.icon_processor import IconProcessor
 from merino_common.utils.version import Version
 from merino.web.models_v1 import SuggestResponse
-from tests.load.common.client_info import DESKTOP_FIREFOX, LOCALES
-from merino.curated_recommendations.protocol import (
-    Locale,
-    CuratedRecommendationsRequest,
-    CuratedRecommendationsResponse,
-)
-from merino.utils.icon_processor import IconProcessor
-from merino.utils.http_client import create_http_client
-from merino.configs import settings
+from tests.load.common.client_info import DESKTOP_FIREFOX, LOCALES, MOBILE_FIREFOX
 
 # Type definitions
 KintoRecords = list[dict[str, Any]]
@@ -65,6 +67,10 @@ SUGGEST_API: str = "/api/v1/suggest"
 MANIFEST_API: str = "/api/v1/manifest"
 VERSION_API: str = "/__version__"
 CURATED_RECOMMENDATIONS_API = "/api/v1/curated-recommendations"
+WCS_MATCHES_API: str = "/api/v1/wcs/matches"
+WCS_LIVE_API: str = "/api/v1/wcs/live"
+WCS_TEAMS_API: str = "/api/v1/wcs/teams"
+WCS_DEFAULT_HOST: str = os.getenv("LOAD_TESTS__WCS__HOST", "https://merino.services.allizom.org")
 
 # Optional. A comma-separated list of any experiments or rollouts that are
 # affecting the client's Suggest experience
@@ -106,18 +112,115 @@ MERINO_REMOTE_SETTINGS__COLLECTION: str | None = os.getenv(
     "MERINO_REMOTE_SETTINGS__COLLECTION", os.getenv("KINTO__COLLECTION")
 )
 
+
+def _int_env(name: str, default: int) -> int:
+    raw_value = os.getenv(name)
+    if raw_value is None:
+        return default
+    try:
+        return int(raw_value)
+    except ValueError:
+        logger.warning("Invalid %s=%r; using %d.", name, raw_value, default)
+        return default
+
+
+WCS_DESKTOP_WEIGHT: int = _int_env("LOAD_TESTS__WCS__DESKTOP_WEIGHT", 1)
+WCS_MOBILE_WEIGHT: int = _int_env("LOAD_TESTS__WCS__MOBILE_WEIGHT", 1)
+
+
+def _comma_separated_env(name: str) -> list[str]:
+    raw_value = os.getenv(name)
+    if not raw_value:
+        return []
+    return [value.strip() for value in raw_value.split(",") if value.strip()]
+
+
+def _load_wcs_json(filename: str) -> list[dict[str, Any]]:
+    data_path = resources.files("merino.data").joinpath(filename)
+    with data_path.open() as data_file:
+        records = json.load(data_file)
+    if not isinstance(records, list):
+        raise ValueError(f"{filename} must contain a list")
+    return cast(list[dict[str, Any]], records)
+
+
+def _load_wcs_dates() -> list[str]:
+    override_dates = _comma_separated_env("LOAD_TESTS__WCS__DATES")
+    if override_dates:
+        return override_dates
+
+    try:
+        records = _load_wcs_json("wcs_schedule.json")
+    except (OSError, ValueError) as exc:
+        logger.warning("Could not load local WCS schedule data: %s", exc)
+        return ["2026-06-15"]
+
+    dates = sorted(
+        {str(record["Day"]).split("T", maxsplit=1)[0] for record in records if record.get("Day")}
+    )
+    return dates or ["2026-06-15"]
+
+
+def _load_wcs_team_keys() -> list[str]:
+    override_team_keys = _comma_separated_env("LOAD_TESTS__WCS__TEAM_KEYS")
+    if override_team_keys:
+        return [team_key.upper() for team_key in override_team_keys]
+
+    try:
+        records = _load_wcs_json("wcs_teams.json")
+    except (OSError, ValueError) as exc:
+        logger.warning("Could not load local WCS team data: %s", exc)
+        return ["BRA", "USA", "MEX", "ARG"]
+
+    team_keys = sorted({str(record["Key"]).upper() for record in records if record.get("Key")})
+    return team_keys or ["BRA", "USA", "MEX", "ARG"]
+
+
+def _desktop_headers() -> dict[str, str]:
+    return {
+        "Accept-Language": choice(LOCALES),  # nosec
+        "User-Agent": choice(DESKTOP_FIREFOX),  # nosec
+    }
+
+
+def _wcs_headers() -> dict[str, str]:
+    desktop_weight = max(WCS_DESKTOP_WEIGHT, 0)
+    mobile_weight = max(WCS_MOBILE_WEIGHT, 0)
+    total_weight = desktop_weight + mobile_weight
+    user_agents = DESKTOP_FIREFOX
+    if total_weight > 0 and randint(1, total_weight) > desktop_weight:  # nosec
+        user_agents = MOBILE_FIREFOX
+
+    return {
+        "Accept-Language": choice(LOCALES),  # nosec
+        "User-Agent": choice(user_agents),  # nosec
+    }
+
+
+def _should_download_query_data(environment) -> bool:
+    user_classes = getattr(environment, "user_classes", [])
+    return not user_classes or any(
+        user_class.__name__ == "MerinoUser" for user_class in user_classes
+    )
+
+
 # This will be populated on each worker
 ADM_QUERIES: QueriesList = []
 AMO_QUERIES: list[str] = []
 IP_RANGES: IpRangeList = []
 TOP_PICKS_QUERIES: QueriesList = []
 WIKIPEDIA_QUERIES: list[str] = []
+WCS_DATES: list[str] = _load_wcs_dates()
+WCS_TEAM_KEYS: list[str] = _load_wcs_team_keys()
 
 
 @events.test_start.add_listener
 async def on_locust_test_start(environment, **kwargs) -> None:
     """Download suggestions from Kinto and store suggestions on workers."""
     if not isinstance(environment.runner, MasterRunner):
+        return
+    if not _should_download_query_data(environment):
+        logger.info("Skipping Suggest query data download for WCS-only load test.")
         return
 
     query_data: QueryData = QueryData()
@@ -353,7 +456,31 @@ class QueryData(BaseModel):
     wikipedia: list[str] = []
 
 
-class MerinoUser(HttpUser):
+class _MerinoBaseUser(HttpUser):
+    """Shared behavior for Merino Locust users."""
+
+    abstract = True
+
+    def _request_version(self, headers: dict[str, str] | None = None) -> Version | None:
+        """Request version information from Merino.
+
+        Returns:
+            Version | None: Merino version information or None
+        Raises:
+            ValidationError: Response data is not as expected.
+        """
+        with self.client.get(
+            url=VERSION_API,
+            headers=headers or _desktop_headers(),
+            catch_response=True,
+        ) as response:
+            if response.status_code != 200:
+                response.failure(f"{response.status_code=}, expected 200, {response.text=}")
+                return None
+            return Version(**response.json())
+
+
+class MerinoUser(_MerinoBaseUser):
     """User that sends requests to the Merino API."""
 
     def on_start(self) -> Any:
@@ -615,20 +742,96 @@ class MerinoUser(HttpUser):
             # fields which will be reported as a failure in Locust's statistics.
             SuggestResponse(**response.json())
 
-    def _request_version(self) -> Version | None:
-        """Request version information from Merino.
 
-        Returns:
-            Version | None: Merino version information or None
-        Raises:
-            ValidationError: Response data is not as expected.
+class WcsUser(_MerinoBaseUser):
+    """User that sends requests to the Merino WCS API."""
+
+    host = WCS_DEFAULT_HOST
+
+    def on_start(self) -> Any:
+        """Instructions to execute for each simulated WCS user when they start."""
+        version: Version | None = self._request_version(headers=_wcs_headers())
+        if not version:
+            logger.error(
+                "The Merino version information was unavailable. Verify that "
+                "the Merino 'Host' is reachable."
+            )
+            raise StopUser()
+        logger.debug(f"WCS user will execute queries against Merino: {version.commit}")
+        logger.debug(
+            "WCS user will send queries based on %d dates and %d team keys.",
+            len(WCS_DATES),
+            len(WCS_TEAM_KEYS),
+        )
+
+        return super().on_start()
+
+    @task(weight=80)
+    def wcs_matches(self) -> None:
+        """Send a request for WCS matches."""
+        params: dict[str, Any] = {"date": choice(WCS_DATES)}  # nosec
+        if randint(1, 100) <= 15:  # nosec
+            params["teams"] = self._sample_wcs_team_keys()
+        if randint(1, 100) <= 10:  # nosec
+            params["limit"] = randint(1, 5)  # nosec
+
+        self._request_wcs(WCS_MATCHES_API, MatchesResponse, params=params)
+
+    @task(weight=15)
+    def wcs_live(self) -> None:
+        """Send a request for live WCS matches."""
+        params: dict[str, Any] | None = None
+        if randint(1, 100) <= 20:  # nosec
+            params = {"teams": self._sample_wcs_team_keys()}
+
+        self._request_wcs(WCS_LIVE_API, LiveMatchesResponse, params=params)
+
+    @task(weight=5)
+    def wcs_teams(self) -> None:
+        """Send a request for WCS team metadata."""
+        self._request_wcs(WCS_TEAMS_API, TeamsResponse)
+
+    @staticmethod
+    def _sample_wcs_team_keys() -> str:
+        sample_size = min(randint(1, 2), len(WCS_TEAM_KEYS))  # nosec
+        return ",".join(sample(WCS_TEAM_KEYS, sample_size))
+
+    def _request_wcs(
+        self,
+        url: str,
+        response_model: type[BaseModel],
+        params: dict[str, Any] | None = None,
+    ) -> None:
+        """Request WCS data from Merino and validate the response shape.
+
+        Args:
+            url: WCS endpoint path.
+            response_model: Pydantic model used to validate the response content.
+            params: Optional query parameters.
         """
-        headers: dict[str, str] = {
-            "Accept-Language": choice(LOCALES),  # nosec
-            "User-Agent": choice(DESKTOP_FIREFOX),  # nosec
-        }
-        with self.client.get(url=VERSION_API, headers=headers, catch_response=True) as response:
+        with self.client.get(
+            url=url,
+            params=params,
+            headers=_wcs_headers(),
+            catch_response=True,
+            name=url,
+        ) as response:
+            if response.status_code == 0:
+                # Do not classify as failure.
+                #
+                # 0: The HttpSession catches any requests.RequestException thrown by
+                #    Session (caused by connection errors, timeouts or similar), instead
+                #    returning a dummy Response object with status_code set to 0 and
+                #    content set to None.
+                logger.warning("Received a response with a status code of 0.")
+                response.success()
+                return
+
             if response.status_code != 200:
                 response.failure(f"{response.status_code=}, expected 200, {response.text=}")
-                return None
-            return Version(**response.json())
+                return
+
+            try:
+                response_model(**response.json())
+            except (TypeError, ValueError, ValidationError) as exc:
+                response.failure(f"Response validation failed for {url}: {exc}")


### PR DESCRIPTION
## References

JIRA: [DISCO-4135](https://mozilla-hub.atlassian.net/browse/DISCO-4135)

## Description
This PR also include some small fixes to be able to run the load tests with the new repo structure. And adds load tests for these endpoints:
* `/wcs/live`
* `/wcs/matches`
* `/wcs/teams`

In the locust UI, you have to select the WcsUser to be able to run the `/wcs` load tests.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2351)


[DISCO-4135]: https://mozilla-hub.atlassian.net/browse/DISCO-4135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ