### PR TITLE
[DISCO-4264] feat(sentry): add region tag

### DIFF
--- a/merino-common/merino_common/app_configs/config_sentry.py
+++ b/merino-common/merino_common/app_configs/config_sentry.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+from collections.abc import Mapping
 
 import sentry_sdk
 from sentry_sdk.integrations.fastapi import FastApiIntegration
@@ -20,6 +21,8 @@ def configure_sentry(
     dsn: str,
     env: str,
     traces_sample_rate: float,
+    *,
+    default_tags: Mapping[str, object] | None = None,
 ) -> None:  # pragma: no cover
     """Configure and initialize Sentry integration.
 
@@ -50,6 +53,8 @@ def configure_sentry(
         # We recommend adjusting this value in production,
         traces_sample_rate=traces_sample_rate,
     )
+    if default_tags:
+        sentry_sdk.set_tags(default_tags)
 
 
 def strip_sensitive_data(event: Event, hint: Hint) -> Event | None:

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -235,6 +235,13 @@ countries = ["US"]
 # Form factors to fetch suggestions for from the MARS API.
 form_factors = ["desktop"]
 
+# GCP metadata
+[default.gcp]
+# MERINO_GCP__REGION
+# Used for things like tagging deployment region in Sentry
+# Should be overridden via env var in release environments
+region = "unset"
+
 # Global Redis settings. The weather provider optionally uses Redis to cache weather suggestions.
 [default.redis]
 # MERINO_REDIS__SERVER - URI to the Redis primary endpoint.

--- a/merino/jobs/cli.py
+++ b/merino/jobs/cli.py
@@ -67,6 +67,7 @@ def setup():
             dsn=settings.sentry.dsn,
             env=settings.sentry.env,
             traces_sample_rate=settings.sentry.traces_sample_rate,
+            default_tags={"server_region": settings.gcp.region},
         )
     except Exception:
         logging.getLogger(__name__).exception("Error configuring Sentry")

--- a/merino/main.py
+++ b/merino/main.py
@@ -96,6 +96,7 @@ def create_lifespan(mode: RuntimeMode | str):
                 dsn=settings.sentry.dsn,
                 env=settings.sentry.env,
                 traces_sample_rate=settings.sentry.traces_sample_rate,
+                default_tags={"server_region": settings.gcp.region},
             )
             await configure_metrics()
             cleanup_callbacks.append(_close_metrics_client)


### PR DESCRIPTION


## References

JIRA: [DISCO-4264]

## Description
Sometimes there are region-specific issues, and
us-central region is not used in production.

Tag with region so that we can understand what
is actually affecting users, and debug more
easily.

Region env var was added by https://github.com/mozilla/webservices-infra/pull/11155

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2362)


[DISCO-4264]: https://mozilla-hub.atlassian.net/browse/DISCO-4264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ