### PR TITLE
[DISCO-4271](fix): remove custom Reddit favicon from nav_suggestion job

### DIFF
--- a/merino/jobs/navigational_suggestions/enrichments/custom_favicons.py
+++ b/merino/jobs/navigational_suggestions/enrichments/custom_favicons.py
@@ -35,7 +35,6 @@ CUSTOM_FAVICONS: dict[str, str] = {
     "etsy": "https://www.etsy.com/apple-touch-icon.png",  # 57x57
     "google": "https://www.gstatic.com/images/branding/googleg/1x/googleg_standard_color_128dp.png",  # 128x128
     "imdb": "https://www.imdb.com/apple-touch-icon.png",  # 60x60
-    "reddit": "https://www.reddit.com/apple-touch-icon.png",  # 57x57
     "twitch": "https://www.twitch.tv/apple-touch-icon.png",  # 180x180
 }
 


### PR DESCRIPTION
## References

JIRA: [DISCO-4271](https://mozilla-hub.atlassian.net/browse/DISCO-4271)

## Description
The custom Reddit favicon is outdated.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2373)


[DISCO-4271]: https://mozilla-hub.atlassian.net/browse/DISCO-4271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ