### PR TITLE
[AIMOD-1234] Add normalized query to logging

### DIFF
--- a/merino/middleware/__init__.py
+++ b/merino/middleware/__init__.py
@@ -12,3 +12,4 @@ class ScopeKey(str, Enum):
     FEATURE_FLAGS = "merino_feature_flags"
     METRICS_CLIENT = "merino_metrics_client"
     PII_DETECTION = "merino_pii_detection"
+    NORMALIZED_QUERY = "merino_normalized_query"

--- a/merino/utils/log_data_creators.py
+++ b/merino/utils/log_data_creators.py
@@ -31,6 +31,7 @@ class SuggestLogDataModel(LogDataModel):
 
     sensitive: bool
     query: str | None = None
+    normalized_query: str | None = None
     code: int
     rid: str  # Provided by the asgi-correlation-id middleware.
     session_id: str | None = None
@@ -62,6 +63,7 @@ def create_suggest_log_data(
         path=request.url.path,
         method=request.method,
         query=request.query_params.get("q"),
+        normalized_query=request.scope.get(ScopeKey.NORMALIZED_QUERY),
         code=message["status"],
         rid=Headers(scope=message)["X-Request-ID"],
         session_id=request.query_params.get("sid"),

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -266,6 +266,8 @@ async def suggest(
     if use_normalization and pipeline:
         with metrics_client.timeit("normalization.experiment.timing"):
             q_normalized = pipeline.normalize(q)
+        # expose normalized query so downstream bigquery has it
+        request.scope[ScopeKey.NORMALIZED_QUERY] = q_normalized
     else:
         q_normalized = q
 

--- a/tests/unit/utils/test_log_data_creator.py
+++ b/tests/unit/utils/test_log_data_creator.py
@@ -127,6 +127,46 @@ def test_create_suggest_log_data(
 
 
 @pytest.mark.parametrize(
+    ["scope_extras", "expected_normalized_query"],
+    [
+        ({}, None),
+        ({ScopeKey.NORMALIZED_QUERY: "amazon"}, "amazon"),
+        ({ScopeKey.NORMALIZED_QUERY: "dow jones"}, "dow jones"),
+    ],
+    ids=["no_normalization", "normalized_amazon", "normalized_dow_jones"],
+)
+def test_create_suggest_log_data_normalized_query(
+    scope_extras: dict, expected_normalized_query: str | None
+) -> None:
+    """Test that normalized_query is populated from the scope when set, and None otherwise."""
+    location: Location = Location(country="US")
+    user_agent: UserAgent = UserAgent(
+        browser="Firefox(103.0)", os_family="macos", form_factor="desktop"
+    )
+    request: Request = Request(
+        scope={
+            "type": "http",
+            "headers": [],
+            "method": "GET",
+            "path": "/api/v1/suggest",
+            "query_string": b"q=amaz",
+            ScopeKey.GEOLOCATION: location,
+            ScopeKey.USER_AGENT: user_agent,
+            **scope_extras,
+        }
+    )
+    message: Message = {
+        "type": "http.response.start",
+        "status": 200,
+        "headers": [(b"x-request-id", b"1b11844c52b34c33a6ad54b7bc2eb7c7")],
+    }
+    log_data = create_suggest_log_data(request, message, datetime(1998, 3, 31))
+
+    assert log_data.query == "amaz"  # raw param is always preserved
+    assert log_data.normalized_query == expected_normalized_query
+
+
+@pytest.mark.parametrize(
     "time_input",
     ["not a datetime string", {"not", "a", "datetime", "object"}],
     ids=["invalid_string", "invalid_object_type"],


### PR DESCRIPTION
## References

JIRA: [AIMOD-1234](https://mozilla-hub.atlassian.net/browse/AIMOD-1234)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->
- Logs `normalized_query` similarly to existing `query` so downstream tasks can handle it in the same way

Downstream dependencies
  1. mozilla/bigquery-etl (https://github.com/mozilla/bigquery-etl)
  - Add `normalized_query` column to `merino_log_sanitized_v3` with LTRIM(LOWER(normalized_query))
  - Propagate to `suggest_impression_sanitized_v3`
  - Update schema files
  Owner: Data Eng.

  2. mozilla/search-terms-sanitization (https://github.com/mozilla/search-terms-sanitization)
  - Apply Layer 2 PII rules to `normalized_query`; drop row if either field has PII
  Owner: Data Eng

  3. mozilla/merino-py (follow-up)
  - Update `merino/jobs/engagement_model/amp_data_downloader.py:15-43` to group by `COALESCE(LOWER(normalized_query), LOWER(query))`
  Owner: DISCO


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2353)


[AIMOD-1234]: https://mozilla-hub.atlassian.net/browse/AIMOD-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ