### PR TITLE
[DISCO-4231](chore): Enable live wcs games

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -526,9 +526,9 @@ retry_factor_sec=0.5
 
 [default.providers.wcs]
 # MERINO_PROVIDERS__WCS__LIVE_DATA_ENABLED
-# Keep the /wcs/live mock response by default. DISCO-4231 can flip this to
-# serve Redis-backed in-progress matches after launch approval.
-live_data_enabled = false
+# Serve Redis-backed in-progress matches for /wcs/live. Set to false to use
+# the static mock response for local widget development.
+live_data_enabled = true
 # MERINO_PROVIDERS__WCS__CIRCUIT_BREAKER_FAILURE_THRESHOLD
 # The circuit breaker will open when the failure is over this threshold.
 circuit_breaker_failure_threshold = 10


### PR DESCRIPTION
## References

JIRA: [DISCO-4231](https://mozilla-hub.atlassian.net/browse/DISCO-4231)

## Description
Change config to `live_data_enabled = true` in `default.toml` to allow reading Redis for games with status `in_progress`.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2366)


[DISCO-4231]: https://mozilla-hub.atlassian.net/browse/DISCO-4231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ