### PR TITLE
[DISCO-4266] fix(wcs): world cup sport_category should be 'soccer'

### DIFF
--- a/merino/providers/suggest/sports/backends/sportsdata/protocol.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/protocol.py
@@ -105,9 +105,9 @@ class SportEventDetail(BaseModel):
         sport_map = {"fifa": "World Cup"}
         home_team_key = event.get("home_team", {}).get("key")
         away_team_key = event.get("away_team", {}).get("key")
-        sport = sport_map.get(event["sport"].lower(), event["sport"])
+        sport = cast(str, sport_map.get(event["sport"].lower(), event["sport"]))
         return cls(
-            sport=cast(str, sport),
+            sport=sport,
             query=build_query(event),
             # The following essentially converts `Z$` to `+00:00`, which
             # keeps the output consistent with prior versions
@@ -129,7 +129,7 @@ class SportEventDetail(BaseModel):
             status=status.as_str(),
             status_type=str(status.as_ui_status()),
             touched=event.get("touched", "None"),
-            sport_category=SPORT_CATEGORY_MAP.get(event["sport"].upper(), SportCategory.Misc),
+            sport_category=SPORT_CATEGORY_MAP.get(sport.upper(), SportCategory.Misc),
         )
 
 

--- a/tests/unit/providers/suggest/sports/backends/test_sports_backend.py
+++ b/tests/unit/providers/suggest/sports/backends/test_sports_backend.py
@@ -457,9 +457,10 @@ async def test_sports_backend_startup(sport_data_store: SportsDataStore, mocker:
         ("MLB", SportCategory.Baseball),
         ("WCS", SportCategory.Soccer),
         ("WORLD CUP", SportCategory.Soccer),
+        ("FIFA", SportCategory.Soccer),
         ("Warhammer40k", SportCategory.Misc),
     ],
-    ids=["NFL", "NHL", "NBA", "UCL", "MLB", "WCS", "WORLD CUP", "miscellaneous"],
+    ids=["NFL", "NHL", "NBA", "UCL", "MLB", "WCS", "WORLD CUP", "FIFA", "miscellaneous"],
 )
 def test_sport_event_detail_category(sport: str, expected_category: SportCategory) -> None:
     """Test sport name mapping and fallback behavior"""
@@ -494,6 +495,7 @@ def test_sport_event_detail_remap() -> None:  # WCS, Widget
     result = SportEventDetail.from_event_dict(event)
     assert result.sport == "World Cup"
     assert result.query == "Home Team vs Away Team World Cup 2026"
+    assert result.sport_category == SportCategory.Soccer
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION


## References

JIRA: [DISCO-4266]

## Description
sport category is currently returning misc -- ensures that it's soccer

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2368)


[DISCO-4266]: https://mozilla-hub.atlassian.net/browse/DISCO-4266?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ