### PR TITLE
[DISCO-4170] Bump GHA versions from Nodejs 20 to Nodejs 24

### DIFF
--- a/.github/actions/weave/action.yaml
+++ b/.github/actions/weave/action.yaml
@@ -7,12 +7,12 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Install uv
       uses: astral-sh/setup-uv@v5
       with:
           enable-cache: true
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version-file: "pyproject.toml"
     - name: Install Build Dependencies

--- a/.github/workflows/build-dockerhub-app-image.yaml
+++ b/.github/workflows/build-dockerhub-app-image.yaml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build Merino app image
         run: make docker-build
       - name: Tag image for Docker Hub
@@ -22,7 +22,7 @@ jobs:
       - name: Save image artifact
         run: docker save ${{ secrets.DOCKERHUB_REPO }}:${{ inputs.image_tag }} | gzip > merino-app.tar.gz
       - name: Upload image artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: merino-app-image
           path: merino-app.tar.gz

--- a/.github/workflows/build-gar-image-fleece.yaml
+++ b/.github/workflows/build-gar-image-fleece.yaml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Get info
         run: |
           uname -v
@@ -33,7 +33,7 @@ jobs:
       - name: Save app:build image
         run: docker save app-fleece:build | gzip > fleece-image.tar.gz
       - name: Upload image artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: merino-fleece
           path: fleece-image.tar.gz

--- a/.github/workflows/build-gar-image-locust.yaml
+++ b/.github/workflows/build-gar-image-locust.yaml
@@ -14,7 +14,7 @@ jobs:
   build-locust:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build Locust Docker image
         run: docker build -t merino-locust -f ./tests/load/Dockerfile .
       - name: Tag with GAR path
@@ -22,7 +22,7 @@ jobs:
       - name: Save image
         run: docker save ${{ secrets.DOCKER_IMAGE_PATH }}/merino-locust:${{ inputs.image_tag }} | gzip > locust-image.tar.gz
       - name: Upload image artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: locust-image
           path: locust-image.tar.gz

--- a/.github/workflows/build-gar-image.yaml
+++ b/.github/workflows/build-gar-image.yaml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Get info
         run: |
           uname -v
@@ -33,7 +33,7 @@ jobs:
       - name: Save app:build image
         run: docker save app:build | gzip > image.tar.gz
       - name: Upload image artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: merino
           path: image.tar.gz

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -7,7 +7,7 @@ jobs:
   checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up to run
         uses: ./.github/actions/weave
       - name: Run Code Linting

--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -7,7 +7,7 @@ jobs:
   docs-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup Build docs
         run: |
           mkdir -p bin

--- a/.github/workflows/docs-publish-github-pages.yaml
+++ b/.github/workflows/docs-publish-github-pages.yaml
@@ -11,7 +11,7 @@ jobs:
       pages: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Ensure workspace directory exists
         run: mkdir -p workspace/doc
       - name: Disable Jekyll builds

--- a/.github/workflows/publish-dockerhub-app-image.yaml
+++ b/.github/workflows/publish-dockerhub-app-image.yaml
@@ -19,10 +19,10 @@ jobs:
     environment: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download app image
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: merino-app-image
           path: .
@@ -31,7 +31,7 @@ jobs:
       - name: Re-tag image as app:build
         run: docker tag ${{ secrets.DOCKERHUB_REPO }}:${{ inputs.image_tag }} app:build
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}

--- a/.github/workflows/publish-gar-image-fleece.yaml
+++ b/.github/workflows/publish-gar-image-fleece.yaml
@@ -25,7 +25,7 @@ jobs:
       id-token: write
     steps:
       - name: Download image artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: merino-fleece
           path: .

--- a/.github/workflows/publish-gar-image-locust.yaml
+++ b/.github/workflows/publish-gar-image-locust.yaml
@@ -24,7 +24,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Check for [load test skip] directive
         run: |
           if git log -1 --pretty=%B | grep -qi '\[load test: skip\]'; then
@@ -32,7 +32,7 @@ jobs:
             exit 0
           fi
       - name: Download Locust image artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: locust-image
           path: .

--- a/.github/workflows/publish-gar-image.yaml
+++ b/.github/workflows/publish-gar-image.yaml
@@ -25,7 +25,7 @@ jobs:
       id-token: write
     steps:
       - name: Download image artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: merino
           path: .

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,7 +13,7 @@ jobs:
   unit-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up to run
         uses: ./.github/actions/weave
       - name: Run unit tests
@@ -26,7 +26,7 @@ jobs:
         env:
           GITHUB_REPONAME: ${{ github.event.repository.name }}
           TEST_RESULTS_DIR: ${{ inputs.test_result_dir }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         if: always() # Ensure the artifacts upload even if tests fail
         with:
           name: unit-test-results
@@ -35,7 +35,7 @@ jobs:
   integration-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up to run
         uses: ./.github/actions/weave
       - name: Set up Docker Buildx
@@ -60,7 +60,7 @@ jobs:
         env:
           GITHUB_REPONAME: ${{ github.event.repository.name }}
           TEST_RESULTS_DIR: ${{ inputs.test_result_dir }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         if: always() # Ensure the artifacts upload even if tests fail
         with:
           name: integration-test-results
@@ -70,11 +70,11 @@ jobs:
     needs: [unit-tests, integration-tests]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up to run
         uses: ./.github/actions/weave
       - name: Download Test Results Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: ${{ inputs.test_result_dir }}
           pattern: "*-test-results"

--- a/.github/workflows/upload-test-artifacts-to-gcs.yaml
+++ b/.github/workflows/upload-test-artifacts-to-gcs.yaml
@@ -30,19 +30,19 @@ jobs:
       id-token: 'write'
     steps:
       - name: Set up Google Cloud Authentication
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           service_account: ${{ inputs.service_account }}
           workload_identity_provider: ${{ vars.GCPV2_GITHUB_WORKLOAD_IDENTITY_PROVIDER }}
       - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
       - name: Download Unit Test Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: unit-test-results
           path: ${{ inputs.source }}
       - name: Download Integration Test Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: integration-test-results
           path: ${{ inputs.source }}


### PR DESCRIPTION
## References

JIRA: [DISCO-4170](https://mozilla-hub.atlassian.net/browse/DISCO-4170)

## Description
Our CI was emitting deprecation warnings because some action versions still declare the node20 runtime. This PR bumps each affected action to the lowest major version that runs on Node.js 24 to clear the warnings ahead of the deadline.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2377)


[DISCO-4170]: https://mozilla-hub.atlassian.net/browse/DISCO-4170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ