### PR TITLE
[AIMOD-1268] Fix inferred interest experiment for timezone IVs

### DIFF
--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -407,6 +407,24 @@ def is_inferred_interest_experiment(request: CuratedRecommendationsRequest) -> b
     )
 
 
+def has_meaningful_interest_signal(personal_interests: ProcessedInterests | None) -> bool:
+    """Return True if the user has at least one positive non-TZ topic strength.
+
+    `bool(personal_interests.scores)` alone is too permissive — the scores dict
+    can be non-empty (carrying model_id and TIME_ZONE_OFFSET_INFERRED_KEY) even
+    when every topic strength is zero. Routing such users into the interest
+    ranker has no personalization effect (they get scored at popularity, the
+    same outcome cohort would produce) but still counts them in the treatment
+    arm, diluting the measured experiment lift.
+    """
+    if personal_interests is None:
+        return False
+    return any(
+        isinstance(value, (int, float)) and value > 0 and key != TIME_ZONE_OFFSET_INFERRED_KEY
+        for key, value in personal_interests.scores.items()
+    )
+
+
 def is_subtopics_experiment(request: CuratedRecommendationsRequest) -> bool:
     """Return True if subtopics should be included based on experiments.
 
@@ -899,12 +917,14 @@ async def get_sections(
         and ml_backend is not None
         and ml_backend.is_valid(surface_id)
     )
-    # use interest ranker if we have interests available
+    # Route to the interest ranker only when the user has at least one positive
+    # non-TZ topic strength. Otherwise zero-signal users get scored at popularity
+    # (the same outcome cohort gives them) but are counted in the treatment arm,
+    # diluting the experiment's measured lift. See `has_meaningful_interest_signal`.
     use_interest_ranker = (
         is_inferred_interest_experiment(request)
         and lints_interest_backend.is_valid(surface_id)
-        and personal_interests is not None
-        and bool(personal_interests.scores)
+        and has_meaningful_interest_signal(personal_interests)
     )
     # Interest ranker is experimental so gets priority over contexual ranker
     if use_interest_ranker:

--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -408,15 +408,7 @@ def is_inferred_interest_experiment(request: CuratedRecommendationsRequest) -> b
 
 
 def has_meaningful_interest_signal(personal_interests: ProcessedInterests | None) -> bool:
-    """Return True if the user has at least one positive non-TZ topic strength.
-
-    `bool(personal_interests.scores)` alone is too permissive — the scores dict
-    can be non-empty (carrying model_id and TIME_ZONE_OFFSET_INFERRED_KEY) even
-    when every topic strength is zero. Routing such users into the interest
-    ranker has no personalization effect (they get scored at popularity, the
-    same outcome cohort would produce) but still counts them in the treatment
-    arm, diluting the measured experiment lift.
-    """
+    """Return True if the user has at least one positive non-TZ topic strength."""
     if personal_interests is None:
         return False
     return any(
@@ -917,10 +909,8 @@ async def get_sections(
         and ml_backend is not None
         and ml_backend.is_valid(surface_id)
     )
-    # Route to the interest ranker only when the user has at least one positive
-    # non-TZ topic strength. Otherwise zero-signal users get scored at popularity
-    # (the same outcome cohort gives them) but are counted in the treatment arm,
-    # diluting the experiment's measured lift. See `has_meaningful_interest_signal`.
+    # Require ≥1 positive non-TZ topic strength so zero-signal users don't dilute
+    # the experiment arm.
     use_interest_ranker = (
         is_inferred_interest_experiment(request)
         and lints_interest_backend.is_valid(surface_id)

--- a/tests/unit/curated_recommendations/test_sections.py
+++ b/tests/unit/curated_recommendations/test_sections.py
@@ -132,28 +132,19 @@ def sample_backend_data() -> list[CorpusSection]:
 
 
 class TestHasMeaningfulInterestSignal:
-    """Gate that decides whether the InterestRanker is eligible for a request.
-
-    Before the fix, `bool(personal_interests.scores)` was True even for users
-    whose only non-zero scores were the model_id (string) and TZ keys. Those
-    requests got routed into the InterestRanker treatment arm but had no
-    personalization signal to apply — diluting the measured experiment lift.
-    The helper now requires ≥1 positive non-TZ topic strength.
-    """
+    """InterestRanker eligibility gate — requires ≥1 positive non-TZ topic strength."""
 
     def test_returns_false_when_personal_interests_is_none(self):
-        """A request with no inferred interests at all fails the gate."""
+        """None input."""
         assert has_meaningful_interest_signal(None) is False
 
     def test_returns_false_for_empty_scores(self):
-        """Empty scores dict means no signal."""
+        """Empty scores dict."""
         pi = ProcessedInterests(model_id="inferred-v3-model", scores={})
         assert has_meaningful_interest_signal(pi) is False
 
     def test_returns_false_when_all_topic_strengths_are_zero(self):
-        """Topic keys present but all values 0 → still no real signal. This is
-        the case the old `bool(personal_interests.scores)` gate let through.
-        """
+        """All topic keys present at strength 0 (case the old gate let through)."""
         pi = ProcessedInterests(
             model_id="inferred-v3-model",
             scores={
@@ -169,7 +160,7 @@ class TestHasMeaningfulInterestSignal:
         assert has_meaningful_interest_signal(pi) is False
 
     def test_returns_false_when_only_tz_is_set(self):
-        """TZ is metadata, not interest signal — it alone must not enable the gate."""
+        """TZ alone is metadata, not signal."""
         pi = ProcessedInterests(
             model_id="inferred-v3-model",
             scores={
@@ -181,7 +172,7 @@ class TestHasMeaningfulInterestSignal:
         assert has_meaningful_interest_signal(pi) is False
 
     def test_returns_true_when_one_topic_has_positive_strength(self):
-        """Any one topic with strength > 0 is enough to enable the interest ranker."""
+        """One positive topic is enough."""
         pi = ProcessedInterests(
             model_id="inferred-v3-model",
             scores={
@@ -193,7 +184,7 @@ class TestHasMeaningfulInterestSignal:
         assert has_meaningful_interest_signal(pi) is True
 
     def test_returns_true_with_multiple_positive_strengths(self):
-        """Multi-topic users obviously pass."""
+        """Multi-topic users pass."""
         pi = ProcessedInterests(
             model_id="inferred-v3-model",
             scores={
@@ -206,11 +197,7 @@ class TestHasMeaningfulInterestSignal:
         assert has_meaningful_interest_signal(pi) is True
 
     def test_ignores_non_numeric_values(self):
-        """`model_id` lives on the ProcessedInterests model itself, but if any
-        non-numeric value slips into scores it must not be counted as signal.
-        """
-        # Mutating the dict directly to simulate stray non-numeric values
-        # without going through ProcessedInterests' validation.
+        """Non-numeric scores don't count as signal."""
         pi = ProcessedInterests(model_id="inferred-v3-model", scores={})
         pi.scores["some_string"] = "v3"
         pi.scores["sports"] = 0.0
@@ -220,11 +207,7 @@ class TestHasMeaningfulInterestSignal:
         assert has_meaningful_interest_signal(pi) is True
 
     def test_zero_strength_with_positive_tz_value_still_false(self):
-        """A user with only TZ=int(0) and zero topics has no real signal.
-
-        Edge case: TZ values are integers and could be 0 (the easternmost
-        bucket). The gate must exclude TZ regardless of its numeric value.
-        """
+        """TZ excluded regardless of its numeric value (could be 0)."""
         pi = ProcessedInterests(
             model_id="inferred-v3-model",
             scores={

--- a/tests/unit/curated_recommendations/test_sections.py
+++ b/tests/unit/curated_recommendations/test_sections.py
@@ -33,6 +33,7 @@ from merino.curated_recommendations.prior_backends.engagment_rescaler import (
 from merino.curated_recommendations.protocol import (
     ITEM_HEADLINES_FLAG,
     ITEM_SUBTOPIC_FLAG,
+    ProcessedInterests,
     Section,
     SectionConfiguration,
     EditorialSectionsBranch,
@@ -42,10 +43,14 @@ from merino.curated_recommendations.protocol import (
     RankingData,
 )
 from merino.curated_recommendations.rankers import ThompsonSamplingRanker
+from merino.curated_recommendations.ml_backends.static_local_model import (
+    TIME_ZONE_OFFSET_INFERRED_KEY,
+)
 from merino.curated_recommendations.sections import (
     adjust_ads_in_sections,
     dedupe_experiment_sections,
     exclude_recommendations_from_blocked_sections,
+    has_meaningful_interest_signal,
     is_subtopics_experiment,
     is_daily_briefing_experiment,
     should_exclude_editorial_sections,
@@ -124,6 +129,110 @@ def sample_backend_data() -> list[CorpusSection]:
         )
         for sec_id, count in [("business", 2), ("sports", 1), ("tech", 3)]
     ]
+
+
+class TestHasMeaningfulInterestSignal:
+    """Gate that decides whether the InterestRanker is eligible for a request.
+
+    Before the fix, `bool(personal_interests.scores)` was True even for users
+    whose only non-zero scores were the model_id (string) and TZ keys. Those
+    requests got routed into the InterestRanker treatment arm but had no
+    personalization signal to apply — diluting the measured experiment lift.
+    The helper now requires ≥1 positive non-TZ topic strength.
+    """
+
+    def test_returns_false_when_personal_interests_is_none(self):
+        """A request with no inferred interests at all fails the gate."""
+        assert has_meaningful_interest_signal(None) is False
+
+    def test_returns_false_for_empty_scores(self):
+        """Empty scores dict means no signal."""
+        pi = ProcessedInterests(model_id="inferred-v3-model", scores={})
+        assert has_meaningful_interest_signal(pi) is False
+
+    def test_returns_false_when_all_topic_strengths_are_zero(self):
+        """Topic keys present but all values 0 → still no real signal. This is
+        the case the old `bool(personal_interests.scores)` gate let through.
+        """
+        pi = ProcessedInterests(
+            model_id="inferred-v3-model",
+            scores={
+                "sports": 0.0,
+                "arts": 0.0,
+                "government": 0.0,
+                "society-parenting": 0.0,
+                "food": 0.0,
+                "tech": 0.0,
+                "education-science": 0.0,
+            },
+        )
+        assert has_meaningful_interest_signal(pi) is False
+
+    def test_returns_false_when_only_tz_is_set(self):
+        """TZ is metadata, not interest signal — it alone must not enable the gate."""
+        pi = ProcessedInterests(
+            model_id="inferred-v3-model",
+            scores={
+                "sports": 0.0,
+                "tech": 0.0,
+                TIME_ZONE_OFFSET_INFERRED_KEY: -5,
+            },
+        )
+        assert has_meaningful_interest_signal(pi) is False
+
+    def test_returns_true_when_one_topic_has_positive_strength(self):
+        """Any one topic with strength > 0 is enough to enable the interest ranker."""
+        pi = ProcessedInterests(
+            model_id="inferred-v3-model",
+            scores={
+                "sports": 0.46,
+                "arts": 0.0,
+                TIME_ZONE_OFFSET_INFERRED_KEY: -5,
+            },
+        )
+        assert has_meaningful_interest_signal(pi) is True
+
+    def test_returns_true_with_multiple_positive_strengths(self):
+        """Multi-topic users obviously pass."""
+        pi = ProcessedInterests(
+            model_id="inferred-v3-model",
+            scores={
+                "sports": 0.46,
+                "politics": 0.8,
+                "tech": 0.25,
+                TIME_ZONE_OFFSET_INFERRED_KEY: -5,
+            },
+        )
+        assert has_meaningful_interest_signal(pi) is True
+
+    def test_ignores_non_numeric_values(self):
+        """`model_id` lives on the ProcessedInterests model itself, but if any
+        non-numeric value slips into scores it must not be counted as signal.
+        """
+        # Mutating the dict directly to simulate stray non-numeric values
+        # without going through ProcessedInterests' validation.
+        pi = ProcessedInterests(model_id="inferred-v3-model", scores={})
+        pi.scores["some_string"] = "v3"
+        pi.scores["sports"] = 0.0
+        assert has_meaningful_interest_signal(pi) is False
+
+        pi.scores["sports"] = 0.25
+        assert has_meaningful_interest_signal(pi) is True
+
+    def test_zero_strength_with_positive_tz_value_still_false(self):
+        """A user with only TZ=int(0) and zero topics has no real signal.
+
+        Edge case: TZ values are integers and could be 0 (the easternmost
+        bucket). The gate must exclude TZ regardless of its numeric value.
+        """
+        pi = ProcessedInterests(
+            model_id="inferred-v3-model",
+            scores={
+                "sports": 0.0,
+                TIME_ZONE_OFFSET_INFERRED_KEY: 0,
+            },
+        )
+        assert has_meaningful_interest_signal(pi) is False
 
 
 class TestExcludeRecommendationsFromBlockedSections:


### PR DESCRIPTION
## References

JIRA: [AIMOD-1268](https://mozilla-hub.atlassian.net/browse/AIMOD-1268)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->
Timezone interest vectors should not go through the interest ranker. In the check we had allowed this and is now removed. Only users with real interest vectors (non-tz) will go through the interest ranker with this change.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2354)


[AIMOD-1268]: https://mozilla-hub.atlassian.net/browse/AIMOD-1268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ