### PR TITLE
[DISCO-4267] fix(fleece): preinstall en_core_web_lg in docker

### DIFF
--- a/dockerfiles/Dockerfile-fleece
+++ b/dockerfiles/Dockerfile-fleece
@@ -19,10 +19,12 @@ RUN groupadd --gid 10001 app \
 # Copy local code to the container image
 COPY . $APP_HOME
 
-# Install app dependencies. Clean up build tools after
+# Install app dependencies. Clean up build tools after.
+# `en_core_web_lg` is also installed by default.
 RUN apt-get update && \
     apt-get install --yes build-essential && \
     uv sync --frozen --no-cache --no-dev --package merino-common --package merino-fleece && \
+    uv pip install "en_core_web_lg @ https://github.com/explosion/spacy-models/releases/download/en_core_web_lg-3.8.0/en_core_web_lg-3.8.0-py3-none-any.whl" && \
     apt-get remove --yes build-essential && \
     apt-get -q --yes autoremove && \
     apt-get clean && \

--- a/dockerfiles/Dockerfile-fleece
+++ b/dockerfiles/Dockerfile-fleece
@@ -24,7 +24,7 @@ COPY . $APP_HOME
 RUN apt-get update && \
     apt-get install --yes build-essential && \
     uv sync --frozen --no-cache --no-dev --package merino-common --package merino-fleece && \
-    uv pip install "en_core_web_lg @ https://github.com/explosion/spacy-models/releases/download/en_core_web_lg-3.8.0/en_core_web_lg-3.8.0-py3-none-any.whl" && \
+    uv run --no-project -- spacy download en_core_web_lg && \
     apt-get remove --yes build-essential && \
     apt-get -q --yes autoremove && \
     apt-get clean && \


### PR DESCRIPTION
## References

JIRA: [DISCO-4267](https://mozilla-hub.atlassian.net/browse/DISCO-4267)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->

Couldn't install `en_core_web_lg` on the fly in stage/prod due to file permission constraint. Pre-install it in the docker image instead as it's always needed there.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2369)


[DISCO-4267]: https://mozilla-hub.atlassian.net/browse/DISCO-4267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ