### PR TITLE
[HNT-2623] Add a publisher constraint to popular today

### DIFF
--- a/merino/curated_recommendations/article_balancer.py
+++ b/merino/curated_recommendations/article_balancer.py
@@ -1,7 +1,8 @@
 """Balancers for curated recommendation articles."""
 
-from collections import defaultdict
+from collections import Counter, defaultdict
 import math
+import random
 
 from merino.curated_recommendations.corpus_backends.protocol import Topic
 from merino.curated_recommendations.article_balancer_configs import (
@@ -12,13 +13,20 @@ from merino.curated_recommendations.protocol import CuratedRecommendation
 
 
 class ArticleBalancer:
-    """Balance articles by multiple criteria."""
+    """Balance articles by multiple criteria.
+
+    Topic and aggregate counters use the controlled feature_counts namespace.
+    Publisher counters are tracked separately because publisher names are arbitrary
+    external strings and can collide with topic values or aggregate keys like "evergreen".
+    """
 
     def __init__(self, expected_num_articles: int, config: ArticleBalancerConfig) -> None:
         """Initialize limits for target number of articles."""
         self.config = config
         self.article_list: list[CuratedRecommendation] = []
         self.feature_counts: defaultdict[str, int] = defaultdict(int)
+        self.publisher_counts: Counter[str] = Counter()
+        self.enforce_publisher = True
         self.num_expected = 0
         self.evergreen_topics = set(config.evergreen_topics)
         self.subtopic_checker = config.subtopic_checker
@@ -41,6 +49,7 @@ class ArticleBalancer:
             self.config.min_subtopic_limit,
             math.ceil(self.config.max_subtopic_ratio * expected_num_articles),
         )
+        self.max_per_publisher = self.config.max_per_publisher
 
         # We round down here to be conservative in blocking topics in initial list, but relax
         # for extra stories or for personalization.
@@ -66,8 +75,18 @@ class ArticleBalancer:
         """Return true if topic is a blocked topic."""
         return rec.is_story_blocked_for_top_stories()
 
-    def _update_stats(self, info_dict, rec: CuratedRecommendation):
-        """Update passed dictionary with new stats to reflect the article added."""
+    def _update_stats(
+        self,
+        info_dict: defaultdict[str, int],
+        publisher_counts: Counter[str],
+        rec: CuratedRecommendation,
+    ):
+        """Update passed dictionary with new stats to reflect the article added.
+
+        Publisher names are arbitrary external strings, so they are counted separately
+        from topic and aggregate counters to prevent namespace collisions.
+        """
+        publisher_counts[rec.publisher] += 1
         if (topic := rec.topic) is not None:
             info_dict[topic.value] += 1
         if self._is_evergreen(rec.topic):
@@ -79,7 +98,9 @@ class ArticleBalancer:
         if self.is_blocked_rec(rec):
             info_dict["blocked_topics"] += 1
 
-    def _does_meet_spec(self, info_dict) -> bool:
+    def _does_meet_spec(
+        self, info_dict: defaultdict[str, int], publisher_counts: Counter[str]
+    ) -> bool:
         """Return true if passed spec meets requirements of the balancer."""
         if info_dict.get("evergreen", 0) > self.max_evergreen:
             return False
@@ -89,6 +110,10 @@ class ArticleBalancer:
             return False
         if info_dict.get("blocked_topics", 0) > self.max_blocked_topics:
             return False
+        if self.enforce_publisher and publisher_counts:
+            _publisher, count = publisher_counts.most_common(1)[0]
+            if count > self.max_per_publisher:
+                return False
         for topic in Topic:
             if info_dict.get(topic.value, 0) > self._max_for_topic(topic):
                 return False
@@ -97,10 +122,12 @@ class ArticleBalancer:
     def add_story(self, rec: CuratedRecommendation) -> bool:
         """Add story if it meets requirements. Return true if story added."""
         provisional_stats = self.feature_counts.copy()
-        self._update_stats(provisional_stats, rec)
-        if self._does_meet_spec(provisional_stats):
+        provisional_publisher_counts = self.publisher_counts.copy()
+        self._update_stats(provisional_stats, provisional_publisher_counts, rec)
+        if self._does_meet_spec(provisional_stats, provisional_publisher_counts):
             self.article_list.append(rec)
             self.feature_counts = provisional_stats
+            self.publisher_counts = provisional_publisher_counts
             return True
         return False
 
@@ -132,7 +159,9 @@ class TopStoriesArticleBalancer(ArticleBalancer):
         expected_num_articles: int,
         config: ArticleBalancerConfig | None = None,
     ) -> None:
+        resolved_config = config or DEFAULT_TOP_STORIES_ARTICLE_BALANCER_CONFIG
         super().__init__(
             expected_num_articles=expected_num_articles,
-            config=config or DEFAULT_TOP_STORIES_ARTICLE_BALANCER_CONFIG,
+            config=resolved_config,
         )
+        self.enforce_publisher = random.random() < resolved_config.publisher_enforcement_likelyhood

--- a/merino/curated_recommendations/article_balancer_configs.py
+++ b/merino/curated_recommendations/article_balancer_configs.py
@@ -21,6 +21,8 @@ class ArticleBalancerConfig:
     min_per_topic_limit: int = 0
     min_subtopic_limit: int = 0
     blocked_topics_multiplier: int = 1
+    max_per_publisher: int = 100
+    publisher_enforcement_likelyhood: float = 0.0
     government_max_override: int | None = None
 
 
@@ -63,6 +65,8 @@ TOP_STORIES_BALANCER_CONFIG_BY_SURFACE: dict[SurfaceId, ArticleBalancerConfig] =
         DEFAULT_TOP_STORIES_ARTICLE_BALANCER_CONFIG,
         min_per_topic_limit=2,
         government_max_override=3,
+        max_per_publisher=1,
+        publisher_enforcement_likelyhood=0.85,
     ),
 }
 

--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -791,7 +791,9 @@ def get_top_story_list(
     if len(top_stories) < total_story_count:
         top_stories = top_stories + remaining_items[: total_story_count - len(top_stories)]
 
-    # Insert the fresh story at the special position, and remove the other story
+    # Insert the fresh story at the special position, and remove the other story.
+    # This intentionally bypasses all ArticleBalancer constraints; pick_random_fresh_story()
+    # only excludes stories blocked from Popular Today.
     if fresh_story_for_fixed_position is not None:
         top_stories = (
             top_stories[0:fixed_fresh_item_position]

--- a/tests/unit/curated_recommendations/fixtures.py
+++ b/tests/unit/curated_recommendations/fixtures.py
@@ -54,7 +54,7 @@ def generate_recommendations(
             title="little larry",
             excerpt="is failing english",
             topic=topics[i] if topics is not None else random.choice(list(Topic)),
-            publisher="cohens",
+            publisher=f"publisher:{item_id}",
             isTimeSensitive=i in time_sensitive_indices,
             imageUrl=HttpUrl("https://placehold.co/600x400/"),
             iconUrl=None,

--- a/tests/unit/curated_recommendations/test_article_balancer_configs.py
+++ b/tests/unit/curated_recommendations/test_article_balancer_configs.py
@@ -23,14 +23,17 @@ def test_get_top_stories_article_balancer_config_returns_surface_config():
     )
     assert config.min_per_topic_limit == 2
     assert config.government_max_override == 3
+    assert config.max_per_publisher == 1
+    assert config.publisher_enforcement_likelyhood == 0.85
 
 
 def test_get_top_stories_article_balancer_config_falls_back_to_default():
     """Return the default config for surfaces without an explicit override."""
-    assert (
-        get_top_stories_article_balancer_config(SurfaceId.NEW_TAB_ES_ES)
-        is DEFAULT_TOP_STORIES_ARTICLE_BALANCER_CONFIG
-    )
+    config = get_top_stories_article_balancer_config(SurfaceId.NEW_TAB_ES_ES)
+
+    assert config is DEFAULT_TOP_STORIES_ARTICLE_BALANCER_CONFIG
+    assert config.max_per_publisher == 100
+    assert config.publisher_enforcement_likelyhood == 0.0
 
 
 def test_top_stories_article_balancer_accepts_custom_config():

--- a/tests/unit/curated_recommendations/test_rankers.py
+++ b/tests/unit/curated_recommendations/test_rankers.py
@@ -1,20 +1,23 @@
 """Unit test for ranker algorithms used to rank curated recommendations."""
 
+from dataclasses import replace
+from datetime import datetime, timezone
 import logging
+import random
 import uuid
 
-import pytest
-import random
-from datetime import datetime, timezone
 import freezegun
+import pytest
 from freezegun import freeze_time
-
 from pydantic import HttpUrl
 
 from merino.curated_recommendations import EngagementBackend
+from merino.curated_recommendations.article_balancer import TopStoriesArticleBalancer
+from merino.curated_recommendations.article_balancer_configs import (
+    DEFAULT_TOP_STORIES_ARTICLE_BALANCER_CONFIG,
+)
 from merino.curated_recommendations.corpus_backends.protocol import SurfaceId, Topic
 from merino.curated_recommendations.engagement_backends.protocol import Engagement
-from merino.curated_recommendations.article_balancer import TopStoriesArticleBalancer
 from merino.curated_recommendations.layouts import layout_4_medium, layout_4_large, layout_6_tiles
 from merino.curated_recommendations.protocol import (
     ITEM_HEADLINES_FLAG,
@@ -1241,6 +1244,48 @@ class TestTopStoriesArticleBalancer:
         assert balancer.add_story(stories[0])
         assert balancer.add_story(stories[1])
         assert balancer.add_story(stories[2]) is False
+        assert len(balancer.get_stories()) == 2
+
+    def test_rejects_story_when_publisher_limit_exceeded(self, monkeypatch):
+        """Ensure adding beyond the per-publisher maximum fails."""
+        monkeypatch.setattr(
+            "merino.curated_recommendations.article_balancer.random.random", lambda: 0.84
+        )
+        config = replace(
+            DEFAULT_TOP_STORIES_ARTICLE_BALANCER_CONFIG,
+            max_per_publisher=1,
+            publisher_enforcement_likelyhood=0.85,
+        )
+        balancer = TopStoriesArticleBalancer(expected_num_articles=9, config=config)
+        stories = [
+            self._build_recommendation("0", Topic.BUSINESS),
+            self._build_recommendation("1", Topic.ARTS),
+        ]
+        stories[1].publisher = stories[0].publisher
+
+        assert balancer.add_story(stories[0])
+        assert balancer.add_story(stories[1]) is False
+        assert len(balancer.get_stories()) == 1
+
+    def test_allows_story_when_publisher_enforcement_is_not_selected(self, monkeypatch):
+        """Duplicate publishers are allowed when the constructor draw disables enforcement."""
+        monkeypatch.setattr(
+            "merino.curated_recommendations.article_balancer.random.random", lambda: 0.85
+        )
+        config = replace(
+            DEFAULT_TOP_STORIES_ARTICLE_BALANCER_CONFIG,
+            max_per_publisher=1,
+            publisher_enforcement_likelyhood=0.85,
+        )
+        balancer = TopStoriesArticleBalancer(expected_num_articles=9, config=config)
+        stories = [
+            self._build_recommendation("0", Topic.BUSINESS),
+            self._build_recommendation("1", Topic.ARTS),
+        ]
+        stories[1].publisher = stories[0].publisher
+
+        assert balancer.add_story(stories[0])
+        assert balancer.add_story(stories[1])
         assert len(balancer.get_stories()) == 2
 
     def test_rejects_story_when_evergreen_limit_exceeded(self):

--- a/tests/unit/curated_recommendations/test_sections.py
+++ b/tests/unit/curated_recommendations/test_sections.py
@@ -1,14 +1,17 @@
 """Module with tests covering merino/curated_recommendations/sections.py"""
 
 import copy
+from dataclasses import replace
 import random
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
-from merino.curated_recommendations.prior_backends.protocol import Prior
 import pytest
 from pydantic import HttpUrl
 
+from merino.curated_recommendations.article_balancer_configs import (
+    DEFAULT_TOP_STORIES_ARTICLE_BALANCER_CONFIG,
+)
 from merino.curated_recommendations.corpus_backends.protocol import (
     Topic,
     SurfaceId,
@@ -30,6 +33,7 @@ from merino.curated_recommendations.prior_backends.engagment_rescaler import (
     DECrawledContentRescaler,
     SchedulerHoldbackRescaler,
 )
+from merino.curated_recommendations.prior_backends.protocol import Prior
 from merino.curated_recommendations.protocol import (
     ITEM_HEADLINES_FLAG,
     ITEM_SUBTOPIC_FLAG,
@@ -906,6 +910,30 @@ class TestGetTopStoryList:
 
         for ix, item in enumerate(result):
             assert item.receivedRank == ix
+
+    def test_basic_publisher_limiting(self):
+        """Duplicate publishers should be skipped in top stories."""
+        items = generate_recommendations(
+            item_ids=["a", "b", "c", "d"],
+            topics=["arts", "business", "food", "government"],
+        )
+        items[1].publisher = items[0].publisher
+        config = replace(
+            DEFAULT_TOP_STORIES_ARTICLE_BALANCER_CONFIG,
+            max_per_publisher=1,
+            publisher_enforcement_likelyhood=1.0,
+        )
+
+        result = get_top_story_list(
+            items,
+            top_count=3,
+            extra_count=0,
+            extra_source_depth=0,
+            article_balancer_config=config,
+        )
+
+        assert [i.corpusItemId for i in result] == ["a", "c", "d"]
+        assert len({i.publisher for i in result}) == len(result)
 
     def test_basic_topic_limiting_with_personalization(self):
         """Extra items should be chosen without repeating topics from top_count items."""


### PR DESCRIPTION
## References

JIRA: [HNT-2623](https://mozilla-hub.atlassian.net/browse/HNT-2623)

## Description
Adds a max number per publisher constraint to Popular Today. This is effectively off by default by setting to 100. For de_DE, this is set as 1 meaning we can have only 1 article per publisher in Popular Today.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ X] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ X] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2357)


[HNT-2623]: https://mozilla-hub.atlassian.net/browse/HNT-2623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ