### PR TITLE
[HNT-2655] Update watch links

### DIFF
--- a/merino/providers/wcs/watch_links.py
+++ b/merino/providers/wcs/watch_links.py
@@ -39,7 +39,7 @@ class CountryEntry(TypedDict):
 
 
 _FIFA_PLUS = HttpUrl(
-    "https://www.plus.fifa.com/showcase/fifa-world-cup-26tm/89de0054-9fa6-4741-88e1-a902dc26740f"
+    "https://www.dazn.com/competition/Competition:50kvbmxi5r9amj2e39hznggqj"
 )
 
 
@@ -64,7 +64,7 @@ def build_watch_link(
 def _build_fifa_watch_link(*, show_in_other_regions: bool = False) -> WatchLinkEntry:
     """Build a FIFA+ entry reusing the shared showcase URL."""
     return WatchLinkEntry(
-        product_name="FIFA+",
+        product_name="FIFA+ (DAZN)",
         url=_FIFA_PLUS,
         sort_order=1,
         in_production=True,
@@ -72,7 +72,6 @@ def _build_fifa_watch_link(*, show_in_other_regions: bool = False) -> WatchLinkE
     )
 
 
-# TODO: SUI has ??? from the source CSV
 
 # Outer key: ISO 3166-1 alpha-2 country code.
 # "langs" inner key: BCP 47 language prefix (e.g. "en", "de") or "*" for country-wide streams
@@ -158,7 +157,7 @@ WATCH_LINKS: dict[str, CountryEntry] = {
             "nl": [
                 build_watch_link(
                     "VRT 1",
-                    "https://www.vrt.be/vrtmax/kanalen/sporza/",
+                    "https://www.vrt.be/vrtmax/a-z/sporza--fifa-wk-voetbal-2026/",
                     2,
                     in_production=True,
                     show_in_other_regions=True,
@@ -395,7 +394,7 @@ WATCH_LINKS: dict[str, CountryEntry] = {
                 _build_fifa_watch_link(),
                 build_watch_link(
                     "DRTV",
-                    "https://www.dr.dk/drtv/kategorier/sport",
+                    "https://www.dr.dk/drtv/liste/fifa-vm-2026-_-kampe-_events__351527",
                     2,
                     in_production=True,
                     show_in_other_regions=True,
@@ -500,21 +499,21 @@ WATCH_LINKS: dict[str, CountryEntry] = {
                 _build_fifa_watch_link(),
                 build_watch_link(
                     "BBC iPlayer",
-                    "https://www.bbc.co.uk/iplayer/episodes/m002gjj0/fifa-world-cup-2026",
+                    "https://www.bbc.co.uk/iplayer/event/fifa-world-cup",
                     2,
                     in_production=True,
                     show_in_other_regions=True,
                 ),
                 build_watch_link(
                     "ITVX",
-                    "https://www.itv.com/watch",
+                    "https://www.itv.com/watch/fifa-world-cup-2026/1a6247",
                     2,
                     in_production=True,
                     show_in_other_regions=True,
                 ),
                 build_watch_link(
                     "STV Player",
-                    "https://player.stv.tv/live",
+                    "https://player.stv.tv/summary/fifa-world-cup",
                     2,
                     in_production=True,
                     show_in_other_regions=True,
@@ -696,7 +695,7 @@ WATCH_LINKS: dict[str, CountryEntry] = {
                 ),
                 build_watch_link(
                     "sport tv",
-                    "https://www.sporttv.pt/mundial-fifa-2026",
+                    "https://www.sporttv.pt/noticias/categoria/mundial/5027",
                     3,
                     in_production=True,
                     show_in_other_regions=True,

--- a/merino/providers/wcs/watch_links.py
+++ b/merino/providers/wcs/watch_links.py
@@ -38,9 +38,7 @@ class CountryEntry(TypedDict):
     langs: dict[str, list[WatchLinkEntry]]
 
 
-_FIFA_PLUS = HttpUrl(
-    "https://www.dazn.com/competition/Competition:50kvbmxi5r9amj2e39hznggqj"
-)
+_FIFA_PLUS = HttpUrl("https://www.dazn.com/competition/Competition:50kvbmxi5r9amj2e39hznggqj")
 
 
 def build_watch_link(
@@ -70,7 +68,6 @@ def _build_fifa_watch_link(*, show_in_other_regions: bool = False) -> WatchLinkE
         in_production=True,
         show_in_other_regions=show_in_other_regions,
     )
-
 
 
 # Outer key: ISO 3166-1 alpha-2 country code.

--- a/merino/providers/wcs/watch_links.py
+++ b/merino/providers/wcs/watch_links.py
@@ -38,7 +38,7 @@ class CountryEntry(TypedDict):
     langs: dict[str, list[WatchLinkEntry]]
 
 
-_FIFA_PLUS = HttpUrl("https://www.dazn.com/competition/Competition:50kvbmxi5r9amj2e39hznggqj")
+_FIFA_PLUS_DAZN = HttpUrl("https://www.dazn.com/competition/Competition:50kvbmxi5r9amj2e39hznggqj")
 
 
 def build_watch_link(
@@ -63,7 +63,7 @@ def _build_fifa_watch_link(*, show_in_other_regions: bool = False) -> WatchLinkE
     """Build a FIFA+ entry reusing the shared showcase URL."""
     return WatchLinkEntry(
         product_name="FIFA+ (DAZN)",
-        url=_FIFA_PLUS,
+        url=_FIFA_PLUS_DAZN,
         sort_order=1,
         in_production=True,
         show_in_other_regions=show_in_other_regions,

--- a/tests/data/wcs/watch_links_response_en_us.json
+++ b/tests/data/wcs/watch_links_response_en_us.json
@@ -1,9 +1,9 @@
 {
   "your_region": [
     {
-      "product_name": "FIFA+",
+      "product_name": "FIFA+ (DAZN)",
       "entitlement": "Free and Paid",
-      "url": "https://www.plus.fifa.com/showcase/fifa-world-cup-26tm/89de0054-9fa6-4741-88e1-a902dc26740f"
+      "url": "https://www.dazn.com/competition/Competition:50kvbmxi5r9amj2e39hznggqj"
     },
     {
       "product_name": "Tubi",
@@ -98,7 +98,7 @@
         {
           "product_name": "VRT 1",
           "entitlement": "Free",
-          "url": "https://www.vrt.be/vrtmax/kanalen/sporza/"
+          "url": "https://www.vrt.be/vrtmax/a-z/sporza--fifa-wk-voetbal-2026/"
         }
       ]
     },
@@ -218,7 +218,7 @@
         {
           "product_name": "DRTV",
           "entitlement": "Free",
-          "url": "https://www.dr.dk/drtv/kategorier/sport"
+          "url": "https://www.dr.dk/drtv/liste/fifa-vm-2026-_-kampe-_events__351527"
         },
         {
           "product_name": "TV 2 Play",
@@ -438,7 +438,7 @@
         {
           "product_name": "sport tv",
           "entitlement": "Free and Paid",
-          "url": "https://www.sporttv.pt/mundial-fifa-2026"
+          "url": "https://www.sporttv.pt/noticias/categoria/mundial/5027"
         }
       ]
     },
@@ -533,17 +533,17 @@
         {
           "product_name": "BBC iPlayer",
           "entitlement": "Free",
-          "url": "https://www.bbc.co.uk/iplayer/episodes/m002gjj0/fifa-world-cup-2026"
+          "url": "https://www.bbc.co.uk/iplayer/event/fifa-world-cup"
         },
         {
           "product_name": "ITVX",
           "entitlement": "Free",
-          "url": "https://www.itv.com/watch"
+          "url": "https://www.itv.com/watch/fifa-world-cup-2026/1a6247"
         },
         {
           "product_name": "STV Player",
           "entitlement": "Free",
-          "url": "https://player.stv.tv/live"
+          "url": "https://player.stv.tv/summary/fifa-world-cup"
         }
       ]
     }

--- a/tests/integration/api/v1/wcs/test_watch_links.py
+++ b/tests/integration/api/v1/wcs/test_watch_links.py
@@ -84,9 +84,9 @@ def test_watch_links_de_de(
     # your_region: German streams sorted by sort_order ASC, product_name ASC
     assert body["your_region"] == [
         {
-            "product_name": "FIFA+",
+            "product_name": "FIFA+ (DAZN)",
             "entitlement": "Free and Paid",
-            "url": "https://www.plus.fifa.com/showcase/fifa-world-cup-26tm/89de0054-9fa6-4741-88e1-a902dc26740f",
+            "url": "https://www.dazn.com/competition/Competition:50kvbmxi5r9amj2e39hznggqj",
         },
         {
             "product_name": "ARD",


### PR DESCRIPTION
## References

JIRA: [HNT-2655](https://mozilla-hub.atlassian.net/browse/HNT-2655)

## Description
Update the stream links. Changes are being made according to this [sheet](https://docs.google.com/spreadsheets/d/1BPuA5eazbvt86xaGMwGxkUZwu86mBns1WHi0jNxWnFw/edit?gid=978438068#gid=978438068)'s rows 2 - 41. Mainly updating the FIFA+ links to DAZN, updating the stream product name, and updating some individual streams and product names for specific countries.

## PR Review Checklist

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2379)


[HNT-2655]: https://mozilla-hub.atlassian.net/browse/HNT-2655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ