### PR TITLE
[HNT-2626] chore: particle cleanup

### DIFF
--- a/merino/providers/games/particle/backends/particle.py
+++ b/merino/providers/games/particle/backends/particle.py
@@ -91,4 +91,6 @@ class ParticleBackend:
 
     async def fetch_manifest_json_from_gcs(self) -> Json | None:
         """Retrieve the manifest json last stored in GCS"""
+        # the gcp client library is synchronous - wrap in an async thread so
+        # we don't block processing
         return await asyncio.to_thread(self.remote_file_manager.get_manifest_file)

--- a/merino/providers/games/particle/backends/utils.py
+++ b/merino/providers/games/particle/backends/utils.py
@@ -61,7 +61,7 @@ def remote_manifest_puzzle_is_updated(manifest_remote: Json, manifest_gcs: Json)
     return bool(daily_remote != daily_gcs)
 
 
-async def update_files_puzzle(manifest_remote: Json, manifest_gcs: Json | None) -> bool:
+async def update_puzzle_files(manifest_remote: Json, manifest_gcs: Json | None) -> bool:
     """Attempt to update the daily puzzle files - partial stub, async operations to come"""
     should_update_puzzle = (
         remote_manifest_puzzle_is_updated(manifest_remote, manifest_gcs) if manifest_gcs else True
@@ -76,7 +76,7 @@ async def update_files_puzzle(manifest_remote: Json, manifest_gcs: Json | None) 
         return False
 
 
-async def update_files_runtime(manifest_remote: Json, manifest_gcs: Json | None) -> bool:
+async def update_runtime_files(manifest_remote: Json, manifest_gcs: Json | None) -> bool:
     """Attempt to update the runtime files - partial stub, async operations to come"""
     should_update_runtime = (
         remote_manifest_runtime_is_updated(manifest_remote, manifest_gcs) if manifest_gcs else True

--- a/merino/providers/games/particle/provider.py
+++ b/merino/providers/games/particle/provider.py
@@ -12,8 +12,8 @@ from typing import Any
 from merino.providers.games.particle.backends.filemanager import ParticleFileManagerError
 from merino.providers.games.particle.backends.protocol import Particle, ParticleBackend
 from merino.providers.games.particle.backends.utils import (
-    update_files_puzzle,
-    update_files_runtime,
+    update_puzzle_files,
+    update_runtime_files,
     validate_manifest_against_schema,
     validate_manifest_schema_version,
     ParticleManifestValidationError,
@@ -131,10 +131,10 @@ class Provider:
             return False
 
         # conditionally attempt to update file sets - daily puzzle and runtime
-        puzzle_updated = await update_files_puzzle(
+        puzzle_updated = await update_puzzle_files(
             manifest_remote=remote_manifest_json, manifest_gcs=gcs_manifest_json
         )
-        runtime_updated = await update_files_runtime(
+        runtime_updated = await update_runtime_files(
             manifest_remote=remote_manifest_json, manifest_gcs=gcs_manifest_json
         )
 

--- a/tests/unit/providers/games/particle/backends/test_filemanager.py
+++ b/tests/unit/providers/games/particle/backends/test_filemanager.py
@@ -27,151 +27,147 @@ from merino.providers.games.particle.backends.filemanager import (
 from merino.utils.gcs.gcs_uploader import GcsUploader
 
 
-@pytest.fixture(name="manifest_json")
-def fixture_manifest_json():
-    """Load manifest data from local file"""
-    with open("tests/data/games/particle/runtime-manifest.v1.json") as f:
-        return f.read()
+class TestLocalFileManager:
+    """Tests against the Particle LocalFileManager"""
+
+    @pytest.fixture(name="filemanager_parameters")
+    def fixture_filemanager_parameters(self) -> dict[str, Any]:
+        """Define ParticleLocalFileManager parameters for test."""
+        return {
+            "static_manifest_schema_file_path": settings.games_providers.particle.manifest_schema_file_path
+        }
+
+    @pytest.fixture(name="filemanager")
+    def fixture_particle_local_filemanager(
+        self,
+        filemanager_parameters: dict[str, Any],
+    ) -> ParticleLocalFileManager:
+        """Create a ParticleLocalFileManager object for test."""
+        return ParticleLocalFileManager(**filemanager_parameters)
+
+    def test_file_exists(self) -> None:
+        """Test that the Particle manifest schema file exists locally"""
+        assert os.path.exists(settings.games_providers.particle.manifest_schema_file_path)
+
+    def test_get_file(self, filemanager: ParticleLocalFileManager) -> None:
+        """Test that the JSON file containing the manifest schema can be processed"""
+        schema = filemanager.get_manifest_schema()
+        assert schema["title"] == "Client Runtime Manifest v1"
+        assert len(schema["properties"]["channels"]["properties"]) == 2
+
+    def test_get_file_json_decode_error(
+        self, filemanager: ParticleLocalFileManager, mocker
+    ) -> None:
+        """Test that the read function fails, raising ParticleFileManagerError when a
+        JSONDecodeError is captured.
+        """
+        mocker.patch("json.load", side_effect=JSONDecodeError("test", "json", 1))
+        with pytest.raises(ParticleFileManagerError):
+            filemanager.get_manifest_schema()
+
+    def test_get_file_os_error(self, filemanager: ParticleLocalFileManager, mocker) -> None:
+        """Test that the read function fails, raising ParticleFileManagerError when an
+        OSError is captured.
+        """
+        mocker.patch("json.load", side_effect=OSError("test", "json", 1))
+        with pytest.raises(ParticleFileManagerError):
+            filemanager.get_manifest_schema()
+
+    def test_get_file_invalid_path(self) -> None:
+        """Test that read domain fails and raises ParticleFileManagerError
+        exception with invalid file path.
+        """
+        test_path = ParticleLocalFileManager("./wrongfile.json")
+        with pytest.raises(ParticleFileManagerError):
+            test_path.get_manifest_schema()
 
 
-@pytest.fixture(name="manifest_gcs_blob_mock")
-def fixture_gcs_manifest_blob(mocker: MockerFixture, manifest_json: str) -> Any:
-    """Create a GCS Blob mock object for testing."""
-    mock_blob = mocker.MagicMock(spec=Blob)
-    mock_blob.name = "runtime-manifest.v1.json"
-    mock_blob.download_as_text.return_value = manifest_json
+class TestRemoteFileManager:
+    """Tests against Particle RemoteFileManager"""
 
-    return mock_blob
+    @pytest.fixture(name="manifest_json")
+    def fixture_manifest_json(self):
+        """Load manifest data from local file"""
+        with open("tests/data/games/particle/runtime-manifest.v1.json") as f:
+            return f.read()
 
+    @pytest.fixture(name="manifest_gcs_blob_mock")
+    def fixture_gcs_manifest_blob(self, mocker: MockerFixture, manifest_json: str) -> Any:
+        """Create a GCS Blob mock object for testing."""
+        mock_blob = mocker.MagicMock(spec=Blob)
+        mock_blob.name = "runtime-manifest.v1.json"
+        mock_blob.download_as_text.return_value = manifest_json
 
-@pytest.fixture(name="particle_local_filemanager_parameters")
-def fixture_particle_local_filemanager_parameters() -> dict[str, Any]:
-    """Define ParticleLocalFileManager parameters for test."""
-    return {
-        "static_manifest_schema_file_path": settings.games_providers.particle.manifest_schema_file_path
-    }
+        return mock_blob
 
+    @pytest.fixture(name="gcs_uploader_mock")
+    def fixture_gcs_uploader_mock(self, manifest_gcs_blob_mock) -> GcsUploader:
+        """Return a mock GcsUploader."""
+        mock = MagicMock(spec=GcsUploader)
+        mock.get_file_by_name.return_value = manifest_gcs_blob_mock
 
-@pytest.fixture(name="particle_local_filemanager")
-def fixture_particle_local_filemanager(
-    particle_local_filemanager_parameters: dict[str, Any],
-) -> ParticleLocalFileManager:
-    """Create a ParticleLocalFileManager object for test."""
-    return ParticleLocalFileManager(**particle_local_filemanager_parameters)
+        return mock
 
+    @pytest.fixture(name="filemanager_parameters")
+    def fixture_filemanager_parameters(self, gcs_uploader_mock) -> dict[str, Any]:
+        """Define ParticleRemoteFileManager parameters for test."""
+        return {"gcs_client": gcs_uploader_mock, "manifest_file_name": "test_file.json"}
 
-@pytest.fixture(name="gcs_uploader_mock")
-def fixture_gcs_uploader_mock(manifest_gcs_blob_mock) -> GcsUploader:
-    """Return a mock GcsUploader."""
-    mock = MagicMock(spec=GcsUploader)
-    mock.get_file_by_name.return_value = manifest_gcs_blob_mock
+    @pytest.fixture(name="filemanager")
+    def fixture_particle_remote_filemanager(
+        self,
+        filemanager_parameters: dict[str, Any],
+    ) -> ParticleRemoteFileManager:
+        """Create a ParticleRemoteFileManager object for test."""
+        with (
+            patch("google.auth.default") as mock_auth_default,
+        ):
+            creds = AnonymousCredentials()  # type: ignore
+            mock_auth_default.return_value = (creds, "test-project")
+            return ParticleRemoteFileManager(**filemanager_parameters)
 
-    return mock
+    def test_get_file(
+        self,
+        filemanager: ParticleRemoteFileManager,
+        caplog: LogCaptureFixture,
+        filter_caplog: FilterCaplogFixture,
+    ) -> None:
+        """Test that the Remote Filemanager get_manifest_file method returns manifest data."""
+        caplog.set_level(logging.INFO)
 
+        result = filemanager.get_manifest_file()
 
-@pytest.fixture(name="particle_remote_filemanager_parameters")
-def fixture_particle_remote_filemanager_parameters(gcs_uploader_mock) -> dict[str, Any]:
-    """Define ParticleRemoteFileManager parameters for test."""
-    return {"gcs_client": gcs_uploader_mock, "manifest_file_name": "test_file.json"}
+        records: list[LogRecord] = filter_caplog(
+            caplog.records, "merino.providers.games.particle.backends.filemanager"
+        )
 
+        # verify basic contents of manifest json
+        assert isinstance(result, dict)
+        assert result["schemaVersion"]
+        assert len(result["channels"]) == 2
 
-@pytest.fixture(name="particle_remote_filemanager")
-def fixture_particle_remote_filemanager(
-    particle_remote_filemanager_parameters: dict[str, Any],
-) -> ParticleRemoteFileManager:
-    """Create a ParticleRemoteFileManager object for test."""
-    with (
-        patch("google.auth.default") as mock_auth_default,
-    ):
-        creds = AnonymousCredentials()  # type: ignore
-        mock_auth_default.return_value = (creds, "test-project")
-        return ParticleRemoteFileManager(**particle_remote_filemanager_parameters)
+        # verify logging
+        assert len(records) == 1
+        assert records[0].message.startswith("Successfully loaded remote Particle manifest file.")
 
+    def test_get_remote_file_empty(
+        self,
+        filemanager: ParticleRemoteFileManager,
+    ) -> None:
+        """Test that the RemoteFileManager returns None when the call to GCS returns None."""
+        filemanager.gcs_client = MagicMock()
+        filemanager.gcs_client.get_file_by_name.return_value = None
 
-def test_local_file_exists() -> None:
-    """Test that the Particle manifest schema file exists locally"""
-    assert os.path.exists(settings.games_providers.particle.manifest_schema_file_path)
+        result = filemanager.get_manifest_file()
+        assert result is None
 
+    def test_get_remote_file_error(
+        self,
+        filemanager: ParticleRemoteFileManager,
+    ) -> None:
+        """Test that the RemoteFileManager returns None when the call to GCS fails."""
+        filemanager.gcs_client = MagicMock()
+        filemanager.gcs_client.get_file_by_name.side_effect = Exception("Test error")
 
-def test_get_local_file(particle_local_filemanager: ParticleLocalFileManager) -> None:
-    """Test that the JSON file containing the manifest schema can be processed"""
-    schema = particle_local_filemanager.get_manifest_schema()
-    assert schema["title"] == "Client Runtime Manifest v1"
-    assert len(schema["properties"]["channels"]["properties"]) == 2
-
-
-def test_local_filemanager_get_file_json_decode_error(
-    particle_local_filemanager: ParticleLocalFileManager, mocker
-) -> None:
-    """Test that the read function fails, raising ParticleFileManagerError when a
-    JSONDecodeError is captured.
-    """
-    mocker.patch("json.load", side_effect=JSONDecodeError("test", "json", 1))
-    with pytest.raises(ParticleFileManagerError):
-        particle_local_filemanager.get_manifest_schema()
-
-
-def test_local_filemanager_get_file_os_error(
-    particle_local_filemanager: ParticleLocalFileManager, mocker
-) -> None:
-    """Test that the read function fails, raising ParticleFileManagerError when an
-    OSError is captured.
-    """
-    mocker.patch("json.load", side_effect=OSError("test", "json", 1))
-    with pytest.raises(ParticleFileManagerError):
-        particle_local_filemanager.get_manifest_schema()
-
-
-def test_local_filemanager_get_file_invalid_path() -> None:
-    """Test that read domain fails and raises ParticleFileManagerError
-    exception with invalid file path.
-    """
-    test_path = ParticleLocalFileManager("./wrongfile.json")
-    with pytest.raises(ParticleFileManagerError):
-        test_path.get_manifest_schema()
-
-
-def test_get_remote_file(
-    particle_remote_filemanager: ParticleRemoteFileManager,
-    caplog: LogCaptureFixture,
-    filter_caplog: FilterCaplogFixture,
-) -> None:
-    """Test that the Remote Filemanager get_manifest_file method returns manifest data."""
-    caplog.set_level(logging.INFO)
-
-    result = particle_remote_filemanager.get_manifest_file()
-
-    records: list[LogRecord] = filter_caplog(
-        caplog.records, "merino.providers.games.particle.backends.filemanager"
-    )
-
-    # verify basic contents of manifest json
-    assert isinstance(result, dict)
-    assert result["schemaVersion"]
-    assert len(result["channels"]) == 2
-
-    # verify logging
-    assert len(records) == 1
-    assert records[0].message.startswith("Successfully loaded remote Particle manifest file.")
-
-
-def test_get_remote_file_empty(
-    particle_remote_filemanager: ParticleRemoteFileManager,
-) -> None:
-    """Test that the RemoteFileManager returns None when the call to GCS returns None."""
-    particle_remote_filemanager.gcs_client = MagicMock()
-    particle_remote_filemanager.gcs_client.get_file_by_name.return_value = None
-
-    result = particle_remote_filemanager.get_manifest_file()
-    assert result is None
-
-
-def test_get_remote_file_error(
-    particle_remote_filemanager: ParticleRemoteFileManager,
-) -> None:
-    """Test that the RemoteFileManager returns None when the call to GCS fails."""
-    particle_remote_filemanager.gcs_client = MagicMock()
-    particle_remote_filemanager.gcs_client.get_file_by_name.side_effect = Exception("Test error")
-
-    with pytest.raises(ParticleFileManagerError):
-        particle_remote_filemanager.get_manifest_file()
+        with pytest.raises(ParticleFileManagerError):
+            filemanager.get_manifest_file()

--- a/tests/unit/providers/games/particle/backends/test_particle_backend.py
+++ b/tests/unit/providers/games/particle/backends/test_particle_backend.py
@@ -75,7 +75,6 @@ def fixture_backend(
 # END FIXTURES
 
 
-# BEGIN get_game_url TESTS
 @pytest.mark.asyncio
 async def test_get_game_url_returns_correct_particle(backend: ParticleBackend) -> None:
     """Test that get_game_url returns the expected game URL value."""
@@ -85,81 +84,73 @@ async def test_get_game_url_returns_correct_particle(backend: ParticleBackend) -
     assert result.url == _game_url
 
 
-# END get_game_url TESTS
+class TestFetchManifestJson:
+    """Tests against fetch_manifest_json"""
 
+    @pytest.mark.asyncio
+    async def test_returns_json(self, valid_manifest_data, backend: ParticleBackend) -> None:
+        """Test fetching manifest JSON succeeds along happy path."""
+        client_mock: AsyncMock = cast(AsyncMock, backend.http_client)
+        client_mock.get.return_value = Response(
+            status_code=200,
+            content=valid_manifest_data,
+            request=Request(method="GET", url=PARTICLE_URL_ROOT),
+        )
 
-# BEGIN _fetch_manifest_json TESTS
-@pytest.mark.asyncio
-async def test_fetch_manifest_json_returns_json(
-    valid_manifest_data, backend: ParticleBackend
-) -> None:
-    """Test fetching manifest JSON succeeds along happy path."""
-    client_mock: AsyncMock = cast(AsyncMock, backend.http_client)
-    client_mock.get.return_value = Response(
-        status_code=200,
-        content=valid_manifest_data,
-        request=Request(method="GET", url=PARTICLE_URL_ROOT),
-    )
+        result = await backend.fetch_manifest_json_from_remote()
 
-    result = await backend.fetch_manifest_json_from_remote()
+        # result should be a python object (result of json.loads)
+        assert isinstance(result, object)
 
-    # result should be a python object (result of json.loads)
-    assert isinstance(result, object)
+    @pytest.mark.asyncio
+    async def test_returns_none_for_invalid_json(
+        self, backend: ParticleBackend, caplog: LogCaptureFixture, filter_caplog: Any
+    ):
+        """Test fetching invalid manifest JSON returns None."""
+        client_mock: AsyncMock = cast(AsyncMock, backend.http_client)
+        client_mock.get.return_value = Response(
+            status_code=200,
+            # foo below isn't double quoted, so json conversion fails
+            content="{foo: 1}",
+            request=Request(method="GET", url=PARTICLE_URL_ROOT),
+        )
 
+        caplog.set_level(logging.ERROR)
 
-@pytest.mark.asyncio
-async def test_fetch_manifest_json_returns_none_for_invalid_json(
-    backend: ParticleBackend, caplog: LogCaptureFixture, filter_caplog: Any
-):
-    """Test fetching invalid manifest JSON returns None."""
-    client_mock: AsyncMock = cast(AsyncMock, backend.http_client)
-    client_mock.get.return_value = Response(
-        status_code=200,
-        # foo below isn't double quoted, so json conversion fails
-        content="{foo: 1}",
-        request=Request(method="GET", url=PARTICLE_URL_ROOT),
-    )
+        result = await backend.fetch_manifest_json_from_remote()
 
-    caplog.set_level(logging.ERROR)
+        # get error records
+        error_records = filter_caplog(
+            caplog.records,
+            "merino.providers.games.particle.backends.particle",
+        )
 
-    result = await backend.fetch_manifest_json_from_remote()
+        # verify result is None and expected error was logged
+        assert result is None
+        assert len(error_records) == 1
+        assert "JSON error when converting Particle response" == error_records[0].message
 
-    # get error records
-    error_records = filter_caplog(
-        caplog.records,
-        "merino.providers.games.particle.backends.particle",
-    )
+    @pytest.mark.asyncio
+    async def test_returns_none_for_http_error(
+        self, backend: ParticleBackend, caplog: LogCaptureFixture, filter_caplog: Any
+    ):
+        """Test fetching invalid manifest JSON returns None."""
+        client_mock: AsyncMock = cast(AsyncMock, backend.http_client)
+        client_mock.get.return_value = Response(
+            status_code=500, request=Request(method="GET", url=PARTICLE_URL_ROOT)
+        )
 
-    # verify result is None and expected error was logged
-    assert result is None
-    assert len(error_records) == 1
-    assert "JSON error when converting Particle response" == error_records[0].message
+        caplog.set_level(logging.ERROR)
 
+        result = await backend.fetch_manifest_json_from_remote()
 
-@pytest.mark.asyncio
-async def test_fetch_manifest_json_returns_none_for_http_error(
-    backend: ParticleBackend, caplog: LogCaptureFixture, filter_caplog: Any
-):
-    """Test fetching invalid manifest JSON returns None."""
-    client_mock: AsyncMock = cast(AsyncMock, backend.http_client)
-    client_mock.get.return_value = Response(
-        status_code=500, request=Request(method="GET", url=PARTICLE_URL_ROOT)
-    )
+        # get error records
+        error_records = filter_caplog(
+            caplog.records,
+            "merino.providers.games.particle.backends.particle",
+        )
 
-    caplog.set_level(logging.ERROR)
-
-    result = await backend.fetch_manifest_json_from_remote()
-
-    # get error records
-    error_records = filter_caplog(
-        caplog.records,
-        "merino.providers.games.particle.backends.particle",
-    )
-
-    # make sure result is None and expected error has been logged
-    assert result is None
-    assert len(error_records) == 1
-    assert "HTTP error when fetching Particle manifest" in error_records[0].message
-
-
-# END _fetch_manifest_json TESTS
+        # make sure result is None and expected error has been logged
+        assert result is None
+        assert len(error_records) == 1
+        assert "HTTP error when fetching Particle manifest" in error_records[0].message

--- a/tests/unit/providers/games/particle/backends/test_utils.py
+++ b/tests/unit/providers/games/particle/backends/test_utils.py
@@ -19,8 +19,8 @@ from merino.providers.games.particle.backends.utils import (
     ParticleManifestValidationError,
     remote_manifest_puzzle_is_updated,
     remote_manifest_runtime_is_updated,
-    update_files_puzzle,
-    update_files_runtime,
+    update_puzzle_files,
+    update_runtime_files,
     validate_manifest_schema_version,
     validate_manifest_against_schema,
 )
@@ -78,21 +78,42 @@ def mock_remote_manifest_runtime_is_updated():
 # END FIXTURES
 
 
-# BEGIN validate_manifest_schema_version TESTS
-def test_validate_manifest_schema_version_does_not_raise_with_valid_json(valid_manifest_data):
-    """Verify valid JSON results in no exception raised."""
-    with does_not_raise():
-        validate_manifest_schema_version(valid_manifest_data, _manifest_schema_version)
+class TestValidateManifestSchemaVersion:
+    """Tests against validate_manifest_schema_version"""
 
+    def test_does_not_raise_with_valid_json(self, valid_manifest_data):
+        """Verify valid JSON results in no exception raised."""
+        with does_not_raise():
+            validate_manifest_schema_version(valid_manifest_data, _manifest_schema_version)
 
-def test_validate_manifest_schema_version_raises_with_invalid_json(
-    caplog: LogCaptureFixture, filter_caplog: Any
-):
-    """Verify invalid JSON raises an exception."""
-    caplog.set_level(logging.ERROR)
+    def test_raises_with_invalid_json(self, caplog: LogCaptureFixture, filter_caplog: Any):
+        """Verify invalid JSON raises an exception."""
+        caplog.set_level(logging.ERROR)
 
-    with pytest.raises(Exception):
-        validate_manifest_schema_version("Not valid JSON", _manifest_schema_version)
+        with pytest.raises(Exception):
+            validate_manifest_schema_version("Not valid JSON", _manifest_schema_version)
+
+            # get error records
+            error_records = filter_caplog(
+                caplog.records,
+                "merino.providers.games.particle.backends.utils",
+            )
+
+            # verify expected error was logged
+            assert len(error_records) == 1
+            assert (
+                "JSON error retrieving 'schemaVersion' from manifest JSON."
+                == error_records[0].message
+            )
+
+    def test_raises_with_invalid_schema_version(
+        self, caplog: LogCaptureFixture, filter_caplog: Any
+    ):
+        """Verify invalid schema version raises an exception."""
+        with pytest.raises(Exception):
+            validate_manifest_schema_version(
+                json.loads('{"schemaVersion": 2}'), _manifest_schema_version
+            )
 
         # get error records
         error_records = filter_caplog(
@@ -102,173 +123,141 @@ def test_validate_manifest_schema_version_raises_with_invalid_json(
 
         # verify expected error was logged
         assert len(error_records) == 1
+        assert "Error validating Particle manifest schema version" in error_records[0].message
+
+    def test_raises_with_no_schema_version_in_json(
+        self, caplog: LogCaptureFixture, filter_caplog: Any
+    ):
+        """Verify missing schema version raises an exception."""
+        with pytest.raises(ParticleManifestValidationError):
+            validate_manifest_schema_version(
+                json.loads('{"cremaVersion": 1}'), _manifest_schema_version
+            )
+
+        # get error records
+        error_records = filter_caplog(
+            caplog.records,
+            "merino.providers.games.particle.backends.utils",
+        )
+
+        # verify expected errors were logged
+        assert len(error_records) == 2
         assert (
-            "JSON error retrieving 'schemaVersion' from manifest JSON." == error_records[0].message
+            "JSON key error retrieving 'schemaVersion' from manifest JSON."
+            == error_records[0].message
+        )
+        assert "Error validating Particle manifest schema version" in error_records[1].message
+
+
+class TestValidateManifestAgainstSchema:
+    """Tests against validate_manifest_against_schema"""
+
+    def test_does_not_raise_with_valid_json(
+        self, valid_manifest_data: Json, manifest_schema_data: Json
+    ):
+        """Verify no exception raised if manifest JSON is valid."""
+        with does_not_raise():
+            validate_manifest_against_schema(valid_manifest_data, manifest_schema_data)
+
+    def test_raises_with_invalid_json(
+        self,
+        invalid_manifest_data: Json,
+        manifest_schema_data: Json,
+        caplog: LogCaptureFixture,
+        filter_caplog: Any,
+    ):
+        """Verify expected error is raised if manifest JSON does not conform to the schema."""
+        with pytest.raises(ParticleManifestValidationError):
+            validate_manifest_against_schema(invalid_manifest_data, manifest_schema_data)
+
+        # get error records
+        error_records = filter_caplog(
+            caplog.records,
+            "merino.providers.games.particle.backends.utils",
         )
 
+        # verify expected error was logged
+        assert len(error_records) == 1
+        assert "Schema validation failed for manifest JSON" in error_records[0].message
 
-def test_validate_manifest_schema_version_raises_with_invalid_schema_version(
-    caplog: LogCaptureFixture, filter_caplog: Any
-):
-    """Verify invalid schema version raises an exception."""
-    with pytest.raises(Exception):
-        validate_manifest_schema_version(
-            json.loads('{"schemaVersion": 2}'), _manifest_schema_version
+
+class TestRemoteManifestRuntimeIsUpdated:
+    """Tests against remote_manifest_runtime_is_updated"""
+
+    def test_was_updated(self, valid_manifest_data, valid_manifest_data_remote_updated):
+        """Test that comparing an old manifest to a new results in an updated signal"""
+        assert remote_manifest_runtime_is_updated(
+            valid_manifest_data_remote_updated, valid_manifest_data
         )
 
-    # get error records
-    error_records = filter_caplog(
-        caplog.records,
-        "merino.providers.games.particle.backends.utils",
-    )
-
-    # verify expected error was logged
-    assert len(error_records) == 1
-    assert "Error validating Particle manifest schema version" in error_records[0].message
+    def test_was_not_updated(self, valid_manifest_data):
+        """Test that comparing the same manifest results in a not updated signal"""
+        assert not remote_manifest_runtime_is_updated(valid_manifest_data, valid_manifest_data)
 
 
-def test_validate_manifest_schema_version_raises_with_no_schema_version_in_json(
-    caplog: LogCaptureFixture, filter_caplog: Any
-):
-    """Verify missing schema version raises an exception."""
-    with pytest.raises(ParticleManifestValidationError):
-        validate_manifest_schema_version(
-            json.loads('{"cremaVersion": 1}'), _manifest_schema_version
+class TestRemoteManifestPuzzleIsUpdated:
+    """Tests against remote_manifest_puzzle_is_updated"""
+
+    def test_was_updated(self, valid_manifest_data, valid_manifest_data_remote_updated):
+        """Test that comparing an old manifest to a new results in an updated signal"""
+        assert remote_manifest_puzzle_is_updated(
+            valid_manifest_data_remote_updated, valid_manifest_data
         )
 
-    # get error records
-    error_records = filter_caplog(
-        caplog.records,
-        "merino.providers.games.particle.backends.utils",
-    )
-
-    # verify expected errors were logged
-    assert len(error_records) == 2
-    assert (
-        "JSON key error retrieving 'schemaVersion' from manifest JSON." == error_records[0].message
-    )
-    assert "Error validating Particle manifest schema version" in error_records[1].message
+    def test_was_not_updated(self, valid_manifest_data):
+        """Test that comparing the same manifest results in a not updated signal"""
+        assert not remote_manifest_puzzle_is_updated(valid_manifest_data, valid_manifest_data)
 
 
-# END validate_manifest_schema_version TESTS
+class TestUpdateFilesPuzzle:
+    """Tests against update_puzzle_files"""
+
+    @pytest.mark.asyncio
+    async def test_update_puzzle_files_should_update_with_gcs_data(
+        self, valid_manifest_data, mock_remote_manifest_puzzle_is_updated
+    ):
+        """Test that puzzle files are updated if gcs data exists and versions mismatch"""
+        mock_remote_manifest_puzzle_is_updated.return_value = True
+
+        assert await update_puzzle_files(valid_manifest_data, valid_manifest_data)
+
+    @pytest.mark.asyncio
+    async def test_update_puzzle_files_should_not_update_with_gcs_data(
+        self, valid_manifest_data, mock_remote_manifest_puzzle_is_updated
+    ):
+        """Test that puzzle files are not updated if gcs data exists and versions match"""
+        mock_remote_manifest_puzzle_is_updated.return_value = False
+
+        assert not await update_puzzle_files(valid_manifest_data, valid_manifest_data)
+
+    @pytest.mark.asyncio
+    async def test_update_puzzle_files_should_update_without_gcs_data(self, valid_manifest_data):
+        """Test that puzzle files are updated if gcs data does not exist"""
+        assert await update_puzzle_files(valid_manifest_data, None)
 
 
-# BEGIN validate_manifest_against_schema TESTS
-def test_validate_manifest_against_schema_does_not_raise_with_valid_json(
-    valid_manifest_data: Json, manifest_schema_data: Json
-):
-    """Verify no exception raised if manifest JSON is valid."""
-    with does_not_raise():
-        validate_manifest_against_schema(valid_manifest_data, manifest_schema_data)
+class TestUpdateFilesRuntime:
+    """Tests against update_runtime_files"""
 
+    @pytest.mark.asyncio
+    async def test_update_runtime_files_should_update_with_gcs_data(
+        self, valid_manifest_data, mock_remote_manifest_runtime_is_updated
+    ):
+        """Test that runtime files are updated if gcs data exists and versions mismatch"""
+        mock_remote_manifest_runtime_is_updated.return_value = True
 
-def test_validate_manifest_against_schema_raises_with_invalid_json(
-    invalid_manifest_data: Json,
-    manifest_schema_data: Json,
-    caplog: LogCaptureFixture,
-    filter_caplog: Any,
-):
-    """Verify expected error is raised if manifest JSON does not conform to the schema."""
-    with pytest.raises(ParticleManifestValidationError):
-        validate_manifest_against_schema(invalid_manifest_data, manifest_schema_data)
+        assert await update_runtime_files(valid_manifest_data, valid_manifest_data)
 
-    # get error records
-    error_records = filter_caplog(
-        caplog.records,
-        "merino.providers.games.particle.backends.utils",
-    )
+    @pytest.mark.asyncio
+    async def test_update_runtime_files_should_not_update_with_gcs_data(
+        self, valid_manifest_data, mock_remote_manifest_runtime_is_updated
+    ):
+        """Test that runtime files are not updated if gcs data exists and versions match"""
+        mock_remote_manifest_runtime_is_updated.return_value = False
 
-    # verify expected error was logged
-    assert len(error_records) == 1
-    assert "Schema validation failed for manifest JSON" in error_records[0].message
+        assert not await update_runtime_files(valid_manifest_data, valid_manifest_data)
 
-
-# END validate_manifest_against_schema TESTS
-
-
-def test_remote_manifest_runtime_is_updated_was_updated(
-    valid_manifest_data, valid_manifest_data_remote_updated
-):
-    """Test that comparing an old manifest to a new results in an updated signal"""
-    assert remote_manifest_runtime_is_updated(
-        valid_manifest_data_remote_updated, valid_manifest_data
-    )
-
-
-def test_remote_manifest_runtime_is_updated_was_not_updated(valid_manifest_data):
-    """Test that comparing the same manifest results in a not updated signal"""
-    assert not remote_manifest_runtime_is_updated(valid_manifest_data, valid_manifest_data)
-
-
-def test_remote_manifest_puzzle_is_updated_was_updated(
-    valid_manifest_data, valid_manifest_data_remote_updated
-):
-    """Test that comparing an old manifest to a new results in an updated signal"""
-    assert remote_manifest_puzzle_is_updated(
-        valid_manifest_data_remote_updated, valid_manifest_data
-    )
-
-
-def test_remote_manifest_puzzle_is_updated_was_not_updated(valid_manifest_data):
-    """Test that comparing the same manifest results in a not updated signal"""
-    assert not remote_manifest_puzzle_is_updated(valid_manifest_data, valid_manifest_data)
-
-
-# BEGIN update_files_puzzle TESTS
-@pytest.mark.asyncio
-async def test_update_files_puzzle_should_update_with_gcs_data(
-    valid_manifest_data, mock_remote_manifest_puzzle_is_updated
-):
-    """Test that puzzle files are updated if gcs data exists and versions mismatch"""
-    mock_remote_manifest_puzzle_is_updated.return_value = True
-
-    assert await update_files_puzzle(valid_manifest_data, valid_manifest_data)
-
-
-@pytest.mark.asyncio
-async def test_update_files_puzzle_should_not_update_with_gcs_data(
-    valid_manifest_data, mock_remote_manifest_puzzle_is_updated
-):
-    """Test that puzzle files are not updated if gcs data exists and versions match"""
-    mock_remote_manifest_puzzle_is_updated.return_value = False
-
-    assert not await update_files_puzzle(valid_manifest_data, valid_manifest_data)
-
-
-@pytest.mark.asyncio
-async def test_update_files_puzzle_should_update_without_gcs_data(valid_manifest_data):
-    """Test that puzzle files are updated if gcs data does not exist"""
-    assert await update_files_puzzle(valid_manifest_data, None)
-
-
-# END update_files_puzzle TESTS
-
-
-# BEGIN update_files_runtime TESTS
-@pytest.mark.asyncio
-async def test_update_files_runtime_should_update_with_gcs_data(
-    valid_manifest_data, mock_remote_manifest_runtime_is_updated
-):
-    """Test that runtime files are updated if gcs data exists and versions mismatch"""
-    mock_remote_manifest_runtime_is_updated.return_value = True
-
-    assert await update_files_runtime(valid_manifest_data, valid_manifest_data)
-
-
-@pytest.mark.asyncio
-async def test_update_files_runtime_should_not_update_with_gcs_data(
-    valid_manifest_data, mock_remote_manifest_runtime_is_updated
-):
-    """Test that runtime files are not updated if gcs data exists and versions match"""
-    mock_remote_manifest_runtime_is_updated.return_value = False
-
-    assert not await update_files_runtime(valid_manifest_data, valid_manifest_data)
-
-
-@pytest.mark.asyncio
-async def test_update_files_runtime_should_update_without_gcs_data(valid_manifest_data):
-    """Test that runtime files are updated if gcs data does not exist"""
-    assert await update_files_runtime(valid_manifest_data, None)
-
-
-# END update_files_runtime TESTS
+    @pytest.mark.asyncio
+    async def test_update_runtime_files_should_update_without_gcs_data(self, valid_manifest_data):
+        """Test that runtime files are updated if gcs data does not exist"""
+        assert await update_runtime_files(valid_manifest_data, None)

--- a/tests/unit/providers/games/particle/test_provider.py
+++ b/tests/unit/providers/games/particle/test_provider.py
@@ -20,6 +20,7 @@ from merino.providers.games.particle.backends.protocol import (
     Particle,
     ParticleBackend,
 )
+from merino.providers.games.particle.backends.utils import ParticleManifestValidationError
 from merino.providers.games.particle.provider import Provider
 
 
@@ -98,301 +99,314 @@ def mock_fetch_from_gcs(provider):
 
 @pytest.fixture
 def mock_update_puzzle():
-    """Return a mocked update_files_puzzle async function"""
+    """Return a mocked update_puzzle_files async function"""
     with patch(
-        "merino.providers.games.particle.provider.update_files_puzzle", new=AsyncMock()
+        "merino.providers.games.particle.provider.update_puzzle_files", new=AsyncMock()
     ) as mock_update_puzzle:
         yield mock_update_puzzle
 
 
 @pytest.fixture
 def mock_update_runtime():
-    """Return a mocked update_files_runtime async function"""
+    """Return a mocked update_runtime_files async function"""
     with patch(
-        "merino.providers.games.particle.provider.update_files_runtime", new=AsyncMock()
+        "merino.providers.games.particle.provider.update_runtime_files", new=AsyncMock()
     ) as mock_update_runtime:
         yield mock_update_runtime
 
 
-def test_provider_name(provider: Provider) -> None:
-    """Test that the provider name is set correctly."""
-    assert provider.name == "particle"
+class TestProvider:
+    """Tests against provider instantiation and initialization"""
 
+    def test_name(self, provider: Provider) -> None:
+        """Test that the provider name is set correctly."""
+        assert provider.name == "particle"
 
-def test_provider_enabled_by_default(provider: Provider) -> None:
-    """Test that enabled_by_default is set correctly."""
-    assert provider._enabled is False
+    def test_enabled(self, provider: Provider) -> None:
+        """Test that enabled is set correctly."""
+        assert provider._enabled is False
 
-
-@pytest.mark.asyncio
-async def test_initialize(provider: Provider) -> None:
-    """Test that initialize completes without error."""
-    await provider.initialize()
-
-
-@pytest.mark.asyncio
-async def test_get_game_url_returns_none_when_backend_returns_none(
-    provider: Provider, backend_mock
-) -> None:
-    """Test that get_game_url returns an empty Particle when backend returns None."""
-    backend_mock.get_game_url.return_value = None
-
-    particle = await provider.get_game_url()
-
-    assert particle is None
-
-
-@pytest.mark.asyncio
-async def test_get_game_url_returns_correct_particle(
-    provider: Provider, backend_mock, test_particle
-) -> None:
-    """Test that get_game_url returns a correct Particle instance."""
-    backend_mock.get_game_url.return_value = test_particle
-
-    particle = await provider.get_game_url()
-
-    assert particle is not None
-    assert particle.url == test_game_url
-
-
-@pytest.mark.asyncio
-async def test_initialize_runs_cron_when_provider_enabled(provider):
-    """Initialize should call _fetch_game_data and create cron job when provider is enabled."""
-    with (
-        patch.object(provider, "_enabled", True),
-        patch("asyncio.create_task", wraps=asyncio.create_task) as mock_create_task,
-        patch("merino.providers.games.particle.provider.cron.Job") as mock_cron_job,
-    ):
-        mock_job_instance = AsyncMock(name="mock_cron_job")
-        mock_cron_job.return_value = mock_job_instance
-
+    @pytest.mark.asyncio
+    async def test_initialize(self, provider: Provider) -> None:
+        """Test that initialize completes without error."""
         await provider.initialize()
 
-        mock_cron_job.assert_called_once_with(
-            name="update_particle_game_data",
-            interval=provider.cron_interval_sec,
-            condition=provider._should_fetch_data,
-            task=provider._fetch_game_data,
-        )
+    @pytest.mark.asyncio
+    async def test_initialize_runs_cron_when_provider_enabled(self, provider):
+        """Initialize should call _fetch_game_data and create cron job when provider is enabled."""
+        with (
+            patch.object(provider, "_enabled", True),
+            patch("asyncio.create_task", wraps=asyncio.create_task) as mock_create_task,
+            patch("merino.providers.games.particle.provider.cron.Job") as mock_cron_job,
+        ):
+            mock_job_instance = AsyncMock(name="mock_cron_job")
+            mock_cron_job.return_value = mock_job_instance
 
-        mock_create_task.assert_called_once()
-        args, _ = mock_create_task.call_args
-        called_arg = args[0]
-        assert asyncio.iscoroutine(called_arg)
-        assert hasattr(provider, "cron_task")
+            await provider.initialize()
+
+            mock_cron_job.assert_called_once_with(
+                name="update_particle_game_data",
+                interval=provider.cron_interval_sec,
+                condition=provider._should_fetch_data,
+                task=provider._fetch_game_data,
+            )
+
+            mock_create_task.assert_called_once()
+            args, _ = mock_create_task.call_args
+            called_arg = args[0]
+            assert asyncio.iscoroutine(called_arg)
+            assert hasattr(provider, "cron_task")
 
 
-def test_should_fetch_data_returns_true_when_interval_satsified(provider):
-    """_should_fetch_data should return True if the time interval condition is satisfied"""
-    with (
-        patch("merino.providers.games.particle.provider.time.time", side_effect=[100]),
-        patch.object(provider, "resync_interval_sec", 50),
-        patch.object(provider, "last_successful_update_at", 50),
+class TestGetGameUrl:
+    """Tests against get_game_url"""
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_backend_returns_none(
+        self, provider: Provider, backend_mock
+    ) -> None:
+        """Test that get_game_url returns an empty Particle when backend returns None."""
+        backend_mock.get_game_url.return_value = None
+
+        particle = await provider.get_game_url()
+
+        assert particle is None
+
+    @pytest.mark.asyncio
+    async def test_returns_correct_particle(
+        self, provider: Provider, backend_mock, test_particle
+    ) -> None:
+        """Test that get_game_url returns a correct Particle instance."""
+        backend_mock.get_game_url.return_value = test_particle
+
+        particle = await provider.get_game_url()
+
+        assert particle is not None
+        assert particle.url == test_game_url
+
+
+class TestShouldFetchData:
+    """Tests against should_fetch_data"""
+
+    def test_should_fetch_data_returns_true_when_interval_satsified(self, provider):
+        """_should_fetch_data should return True if the time interval condition is satisfied"""
+        with (
+            patch("merino.providers.games.particle.provider.time.time", side_effect=[100]),
+            patch.object(provider, "resync_interval_sec", 50),
+            patch.object(provider, "last_successful_update_at", 50),
+        ):
+            assert provider._should_fetch_data() is True
+
+    def test_should_fetch_data_returns_false_when_interval_not_satsified(self, provider):
+        """_should_fetch_data should return False if the time interval condition is not satisfied"""
+        with (
+            patch("merino.providers.games.particle.provider.time.time", side_effect=[100]),
+            patch.object(provider, "resync_interval_sec", 60),
+            patch.object(provider, "last_successful_update_at", 50),
+        ):
+            assert provider._should_fetch_data() is False
+
+
+class TestFetchGameData:
+    """Tests against fetch_game_data"""
+
+    @pytest.mark.asyncio
+    async def test_happy_path(self, provider, valid_manifest_data):
+        """Test that _fetch_game_data retrieves remote json and updates as expected"""
+        with (
+            patch.object(
+                provider.backend, "fetch_manifest_json_from_remote", new=AsyncMock()
+            ) as mock_fetch_manifest,
+            patch.object(provider, "process_remote_particle_data") as mock_process_data,
+            patch("merino.providers.games.particle.provider.time.time", side_effect=[100]),
+        ):
+            mock_fetch_manifest.return_value = valid_manifest_data
+            mock_process_data.return_value = True
+
+            await provider._fetch_game_data()
+
+            mock_fetch_manifest.assert_awaited_once()
+            mock_process_data.assert_called_once()
+            assert provider.last_successful_update_at == 100
+
+    @pytest.mark.asyncio
+    async def test_processing_remote_data_fails(self, provider, valid_manifest_data):
+        """Test that _fetch_game_data retrieves remote json but processing the json fails"""
+        with (
+            patch.object(
+                provider.backend, "fetch_manifest_json_from_remote", new=AsyncMock()
+            ) as mock_fetch_manifest,
+            patch.object(provider, "process_remote_particle_data") as mock_process_data,
+            patch.object(provider, "last_successful_update_at", 0.0),
+            patch("merino.providers.games.particle.provider.time.time", side_effect=[100]),
+        ):
+            mock_fetch_manifest.return_value = valid_manifest_data
+            mock_process_data.return_value = False
+
+            await provider._fetch_game_data()
+
+            mock_fetch_manifest.assert_awaited_once()
+            mock_process_data.assert_called_once()
+            assert provider.last_successful_update_at == 0.0
+
+    @pytest.mark.asyncio
+    async def test_remote_fetch_fails(
+        self,
+        provider,
+        caplog: LogCaptureFixture,
+        filter_caplog: FilterCaplogFixture,
     ):
-        assert provider._should_fetch_data() is True
+        """Test that _fetch_game_data logs as expected if the remote fetch fails"""
+        with (
+            patch.object(
+                provider.backend, "fetch_manifest_json_from_remote", new=AsyncMock()
+            ) as mock_fetch_manifest,
+            patch.object(provider, "process_remote_particle_data") as mock_process_data,
+            patch.object(provider, "last_successful_update_at", 0.0),
+            patch("merino.providers.games.particle.provider.time.time", side_effect=[100]),
+        ):
+            caplog.set_level(logging.INFO)
+
+            mock_fetch_manifest.side_effect = Exception("kaboom!")
+
+            await provider._fetch_game_data()
+
+            mock_fetch_manifest.assert_awaited_once()
+            mock_process_data.assert_not_awaited()
+
+            # ensure the last_successful_update_at value was not updated
+            assert provider.last_successful_update_at == 0.0
+
+            records: list[LogRecord] = filter_caplog(
+                caplog.records, "merino.providers.games.particle.provider"
+            )
+
+            # verify logging
+            assert len(records) == 2
+            assert records[0].message.startswith(
+                "Failed to fetch Particle game data from remote endpoint"
+            )
+            assert records[1].message.startswith(
+                "Particle game data fetch returned None - will retry on next cron tick"
+            )
 
 
-def test_should_fetch_data_returns_false_when_interval_not_satsified(provider):
-    """_should_fetch_data should return False if the time interval condition is not satisfied"""
-    with (
-        patch("merino.providers.games.particle.provider.time.time", side_effect=[100]),
-        patch.object(provider, "resync_interval_sec", 60),
-        patch.object(provider, "last_successful_update_at", 50),
+class TestProcessRemoteParticleData:
+    """Tests against process_remote_particle_data"""
+
+    did_process_test_parameters = [(True, True), (True, False), (False, True)]
+
+    @pytest.mark.parametrize("update_puzzle, update_runtime", did_process_test_parameters)
+    @pytest.mark.asyncio
+    async def test_puzzle_and_or_runtime_updated(
+        self,
+        update_puzzle,
+        update_runtime,
+        provider,
+        valid_manifest_data,
+        mock_validate_schema,
+        mock_validate_schema_version,
+        mock_fetch_from_gcs,
+        mock_update_puzzle,
+        mock_update_runtime,
     ):
-        assert provider._should_fetch_data() is False
+        """Assert process_remote_particle_data returns True and all expected functions are called when either puzzle and/or runtime files require updating"""
+        mock_update_puzzle.return_value = update_puzzle
+        mock_update_runtime.return_value = update_runtime
 
+        assert await provider.process_remote_particle_data(valid_manifest_data)
 
-@pytest.mark.asyncio
-async def test_fetch_game_data_happy_path(provider, valid_manifest_data):
-    """Test that _fetch_game_data retrieves remote json and updates as expected"""
-    with (
-        patch.object(
-            provider.backend, "fetch_manifest_json_from_remote", new=AsyncMock()
-        ) as mock_fetch_manifest,
-        patch.object(provider, "process_remote_particle_data") as mock_process_data,
-        patch("merino.providers.games.particle.provider.time.time", side_effect=[100]),
+        mock_validate_schema.assert_called_once()
+        mock_validate_schema_version.assert_called_once()
+        mock_fetch_from_gcs.assert_awaited_once()
+        mock_update_puzzle.assert_awaited_once()
+        mock_update_runtime.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_process_remote_particle_data_no_files_updated(
+        self,
+        provider,
+        valid_manifest_data,
+        mock_validate_schema,
+        mock_validate_schema_version,
+        mock_fetch_from_gcs,
+        mock_update_puzzle,
+        mock_update_runtime,
     ):
-        mock_fetch_manifest.return_value = valid_manifest_data
-        mock_process_data.return_value = True
+        """Assert process_remote_particle_data returns False and all expected functions are called when no files require updating"""
+        mock_update_puzzle.return_value = False
+        mock_update_runtime.return_value = False
 
-        await provider._fetch_game_data()
+        assert not await provider.process_remote_particle_data(valid_manifest_data)
 
-        mock_fetch_manifest.assert_awaited_once()
-        mock_process_data.assert_called_once()
-        assert provider.last_successful_update_at == 100
+        mock_validate_schema.assert_called_once()
+        mock_validate_schema_version.assert_called_once()
+        mock_fetch_from_gcs.assert_awaited_once()
+        mock_update_puzzle.assert_awaited_once()
+        mock_update_runtime.assert_awaited_once()
 
-
-@pytest.mark.asyncio
-async def test_fetch_game_data_processing_remote_data_fails(provider, valid_manifest_data):
-    """Test that _fetch_game_data retrieves remote json but processing the json fails"""
-    with (
-        patch.object(
-            provider.backend, "fetch_manifest_json_from_remote", new=AsyncMock()
-        ) as mock_fetch_manifest,
-        patch.object(provider, "process_remote_particle_data") as mock_process_data,
-        patch.object(provider, "last_successful_update_at", 0.0),
-        patch("merino.providers.games.particle.provider.time.time", side_effect=[100]),
+    @pytest.mark.asyncio
+    async def test_process_remote_particle_data_gcs_fetch_raises(
+        self,
+        provider,
+        valid_manifest_data,
+        mock_validate_schema,
+        mock_validate_schema_version,
+        mock_fetch_from_gcs,
+        mock_update_puzzle,
+        mock_update_runtime,
     ):
-        mock_fetch_manifest.return_value = valid_manifest_data
-        mock_process_data.return_value = False
+        """Assert process_remote_particle_data returns False and all expected functions are called when no files require updating"""
+        mock_fetch_from_gcs.side_effect = ParticleFileManagerError("GCS call failed")
 
-        await provider._fetch_game_data()
+        assert not await provider.process_remote_particle_data(valid_manifest_data)
 
-        mock_fetch_manifest.assert_awaited_once()
-        mock_process_data.assert_called_once()
-        assert provider.last_successful_update_at == 0.0
+        mock_validate_schema.assert_called_once()
+        mock_validate_schema_version.assert_called_once()
+        mock_fetch_from_gcs.assert_awaited_once()
+        mock_update_puzzle.assert_not_awaited()
+        mock_update_runtime.assert_not_awaited()
 
-
-@pytest.mark.asyncio
-async def test_fetch_game_data_remote_fetch_fails(
-    provider,
-    caplog: LogCaptureFixture,
-    filter_caplog: FilterCaplogFixture,
-):
-    """Test that _fetch_game_data logs as expected if the remote fetch fails"""
-    with (
-        patch.object(
-            provider.backend, "fetch_manifest_json_from_remote", new=AsyncMock()
-        ) as mock_fetch_manifest,
-        patch.object(provider, "process_remote_particle_data") as mock_process_data,
-        patch.object(provider, "last_successful_update_at", 0.0),
-        patch("merino.providers.games.particle.provider.time.time", side_effect=[100]),
+    @pytest.mark.asyncio
+    async def test_process_remote_particle_data_validate_schema_raises(
+        self,
+        provider,
+        valid_manifest_data,
+        mock_validate_schema,
+        mock_validate_schema_version,
+        mock_fetch_from_gcs,
+        mock_update_puzzle,
+        mock_update_runtime,
     ):
-        caplog.set_level(logging.INFO)
+        """Assert process_remote_particle_data returns False when validating schema raises and all subsequent functions are not called"""
+        mock_validate_schema.side_effect = ParticleManifestValidationError("forced error")
 
-        mock_fetch_manifest.side_effect = Exception("kaboom!")
+        assert not await provider.process_remote_particle_data(valid_manifest_data)
 
-        await provider._fetch_game_data()
+        mock_validate_schema.assert_called_once()
+        mock_validate_schema_version.assert_not_called()
+        mock_fetch_from_gcs.assert_not_awaited()
+        mock_update_puzzle.assert_not_awaited()
+        mock_update_runtime.assert_not_awaited()
 
-        mock_fetch_manifest.assert_awaited_once()
-        mock_process_data.assert_not_awaited()
+    @pytest.mark.asyncio
+    async def test_process_remote_particle_data_validate_schema_version_raises(
+        self,
+        provider,
+        valid_manifest_data,
+        mock_validate_schema,
+        mock_validate_schema_version,
+        mock_fetch_from_gcs,
+        mock_update_puzzle,
+        mock_update_runtime,
+    ):
+        """Assert process_remote_particle_data returns False when validating schema version raises and all subsequent functions are not called"""
+        mock_validate_schema_version.side_effect = ParticleManifestValidationError("forced error")
 
-        # ensure the last_successful_update_at value was not updated
-        assert provider.last_successful_update_at == 0.0
+        assert not await provider.process_remote_particle_data(valid_manifest_data)
 
-        records: list[LogRecord] = filter_caplog(
-            caplog.records, "merino.providers.games.particle.provider"
-        )
-
-        # verify logging
-        assert len(records) == 2
-        assert records[0].message.startswith(
-            "Failed to fetch Particle game data from remote endpoint"
-        )
-        assert records[1].message.startswith(
-            "Particle game data fetch returned None - will retry on next cron tick"
-        )
-
-
-@pytest.mark.asyncio
-async def test_process_remote_particle_data_puzzle_and_runtime_updated(
-    provider,
-    valid_manifest_data,
-    mock_validate_schema,
-    mock_validate_schema_version,
-    mock_fetch_from_gcs,
-    mock_update_puzzle,
-    mock_update_runtime,
-):
-    """Assert process_remote_particle_data returns True and all expected functions are called when both puzzle and runtime files require updating"""
-    mock_update_puzzle.return_value = True
-    mock_update_runtime.return_value = True
-
-    assert await provider.process_remote_particle_data(valid_manifest_data)
-
-    mock_validate_schema.assert_called_once()
-    mock_validate_schema_version.assert_called_once()
-    mock_fetch_from_gcs.assert_awaited_once()
-    mock_update_puzzle.assert_awaited_once()
-    mock_update_runtime.assert_awaited_once()
-
-
-@pytest.mark.asyncio
-async def test_process_remote_particle_data_puzzle_updated(
-    provider,
-    valid_manifest_data,
-    mock_validate_schema,
-    mock_validate_schema_version,
-    mock_fetch_from_gcs,
-    mock_update_puzzle,
-    mock_update_runtime,
-):
-    """Assert process_remote_particle_data returns True and all expected functions are called when only puzzle files require updating"""
-    mock_update_puzzle.return_value = True
-    mock_update_runtime.return_value = False
-
-    assert await provider.process_remote_particle_data(valid_manifest_data)
-
-    mock_validate_schema.assert_called_once()
-    mock_validate_schema_version.assert_called_once()
-    mock_fetch_from_gcs.assert_awaited_once()
-    mock_update_puzzle.assert_awaited_once()
-    mock_update_runtime.assert_awaited_once()
-
-
-@pytest.mark.asyncio
-async def test_process_remote_particle_data_runtime_updated(
-    provider,
-    valid_manifest_data,
-    mock_validate_schema,
-    mock_validate_schema_version,
-    mock_fetch_from_gcs,
-    mock_update_puzzle,
-    mock_update_runtime,
-):
-    """Assert process_remote_particle_data returns True and all expected functions are called when only runtime files require updating"""
-    mock_update_puzzle.return_value = False
-    mock_update_runtime.return_value = True
-
-    assert await provider.process_remote_particle_data(valid_manifest_data)
-
-    mock_validate_schema.assert_called_once()
-    mock_validate_schema_version.assert_called_once()
-    mock_fetch_from_gcs.assert_awaited_once()
-    mock_update_puzzle.assert_awaited_once()
-    mock_update_runtime.assert_awaited_once()
-
-
-@pytest.mark.asyncio
-async def test_process_remote_particle_data_no_files_updated(
-    provider,
-    valid_manifest_data,
-    mock_validate_schema,
-    mock_validate_schema_version,
-    mock_fetch_from_gcs,
-    mock_update_puzzle,
-    mock_update_runtime,
-):
-    """Assert process_remote_particle_data returns False and all expected functions are called when no files require updating"""
-    mock_update_puzzle.return_value = False
-    mock_update_runtime.return_value = False
-
-    assert not await provider.process_remote_particle_data(valid_manifest_data)
-
-    mock_validate_schema.assert_called_once()
-    mock_validate_schema_version.assert_called_once()
-    mock_fetch_from_gcs.assert_awaited_once()
-    mock_update_puzzle.assert_awaited_once()
-    mock_update_runtime.assert_awaited_once()
-
-
-@pytest.mark.asyncio
-async def test_process_remote_particle_data_gcs_fetch_raises(
-    provider,
-    valid_manifest_data,
-    mock_validate_schema,
-    mock_validate_schema_version,
-    mock_fetch_from_gcs,
-    mock_update_puzzle,
-    mock_update_runtime,
-):
-    """Assert process_remote_particle_data returns False and all expected functions are called when no files require updating"""
-    mock_fetch_from_gcs.side_effect = ParticleFileManagerError("GCS call failed")
-
-    assert not await provider.process_remote_particle_data(valid_manifest_data)
-
-    mock_validate_schema.assert_called_once()
-    mock_validate_schema_version.assert_called_once()
-    mock_fetch_from_gcs.assert_awaited_once()
-    mock_update_puzzle.assert_not_awaited()
-    mock_update_runtime.assert_not_awaited()
+        mock_validate_schema.assert_called_once()
+        mock_validate_schema_version.assert_called_once()
+        mock_fetch_from_gcs.assert_not_awaited()
+        mock_update_puzzle.assert_not_awaited()
+        mock_update_runtime.assert_not_awaited()


### PR DESCRIPTION
## References

JIRA: [HNT-2626](https://mozilla-hub.atlassian.net/browse/HNT-2626)

## Description

particle housekeeping:

- organize tests into classes
- renaming a couple functions for better readability

the only new code in this PR are two added tests to `test_provider.py` (commented in the file diff). the vast majority of the change set is moving preexisting tests into classes.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2352)


[HNT-2626]: https://mozilla-hub.atlassian.net/browse/HNT-2626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ