### PR TITLE
[DISCO-4259] wcs: circuit breaker to return 503

### DIFF
--- a/merino/configs/__init__.py
+++ b/merino/configs/__init__.py
@@ -162,6 +162,15 @@ _validators = [
     Validator("providers.sports.event_ttl_weeks", is_type_of=int, gte=1, required=False),
     Validator("providers.sports.intent_words", is_type_of=list),
     Validator("providers.wcs.live_data_enabled", is_type_of=bool),
+    Validator(
+        "providers.wcs.circuit_breaker_failure_threshold", is_type_of=int, gte=1, required=True
+    ),
+    Validator(
+        "providers.wcs.circuit_breaker_recover_timeout_sec", is_type_of=int, gte=1, required=True
+    ),
+    Validator(
+        "providers.wcs.circuit_breaker_retry_after_sec", is_type_of=int, gte=1, required=True
+    ),
     # TODO: Break these out into a generic "elastic search" set?
     Validator("providers.sports.es.dsn", is_type_of=str, required=True),
     Validator("providers.sports.es.api_key", is_type_of=str, required=True),

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -545,6 +545,9 @@ circuit_breaker_recover_timeout_sec = 30
 # MERINO_PROVIDERS__WCS__WATCH_LINKS_CACHE_CONTROL_TTL
 # TTL value for the cache-control header set on the /wcs/watch-links endpoint response.
 watch_links_cache_control_ttl = 3600 # 1 hour
+# MERINO_PROVIDERS__WCS__CIRCUIT_BREAKER_RETRY_AFTER_SEC
+# Value for the `Retry-After` header on 503 responses when the breaker is open.
+circuit_breaker_retry_after_sec = 90
 
 [default.manifest]
 # MERINO_PROVIDERS__MANIFEST__CRON_INTERVAL_SEC

--- a/merino/configs/testing.toml
+++ b/merino/configs/testing.toml
@@ -138,6 +138,7 @@ resync_interval_sec = 86400
 [testing.providers.wcs]
 circuit_breaker_failure_threshold = 1
 circuit_breaker_recover_timeout_sec = 3
+circuit_breaker_retry_after_sec = 5
 backend = "test"
 
 

--- a/merino/web/api_v1_wcs.py
+++ b/merino/web/api_v1_wcs.py
@@ -13,7 +13,6 @@ from merino.middleware import ScopeKey
 from merino.middleware.geolocation import Location
 from circuitbreaker import CircuitBreakerError
 
-from merino.configs import settings
 from merino.providers.wcs import get_provider as get_wcs_provider
 from merino.providers.wcs.protocol import (
     LiveMatchesResponse,

--- a/merino/web/api_v1_wcs.py
+++ b/merino/web/api_v1_wcs.py
@@ -4,13 +4,16 @@ from datetime import UTC, datetime
 from datetime import date as Date
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Query, Request, Header
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Header
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
 
 from merino.configs import settings
 from merino.middleware import ScopeKey
 from merino.middleware.geolocation import Location
+from circuitbreaker import CircuitBreakerError
+
+from merino.configs import settings
 from merino.providers.wcs import get_provider as get_wcs_provider
 from merino.providers.wcs.protocol import (
     LiveMatchesResponse,
@@ -55,8 +58,17 @@ async def get_wcs_matches(
     """
     target_date = date or datetime.now(UTC).date()
     team_keys = _parse_team_keys(teams)
-    matches: MatchesResponse = await provider.get_matches(target_date, limit, team_keys)
-    return matches
+    try:
+        matches: MatchesResponse = await provider.get_matches(target_date, limit, team_keys)
+        return matches
+    except CircuitBreakerError:
+        raise HTTPException(
+            status_code=503,
+            detail="WCS temporarily unavailable",
+            headers={
+                "Retry-After": str(settings.providers.wcs.circuit_breaker_recover_timeout_sec)
+            },
+        )
 
 
 @router.get(
@@ -73,8 +85,19 @@ async def get_wcs_live(
     provider: WcsProvider = Depends(get_wcs_provider),
 ) -> LiveMatchesResponse:
     """Return in-progress matches sorted ascending by date."""
-    live_matches: LiveMatchesResponse = await provider.get_live_matches(_parse_team_keys(teams))
-    return live_matches
+    try:
+        live_matches: LiveMatchesResponse = await provider.get_live_matches(
+            _parse_team_keys(teams)
+        )
+        return live_matches
+    except CircuitBreakerError:
+        raise HTTPException(
+            status_code=503,
+            detail="WCS temporarily unavailable",
+            headers={
+                "Retry-After": str(settings.providers.wcs.circuit_breaker_recover_timeout_sec)
+            },
+        )
 
 
 @router.get(
@@ -110,8 +133,17 @@ async def get_wcs_teams(
     provider: WcsProvider = Depends(get_wcs_provider),
 ) -> TeamsResponse:
     """Return all teams participating in the World Cup."""
-    teams: TeamsResponse = await provider.get_teams()
-    return teams
+    try:
+        teams: TeamsResponse = await provider.get_teams()
+        return teams
+    except CircuitBreakerError:
+        raise HTTPException(
+            status_code=503,
+            detail="WCS temporarily unavailable",
+            headers={
+                "Retry-After": str(settings.providers.wcs.circuit_breaker_recover_timeout_sec)
+            },
+        )
 
 
 def _parse_team_keys(teams: str | None) -> frozenset[str] | None:

--- a/merino/web/api_v1_wcs.py
+++ b/merino/web/api_v1_wcs.py
@@ -30,6 +30,7 @@ router = APIRouter()
 
 HEADER_CHARACTER_MAX = settings.web.api.v1.header_character_max
 WATCH_LINKS_CACHE_CONTROL_TTL = settings.providers.wcs.watch_links_cache_control_ttl
+_RETRY_AFTER = str(settings.providers.wcs.circuit_breaker_retry_after_sec)
 
 
 @router.get(
@@ -65,9 +66,7 @@ async def get_wcs_matches(
         raise HTTPException(
             status_code=503,
             detail="WCS temporarily unavailable",
-            headers={
-                "Retry-After": str(settings.providers.wcs.circuit_breaker_recover_timeout_sec)
-            },
+            headers={"Retry-After": _RETRY_AFTER},
         )
 
 
@@ -94,9 +93,7 @@ async def get_wcs_live(
         raise HTTPException(
             status_code=503,
             detail="WCS temporarily unavailable",
-            headers={
-                "Retry-After": str(settings.providers.wcs.circuit_breaker_recover_timeout_sec)
-            },
+            headers={"Retry-After": _RETRY_AFTER},
         )
 
 
@@ -140,9 +137,7 @@ async def get_wcs_teams(
         raise HTTPException(
             status_code=503,
             detail="WCS temporarily unavailable",
-            headers={
-                "Retry-After": str(settings.providers.wcs.circuit_breaker_recover_timeout_sec)
-            },
+            headers={"Retry-After": _RETRY_AFTER},
         )
 
 

--- a/tests/integration/api/v1/wcs/test_live.py
+++ b/tests/integration/api/v1/wcs/test_live.py
@@ -98,4 +98,4 @@ def test_open_circuit_breaker_returns_503(client: TestClient, mocker) -> None:
 
     assert response.status_code == 503
     assert response.json() == {"detail": "WCS temporarily unavailable"}
-    assert response.headers["retry-after"] == "3"
+    assert response.headers["retry-after"] == "5"

--- a/tests/integration/api/v1/wcs/test_live.py
+++ b/tests/integration/api/v1/wcs/test_live.py
@@ -8,7 +8,12 @@ from collections.abc import Iterator
 
 import freezegun
 import pytest
+from circuitbreaker import CircuitBreakerError
 from starlette.testclient import TestClient
+
+from merino.main import app
+from merino.providers.wcs import get_provider as get_wcs_provider
+from merino.providers.wcs.provider import WcsProvider
 
 
 _PATH = "/api/v1/wcs/live"
@@ -81,3 +86,16 @@ def test_team_icons_are_svg(client: TestClient) -> None:
 
     expected_prefix = "https://storage.googleapis.com/merino-images-prod/logos/nations/svg/"
     assert all(icon.startswith(expected_prefix) for icon in icons)
+
+
+def test_open_circuit_breaker_returns_503(client: TestClient, mocker) -> None:
+    """An open circuit breaker surfaces as HTTP 503 with `Retry-After`."""
+    provider = mocker.AsyncMock(spec=WcsProvider)
+    provider.get_live_matches.side_effect = CircuitBreakerError("wcs breaker open")
+    app.dependency_overrides[get_wcs_provider] = lambda: provider
+
+    response = client.get(_PATH)
+
+    assert response.status_code == 503
+    assert response.json() == {"detail": "WCS temporarily unavailable"}
+    assert response.headers["retry-after"] == "3"

--- a/tests/integration/api/v1/wcs/test_live.py
+++ b/tests/integration/api/v1/wcs/test_live.py
@@ -8,9 +8,10 @@ from collections.abc import Iterator
 
 import freezegun
 import pytest
-from circuitbreaker import CircuitBreakerError
 from starlette.testclient import TestClient
 
+from merino.configs import settings
+from merino.exceptions import CacheAdapterError
 from merino.main import app
 from merino.providers.wcs import get_provider as get_wcs_provider
 from merino.providers.wcs.provider import WcsProvider
@@ -89,13 +90,23 @@ def test_team_icons_are_svg(client: TestClient) -> None:
 
 
 def test_open_circuit_breaker_returns_503(client: TestClient, mocker) -> None:
-    """An open circuit breaker surfaces as HTTP 503 with `Retry-After`."""
-    provider = mocker.AsyncMock(spec=WcsProvider)
-    provider.get_live_matches.side_effect = CircuitBreakerError("wcs breaker open")
-    app.dependency_overrides[get_wcs_provider] = lambda: provider
+    """A Redis cache failure trips the breaker; subsequent requests return 503 + Retry-After."""
+    with freezegun.freeze_time("2026-06-15T16:00:00Z") as freezer:
+        sport = mocker.Mock()
+        sport.get_events_by_date = mocker.AsyncMock(side_effect=CacheAdapterError("redis down"))
+        app.dependency_overrides[get_wcs_provider] = lambda: WcsProvider(
+            sport=sport, live_data_enabled=True
+        )
 
-    response = client.get(_PATH)
+        # Trip the breaker
+        with pytest.raises(CacheAdapterError):
+            client.get(_PATH)
 
-    assert response.status_code == 503
-    assert response.json() == {"detail": "WCS temporarily unavailable"}
-    assert response.headers["retry-after"] == "5"
+        response = client.get(_PATH)
+        assert response.status_code == 503
+        assert response.json() == {"detail": "WCS temporarily unavailable"}
+        assert response.headers["retry-after"] == "5"
+
+        freezer.tick(settings.providers.wcs.circuit_breaker_recover_timeout_sec + 1)
+        sport.get_events_by_date = mocker.AsyncMock(return_value=[])
+        client.get(_PATH)

--- a/tests/integration/api/v1/wcs/test_matches.py
+++ b/tests/integration/api/v1/wcs/test_matches.py
@@ -4,9 +4,12 @@
 
 """Integration tests for `GET /api/v1/wcs/matches`."""
 
-from circuitbreaker import CircuitBreakerError
+import freezegun
+import pytest
 from starlette.testclient import TestClient
 
+from merino.configs import settings
+from merino.exceptions import CacheAdapterError
 from merino.main import app
 from merino.providers.suggest.sports.backends.sportsdata.common import GameStatus
 from merino.providers.wcs import get_provider as get_wcs_provider
@@ -121,16 +124,24 @@ def test_invalid_date_returns_400(client: TestClient) -> None:
 
 
 def test_open_circuit_breaker_returns_503(client: TestClient, mocker) -> None:
-    """An open circuit breaker surfaces as HTTP 503 with `Retry-After`."""
-    provider = mocker.AsyncMock(spec=WcsProvider)
-    provider.get_matches.side_effect = CircuitBreakerError("wcs breaker open")
-    app.dependency_overrides[get_wcs_provider] = lambda: provider
+    """A Redis cache failure trips the breaker; subsequent requests return 503 + Retry-After."""
+    with freezegun.freeze_time("2026-06-15T16:00:00Z") as freezer:
+        sport = mocker.Mock()
+        sport.get_events_by_date = mocker.AsyncMock(side_effect=CacheAdapterError("redis down"))
+        app.dependency_overrides[get_wcs_provider] = lambda: WcsProvider(sport=sport)
 
-    response = client.get(_PATH)
+        # Trip the breaker
+        with pytest.raises(CacheAdapterError):
+            client.get(_PATH)
 
-    assert response.status_code == 503
-    assert response.json() == {"detail": "WCS temporarily unavailable"}
-    assert response.headers["retry-after"] == "5"
+        response = client.get(_PATH)
+        assert response.status_code == 503
+        assert response.json() == {"detail": "WCS temporarily unavailable"}
+        assert response.headers["retry-after"] == "5"
+
+        freezer.tick(settings.providers.wcs.circuit_breaker_recover_timeout_sec + 1)
+        sport.get_events_by_date = mocker.AsyncMock(return_value=[])
+        client.get(_PATH)
 
 
 def test_team_icons_pinned_to_prod_logo_bucket(client: TestClient) -> None:

--- a/tests/integration/api/v1/wcs/test_matches.py
+++ b/tests/integration/api/v1/wcs/test_matches.py
@@ -4,11 +4,13 @@
 
 """Integration tests for `GET /api/v1/wcs/matches`."""
 
+from circuitbreaker import CircuitBreakerError
 from starlette.testclient import TestClient
 
 from merino.main import app
 from merino.providers.suggest.sports.backends.sportsdata.common import GameStatus
 from merino.providers.wcs import get_provider as get_wcs_provider
+from merino.providers.wcs.provider import WcsProvider
 from tests.wcs.factories import build_provider, event as build_event
 
 
@@ -116,6 +118,19 @@ def test_invalid_date_returns_400(client: TestClient) -> None:
     """Merino's validation handler in main.py converts FastAPI's 422 to 400."""
     response = client.get(_PATH, params={"date": "not-a-date"})
     assert response.status_code == 400
+
+
+def test_open_circuit_breaker_returns_503(client: TestClient, mocker) -> None:
+    """An open circuit breaker surfaces as HTTP 503 with `Retry-After`."""
+    provider = mocker.AsyncMock(spec=WcsProvider)
+    provider.get_matches.side_effect = CircuitBreakerError("wcs breaker open")
+    app.dependency_overrides[get_wcs_provider] = lambda: provider
+
+    response = client.get(_PATH)
+
+    assert response.status_code == 503
+    assert response.json() == {"detail": "WCS temporarily unavailable"}
+    assert response.headers["retry-after"] == "3"
 
 
 def test_team_icons_pinned_to_prod_logo_bucket(client: TestClient) -> None:

--- a/tests/integration/api/v1/wcs/test_matches.py
+++ b/tests/integration/api/v1/wcs/test_matches.py
@@ -130,7 +130,7 @@ def test_open_circuit_breaker_returns_503(client: TestClient, mocker) -> None:
 
     assert response.status_code == 503
     assert response.json() == {"detail": "WCS temporarily unavailable"}
-    assert response.headers["retry-after"] == "3"
+    assert response.headers["retry-after"] == "5"
 
 
 def test_team_icons_pinned_to_prod_logo_bucket(client: TestClient) -> None:

--- a/tests/integration/api/v1/wcs/test_teams.py
+++ b/tests/integration/api/v1/wcs/test_teams.py
@@ -4,9 +4,12 @@
 
 """Integration tests for `GET /api/v1/wcs/teams`."""
 
-from circuitbreaker import CircuitBreakerError
+import freezegun
+import pytest
 from fastapi.testclient import TestClient
 
+from merino.configs import settings
+from merino.exceptions import CacheAdapterError
 from merino.main import app
 from merino.providers.wcs import get_provider as get_wcs_provider
 from merino.providers.wcs.provider import WcsProvider
@@ -62,13 +65,22 @@ def test_team_icons_are_svg_from_prod_logo_bucket(client: TestClient) -> None:
 
 
 def test_open_circuit_breaker_returns_503(client: TestClient, mocker) -> None:
-    """An open circuit breaker surfaces as HTTP 503 with `Retry-After`."""
-    provider = mocker.AsyncMock(spec=WcsProvider)
-    provider.get_teams.side_effect = CircuitBreakerError("wcs breaker open")
-    app.dependency_overrides[get_wcs_provider] = lambda: provider
+    """A Redis cache failure trips the breaker; subsequent requests return 503 + Retry-After."""
+    with freezegun.freeze_time("2026-06-15T16:00:00Z") as freezer:
+        sport = mocker.Mock()
+        sport.get_all_teams = mocker.AsyncMock(side_effect=CacheAdapterError("redis down"))
+        sport.get_eliminated_team_keys = mocker.AsyncMock(return_value=set())
+        app.dependency_overrides[get_wcs_provider] = lambda: WcsProvider(sport=sport)
 
-    response = client.get(_PATH)
+        # Trip the breaker
+        with pytest.raises(CacheAdapterError):
+            client.get(_PATH)
 
-    assert response.status_code == 503
-    assert response.json() == {"detail": "WCS temporarily unavailable"}
-    assert response.headers["retry-after"] == "5"
+        response = client.get(_PATH)
+        assert response.status_code == 503
+        assert response.json() == {"detail": "WCS temporarily unavailable"}
+        assert response.headers["retry-after"] == "5"
+
+        freezer.tick(settings.providers.wcs.circuit_breaker_recover_timeout_sec + 1)
+        sport.get_all_teams = mocker.AsyncMock(return_value={})
+        client.get(_PATH)

--- a/tests/integration/api/v1/wcs/test_teams.py
+++ b/tests/integration/api/v1/wcs/test_teams.py
@@ -71,4 +71,4 @@ def test_open_circuit_breaker_returns_503(client: TestClient, mocker) -> None:
 
     assert response.status_code == 503
     assert response.json() == {"detail": "WCS temporarily unavailable"}
-    assert response.headers["retry-after"] == "3"
+    assert response.headers["retry-after"] == "5"

--- a/tests/integration/api/v1/wcs/test_teams.py
+++ b/tests/integration/api/v1/wcs/test_teams.py
@@ -4,7 +4,12 @@
 
 """Integration tests for `GET /api/v1/wcs/teams`."""
 
+from circuitbreaker import CircuitBreakerError
 from fastapi.testclient import TestClient
+
+from merino.main import app
+from merino.providers.wcs import get_provider as get_wcs_provider
+from merino.providers.wcs.provider import WcsProvider
 
 _PATH = "/api/v1/wcs/teams"
 
@@ -54,3 +59,16 @@ def test_team_icons_are_svg_from_prod_logo_bucket(client: TestClient) -> None:
     assert icons
     expected_prefix = "https://storage.googleapis.com/merino-images-prod/logos/nations/svg/"
     assert all(icon.startswith(expected_prefix) for icon in icons)
+
+
+def test_open_circuit_breaker_returns_503(client: TestClient, mocker) -> None:
+    """An open circuit breaker surfaces as HTTP 503 with `Retry-After`."""
+    provider = mocker.AsyncMock(spec=WcsProvider)
+    provider.get_teams.side_effect = CircuitBreakerError("wcs breaker open")
+    app.dependency_overrides[get_wcs_provider] = lambda: provider
+
+    response = client.get(_PATH)
+
+    assert response.status_code == 503
+    assert response.json() == {"detail": "WCS temporarily unavailable"}
+    assert response.headers["retry-after"] == "3"


### PR DESCRIPTION
## References

JIRA: [DISCO-4259](https://mozilla-hub.atlassian.net/browse/DISCO-4259)

## Description
Return 503 instead of defaulting to 500 for wcs CircuitBreakerError



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2355)


[DISCO-4259]: https://mozilla-hub.atlassian.net/browse/DISCO-4259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ