### PR TITLE
DISCO-4260 Adding retry mechanism for wcs cron job

### DIFF
--- a/merino/configs/__init__.py
+++ b/merino/configs/__init__.py
@@ -155,6 +155,8 @@ _validators = [
     Validator("providers.sports.enabled_by_default", is_type_of=bool),
     Validator("providers.sports.sportsdata.api_key", is_type_of=str),
     Validator("providers.sports.sportsdata.cache_dir", is_type_of=str),
+    Validator("providers.sports.sportsdata.retry_max_tries", is_type_of=int, gte=1),
+    Validator("providers.sports.sportsdata.retry_factor_sec", is_type_of=float, gte=0),
     Validator("providers.sports.mix_sports", is_type_of=bool, required=False),
     Validator("providers.sports.max_suggestions", is_type_of=int, gte=1, required=True),
     Validator("providers.sports.event_ttl_weeks", is_type_of=int, gte=1, required=False),

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -507,6 +507,14 @@ api_key=""
 # Directory to store JSON request responses
 cache_dir="/tmp"
 
+# MERINO_PROVIDERS__SPORTS__SPORTSDATA__RETRY_MAX_TRIES
+# Total provider fetch attempts, including the first request
+retry_max_tries=5
+
+# MERINO_PROVIDERS__SPORTS__SPORTSDATA__RETRY_FACTOR_SEC
+# Initial exponential backoff delay in seconds
+retry_factor_sec=0.5
+
 # SportsData may have different base_urls per sport (e.g.
 # NFL may use `https://api.sportsdata.io/v3/nfl/scores/json` where
 # UCL may use `https://api.sportsdata.io/v4/soccer/scores/json`

--- a/merino/jobs/sportsdata_jobs/__init__.py
+++ b/merino/jobs/sportsdata_jobs/__init__.py
@@ -270,12 +270,14 @@ class SportDataUpdater:
             # TODO: Ensure errors bubble up to caller or are otherwise elevated
             # so we can track success/fail here
             await self.store.startup()
-            # NOTE: Widget data must be done first, otherwise there may
-            # be missing data like no terms aliases, due to mutable internal
-            # state which depends on ordering of calls in the WCS class
-            await self.update_widget()
-            await self.update_data()
-            await self.store.shutdown()
+            try:
+                # NOTE: Widget data must be done first, otherwise there may
+                # be missing data like no terms aliases, due to mutable internal
+                # state which depends on ordering of calls in the WCS class
+                await self.update_widget()
+                await self.update_data()
+            finally:
+                await self.store.shutdown()
 
 
 logger = logging.getLogger(__name__)

--- a/merino/providers/suggest/sports/backends/__init__.py
+++ b/merino/providers/suggest/sports/backends/__init__.py
@@ -1,16 +1,134 @@
 """SportsData live query system"""
 
+import asyncio
+import hashlib
+import json
 import logging
 import os
-import json
-import hashlib
+from collections.abc import Awaitable
+from datetime import datetime, timedelta
 from typing import Any
 
-from datetime import datetime, timedelta
-from httpx import AsyncClient, HTTPError
+from httpx import AsyncClient, HTTPError, HTTPStatusError
+from tenacity import (
+    AsyncRetrying,
+    RetryCallState,
+    retry_if_exception,
+    stop_after_attempt,
+    wait_random_exponential,
+)
 
+from merino.configs import settings
 from merino.providers.suggest.sports import LOGGING_TAG
 from merino.providers.suggest.sports.backends.sportsdata.common.error import SportsDataError
+from merino.utils.metrics import get_metrics_client
+
+SPORTSDATA_DEFAULT_MAX_TRIES = 5
+SPORTSDATA_DEFAULT_RETRY_FACTOR_SECONDS = 0.5
+SPORTSDATA_RETRYABLE_STATUS_CODES = {408, 425, 429}
+SPORTSDATA_STALE_FALLBACK_METRIC = "sports.fetch.stale_fallback"
+
+
+def _sportsdata_retry_max_tries() -> int:
+    """Return the configured number of SportsData fetch attempts."""
+    return int(
+        settings.providers.sports.sportsdata.get("retry_max_tries", SPORTSDATA_DEFAULT_MAX_TRIES)
+    )
+
+
+def _sportsdata_retry_factor_seconds() -> float:
+    """Return the configured initial SportsData exponential backoff delay."""
+    return float(
+        settings.providers.sports.sportsdata.get(
+            "retry_factor_sec", SPORTSDATA_DEFAULT_RETRY_FACTOR_SECONDS
+        )
+    )
+
+
+def _sportsdata_status_suffix(error: HTTPError) -> str:
+    """Return a concise HTTP status fragment for provider fetch logs/errors."""
+    if isinstance(error, HTTPStatusError):
+        return f" with status {error.response.status_code}"
+    return ""
+
+
+def _is_retryable_sportsdata_error(error: HTTPError) -> bool:
+    """Return whether a SportsData fetch error is likely transient."""
+    if not isinstance(error, HTTPStatusError):
+        return True
+    status_code = error.response.status_code
+    return status_code in SPORTSDATA_RETRYABLE_STATUS_CODES or status_code >= 500
+
+
+def _should_retry_sportsdata_error(error: BaseException) -> bool:
+    """Return whether a SportsData fetch error should be retried."""
+    return isinstance(error, HTTPError) and _is_retryable_sportsdata_error(error)
+
+
+def _retry_detail_url(args: tuple[Any, ...], kwargs: dict[str, Any]) -> str:
+    """Return the URL from retry callback details."""
+    if url := kwargs.get("url"):
+        return str(url)
+    if len(args) >= 2:
+        return str(args[1])
+    return "unknown URL"
+
+
+def _log_sportsdata_retry(retry_state: RetryCallState) -> None:
+    """Log a SportsData request retry attempt."""
+    exception = retry_state.outcome.exception() if retry_state.outcome else None
+    status_suffix = (
+        _sportsdata_status_suffix(exception) if isinstance(exception, HTTPError) else ""
+    )
+    url = _retry_detail_url(retry_state.args, retry_state.kwargs)
+    wait = retry_state.next_action.sleep if retry_state.next_action else 0
+    next_attempt = retry_state.attempt_number + 1
+    max_tries = _sportsdata_retry_max_tries()
+    logger = logging.getLogger(__name__)
+    logger.warning(
+        f"{LOGGING_TAG} Provider fetch failed{status_suffix}; "
+        f"retrying {url} attempt {next_attempt}/{max_tries} "
+        f"in {wait:.2f}s"
+    )
+
+
+def _record_stale_fallback(error: HTTPError) -> None:
+    """Record that a stale SportsData cache entry was used after a fetch failure."""
+    status = str(error.response.status_code) if isinstance(error, HTTPStatusError) else "unknown"
+    get_metrics_client().increment(SPORTSDATA_STALE_FALLBACK_METRIC, tags={"status": status})
+
+
+def _sportsdata_retry_sleep(seconds: float) -> Awaitable[None]:
+    """Sleep between SportsData retry attempts."""
+    return asyncio.sleep(seconds)
+
+
+async def _fetch_provider_data_once(
+    client: AsyncClient,
+    url: str,
+    request_args: dict[str, Any],
+) -> Any:
+    """Fetch and parse one SportsData response."""
+    response = await client.get(url, **request_args)
+    response.raise_for_status()
+    return response.json()
+
+
+async def _fetch_provider_data(
+    client: AsyncClient,
+    url: str,
+    request_args: dict[str, Any],
+) -> Any:
+    """Fetch and parse one SportsData response with retryable transient errors."""
+    retryer = AsyncRetrying(
+        retry=retry_if_exception(_should_retry_sportsdata_error),
+        wait=wait_random_exponential(multiplier=_sportsdata_retry_factor_seconds()),
+        stop=stop_after_attempt(_sportsdata_retry_max_tries()),
+        before_sleep=_log_sportsdata_retry,
+        sleep=_sportsdata_retry_sleep,
+        reraise=True,
+    )
+    return await retryer(_fetch_provider_data_once, client, url, request_args)
 
 
 # TODO: convert this to use `sport.cache`; obsolete the `cache_dir` arg
@@ -22,9 +140,10 @@ async def get_data(
     args: dict[str, Any] | None = None,
     headers: dict[str, str] | None = None,
 ) -> Any:
-    """Fetch data from the provider. This may pull from the local cache or from the remote site depending on the
-    `ttl` for the local cache.
+    """Fetch data from the provider.
 
+    Fresh cache entries are returned until `ttl` expires. When the provider fetch fails after
+    retrying, an expired cache entry may be returned as a stale fallback.
     """
     logger = logging.getLogger(__name__)
     cache_file = None
@@ -54,15 +173,31 @@ async def get_data(
                 # possible read on a closed file.
                 pass
     logger.debug(f"{LOGGING_TAG} fetching data from {url}")
+    request_args: dict[str, Any] = {"params": args}
+    if headers:
+        request_args["headers"] = headers
     try:
-        request_args: dict[str, Any] = {"params": args}
-        if headers:
-            request_args["headers"] = headers
-        response = await client.get(url, **request_args)
-        response.raise_for_status()
-        response = response.json()
-    except HTTPError:
-        raise SportsDataError(f"Could not fetch data from provider for {url}") from None
+        response = await _fetch_provider_data(
+            client=client,
+            url=url,
+            request_args=request_args,
+        )
+    except HTTPError as ex:
+        if cache_file and os.path.exists(cache_file):
+            try:
+                logger.warning(
+                    f"{LOGGING_TAG} Provider fetch failed; reading stale cache for {url}"
+                )
+                _record_stale_fallback(ex)
+                with open(cache_file, "r") as cache:
+                    return json.load(cache)
+            except PermissionError:
+                logger.warning(f"{LOGGING_TAG} Unable to read stale cache {cache_file}")
+            except ValueError:
+                logger.warning(f"{LOGGING_TAG} Unable to deserialize stale cache {cache_file}")
+        raise SportsDataError(
+            f"Could not fetch data from provider for {url}{_sportsdata_status_suffix(ex)}"
+        ) from None
     if cache_file:
         logger.debug(f"{LOGGING_TAG}💾 Writing cache for {url}")
         try:

--- a/merino/providers/suggest/sports/backends/sportsdata/common/error.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/error.py
@@ -2,12 +2,13 @@
 
 
 # Errors
-class SportsDataError(BaseException):
+class SportsDataError(Exception):
     """Significant error occurring with Sports"""
 
     message: str
 
     def __init__(self, message: str):
+        super().__init__(message)
         self.message = message
 
     def __str__(self):
@@ -15,12 +16,13 @@ class SportsDataError(BaseException):
         return f"{name}: {self.message}"
 
 
-class SportsDataWarning(BaseException):
+class SportsDataWarning(Exception):
     """Cautionary error occurring with Sports"""
 
     message: str
 
     def __init__(self, message: str):
+        super().__init__(message)
         self.message = message
 
     def __str__(self):

--- a/merino/providers/suggest/sports/backends/sportsdata/common/sports.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/sports.py
@@ -1189,22 +1189,33 @@ class WCS(Sport):
 
     async def update_events(self, client: AsyncClient, allow_no_teams: bool = False):
         """Update schedules and game scores for this sport"""
+        # WCS backs the live World Cup cron/widget, so it preserves the existing
+        # cache and degrades partially when SportsData has an intermittent failure.
         await self.get_season(client=client)
         # Stage names are joined by Event.RoundId onto self.rounds
         # Rounds are lazy loaded, so ensure we got them (otherwise
         # stage will always default to None)
         if not self.rounds:
-            await self.load_rounds(client=client)
+            try:
+                await self.load_rounds(client=client)
+            except SportsDataError as ex:
+                logger.warning(
+                    f"{LOGGING_TAG} Could not load WCS rounds; continuing without stages: {ex}"
+                )
         logger.debug(f"{LOGGING_TAG} Getting {self.name} schedules")
         url = f"{self.base_url}/SchedulesBasic/{self.name}/{self.season}"
         local_timezone = SPORTSDATA_UTC
-        response = await get_data(
-            client=client,
-            url=url,
-            ttl=timedelta(minutes=5),
-            cache_dir=self.cache_dir,
-            headers=self.api_headers(),
-        )
+        try:
+            response = await get_data(
+                client=client,
+                url=url,
+                ttl=timedelta(minutes=5),
+                cache_dir=self.cache_dir,
+                headers=self.api_headers(),
+            )
+        except SportsDataError as ex:
+            logger.warning(f"{LOGGING_TAG} Could not refresh WCS schedules: {ex}")
+            return
         if not response:
             logger.warning(f"{LOGGING_TAG} No WCS schedules returned; skipping event cache update")
             return
@@ -1215,13 +1226,17 @@ class WCS(Sport):
             self.events.values(), event_timezone=local_timezone
         ):
             url = f"{self.base_url}/GamesByDate/{self.name}/{day}"
-            response = await get_data(
-                client=client,
-                url=url,
-                ttl=_WCS_GAMES_BY_DATE_TTL,
-                cache_dir=self.cache_dir,
-                headers=self.api_headers(),
-            )
+            try:
+                response = await get_data(
+                    client=client,
+                    url=url,
+                    ttl=_WCS_GAMES_BY_DATE_TTL,
+                    cache_dir=self.cache_dir,
+                    headers=self.api_headers(),
+                )
+            except SportsDataError as ex:
+                logger.warning(f"{LOGGING_TAG} Could not refresh WCS scores for {day}: {ex}")
+                continue
             self.load_scores_from_source(
                 response,
                 event_timezone=local_timezone,

--- a/merino/providers/suggest/sports/provider.py
+++ b/merino/providers/suggest/sports/provider.py
@@ -29,9 +29,6 @@ from merino.providers.suggest.sports.backends.sportsdata.backend import (
     SportsDataBackend,
     SportSummary,
 )
-from merino.providers.suggest.sports.backends.sportsdata.common.error import (
-    SportsDataError,
-)
 from merino.utils.metrics import INTENT_WORD_COUNT_METRIC_NAME
 
 
@@ -77,7 +74,7 @@ class SportsDataProvider(BaseProvider):
         try:
             if self.backend:
                 await self.backend.startup()
-        except (Exception, SportsDataError) as ex:
+        except Exception as ex:
             logger.error(f"{LOGGING_TAG} Could not start sports backend: {ex}")
             self.backend = None
 

--- a/tests/unit/jobs/sports/test_sportsdata.py
+++ b/tests/unit/jobs/sports/test_sportsdata.py
@@ -4,12 +4,14 @@
 
 """Unit tests for fetch_schedules.py module."""
 
-import pytest
+from contextlib import nullcontext
 from datetime import datetime, timedelta, timezone
-from httpx import AsyncClient
-from unittest.mock import MagicMock
-from pytest_mock import MockerFixture
 from typing import Any, cast
+from unittest.mock import MagicMock
+
+import pytest
+from httpx import AsyncClient
+from pytest_mock import MockerFixture
 
 from merino.configs import settings
 from merino.jobs.sportsdata_jobs import SportDataUpdater
@@ -23,6 +25,7 @@ from merino.providers.suggest.sports.backends.sportsdata.common.data import (
     Sport,
     Event,
 )
+from merino.providers.suggest.sports.backends.sportsdata.common.error import SportsDataError
 
 
 @pytest.fixture(name="httpx_client")
@@ -65,7 +68,10 @@ def fixture_sport_data_store(es_client: MagicMock, statsd_mock: Any) -> SportsDa
 
 @pytest.mark.asyncio
 async def test_updater(
-    sport_data_store: SportsDataStore, httpx_client: AsyncClient, mocker: MockerFixture
+    sport_data_store: SportsDataStore,
+    httpx_client: AsyncClient,
+    mocker: MockerFixture,
+    monkeypatch: pytest.MonkeyPatch,
 ):
     """Test provider functions:"""
 
@@ -90,7 +96,7 @@ async def test_updater(
         }
         return mock_sport
 
-    settings.providers.sports.sports = ["nfl", "NbA", "NHL", "NoneSuch"]
+    monkeypatch.setattr(settings.providers.sports, "sports", ["nfl", "NbA", "NHL", "NoneSuch"])
     updater = SportDataUpdater(settings=settings.providers.sports, store=sport_data_store)
     assert list(updater.sports.keys()) == ["NFL", "NBA", "NHL"]
     assert updater.store == sport_data_store
@@ -122,3 +128,25 @@ async def test_updater(
     await updater.quick_update()
     assert not mock_sport.update_teams.called
     assert mock_sport.update_events.called
+
+
+@pytest.mark.asyncio
+async def test_update_and_cache_wcs_closes_store_on_error(
+    sport_data_store: SportsDataStore,
+    mocker: MockerFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """WCS cache updates should close the datastore when refresh work fails."""
+    monkeypatch.setattr(settings.providers.sports, "sports", ["WCS"])
+    updater = SportDataUpdater(settings=settings.providers.sports, store=sport_data_store)
+    shutdown = mocker.AsyncMock()
+    cast(Any, updater.store).startup = mocker.AsyncMock()
+    cast(Any, updater.store).shutdown = shutdown
+    cast(Any, updater).update_widget = mocker.AsyncMock()
+    cast(Any, updater).update_data = mocker.AsyncMock(side_effect=SportsDataError("provider down"))
+    mocker.patch("merino.jobs.sportsdata_jobs.monitor", return_value=nullcontext())
+
+    with pytest.raises(SportsDataError):
+        await updater.update_and_cache_wcs()
+
+    shutdown.assert_awaited_once()

--- a/tests/unit/providers/suggest/sports/backends/common/test_sports.py
+++ b/tests/unit/providers/suggest/sports/backends/common/test_sports.py
@@ -2474,6 +2474,53 @@ async def test_wcs_update_events_fetches_games_by_date_for_live_relevant_days(
 
 
 @pytest.mark.asyncio
+async def test_wcs_update_events_keeps_existing_events_when_schedule_fetch_fails(
+    mock_client: AsyncClient,
+    mocker: MockerFixture,
+) -> None:
+    """Schedule fetch failures should not prune existing WCS cache data."""
+    sport = WCS(settings=settings.providers.sports)
+    sport.rounds = {1615: "Group Stage"}
+    existing_events = {123: mocker.Mock(spec=Event)}
+    sport.events = existing_events
+    cache_events = mocker.patch.object(sport, "cache_events", new=mocker.AsyncMock())
+    get_data = mocker.patch(
+        "merino.providers.suggest.sports.backends.sportsdata.common.sports.get_data",
+        side_effect=SportsDataError("provider down"),
+    )
+
+    await sport.update_events(client=mock_client)
+
+    assert sport.events == existing_events
+    get_data.assert_called_once()
+    cache_events.assert_not_awaited()
+
+
+@freezegun.freeze_time("2026-06-11T12:00:00", tz_offset=0)
+@pytest.mark.asyncio
+async def test_wcs_update_events_caches_schedule_when_score_fetch_fails(
+    mock_client: AsyncClient,
+    mocker: MockerFixture,
+) -> None:
+    """Detailed score fetch failures should still cache the schedule refresh."""
+    sport = WCS(settings=settings.providers.sports)
+    await sport.async_load_teams_from_source(wcs_teams_payload())
+    sport.event_ttl = timedelta(weeks=8)
+    sport.rounds = {1615: "Group Stage"}
+    cache_events = mocker.patch.object(sport, "cache_events", new=mocker.AsyncMock())
+    get_data = mocker.patch(
+        "merino.providers.suggest.sports.backends.sportsdata.common.sports.get_data",
+        side_effect=[[wcs_schedule_payload()[0]], SportsDataError("provider down")],
+    )
+
+    await sport.update_events(client=mock_client)
+
+    assert 90011111 in sport.events
+    assert get_data.call_count == 2
+    cache_events.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_wcs_national_teams_use_country_name_for_event_display() -> None:
     """WCS team full names are federation names, not widget display names."""
     sport = WCS(settings=settings.providers.sports)
@@ -3197,9 +3244,11 @@ def test_sport_subclasses_have_category_mapping() -> None:
 async def test_sportsdata_errors() -> None:
     """Test that the warning and error wrappers work."""
     warning = SportsDataWarning("Foo")
+    assert isinstance(warning, Exception)
     assert str(warning) == "SportsDataWarning: Foo"
 
     error = SportsDataError("Foo")
+    assert isinstance(error, Exception)
     assert str(error) == "SportsDataError: Foo"
 
 

--- a/tests/unit/providers/suggest/sports/backends/test_sports_backend.py
+++ b/tests/unit/providers/suggest/sports/backends/test_sports_backend.py
@@ -1,22 +1,20 @@
 """Test Gauntlet for SportsData.io"""
 
+import hashlib
+import json
 import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import freezegun
-import pytest
-import json
-from datetime import datetime, timedelta, timezone
-
-from unittest.mock import patch, AsyncMock
-
 import httpx
-
-from unittest.mock import MagicMock
+import pytest
 from pytest_mock import MockerFixture
-from typing import Any, cast
 
 from merino.configs import settings
-from merino.providers.suggest.sports.backends import get_data
+from merino.providers.suggest.sports.backends import SPORTSDATA_STALE_FALLBACK_METRIC, get_data
 from merino.providers.suggest.sports.backends.sportsdata.backend import (
     SportsDataBackend,
 )
@@ -124,7 +122,82 @@ async def test_get_data_sends_headers():
         headers={SPORTSDATA_API_KEY_HEADER: api_key},
     )
     assert api_key not in str(exc_info.value)
+    assert "status 403" in str(exc_info.value)
     assert exc_info.value.__cause__ is None
+
+
+@pytest.mark.asyncio
+async def test_get_data_retries_transient_provider_fetch_failures(mocker: MockerFixture):
+    """Test that `get_data` retries transient provider fetch errors."""
+    mock_response_error = httpx.Response(
+        status_code=503,
+        request=httpx.Request("GET", "http://example.org"),
+    )
+    mock_response_success = httpx.Response(
+        status_code=200,
+        json={"ok": True},
+        request=httpx.Request("GET", "http://example.org"),
+    )
+    mock_client = MagicMock()
+    mock_client.get = AsyncMock(side_effect=[mock_response_error, mock_response_success])
+    sleep = mocker.patch(
+        "merino.providers.suggest.sports.backends._sportsdata_retry_sleep",
+        new=mocker.AsyncMock(),
+    )
+
+    data = await get_data(
+        client=mock_client,
+        url="http://example.org",
+    )
+
+    assert data == {"ok": True}
+    assert mock_client.get.await_count == 2
+    assert sleep.await_count == 1
+
+
+@pytest.mark.asyncio
+@freezegun.freeze_time("2099-01-01T00:00:00", tz_offset=0)
+async def test_get_data_returns_stale_cache_when_provider_fetch_fails(
+    mocker: MockerFixture, tmp_path: Path
+):
+    """Test that `get_data` falls back to stale cache after provider fetch errors."""
+    ttl = timedelta(seconds=5)
+    url = "http://example.org"
+    cached_data = {"stale": True}
+    hasher = hashlib.new("sha1", usedforsecurity=False)
+    hasher.update(url.encode())
+    cache_file = tmp_path / f"{hasher.hexdigest()}.json"
+    cache_file.write_text(json.dumps(cached_data))
+    mock_response = httpx.Response(
+        status_code=503,
+        request=httpx.Request("GET", url),
+    )
+    mock_client = MagicMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+    metrics_client = mocker.patch(
+        "merino.providers.suggest.sports.backends.get_metrics_client"
+    ).return_value
+    sleep = mocker.patch(
+        "merino.providers.suggest.sports.backends._sportsdata_retry_sleep",
+        new=mocker.AsyncMock(),
+    )
+
+    with patch.object(json, "dump") as mock_dump:
+        data = await get_data(
+            client=mock_client,
+            url=url,
+            ttl=ttl,
+            cache_dir=str(tmp_path),
+        )
+
+    assert mock_client.get.await_count == settings.providers.sports.sportsdata.retry_max_tries
+    mock_client.get.assert_awaited_with(url, params=None)
+    assert sleep.await_count == settings.providers.sports.sportsdata.retry_max_tries - 1
+    metrics_client.increment.assert_called_once_with(
+        SPORTSDATA_STALE_FALLBACK_METRIC, tags={"status": "503"}
+    )
+    mock_dump.assert_not_called()
+    assert data == cached_data
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## References

JIRA: [DISCO-4260](https://mozilla-hub.atlassian.net/browse/DISCO-4260)

## Description
This adds retry/backoff behavior for SportsData.io fetches and makes the WCS cron more resilient to intermittent upstream failures.

SportsData.io has been returning transient failures from endpoints such as `SchedulesBasic/fifa/2026`, which previously could bubble up as `SportsDataError` and fail the WCS cron. The shared SportsData fetch helper now retries transient request failures with exponential backoff and jitter, while the WCS event refresh path degrades more gracefully when schedule or per-day score refreshes fail.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2358)


[DISCO-4260]: https://mozilla-hub.atlassian.net/browse/DISCO-4260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ