### PR TITLE
[HNT-2622] Popular today config is keyed by locale; increase topic limit in de_DE to 3

### DIFF
--- a/merino/curated_recommendations/article_balancer.py
+++ b/merino/curated_recommendations/article_balancer.py
@@ -1,28 +1,20 @@
 """Balancers for curated recommendation articles."""
 
 from collections import defaultdict
-from dataclasses import dataclass
 import math
-from typing import Callable, Collection
 
 from merino.curated_recommendations.corpus_backends.protocol import Topic
-from merino.curated_recommendations.protocol import ITEM_SUBTOPIC_FLAG, CuratedRecommendation
-
-
-@dataclass(frozen=True)
-class ArticleBalancerConfig:
-    """Configuration for an ArticleBalancer instance."""
-
-    max_topical_ratio: float
-    max_evergreen_ratio: float
-    max_per_topic_ratio: float
-    max_subtopic_ratio: float
-    max_blocked_topics_ratio: float
-    evergreen_topics: Collection[Topic]
-    subtopic_checker: Callable[[CuratedRecommendation], bool]
-    min_per_topic_limit: int = 0
-    min_subtopic_limit: int = 0
-    blocked_topics_multiplier: int = 1
+from merino.curated_recommendations.article_balancer_configs import (
+    ArticleBalancerConfig,
+    BALANCER_MAX_EVERGREEN as BALANCER_MAX_EVERGREEN,
+    BALANCER_MAX_PER_TOPIC as BALANCER_MAX_PER_TOPIC,
+    BALANCER_MAX_SUBTOPIC as BALANCER_MAX_SUBTOPIC,
+    BALANCER_MAX_TOPICAL as BALANCER_MAX_TOPICAL,
+    DEFAULT_TOP_STORIES_ARTICLE_BALANCER_CONFIG,
+    EVERGREEN_TOPICS as EVERGREEN_TOPICS,
+    MAX_BLOCKED_TOPICS as MAX_BLOCKED_TOPICS,
+)
+from merino.curated_recommendations.protocol import CuratedRecommendation
 
 
 class ArticleBalancer:
@@ -132,38 +124,15 @@ class ArticleBalancer:
         return self.article_list
 
 
-BALANCER_MAX_TOPICAL = 0.75
-BALANCER_MAX_EVERGREEN = 0.4
-
-BALANCER_MAX_PER_TOPIC = 0.2
-BALANCER_MAX_SUBTOPIC = 0.1
-MAX_BLOCKED_TOPICS = 0.0  # When set to 0.1 it effectively means 0 when num articles < 10, which is typical (non personalized) case
-
-EVERGREEN_TOPICS = {
-    Topic.FOOD,
-    Topic.SELF_IMPROVEMENT,
-    Topic.PERSONAL_FINANCE,
-    Topic.PARENTING,
-    Topic.HOME,
-}
-
-
 class TopStoriesArticleBalancer(ArticleBalancer):
     """Balancer configured for top stories."""
 
-    def __init__(self, expected_num_articles: int) -> None:
+    def __init__(
+        self,
+        expected_num_articles: int,
+        config: ArticleBalancerConfig | None = None,
+    ) -> None:
         super().__init__(
             expected_num_articles=expected_num_articles,
-            config=ArticleBalancerConfig(
-                max_topical_ratio=BALANCER_MAX_TOPICAL,
-                max_evergreen_ratio=BALANCER_MAX_EVERGREEN,
-                max_per_topic_ratio=BALANCER_MAX_PER_TOPIC,
-                max_subtopic_ratio=BALANCER_MAX_SUBTOPIC,
-                max_blocked_topics_ratio=MAX_BLOCKED_TOPICS,
-                evergreen_topics=EVERGREEN_TOPICS,
-                subtopic_checker=lambda rec: rec.in_experiment(ITEM_SUBTOPIC_FLAG),
-                min_per_topic_limit=2,
-                min_subtopic_limit=1,
-                blocked_topics_multiplier=3,
-            ),
+            config=config or DEFAULT_TOP_STORIES_ARTICLE_BALANCER_CONFIG,
         )

--- a/merino/curated_recommendations/article_balancer.py
+++ b/merino/curated_recommendations/article_balancer.py
@@ -56,6 +56,12 @@ class ArticleBalancer:
         """Return true if item is in a subtopic."""
         return self.subtopic_checker(rec)
 
+    def _max_for_topic(self, topic: Topic) -> int:
+        """Return the max article count for a topic, including configured topic overrides."""
+        if topic == Topic.POLITICS and self.config.government_max_override is not None:
+            return self.config.government_max_override
+        return self.max_per_topic
+
     def is_blocked_rec(self, rec: CuratedRecommendation) -> bool:
         """Return true if topic is a blocked topic."""
         return rec.is_story_blocked_for_top_stories()
@@ -84,7 +90,7 @@ class ArticleBalancer:
         if info_dict.get("blocked_topics", 0) > self.max_blocked_topics:
             return False
         for topic in Topic:
-            if info_dict.get(topic.value, 0) > self.max_per_topic:
+            if info_dict.get(topic.value, 0) > self._max_for_topic(topic):
                 return False
         return True
 

--- a/merino/curated_recommendations/article_balancer.py
+++ b/merino/curated_recommendations/article_balancer.py
@@ -6,13 +6,7 @@ import math
 from merino.curated_recommendations.corpus_backends.protocol import Topic
 from merino.curated_recommendations.article_balancer_configs import (
     ArticleBalancerConfig,
-    BALANCER_MAX_EVERGREEN as BALANCER_MAX_EVERGREEN,
-    BALANCER_MAX_PER_TOPIC as BALANCER_MAX_PER_TOPIC,
-    BALANCER_MAX_SUBTOPIC as BALANCER_MAX_SUBTOPIC,
-    BALANCER_MAX_TOPICAL as BALANCER_MAX_TOPICAL,
     DEFAULT_TOP_STORIES_ARTICLE_BALANCER_CONFIG,
-    EVERGREEN_TOPICS as EVERGREEN_TOPICS,
-    MAX_BLOCKED_TOPICS as MAX_BLOCKED_TOPICS,
 )
 from merino.curated_recommendations.protocol import CuratedRecommendation
 

--- a/merino/curated_recommendations/article_balancer_configs.py
+++ b/merino/curated_recommendations/article_balancer_configs.py
@@ -21,6 +21,7 @@ class ArticleBalancerConfig:
     min_per_topic_limit: int = 0
     min_subtopic_limit: int = 0
     blocked_topics_multiplier: int = 1
+    government_max_override: int | None = None
 
 
 BALANCER_MAX_TOPICAL = 0.75
@@ -57,7 +58,8 @@ DEFAULT_TOP_STORIES_ARTICLE_BALANCER_CONFIG = ArticleBalancerConfig(
 TOP_STORIES_BALANCER_CONFIG_BY_SURFACE: dict[SurfaceId, ArticleBalancerConfig] = {
     SurfaceId.NEW_TAB_DE_DE: replace(
         DEFAULT_TOP_STORIES_ARTICLE_BALANCER_CONFIG,
-        min_per_topic_limit=3,
+        min_per_topic_limit=2,
+        government_max_override=3,
     ),
 }
 

--- a/merino/curated_recommendations/article_balancer_configs.py
+++ b/merino/curated_recommendations/article_balancer_configs.py
@@ -28,7 +28,7 @@ BALANCER_MAX_TOPICAL = 0.75
 BALANCER_MAX_EVERGREEN = 0.4
 
 # there are two passes where this is used, a top-9 pass then an additional 5
-# BALANCER_MAX_PER_TOPIC = 0.2 causes a max per topic of 2 in top-9 
+# BALANCER_MAX_PER_TOPIC = 0.2 causes a max per topic of 2 in top-9
 # there is also the min_per_topic_limit which affects the two passes independently
 BALANCER_MAX_PER_TOPIC = 0.2
 BALANCER_MAX_SUBTOPIC = 0.1

--- a/merino/curated_recommendations/article_balancer_configs.py
+++ b/merino/curated_recommendations/article_balancer_configs.py
@@ -27,6 +27,9 @@ class ArticleBalancerConfig:
 BALANCER_MAX_TOPICAL = 0.75
 BALANCER_MAX_EVERGREEN = 0.4
 
+# there are two passes where this is used, a top-9 pass then an additional 5
+# BALANCER_MAX_PER_TOPIC = 0.2 causes a max per topic of 2 in top-9 
+# there is also the min_per_topic_limit which affects the two passes independently
 BALANCER_MAX_PER_TOPIC = 0.2
 BALANCER_MAX_SUBTOPIC = 0.1
 MAX_BLOCKED_TOPICS = 0.0  # 0.1 effectively means 0 when num articles < 10.

--- a/merino/curated_recommendations/article_balancer_configs.py
+++ b/merino/curated_recommendations/article_balancer_configs.py
@@ -1,0 +1,71 @@
+"""Configuration constants for curated recommendation article balancers."""
+
+from collections.abc import Callable, Collection
+from dataclasses import dataclass, replace
+
+from merino.curated_recommendations.corpus_backends.protocol import SurfaceId, Topic
+from merino.curated_recommendations.protocol import ITEM_SUBTOPIC_FLAG, CuratedRecommendation
+
+
+@dataclass(frozen=True)
+class ArticleBalancerConfig:
+    """Configuration for an ArticleBalancer instance."""
+
+    max_topical_ratio: float
+    max_evergreen_ratio: float
+    max_per_topic_ratio: float
+    max_subtopic_ratio: float
+    max_blocked_topics_ratio: float
+    evergreen_topics: Collection[Topic]
+    subtopic_checker: Callable[[CuratedRecommendation], bool]
+    min_per_topic_limit: int = 0
+    min_subtopic_limit: int = 0
+    blocked_topics_multiplier: int = 1
+
+
+BALANCER_MAX_TOPICAL = 0.75
+BALANCER_MAX_EVERGREEN = 0.4
+
+BALANCER_MAX_PER_TOPIC = 0.2
+BALANCER_MAX_SUBTOPIC = 0.1
+MAX_BLOCKED_TOPICS = 0.0  # 0.1 effectively means 0 when num articles < 10.
+
+EVERGREEN_TOPICS = frozenset(
+    {
+        Topic.FOOD,
+        Topic.SELF_IMPROVEMENT,
+        Topic.PERSONAL_FINANCE,
+        Topic.PARENTING,
+        Topic.HOME,
+    }
+)
+
+DEFAULT_TOP_STORIES_ARTICLE_BALANCER_CONFIG = ArticleBalancerConfig(
+    max_topical_ratio=BALANCER_MAX_TOPICAL,
+    max_evergreen_ratio=BALANCER_MAX_EVERGREEN,
+    max_per_topic_ratio=BALANCER_MAX_PER_TOPIC,
+    max_subtopic_ratio=BALANCER_MAX_SUBTOPIC,
+    max_blocked_topics_ratio=MAX_BLOCKED_TOPICS,
+    evergreen_topics=EVERGREEN_TOPICS,
+    subtopic_checker=lambda rec: rec.in_experiment(ITEM_SUBTOPIC_FLAG),
+    min_per_topic_limit=2,
+    min_subtopic_limit=1,
+    blocked_topics_multiplier=3,
+)
+
+# Surface IDs are the locale-normalized key Merino uses for corpus content.
+TOP_STORIES_BALANCER_CONFIG_BY_SURFACE: dict[SurfaceId, ArticleBalancerConfig] = {
+    SurfaceId.NEW_TAB_DE_DE: replace(
+        DEFAULT_TOP_STORIES_ARTICLE_BALANCER_CONFIG,
+        min_per_topic_limit=3,
+    ),
+}
+
+
+def get_top_stories_article_balancer_config(surface_id: SurfaceId) -> ArticleBalancerConfig:
+    """Return the Top Stories/Popular Today balancer config for a surface."""
+    # Future experiment-specific overrides should be selected here once the experiment id
+    # is threaded into this function.
+    return TOP_STORIES_BALANCER_CONFIG_BY_SURFACE.get(
+        surface_id, DEFAULT_TOP_STORIES_ARTICLE_BALANCER_CONFIG
+    )

--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -57,6 +57,10 @@ from merino.curated_recommendations.protocol import (
     ProcessedInterests,
     Layout,
 )
+from merino.curated_recommendations.article_balancer_configs import (
+    ArticleBalancerConfig,
+    get_top_stories_article_balancer_config,
+)
 from merino.curated_recommendations.article_balancer import TopStoriesArticleBalancer
 from merino.curated_recommendations.rankers import (
     ContextualRanker,
@@ -720,6 +724,7 @@ def get_top_story_list(
     rescaler: EngagementRescaler | None = None,
     relax_constraints_for_personalization=False,
     prior: Prior | None = None,
+    article_balancer_config: ArticleBalancerConfig | None = None,
 ) -> list[CuratedRecommendation]:
     """Build a top story list of top_count items from a full list. Adds some extra items from further down
     in the list of recs with some care to not use the same topic more than once.
@@ -764,7 +769,9 @@ def get_top_story_list(
     )
     non_throttled = items[len(items_throttled_fresh) + len(unused_fresh) :]
 
-    balancer = TopStoriesArticleBalancer(round(top_count * constraint_scale))
+    balancer = TopStoriesArticleBalancer(
+        round(top_count * constraint_scale), config=article_balancer_config
+    )
     topic_limited_stories, remaining_stories = balancer.add_stories(
         items_throttled_fresh, top_count
     )
@@ -959,6 +966,7 @@ async def get_sections(
         rescaler=rescaler,
         relax_constraints_for_personalization=False,  # In the future we can set to true for non-empty personal_interests
         prior=prior,
+        article_balancer_config=get_top_stories_article_balancer_config(surface_id),
     )
 
     # 9. Create a global rank lookup from the already-ranked recommendations

--- a/tests/unit/curated_recommendations/test_article_balancer_configs.py
+++ b/tests/unit/curated_recommendations/test_article_balancer_configs.py
@@ -17,7 +17,12 @@ def test_get_top_stories_article_balancer_config_returns_surface_config():
     config = get_top_stories_article_balancer_config(SurfaceId.NEW_TAB_DE_DE)
 
     assert config is TOP_STORIES_BALANCER_CONFIG_BY_SURFACE[SurfaceId.NEW_TAB_DE_DE]
-    assert config.min_per_topic_limit == 3
+    assert (
+        config.max_per_topic_ratio
+        == DEFAULT_TOP_STORIES_ARTICLE_BALANCER_CONFIG.max_per_topic_ratio
+    )
+    assert config.min_per_topic_limit == 2
+    assert config.government_max_override == 3
 
 
 def test_get_top_stories_article_balancer_config_falls_back_to_default():
@@ -40,3 +45,47 @@ def test_top_stories_article_balancer_accepts_custom_config():
 
     assert [balancer.add_story(story) for story in stories] == [True, True, True]
     assert [story.corpusItemId for story in balancer.get_stories()] == ["a", "b", "c"]
+
+
+def test_top_stories_article_balancer_accepts_government_override():
+    """A config can give government stories a topic limit separate from the default."""
+    config = replace(DEFAULT_TOP_STORIES_ARTICLE_BALANCER_CONFIG, government_max_override=3)
+    balancer = TopStoriesArticleBalancer(expected_num_articles=10, config=config)
+    stories = generate_recommendations(
+        item_ids=["a", "b", "c", "d"],
+        topics=[Topic.POLITICS, Topic.POLITICS, Topic.POLITICS, Topic.POLITICS],
+        time_sensitive_count=0,
+    )
+
+    assert [balancer.add_story(story) for story in stories] == [True, True, True, False]
+    assert [story.corpusItemId for story in balancer.get_stories()] == ["a", "b", "c"]
+
+
+def test_de_config_uses_default_topic_ratio_and_government_override():
+    """The DE surface config uses the normal ratio but allows three government stories."""
+    config = get_top_stories_article_balancer_config(SurfaceId.NEW_TAB_DE_DE)
+    balancer = TopStoriesArticleBalancer(expected_num_articles=9, config=config)
+    stories = generate_recommendations(
+        item_ids=["a", "b", "c", "d", "e", "f", "g"],
+        topics=[
+            Topic.BUSINESS,
+            Topic.BUSINESS,
+            Topic.BUSINESS,
+            Topic.POLITICS,
+            Topic.POLITICS,
+            Topic.POLITICS,
+            Topic.POLITICS,
+        ],
+        time_sensitive_count=0,
+    )
+
+    assert [balancer.add_story(story) for story in stories] == [
+        True,
+        True,
+        False,
+        True,
+        True,
+        True,
+        False,
+    ]
+    assert [story.corpusItemId for story in balancer.get_stories()] == ["a", "b", "d", "e", "f"]

--- a/tests/unit/curated_recommendations/test_article_balancer_configs.py
+++ b/tests/unit/curated_recommendations/test_article_balancer_configs.py
@@ -1,0 +1,42 @@
+"""Tests for article balancer configuration constants."""
+
+from dataclasses import replace
+
+from merino.curated_recommendations.article_balancer import TopStoriesArticleBalancer
+from merino.curated_recommendations.article_balancer_configs import (
+    DEFAULT_TOP_STORIES_ARTICLE_BALANCER_CONFIG,
+    TOP_STORIES_BALANCER_CONFIG_BY_SURFACE,
+    get_top_stories_article_balancer_config,
+)
+from merino.curated_recommendations.corpus_backends.protocol import SurfaceId, Topic
+from tests.unit.curated_recommendations.fixtures import generate_recommendations
+
+
+def test_get_top_stories_article_balancer_config_returns_surface_config():
+    """Return the configured balancer config for a section surface."""
+    config = get_top_stories_article_balancer_config(SurfaceId.NEW_TAB_DE_DE)
+
+    assert config is TOP_STORIES_BALANCER_CONFIG_BY_SURFACE[SurfaceId.NEW_TAB_DE_DE]
+    assert config.min_per_topic_limit == 3
+
+
+def test_get_top_stories_article_balancer_config_falls_back_to_default():
+    """Return the default config for surfaces without an explicit override."""
+    assert (
+        get_top_stories_article_balancer_config(SurfaceId.NEW_TAB_ES_ES)
+        is DEFAULT_TOP_STORIES_ARTICLE_BALANCER_CONFIG
+    )
+
+
+def test_top_stories_article_balancer_accepts_custom_config():
+    """A surface-specific config can raise the per-topic floor."""
+    config = replace(DEFAULT_TOP_STORIES_ARTICLE_BALANCER_CONFIG, min_per_topic_limit=3)
+    balancer = TopStoriesArticleBalancer(expected_num_articles=9, config=config)
+    stories = generate_recommendations(
+        item_ids=["a", "b", "c"],
+        topics=[Topic.POLITICS, Topic.POLITICS, Topic.POLITICS],
+        time_sensitive_count=0,
+    )
+
+    assert [balancer.add_story(story) for story in stories] == [True, True, True]
+    assert [story.corpusItemId for story in balancer.get_stories()] == ["a", "b", "c"]


### PR DESCRIPTION
## References

JIRA: [HNT-2622](https://mozilla-hub.atlassian.net/browse/HNT-2622)

## Description
Creates a mapping from locale to Popular Today balancing config. This mapping could be changed in the future to also depend on experiment. This mapping defaults to what as applied in all locales. DE_DE is the only non-default override. In DE_DE, the max number of articles for topic moves from 2->3. The editorial ticket specifically asked for Politics to have the limit removed. This PR deviates for implementation simplicity and maintainability.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ X] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ X] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2356)


[HNT-2622]: https://mozilla-hub.atlassian.net/browse/HNT-2622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ