### PR TITLE
feat: Filter sport suggestions to active sports

### DIFF
--- a/merino/providers/suggest/sports/backends/sportsdata/backend.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/backend.py
@@ -65,7 +65,7 @@ class SportsDataBackend(SportsDataProtocol):
                 q=query_string,
                 language_code=language_code,
                 mix_sports=self.mix_sports,
-                filter=self.settings.sports,
+                filter=self.settings.get("sports"),
             )
             suggestions: list[SportSummary] = []
             for sport, events in events.items():

--- a/merino/providers/suggest/sports/backends/sportsdata/backend.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/backend.py
@@ -62,7 +62,10 @@ class SportsDataBackend(SportsDataProtocol):
             # should mix events for sports
             # (e.g. prior NHL, current MLB, future NFL)
             events = await self.data_store.search_events(
-                q=query_string, language_code=language_code, mix_sports=self.mix_sports
+                q=query_string,
+                language_code=language_code,
+                mix_sports=self.mix_sports,
+                filter=self.settings.sports,
             )
             suggestions: list[SportSummary] = []
             for sport, events in events.items():

--- a/merino/providers/suggest/sports/backends/sportsdata/common/elastic.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/elastic.py
@@ -690,7 +690,7 @@ class SportsDataStore(ElasticDataStore):
             cls.choose_current_event(selected_events, event)
 
     async def search_events(
-        self, q: str, language_code: str, mix_sports: bool = False
+        self, q: str, language_code: str, mix_sports: bool = False, filter: list | None = None
     ) -> dict[str, dict]:
         """Search based on the language and platform template"""
         index_id = self.index_map["event"].format(lang=language_code)
@@ -755,6 +755,9 @@ class SportsDataStore(ElasticDataStore):
                         logger.info(f"{LOGGING_TAG}Event has no date, skipping")
                         continue
                     sport = "all" if mix_sports else event["sport"]
+                    if filter and event["sport"] not in filter:
+                        logger.info(f"{LOGGING_TAG} skipping {event['sport']}")
+                        continue
                     selected_events = selected_events_by_sport.setdefault(sport, {})
 
                     # This may be a bit confusing.

--- a/tests/unit/providers/suggest/sports/backends/common/test_elastic.py
+++ b/tests/unit/providers/suggest/sports/backends/common/test_elastic.py
@@ -567,6 +567,42 @@ async def test_sports_search_previous_uses_game_date_over_late_update(
     assert result["all"]["previous"]["away_score"] == 6
 
 
+@freezegun.freeze_time("2026-05-13T13:30:00Z")
+@pytest.mark.asyncio
+async def test_sports_skip_filtered_games(
+    sport_data_store: SportsDataStore,
+    es_client: AsyncMock,
+) -> None:
+    """Do not return sports that are not active and not in the filter."""
+    hits = [
+        {
+            "_score": 1.0,
+            "_source": {
+                "event": json.dumps(
+                    {
+                        "sport": "NFL",
+                        "id": 77896,
+                        "status": "Final",
+                        "label": "may-11-game",
+                        "date": "2026-05-12T02:10:00+00:00",
+                        "updated": "2026-05-13T11:58:54+00:00",
+                        "home_score": 3,
+                        "away_score": 9,
+                    }
+                )
+            },
+        },
+    ]
+    es_client.search.return_value = {"hits": {"total": {"value": 1}, "hits": hits}}
+
+    result = await sport_data_store.search_events(
+        q="los angeles", language_code="en", mix_sports=True, filter=["NFL", "WCS"]
+    )
+    assert result["all"]["previous"]["label"] == "may-11-game"
+    assert result["all"]["previous"]["home_score"] == 3
+    assert result["all"]["previous"]["away_score"] == 9
+
+
 def test_choose_previous_ignores_final_when_current_exists() -> None:
     """Final events should not be selected when a current game already exists."""
     selected_events = {


### PR DESCRIPTION
## References

JIRA: [DISCO-TODO](https://mozilla-hub.atlassian.net/browse/DISCO-TODO)

## Description
Filters returned sport suggestions against the list of active sports. This prevents previously loaded events for a newly inactive sport from "leaking" into returned results




## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2372)
