### PR TITLE
[HNT-2639] feat: Add sections-in-germany-v2 experiment

### DIFF
--- a/merino/curated_recommendations/prior_backends/engagment_rescaler.py
+++ b/merino/curated_recommendations/prior_backends/engagment_rescaler.py
@@ -142,12 +142,18 @@ class CrawledContentPinnedFreshRescaler(CrawledContentRescaler):
         return round(impressions_for_tile_for_period * scale)
 
 
-DE_EXPERIMENT_TREATMENT_PERCENT = 0.10
+DE_EXPERIMENT_TREATMENT_PERCENT = 0.30
 
 
 class DECrawledContentRescaler(CrawledContentRescaler):
-    """Rescaler for DE experiment — scales engagement up by 1/0.10 = 10x
-    to compensate for only 10% of DE traffic generating engagement data.
+    """Rescaler for DE sections experiments — scales engagement up by 1/p
+    to compensate for the fraction p of DE traffic that generates
+    sections-backend engagement data.
+
+    p = 0.30 reflects three disjoint 10% slices of DE traffic that route
+    through the sections backend: sections-in-germany `sections` branch (v1),
+    sections-in-germany-v2 `sections` branch, and sections-in-germany-v2
+    `content-only` branch (grid layout served from the same backend).
     """
 
     def __init__(self, **data: Any):

--- a/merino/curated_recommendations/protocol.py
+++ b/merino/curated_recommendations/protocol.py
@@ -116,6 +116,9 @@ class ExperimentName(str, Enum):
     INFERRED_LOCAL_EXPERIMENT_V3 = "new-tab-automated-personalization-v3"
     INFERRED_LOCAL_EXPERIMENT_V4 = "new-tab-automated-personalization-v4"
 
+    # Second German sections experiment (3-arm: control / content-only / sections), pre-World Cup.
+    SECTIONS_IN_GERMANY_V2 = "sections-in-germany-v2"
+
 
 class DailyBriefingBranch(str, Enum):
     """Treatment branches for the Daily Briefing experiment."""
@@ -131,6 +134,17 @@ class EditorialSectionsBranch(str, Enum):
 
     # Remove editorial (manually curated) sections; keep ML sections + Popular Today.
     NO_EDITORIAL_SECTIONS = "no-editorial-sections"
+
+
+class SectionsInGermanyV2Branch(str, Enum):
+    """Treatment branches for the sections-in-germany-v2 experiment."""
+
+    # Scheduled-surface content in the legacy (non-sections) response.
+    CONTROL = "control"
+    # Sections-backend content delivered in the legacy (grid) response.
+    CONTENT_ONLY = "content-only"
+    # Sections-backend content delivered in the sections response.
+    SECTIONS = "sections"
 
 
 # Maximum tileId that Firefox can support. Firefox uses Javascript to store this value. The max

--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -27,7 +27,9 @@ from merino.curated_recommendations.protocol import (
     CuratedRecommendation,
     CuratedRecommendationsRequest,
     CuratedRecommendationsResponse,
+    ExperimentName,
     ProcessedInterests,
+    SectionsInGermanyV2Branch,
 )
 
 from merino.curated_recommendations.rankers import (
@@ -40,6 +42,7 @@ from merino.curated_recommendations.legacy.sections_adapter import (
 )
 from merino.curated_recommendations.prior_backends.engagment_rescaler import (
     CrawledContentRescaler,
+    DECrawledContentRescaler,
 )
 from merino.curated_recommendations.sections import get_sections
 from merino.curated_recommendations.utils import (
@@ -89,16 +92,13 @@ class CuratedRecommendationsProvider:
         """Check if the 'sections' feed is enabled.
 
         Sections are enabled when the request includes 'sections' in the feeds list
-        and the surface_id is supported (has localized section titles).
-        For surfaces still behind an experiment (e.g. DE), also check enrollment.
+        and the surface_id is supported (has localized section titles). Clients
+        opt in via the request; we don't gate on experiment enrollment here.
         """
         if request.feeds is None or "sections" not in request.feeds:
             return False
         if surface_id not in LOCALIZED_SECTION_TITLES:
             return False
-        # DE sections are gated behind the sections-in-germany experiment
-        if surface_id == SurfaceId.NEW_TAB_DE_DE:
-            return is_enrolled_in_experiment(request, "sections-in-germany", "sections")
         return True
 
     def rank_recommendations(
@@ -186,6 +186,22 @@ class CuratedRecommendationsProvider:
                 count=request.count,
                 region=derive_region(request.locale, request.region),
                 rescaler=rescaler,
+            )
+        elif surface_id == SurfaceId.NEW_TAB_DE_DE and is_enrolled_in_experiment(
+            request,
+            ExperimentName.SECTIONS_IN_GERMANY_V2.value,
+            SectionsInGermanyV2Branch.CONTENT_ONLY.value,
+        ):
+            # sections-in-germany-v2 content-only branch: sections-backend content
+            # delivered in the legacy (grid) response.
+            general_feed = await get_legacy_recommendations_from_sections(
+                sections_backend=self.sections_backend,
+                engagement_backend=self.engagement_backend,
+                prior_backend=self.prior_backend,
+                surface_id=surface_id,
+                count=request.count,
+                region=derive_region(request.locale, request.region),
+                rescaler=DECrawledContentRescaler(),
             )
         else:
             # Other markets: fetch from scheduled surface backend

--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -56,6 +56,7 @@ from merino.curated_recommendations.protocol import (
     DailyBriefingBranch,
     ProcessedInterests,
     Layout,
+    SectionsInGermanyV2Branch,
 )
 from merino.curated_recommendations.article_balancer_configs import (
     ArticleBalancerConfig,
@@ -462,8 +463,13 @@ def get_ranking_rescaler_for_branch(
     if surface_id == SurfaceId.NEW_TAB_EN_IE:
         return CrawledContentRescaler()
 
-    if surface_id == SurfaceId.NEW_TAB_DE_DE and is_enrolled_in_experiment(
-        request, "sections-in-germany", "sections"
+    if surface_id == SurfaceId.NEW_TAB_DE_DE and (
+        is_enrolled_in_experiment(request, "sections-in-germany", "sections")
+        or is_enrolled_in_experiment(
+            request,
+            ExperimentName.SECTIONS_IN_GERMANY_V2.value,
+            SectionsInGermanyV2Branch.SECTIONS.value,
+        )
     ):
         return DECrawledContentRescaler()
 

--- a/tests/unit/curated_recommendations/test_provider.py
+++ b/tests/unit/curated_recommendations/test_provider.py
@@ -3,11 +3,13 @@
 import pytest
 from pydantic import HttpUrl
 
-from merino.curated_recommendations.corpus_backends.protocol import Topic
+from merino.curated_recommendations.corpus_backends.protocol import SurfaceId, Topic
+from merino.curated_recommendations.provider import CuratedRecommendationsProvider
 from merino.curated_recommendations.protocol import (
     MAX_TILE_ID,
     MIN_TILE_ID,
     CuratedRecommendation,
+    CuratedRecommendationsRequest,
 )
 
 
@@ -67,3 +69,53 @@ class TestCuratedRecommendationTileId:
                 tileId=invalid_tile_id,
                 **self.common_params,
             )
+
+
+class TestIsSectionsExperiment:
+    """Unit tests for CuratedRecommendationsProvider.is_sections_experiment."""
+
+    @pytest.mark.parametrize(
+        "experiment_name, experiment_branch",
+        [
+            (None, None),
+            ("sections-in-germany", "control"),
+            ("sections-in-germany", "sections"),
+            ("sections-in-germany-v2", "control"),
+            ("sections-in-germany-v2", "content-only"),
+            ("sections-in-germany-v2", "sections"),
+            ("some-unrelated-experiment", "treatment"),
+        ],
+    )
+    def test_de_with_sections_feed_returns_true_regardless_of_enrollment(
+        self, experiment_name, experiment_branch
+    ):
+        """DE clients that request the sections feed get sections, regardless of Nimbus enrollment.
+
+        Gating sections response on enrollment caused the Ireland incident where an experiment
+        gate was forgotten and clients kept receiving the wrong treatment. Sections branches in
+        sections-in-germany-v2 are differentiated from control by what the client requests, not
+        by a backend gate.
+        """
+        request = CuratedRecommendationsRequest(
+            locale="de-DE",
+            feeds=["sections"],
+            experimentName=experiment_name,
+            experimentBranch=experiment_branch,
+        )
+        assert (
+            CuratedRecommendationsProvider.is_sections_experiment(request, SurfaceId.NEW_TAB_DE_DE)
+            is True
+        )
+
+    def test_de_without_sections_feed_returns_false(self):
+        """If the client does not request sections, the response is not sections."""
+        request = CuratedRecommendationsRequest(
+            locale="de-DE",
+            feeds=None,
+            experimentName="sections-in-germany-v2",
+            experimentBranch="content-only",
+        )
+        assert (
+            CuratedRecommendationsProvider.is_sections_experiment(request, SurfaceId.NEW_TAB_DE_DE)
+            is False
+        )

--- a/tests/unit/curated_recommendations/test_sections.py
+++ b/tests/unit/curated_recommendations/test_sections.py
@@ -502,6 +502,14 @@ class TestFilterSectionsByExperiment:
                 SurfaceId.NEW_TAB_DE_DE,
                 CrawledContentPinnedFreshRescaler,
             ),
+            # DE v2 sections branch gets DECrawledContentRescaler
+            (
+                "sections-in-germany-v2",
+                "sections",
+                "DE",
+                SurfaceId.NEW_TAB_DE_DE,
+                DECrawledContentRescaler,
+            ),
             # DE surface without experiment falls through to CrawledContentPinnedFreshRescaler
             (None, None, "DE", SurfaceId.NEW_TAB_DE_DE, CrawledContentPinnedFreshRescaler),
         ],


### PR DESCRIPTION
## References

JIRA: [HNT-2639](https://mozilla-hub.atlassian.net/browse/HNT-2639)
Experimenter: https://experimenter.services.mozilla.com/nimbus/sections-in-germany-v2/

## Description

Wires the 3-arm `sections-in-germany-v2` experiment, a pre-World-Cup iteration on `sections-in-germany`. Branches:

- **control** — scheduled-surface content in the legacy (non-sections) response. DE default, unchanged behavior.
- **content-only** — sections-backend content delivered in the legacy grid response. Isolates the layout dimension from the content dimension.
- **sections** — sections-backend content delivered in the sections response.

v1 (`sections-in-germany`) continues to run alongside v2; Nimbus enforces mutual exclusion between them.

## Implementation decisions

1. **No enrollment gate on sections response.** `is_sections_experiment` no longer special-cases DE — any DE client that requests `feeds=["sections"]` receives sections, regardless of `experimentName`/`experimentBranch`. Defense-in-depth gating caused the Ireland incident (#1525) where a forgotten gate kept clients on the wrong treatment after rollout. Branches are differentiated by what the client requests, not by a backend gate.

2. **content-only stays enrollment-gated.** Structurally required: its request is identical to control's (no `feeds=sections`), so Nimbus enrollment is the only signal. Added as an explicit `elif` in `provider.fetch` ahead of the scheduled-surface fallback; routes through `get_legacy_recommendations_from_sections` with `DECrawledContentRescaler`.

3. **`DE_EXPERIMENT_TREATMENT_PERCENT` bumped 0.10 -> 0.30.** Three disjoint 10% DE slices now generate sections-backend engagement: v1 `sections`, v2 `sections`, v2 `content-only`. The rescaler value reflects the fraction of DE traffic feeding the engagement counter, not the fraction of users on any one branch. Confirmed with Jim that v1 and v2 are mutex.

4. **v1 wiring left untouched.** v1 is on-going; modifying its gating mid-experiment would alter its measured outcome. The new v2 `sections` enrollment OR-clause in `get_ranking_rescaler_for_branch` is the only v1-adjacent edit, and the rescaler is now driven by the same `DECrawledContentRescaler` for both experiments.

## QA

Start Merino locally with `make docker-compose-up-daemon && make dev`, then:

**1. v2 control — no Nimbus enrollment effect; scheduled-surface grid:**
```bash
curl -s -X POST localhost:8000/api/v1/curated-recommendations \
  -H 'Content-Type: application/json' \
  -d '{"locale":"de-DE","region":"DE","experimentName":"sections-in-germany-v2","experimentBranch":"control","count":5}' \
  | jq '{surfaceId, has_feeds: (.feeds != null), data_len: (.data | length), first_topic: .data[0].topic}'
# -> {"surfaceId": "NEW_TAB_DE_DE", "has_feeds": false, "data_len": 5, "first_topic": "arts"}
```

**2. v2 content-only — flat grid response, but content from the sections backend:**
```bash
curl -s -X POST localhost:8000/api/v1/curated-recommendations \
  -H 'Content-Type: application/json' \
  -d '{"locale":"de-DE","region":"DE","experimentName":"sections-in-germany-v2","experimentBranch":"content-only","count":50}' \
  | jq '{surfaceId, has_feeds: (.feeds != null), data_len: (.data | length), topics: ([.data[].topic] | unique)}'
# -> {"surfaceId": "NEW_TAB_DE_DE", "has_feeds": false, "data_len": 50, "topics": [...includes "business", "education", "home"...]}
```
Distinguishing signature: `business`, `education`, `home` only appear via the sections backend; `society` only via scheduled surface.

**3. v2 sections — sections response shape:**
```bash
curl -s -X POST localhost:8000/api/v1/curated-recommendations \
  -H 'Content-Type: application/json' \
  -d '{"locale":"de-DE","region":"DE","experimentName":"sections-in-germany-v2","experimentBranch":"sections","feeds":["sections"]}' \
  | jq '{surfaceId, data_len: (.data | length), section_keys: (.feeds | keys)}'
# -> {"surfaceId": "NEW_TAB_DE_DE", "data_len": 0, "section_keys": ["arts", "business", ..., "top_stories_section", ...]}
```

**4. Ireland-fix principle — DE + `feeds=sections` with no enrollment still gets sections:**
```bash
curl -s -X POST localhost:8000/api/v1/curated-recommendations \
  -H 'Content-Type: application/json' \
  -d '{"locale":"de-DE","region":"DE","feeds":["sections"]}' \
  | jq '{surfaceId, has_feeds: (.feeds != null)}'
# -> {"surfaceId": "NEW_TAB_DE_DE", "has_feeds": true}
```

**5. v1 regression — `sections-in-germany`/`sections` still returns the sections response:**
```bash
curl -s -X POST localhost:8000/api/v1/curated-recommendations \
  -H 'Content-Type: application/json' \
  -d '{"locale":"de-DE","region":"DE","experimentName":"sections-in-germany","experimentBranch":"sections","feeds":["sections"]}' \
  | jq '{surfaceId, has_feeds: (.feeds != null)}'
# -> {"surfaceId": "NEW_TAB_DE_DE", "has_feeds": true}
```

**6. Misconfigured client (v2 sections branch but no `feeds=sections`) — falls through to scheduled surface:**
```bash
curl -s -X POST localhost:8000/api/v1/curated-recommendations \
  -H 'Content-Type: application/json' \
  -d '{"locale":"de-DE","region":"DE","experimentName":"sections-in-germany-v2","experimentBranch":"sections","count":5}' \
  | jq '{surfaceId, has_feeds: (.feeds != null)}'
# -> {"surfaceId": "NEW_TAB_DE_DE", "has_feeds": false}
```

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)

[HNT-2639]: https://mozilla-hub.atlassian.net/browse/HNT-2639

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2364)
