### PR TITLE
[HNT-2156] Add image download and upload functionality

### DIFF
--- a/merino/providers/rss/manager.py
+++ b/merino/providers/rss/manager.py
@@ -6,7 +6,6 @@ from dynaconf.base import Settings
 
 from merino.configs import settings
 from merino.utils.http_client import create_http_client
-from merino.utils.gcs.gcs_uploader import GcsUploader
 from merino.providers.rss.base import BaseRssProvider
 from merino.providers.rss.wikimedia_potd.backends.wikimedia_potd import (
     WikimediaPotdBackend,
@@ -38,11 +37,8 @@ def _create_provider(provider_id: str, setting: Settings) -> BaseRssProvider:
             return WikimediaPictureOfTheDayProvider(
                 backend=WikimediaPotdBackend(
                     feed_url=setting.feed_url,
-                    gcs_uploader=GcsUploader(
-                        settings.image_gcs.gcs_project,
-                        settings.image_gcs.gcs_bucket,
-                        settings.image_gcs.cdn_hostname,
-                    ),
+                    bucket_name=settings.image_gcs_v2.gcs_bucket,
+                    cdn_hostname=settings.image_gcs_v2.cdn_hostname,
                     http_client=http_client,
                     metrics_client=get_metrics_client(),
                 ),

--- a/merino/providers/rss/manager.py
+++ b/merino/providers/rss/manager.py
@@ -12,6 +12,7 @@ from merino.providers.rss.wikimedia_potd.backends.wikimedia_potd import (
 )
 from merino.providers.rss.wikimedia_potd.provider import WikimediaPictureOfTheDayProvider
 from merino.utils.metrics import get_metrics_client
+from merino.utils.gcs.gcs_uploader import GcsUploader
 
 
 @unique
@@ -37,10 +38,13 @@ def _create_provider(provider_id: str, setting: Settings) -> BaseRssProvider:
             return WikimediaPictureOfTheDayProvider(
                 backend=WikimediaPotdBackend(
                     feed_url=setting.feed_url,
-                    bucket_name=settings.image_gcs_v2.gcs_bucket,
-                    cdn_hostname=settings.image_gcs_v2.cdn_hostname,
                     http_client=http_client,
                     metrics_client=get_metrics_client(),
+                    gcs_uploader=GcsUploader(
+                        settings.image_gcs_v2.gcs_project,
+                        settings.image_gcs_v2.gcs_bucket,
+                        settings.image_gcs_v2.cdn_hostname,
+                    ),
                 ),
                 metrics_client=get_metrics_client(),
                 name=provider_id,

--- a/merino/providers/rss/wikimedia_potd/backends/utils.py
+++ b/merino/providers/rss/wikimedia_potd/backends/utils.py
@@ -97,3 +97,8 @@ def build_potd_path_and_name(image: Image, is_thumbnail: bool) -> str:
     # the path in the bucket for the image would look like:
     # "merino-images-prod/rss/wikimedia_potd/POTD_2026-06-07_thumbnail.jpeg"
     return f"{DIR_PATH_IN_BUCKET}/{prefix}_{date_time}_{suffix}.{extension}"
+
+
+def is_valid_potd_image_url(url: HttpUrl) -> bool:
+    """Validate url is an image url."""
+    return bool(str(url).split(".")[-1] in ["jpg", "jpeg", "png", "webp"])

--- a/merino/providers/rss/wikimedia_potd/backends/utils.py
+++ b/merino/providers/rss/wikimedia_potd/backends/utils.py
@@ -1,15 +1,20 @@
 """Utility functions for parsing Wikimedia POTD RSS feed data."""
 
 from bs4 import BeautifulSoup, Tag
+from datetime import datetime
 from feedparser import FeedParserDict
 from pydantic import HttpUrl
 
 from merino.providers.rss.wikimedia_potd.backends.protocol import PictureOfTheDay
+from merino.utils.gcs.models import Image
 
 # This is needed to prevent Wikimedia from blocking our requests as bot requests.
 RSS_FETCH_REQUEST_HEADERS = {
     "User-Agent": "Mozilla/5.0 (compatible; Merino/1.0; +https://github.com/mozilla-services/merino-py)"
 }
+
+# Under the bucket merino-images-prod, potd images are stored under the following directory.
+DIR_PATH_IN_BUCKET = "rss/wikimedia_potd"
 
 
 def parse_potd(potd: FeedParserDict) -> PictureOfTheDay | None:
@@ -75,3 +80,20 @@ def extract_potd(parsed_feed: FeedParserDict) -> FeedParserDict | None:
         return None
 
     return potd
+
+
+def build_potd_path_and_name(image: Image, is_thumbnail: bool) -> str:
+    """Build the name string for a potd and prepend the bucket directory path to it."""
+    # YYYY-MM-DD format
+    date_time = datetime.today().strftime("%Y-%m-%d")
+
+    prefix = "POTD"
+    # append "_thumbnail" to the object name if it is a thumbnail image
+    suffix = "thumbnail" if is_thumbnail else "hi_res"
+
+    # extract image extension since the image.content_type has the format image/jpeg
+    extension = image.content_type.split("/")[-1]
+
+    # the path in the bucket for the image would look like:
+    # "merino-images-prod/rss/wikimedia_potd/POTD_2026-06-07_thumbnail.jpeg"
+    return f"{DIR_PATH_IN_BUCKET}/{prefix}_{date_time}_{suffix}.{extension}"

--- a/merino/providers/rss/wikimedia_potd/backends/utils.py
+++ b/merino/providers/rss/wikimedia_potd/backends/utils.py
@@ -13,9 +13,6 @@ RSS_FETCH_REQUEST_HEADERS = {
     "User-Agent": "Mozilla/5.0 (compatible; Merino/1.0; +https://github.com/mozilla-services/merino-py)"
 }
 
-# Under the bucket merino-images-prod, potd images are stored under the following directory.
-DIR_PATH_IN_BUCKET = "rss/wikimedia_potd"
-
 
 def parse_potd(potd: FeedParserDict) -> PictureOfTheDay | None:
     """Parse the RSS entry description HTML to extract image URLs and text.
@@ -87,16 +84,17 @@ def build_potd_path_and_name(image: Image, is_thumbnail: bool) -> str:
     # YYYY-MM-DD format
     date_time = datetime.today().strftime("%Y-%m-%d")
 
-    prefix = "POTD"
+    # Under the bucket merino-images-prod, potd images are stored in the following directory.
+    dir_path_in_bucket = "rss/wikimedia_potd"
     # append "_thumbnail" to the object name if it is a thumbnail image
     suffix = "thumbnail" if is_thumbnail else "hi_res"
 
     # extract image extension since the image.content_type has the format image/jpeg
     extension = image.content_type.split("/")[-1]
 
-    # the path in the bucket for the image would look like:
-    # "merino-images-prod/rss/wikimedia_potd/POTD_2026-06-07_thumbnail.jpeg"
-    return f"{DIR_PATH_IN_BUCKET}/{prefix}_{date_time}_{suffix}.{extension}"
+    # the path in the gcs bucket directory for the image would look like:
+    # "rss/wikimedia_potd/POTD_2026-06-07_thumbnail.jpeg"
+    return f"{dir_path_in_bucket}/POTD_{date_time}_{suffix}.{extension}"
 
 
 def is_valid_potd_image_url(url: HttpUrl) -> bool:

--- a/merino/providers/rss/wikimedia_potd/backends/wikimedia_potd.py
+++ b/merino/providers/rss/wikimedia_potd/backends/wikimedia_potd.py
@@ -3,20 +3,19 @@
 import logging
 import aiodogstatsd
 import feedparser
-from datetime import datetime
 from pydantic import HttpUrl
 from feedparser import FeedParserDict
-from httpx import AsyncClient, HTTPError, Response, HTTPStatusError
+from httpx import AsyncClient, HTTPError, Response
 
 from merino.providers.rss.wikimedia_potd.backends.protocol import PictureOfTheDay
+from merino.utils.gcs.gcs_uploader import GcsUploader
 from merino.utils.gcs.models import Image
 from merino.providers.rss.wikimedia_potd.backends.utils import (
-    extract_potd,
     RSS_FETCH_REQUEST_HEADERS,
+    extract_potd,
+    build_potd_path_and_name,
 )
-from merino.utils.storage import get_storage_client
-from gcloud.aio.storage import Storage
-from sentry_sdk import capture_exception
+import sentry_sdk
 
 logger = logging.getLogger(__name__)
 
@@ -26,25 +25,20 @@ class WikimediaPotdBackend:
 
     metrics_client: aiodogstatsd.Client
     http_client: AsyncClient
-    gcs_client: Storage
-    bucket_name: str
-    cdn_hostname: str
+    gcs_uploader: GcsUploader
 
     def __init__(
         self,
         metrics_client: aiodogstatsd.Client,
         http_client: AsyncClient,
         feed_url: str,
-        bucket_name: str,
-        cdn_hostname: str,
+        gcs_uploader: GcsUploader,
     ) -> None:
         """Initialize the backend with the RSS feed URL."""
         self.feed_url = feed_url
         self.metrics_client = metrics_client
         self.http_client = http_client
-        self.gcs_client = get_storage_client()
-        self.bucket_name = bucket_name
-        self.cdn_hostname = cdn_hostname
+        self.gcs_uploader = gcs_uploader
 
     async def get_picture_of_the_day(self) -> PictureOfTheDay | None:
         """Fetch the current Wikimedia Picture of the Day.
@@ -94,7 +88,7 @@ class WikimediaPotdBackend:
         """Download the image using the image URL.
 
         Returns an Image object containing the binary content and content type,
-        or None if no image URL is found.
+        or None.
         """
         # verify that the url is an image url
         if str(url).split(".")[-1] not in ["jpg", "jpeg", "png", "webp"]:
@@ -113,39 +107,17 @@ class WikimediaPotdBackend:
                 content=content,
                 content_type=str(content_type),
             )
-        except HTTPStatusError as ex:
-            # throw sentry exception for HTTP exceptions
-            capture_exception(ex)
-            return None
         except Exception as ex:
-            # throw sentry exception for generic exceptions
-            capture_exception(ex)
+            sentry_sdk.capture_exception(ex)
             return None
 
-    async def upload_image(self, image: Image, is_thumbnail: bool) -> str:
+    def upload_image(self, image: Image, is_thumbnail: bool) -> str | None:
         """Upload an image to the bucket."""
-        folder_path_in_bucket = "rss/wikimedia_potd"
+        potd_path_and_name = build_potd_path_and_name(image=image, is_thumbnail=is_thumbnail)
 
-        # YYYY-MM-DD format
-        date_time = datetime.today().strftime("%Y-%m-%d")
-
-        prefix = "POTD"
-        # append "_thumbnail" to the object name if it is a thumbnail image
-        suffix = "thumbnail" if is_thumbnail else "hi_res"
-
-        # extract image extension since the image.content_type has the format image/jpeg
-        extension = image.content_type.split("/")[-1]
-
-        # the path in the bucket for the image
-        # would look like: "merino-images-prod/rss/wikimedia_potd/POTD_2026-06-07_thumbnail.jpeg"
-        object_name = f"{folder_path_in_bucket}/{prefix}_{date_time}_{suffix}.{extension}"
-
-        await self.gcs_client.upload(
-            bucket=self.bucket_name,
-            object_name=object_name,
-            file_data=image.content,
-            content_type=image.content_type,
-        )
-
-        # TODO return public cdn image url
-        return f"https://{self.cdn_hostname}/{object_name}"
+        try:
+            # return a public cdn url for the image after a successful upload
+            return self.gcs_uploader.upload_image(image=image, destination_name=potd_path_and_name)
+        except Exception as ex:
+            sentry_sdk.capture_exception(ex)
+            return None

--- a/merino/providers/rss/wikimedia_potd/backends/wikimedia_potd.py
+++ b/merino/providers/rss/wikimedia_potd/backends/wikimedia_potd.py
@@ -14,6 +14,7 @@ from merino.providers.rss.wikimedia_potd.backends.utils import (
     RSS_FETCH_REQUEST_HEADERS,
     extract_potd,
     build_potd_path_and_name,
+    is_valid_potd_image_url,
 )
 import sentry_sdk
 
@@ -90,18 +91,17 @@ class WikimediaPotdBackend:
         Returns an Image object containing the binary content and content type,
         or None.
         """
-        # verify that the url is an image url
-        if str(url).split(".")[-1] not in ["jpg", "jpeg", "png", "webp"]:
+        if not is_valid_potd_image_url(url):
             return None
 
         try:
             # set up request headers to only accept image content types
-            request_headers = {"Accept": "image/jpeg,image/png,image/webp"}
+            request_headers = {"accept": "image/jpeg,image/png,image/webp"}
             response: Response = await self.http_client.get(str(url), headers=request_headers)
             response.raise_for_status()
 
             content = response.content
-            content_type = response.headers["Content-Type"]
+            content_type = response.headers["content-type"]
 
             return Image(
                 content=content,

--- a/merino/providers/rss/wikimedia_potd/backends/wikimedia_potd.py
+++ b/merino/providers/rss/wikimedia_potd/backends/wikimedia_potd.py
@@ -3,16 +3,20 @@
 import logging
 import aiodogstatsd
 import feedparser
+from datetime import datetime
 from pydantic import HttpUrl
 from feedparser import FeedParserDict
-from httpx import AsyncClient, HTTPError, Response
+from httpx import AsyncClient, HTTPError, Response, HTTPStatusError
 
 from merino.providers.rss.wikimedia_potd.backends.protocol import PictureOfTheDay
+from merino.utils.gcs.models import Image
 from merino.providers.rss.wikimedia_potd.backends.utils import (
     extract_potd,
     RSS_FETCH_REQUEST_HEADERS,
 )
-from merino.utils.gcs.gcs_uploader import GcsUploader
+from merino.utils.storage import get_storage_client
+from gcloud.aio.storage import Storage
+from sentry_sdk import capture_exception
 
 logger = logging.getLogger(__name__)
 
@@ -22,20 +26,25 @@ class WikimediaPotdBackend:
 
     metrics_client: aiodogstatsd.Client
     http_client: AsyncClient
-    gcs_uploader: GcsUploader
+    gcs_client: Storage
+    bucket_name: str
+    cdn_hostname: str
 
     def __init__(
         self,
         metrics_client: aiodogstatsd.Client,
         http_client: AsyncClient,
-        gcs_uploader: GcsUploader,
         feed_url: str,
+        bucket_name: str,
+        cdn_hostname: str,
     ) -> None:
         """Initialize the backend with the RSS feed URL."""
         self.feed_url = feed_url
         self.metrics_client = metrics_client
         self.http_client = http_client
-        self.gcs_uploader = gcs_uploader
+        self.gcs_client = get_storage_client()
+        self.bucket_name = bucket_name
+        self.cdn_hostname = cdn_hostname
 
     async def get_picture_of_the_day(self) -> PictureOfTheDay | None:
         """Fetch the current Wikimedia Picture of the Day.
@@ -80,3 +89,63 @@ class WikimediaPotdBackend:
         except HTTPError as ex:
             logger.error(f"HTTP error occurred when fetching Wikimedia POTD feed: {ex}")
             return None
+
+    async def download_image(self, url: HttpUrl) -> Image | None:
+        """Download the image using the image URL.
+
+        Returns an Image object containing the binary content and content type,
+        or None if no image URL is found.
+        """
+        # verify that the url is an image url
+        if str(url).split(".")[-1] not in ["jpg", "jpeg", "png", "webp"]:
+            return None
+
+        try:
+            # set up request headers to only accept image content types
+            request_headers = {"Accept": "image/jpeg,image/png,image/webp"}
+            response: Response = await self.http_client.get(str(url), headers=request_headers)
+            response.raise_for_status()
+
+            content = response.content
+            content_type = response.headers["Content-Type"]
+
+            return Image(
+                content=content,
+                content_type=str(content_type),
+            )
+        except HTTPStatusError as ex:
+            # throw sentry exception for HTTP exceptions
+            capture_exception(ex)
+            return None
+        except Exception as ex:
+            # throw sentry exception for generic exceptions
+            capture_exception(ex)
+            return None
+
+    async def upload_image(self, image: Image, is_thumbnail: bool) -> str:
+        """Upload an image to the bucket."""
+        folder_path_in_bucket = "rss/wikimedia_potd"
+
+        # YYYY-MM-DD format
+        date_time = datetime.today().strftime("%Y-%m-%d")
+
+        prefix = "POTD"
+        # append "_thumbnail" to the object name if it is a thumbnail image
+        suffix = "thumbnail" if is_thumbnail else "hi_res"
+
+        # extract image extension since the image.content_type has the format image/jpeg
+        extension = image.content_type.split("/")[-1]
+
+        # the path in the bucket for the image
+        # would look like: "merino-images-prod/rss/wikimedia_potd/POTD_2026-06-07_thumbnail.jpeg"
+        object_name = f"{folder_path_in_bucket}/{prefix}_{date_time}_{suffix}.{extension}"
+
+        await self.gcs_client.upload(
+            bucket=self.bucket_name,
+            object_name=object_name,
+            file_data=image.content,
+            content_type=image.content_type,
+        )
+
+        # TODO return public cdn image url
+        return f"https://{self.cdn_hostname}/{object_name}"

--- a/tests/integration/providers/rss/potd/test_wikimedia_potd.py
+++ b/tests/integration/providers/rss/potd/test_wikimedia_potd.py
@@ -5,10 +5,12 @@
 """Integration tests for the Picture of the Day Provider."""
 
 import pytest
-
 import freezegun
-from unittest.mock import call
-from httpx import AsyncClient
+
+from typing import cast
+from pydantic import HttpUrl
+from unittest.mock import call, AsyncMock
+from httpx import AsyncClient, HTTPError, Request, Response
 from pytest_mock import MockerFixture
 from merino.providers.rss.wikimedia_potd.backends.wikimedia_potd import (
     WikimediaPotdBackend,
@@ -34,64 +36,125 @@ def fixture_backend(
     )
 
 
-@freezegun.freeze_time("2026-06-07")
-def test_upload_image_thumbnail_only_success(
-    backend: WikimediaPotdBackend, gcs_storage_client, gcs_storage_bucket
-) -> None:
-    """Test upload_image method successfully uploads an image and returns a public cdn url."""
-    test_image = Image(content=b"", content_type="Image/jpeg")
+class TestUploadImageMethod:
+    """Tests for the upload_image method."""
 
-    # call the backend method to upload the image
-    backend.upload_image(image=test_image, is_thumbnail=True)
+    @freezegun.freeze_time("2026-06-07")
+    def test_thumbnail_upload_only_success(
+        self, backend: WikimediaPotdBackend, gcs_storage_client, gcs_storage_bucket
+    ) -> None:
+        """Test upload_image method successfully uploads an image and returns a public cdn url."""
+        test_image = Image(content=b"", content_type="Image/jpeg")
 
-    # get the blob (image) from the same bucket assigned to the gcs_uploader instance of the backend object
-    blobs_in_bucket = list(gcs_storage_client.get_bucket(gcs_storage_bucket.name).list_blobs())
+        # call the backend method to upload the image
+        backend.upload_image(image=test_image, is_thumbnail=True)
 
-    # should be only one blob (thumbnail image)
-    assert len(blobs_in_bucket) == 1
-    assert blobs_in_bucket[0].name == "rss/wikimedia_potd/POTD_2026-06-07_thumbnail.jpeg"
+        # get the blob (image) from the same bucket assigned to the gcs_uploader instance of the backend object
+        blobs_in_bucket = list(gcs_storage_client.get_bucket(gcs_storage_bucket.name).list_blobs())
+
+        # should be only one blob (thumbnail image)
+        assert len(blobs_in_bucket) == 1
+        assert blobs_in_bucket[0].name == "rss/wikimedia_potd/POTD_2026-06-07_thumbnail.jpeg"
+
+    @freezegun.freeze_time("2026-06-07")
+    def test_thumbnail_and_hi_res_success(
+        self, backend: WikimediaPotdBackend, gcs_storage_client, gcs_storage_bucket
+    ) -> None:
+        """Test upload_image method successfully uploads two images and returns public cdn urls."""
+        test_image = Image(content=b"", content_type="Image/jpeg")
+
+        # call the backend method to upload the thumbnail and hi-res image
+        backend.upload_image(image=test_image, is_thumbnail=True)
+        backend.upload_image(image=test_image, is_thumbnail=False)
+
+        # get the blob (image) from the same bucket assigned to the gcs_uploader instance of the backend object
+        blobs_in_bucket = list(gcs_storage_client.get_bucket(gcs_storage_bucket.name).list_blobs())
+
+        # should be two blobs (thumbnail and hi-res)
+        assert len(blobs_in_bucket) == 2
+        assert blobs_in_bucket[0].name == "rss/wikimedia_potd/POTD_2026-06-07_hi_res.jpeg"
+        assert blobs_in_bucket[1].name == "rss/wikimedia_potd/POTD_2026-06-07_thumbnail.jpeg"
+
+    def test_captures_sentry_exception(
+        self, backend: WikimediaPotdBackend, mocker: MockerFixture
+    ) -> None:
+        """Test upload_image method successfully uploads two images and returns public cdn urls."""
+        test_image = Image(content=b"", content_type="Image/jpeg")
+
+        ex = Exception("Test Exception")
+        mocker.patch.object(backend.gcs_uploader, "upload_image").side_effect = ex
+
+        sentry_capture = mocker.patch(
+            "merino.providers.rss.wikimedia_potd.backends.wikimedia_potd.sentry_sdk.capture_exception"
+        )
+
+        actual = backend.upload_image(image=test_image, is_thumbnail=True)
+        assert actual is None
+
+        # assert on sentry calls
+        mock_call = [call(ex)]
+        assert sentry_capture.call_count == 1
+        sentry_capture.assert_has_calls(mock_call)
 
 
-@freezegun.freeze_time("2026-06-07")
-def test_upload_image_thumbnail_and_hi_res_success(
-    backend: WikimediaPotdBackend, gcs_storage_client, gcs_storage_bucket
-) -> None:
-    """Test upload_image method successfully uploads two images and returns public cdn urls."""
-    test_image = Image(content=b"", content_type="Image/jpeg")
+class TestDownloadImageMethod:
+    """Tests for the download_image method."""
 
-    # call the backend method to upload the thumbnail and hi-res image
-    backend.upload_image(image=test_image, is_thumbnail=True)
-    backend.upload_image(image=test_image, is_thumbnail=False)
+    @pytest.mark.asyncio
+    async def test_returns_none_on_incorrect_extenstion(
+        self, backend: WikimediaPotdBackend
+    ) -> None:
+        """Test download_image method returns None if the url image extension is not supported."""
+        url_with_incorrect_extension = HttpUrl("http://www.test-image.com/image.txt")
 
-    # get the blob (image) from the same bucket assigned to the gcs_uploader instance of the backend object
-    blobs_in_bucket = list(gcs_storage_client.get_bucket(gcs_storage_bucket.name).list_blobs())
+        # call the backend method to download the image
+        actual = await backend.download_image(url=url_with_incorrect_extension)
 
-    # should be two blobs (thumbnail and hi-res)
-    assert len(blobs_in_bucket) == 2
-    assert blobs_in_bucket[0].name == "rss/wikimedia_potd/POTD_2026-06-07_hi_res.jpeg"
-    assert blobs_in_bucket[1].name == "rss/wikimedia_potd/POTD_2026-06-07_thumbnail.jpeg"
+        assert actual is None
 
+    @pytest.mark.asyncio
+    async def test_returns_none_on_http_exception(
+        self, backend: WikimediaPotdBackend, mocker: MockerFixture
+    ) -> None:
+        """Test download_image method returns None http request raises exception."""
+        image_url = HttpUrl("http://www.test-image.com/image.jpeg")
+        http_error = HTTPError("Error fetching POTD")
 
-def test_upload_image_captures_sentry_exception(
-    backend: WikimediaPotdBackend, mocker: MockerFixture
-) -> None:
-    """Test upload_image method successfully uploads two images and returns public cdn urls."""
-    test_image = Image(content=b"", content_type="Image/jpeg")
+        client_mock: AsyncMock = cast(AsyncMock, backend.http_client)
+        client_mock.get.side_effect = http_error
 
-    ex = Exception("Test Exception")
-    mocker.patch.object(backend.gcs_uploader, "upload_image").side_effect = ex
+        sentry_capture = mocker.patch(
+            "merino.providers.rss.wikimedia_potd.backends.wikimedia_potd.sentry_sdk.capture_exception"
+        )
 
-    # mocker.patch("merino.providers.rss.wikimedia_potd.backends.wikimedia_potd.GcsUploader.upload_image").side_effect = Exception("Test Exception")
-    sentry_capture = mocker.patch(
-        "merino.providers.rss.wikimedia_potd.backends.wikimedia_potd.sentry_sdk.capture_exception"
-    )
-    backend.upload_image(image=test_image, is_thumbnail=True)
+        # call the backend method to download the image
+        actual = await backend.download_image(url=image_url)
 
-    assert sentry_capture.call_count == 1
-    # import pdb; pdb.set_trace()
+        assert actual is None
 
-    mock_call = [call(ex)]
-    sentry_capture.assert_has_calls(mock_call)
+        # assert on sentry calls
+        mock_call = [call(http_error)]
+        assert sentry_capture.call_count == 1
+        sentry_capture.assert_has_calls(mock_call)
 
-    # with pytest.raises(Exception) as ex:
-    #     # call the backend method to upload an image
+    @pytest.mark.asyncio
+    async def test_returns_image_on_successful_download(
+        self, backend: WikimediaPotdBackend, mocker: MockerFixture
+    ) -> None:
+        """Test download_image method returns Image on successful download."""
+        image_url = HttpUrl("http://www.test-image.com/image.png")
+
+        client_mock: AsyncMock = cast(AsyncMock, backend.http_client)
+        client_mock.get.return_value = Response(
+            status_code=200,
+            content=b"255",
+            headers={"content-type": "image/png"},
+            request=Request(method="GET", url=str(image_url)),
+        )
+
+        # call the backend method to download the image
+        actual: Image | None = await backend.download_image(url=image_url)
+
+        assert actual is not None
+        assert actual.content == b"255"
+        assert actual.content_type == "image/png"

--- a/tests/integration/providers/rss/potd/test_wikimedia_potd.py
+++ b/tests/integration/providers/rss/potd/test_wikimedia_potd.py
@@ -6,9 +6,9 @@
 
 import pytest
 
-from unittest.mock import MagicMock, call
+import freezegun
+from unittest.mock import call
 from httpx import AsyncClient
-from datetime import datetime
 from pytest_mock import MockerFixture
 from merino.providers.rss.wikimedia_potd.backends.wikimedia_potd import (
     WikimediaPotdBackend,
@@ -34,6 +34,7 @@ def fixture_backend(
     )
 
 
+@freezegun.freeze_time("2026-06-07")
 def test_upload_image_thumbnail_only_success(
     backend: WikimediaPotdBackend, gcs_storage_client, gcs_storage_bucket
 ) -> None:
@@ -46,14 +47,12 @@ def test_upload_image_thumbnail_only_success(
     # get the blob (image) from the same bucket assigned to the gcs_uploader instance of the backend object
     blobs_in_bucket = list(gcs_storage_client.get_bucket(gcs_storage_bucket.name).list_blobs())
 
-    # YYYY-MM-DD format
-    todays_date = datetime.today().strftime("%Y-%m-%d")
-
     # should be only one blob (thumbnail image)
     assert len(blobs_in_bucket) == 1
-    assert blobs_in_bucket[0].name == f"rss/wikimedia_potd/POTD_{todays_date}_thumbnail.jpeg"
+    assert blobs_in_bucket[0].name == "rss/wikimedia_potd/POTD_2026-06-07_thumbnail.jpeg"
 
 
+@freezegun.freeze_time("2026-06-07")
 def test_upload_image_thumbnail_and_hi_res_success(
     backend: WikimediaPotdBackend, gcs_storage_client, gcs_storage_bucket
 ) -> None:
@@ -67,13 +66,11 @@ def test_upload_image_thumbnail_and_hi_res_success(
     # get the blob (image) from the same bucket assigned to the gcs_uploader instance of the backend object
     blobs_in_bucket = list(gcs_storage_client.get_bucket(gcs_storage_bucket.name).list_blobs())
 
-    # YYYY-MM-DD format
-    todays_date = datetime.today().strftime("%Y-%m-%d")
-
     # should be two blobs (thumbnail and hi-res)
     assert len(blobs_in_bucket) == 2
-    assert blobs_in_bucket[0].name == f"rss/wikimedia_potd/POTD_{todays_date}_hi_res.jpeg"
-    assert blobs_in_bucket[1].name == f"rss/wikimedia_potd/POTD_{todays_date}_thumbnail.jpeg"
+    assert blobs_in_bucket[0].name == "rss/wikimedia_potd/POTD_2026-06-07_hi_res.jpeg"
+    assert blobs_in_bucket[1].name == "rss/wikimedia_potd/POTD_2026-06-07_thumbnail.jpeg"
+
 
 def test_upload_image_captures_sentry_exception(
     backend: WikimediaPotdBackend, mocker: MockerFixture
@@ -85,7 +82,9 @@ def test_upload_image_captures_sentry_exception(
     mocker.patch.object(backend.gcs_uploader, "upload_image").side_effect = ex
 
     # mocker.patch("merino.providers.rss.wikimedia_potd.backends.wikimedia_potd.GcsUploader.upload_image").side_effect = Exception("Test Exception")
-    sentry_capture = mocker.patch("merino.providers.rss.wikimedia_potd.backends.wikimedia_potd.sentry_sdk.capture_exception")
+    sentry_capture = mocker.patch(
+        "merino.providers.rss.wikimedia_potd.backends.wikimedia_potd.sentry_sdk.capture_exception"
+    )
     backend.upload_image(image=test_image, is_thumbnail=True)
 
     assert sentry_capture.call_count == 1

--- a/tests/integration/providers/rss/potd/test_wikimedia_potd.py
+++ b/tests/integration/providers/rss/potd/test_wikimedia_potd.py
@@ -56,29 +56,10 @@ class TestUploadImageMethod:
         assert len(blobs_in_bucket) == 1
         assert blobs_in_bucket[0].name == "rss/wikimedia_potd/POTD_2026-06-07_thumbnail.jpeg"
 
-    @freezegun.freeze_time("2026-06-07")
-    def test_thumbnail_and_hi_res_success(
-        self, backend: WikimediaPotdBackend, gcs_storage_client, gcs_storage_bucket
-    ) -> None:
-        """Test upload_image method successfully uploads two images and returns public cdn urls."""
-        test_image = Image(content=b"", content_type="Image/jpeg")
-
-        # call the backend method to upload the thumbnail and hi-res image
-        backend.upload_image(image=test_image, is_thumbnail=True)
-        backend.upload_image(image=test_image, is_thumbnail=False)
-
-        # get the blob (image) from the same bucket assigned to the gcs_uploader instance of the backend object
-        blobs_in_bucket = list(gcs_storage_client.get_bucket(gcs_storage_bucket.name).list_blobs())
-
-        # should be two blobs (thumbnail and hi-res)
-        assert len(blobs_in_bucket) == 2
-        assert blobs_in_bucket[0].name == "rss/wikimedia_potd/POTD_2026-06-07_hi_res.jpeg"
-        assert blobs_in_bucket[1].name == "rss/wikimedia_potd/POTD_2026-06-07_thumbnail.jpeg"
-
     def test_captures_sentry_exception(
         self, backend: WikimediaPotdBackend, mocker: MockerFixture
     ) -> None:
-        """Test upload_image method successfully uploads two images and returns public cdn urls."""
+        """Test upload_image method successfully captures sentry exception."""
         test_image = Image(content=b"", content_type="Image/jpeg")
 
         ex = Exception("Test Exception")

--- a/tests/integration/providers/rss/potd/test_wikimedia_potd.py
+++ b/tests/integration/providers/rss/potd/test_wikimedia_potd.py
@@ -1,0 +1,98 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Integration tests for the Picture of the Day Provider."""
+
+import pytest
+
+from unittest.mock import MagicMock, call
+from httpx import AsyncClient
+from datetime import datetime
+from pytest_mock import MockerFixture
+from merino.providers.rss.wikimedia_potd.backends.wikimedia_potd import (
+    WikimediaPotdBackend,
+)
+from merino.utils.gcs.gcs_uploader import GcsUploader
+from merino.utils.gcs.models import Image
+
+
+@pytest.fixture(name="backend")
+def fixture_backend(
+    statsd_mock, mocker: MockerFixture, gcs_storage_client, gcs_storage_bucket
+) -> WikimediaPotdBackend:
+    """Return a WikimediaPotdBackend instance for testing."""
+    return WikimediaPotdBackend(
+        metrics_client=statsd_mock,
+        http_client=mocker.AsyncMock(spec=AsyncClient),
+        feed_url="https://example.com/feed",
+        gcs_uploader=GcsUploader(
+            destination_gcp_project=gcs_storage_client.project,
+            destination_bucket_name=gcs_storage_bucket.name,
+            destination_cdn_hostname="test-cdn-name",
+        ),
+    )
+
+
+def test_upload_image_thumbnail_only_success(
+    backend: WikimediaPotdBackend, gcs_storage_client, gcs_storage_bucket
+) -> None:
+    """Test upload_image method successfully uploads an image and returns a public cdn url."""
+    test_image = Image(content=b"", content_type="Image/jpeg")
+
+    # call the backend method to upload the image
+    backend.upload_image(image=test_image, is_thumbnail=True)
+
+    # get the blob (image) from the same bucket assigned to the gcs_uploader instance of the backend object
+    blobs_in_bucket = list(gcs_storage_client.get_bucket(gcs_storage_bucket.name).list_blobs())
+
+    # YYYY-MM-DD format
+    todays_date = datetime.today().strftime("%Y-%m-%d")
+
+    # should be only one blob (thumbnail image)
+    assert len(blobs_in_bucket) == 1
+    assert blobs_in_bucket[0].name == f"rss/wikimedia_potd/POTD_{todays_date}_thumbnail.jpeg"
+
+
+def test_upload_image_thumbnail_and_hi_res_success(
+    backend: WikimediaPotdBackend, gcs_storage_client, gcs_storage_bucket
+) -> None:
+    """Test upload_image method successfully uploads two images and returns public cdn urls."""
+    test_image = Image(content=b"", content_type="Image/jpeg")
+
+    # call the backend method to upload the thumbnail and hi-res image
+    backend.upload_image(image=test_image, is_thumbnail=True)
+    backend.upload_image(image=test_image, is_thumbnail=False)
+
+    # get the blob (image) from the same bucket assigned to the gcs_uploader instance of the backend object
+    blobs_in_bucket = list(gcs_storage_client.get_bucket(gcs_storage_bucket.name).list_blobs())
+
+    # YYYY-MM-DD format
+    todays_date = datetime.today().strftime("%Y-%m-%d")
+
+    # should be two blobs (thumbnail and hi-res)
+    assert len(blobs_in_bucket) == 2
+    assert blobs_in_bucket[0].name == f"rss/wikimedia_potd/POTD_{todays_date}_hi_res.jpeg"
+    assert blobs_in_bucket[1].name == f"rss/wikimedia_potd/POTD_{todays_date}_thumbnail.jpeg"
+
+def test_upload_image_captures_sentry_exception(
+    backend: WikimediaPotdBackend, mocker: MockerFixture
+) -> None:
+    """Test upload_image method successfully uploads two images and returns public cdn urls."""
+    test_image = Image(content=b"", content_type="Image/jpeg")
+
+    ex = Exception("Test Exception")
+    mocker.patch.object(backend.gcs_uploader, "upload_image").side_effect = ex
+
+    # mocker.patch("merino.providers.rss.wikimedia_potd.backends.wikimedia_potd.GcsUploader.upload_image").side_effect = Exception("Test Exception")
+    sentry_capture = mocker.patch("merino.providers.rss.wikimedia_potd.backends.wikimedia_potd.sentry_sdk.capture_exception")
+    backend.upload_image(image=test_image, is_thumbnail=True)
+
+    assert sentry_capture.call_count == 1
+    # import pdb; pdb.set_trace()
+
+    mock_call = [call(ex)]
+    sentry_capture.assert_has_calls(mock_call)
+
+    # with pytest.raises(Exception) as ex:
+    #     # call the backend method to upload an image

--- a/tests/unit/providers/rss/wikimedia_potd/backends/test_utils.py
+++ b/tests/unit/providers/rss/wikimedia_potd/backends/test_utils.py
@@ -5,6 +5,7 @@
 """Unit tests for Wikimedia POTD backend utility functions."""
 
 import pytest
+import freezegun
 from feedparser import FeedParserDict
 from pydantic import HttpUrl
 
@@ -13,7 +14,9 @@ from merino.providers.rss.wikimedia_potd.backends.utils import (
     extract_potd,
     is_valid_potd_image_url,
     parse_potd,
+    build_potd_path_and_name,
 )
+from merino.utils.gcs.models import Image
 
 VALID_FIELDS: dict[str, str] = {
     "title": "Test Title",
@@ -160,3 +163,18 @@ def test_parse_potd_derives_high_res_url_from_thumbnail(potd_entry: FeedParserDi
 def test_is_valid_potd_image_url(url: HttpUrl, expected: bool) -> None:
     """Test is_valid_potd_image_url for each supported image extension."""
     assert is_valid_potd_image_url(url) == expected
+
+
+@freezegun.freeze_time("2026-06-07")
+def test_build_potd_path_and_name() -> None:
+    """Test build_potd_path_and_name returns correct path for thumbnail and hi-res urls."""
+    image = Image(content=b"255", content_type="Image/jpeg")
+
+    expected_thumbnail_path = "rss/wikimedia_potd/POTD_2026-06-07_thumbnail.jpeg"
+    expected_hires_path = "rss/wikimedia_potd/POTD_2026-06-07_hi_res.jpeg"
+
+    actual_thumbnail_path = build_potd_path_and_name(image=image, is_thumbnail=True)
+    actual_hires_path = build_potd_path_and_name(image=image, is_thumbnail=False)
+
+    assert actual_thumbnail_path == expected_thumbnail_path
+    assert actual_hires_path == expected_hires_path

--- a/tests/unit/providers/rss/wikimedia_potd/backends/test_utils.py
+++ b/tests/unit/providers/rss/wikimedia_potd/backends/test_utils.py
@@ -9,7 +9,11 @@ from feedparser import FeedParserDict
 from pydantic import HttpUrl
 
 from merino.providers.rss.wikimedia_potd.backends.protocol import PictureOfTheDay
-from merino.providers.rss.wikimedia_potd.backends.utils import extract_potd, parse_potd
+from merino.providers.rss.wikimedia_potd.backends.utils import (
+    extract_potd,
+    is_valid_potd_image_url,
+    parse_potd,
+)
 
 VALID_FIELDS: dict[str, str] = {
     "title": "Test Title",
@@ -140,3 +144,19 @@ def test_parse_potd_derives_high_res_url_from_thumbnail(potd_entry: FeedParserDi
         str(result.high_res_image_url)
         == "https://upload.wikimedia.org/wikipedia/commons/a/ab/Photo.jpg"
     )
+
+
+@pytest.mark.parametrize(
+    ["url", "expected"],
+    [
+        (HttpUrl("http://www.test-image.com/image.jpeg"), True),
+        (HttpUrl("http://www.test-image.com/image.jpg"), True),
+        (HttpUrl("http://www.test-image.com/image.png"), True),
+        (HttpUrl("http://www.test-image.com/image.webp"), True),
+        (HttpUrl("http://www.test-image.com/image.text"), False),
+    ],
+    ids=["jpeg", "jpg", "png", "webp", "text"],
+)
+def test_is_valid_potd_image_url(url: HttpUrl, expected: bool) -> None:
+    """Test is_valid_potd_image_url for each supported image extension."""
+    assert is_valid_potd_image_url(url) == expected

--- a/tests/unit/providers/rss/wikimedia_potd/backends/test_wikimedia_potd_backend.py
+++ b/tests/unit/providers/rss/wikimedia_potd/backends/test_wikimedia_potd_backend.py
@@ -6,7 +6,7 @@
 
 import logging
 from typing import Any, cast
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 from httpx import AsyncClient, Request, Response
@@ -42,13 +42,6 @@ TEST_RSS_FEED_MISSING_FIELDS = """<?xml version="1.0" encoding="UTF-8"?>
     </item>
   </channel>
 </rss>"""
-
-
-# TODO remove this?
-@pytest.fixture(name="gcs_uploader_mock")
-def fixture_gcs_uploader_mock() -> GcsUploader:
-    """Return a mock GcsUploader."""
-    return MagicMock(spec=GcsUploader)
 
 
 @pytest.fixture(name="backend")

--- a/tests/unit/providers/rss/wikimedia_potd/backends/test_wikimedia_potd_backend.py
+++ b/tests/unit/providers/rss/wikimedia_potd/backends/test_wikimedia_potd_backend.py
@@ -44,6 +44,7 @@ TEST_RSS_FEED_MISSING_FIELDS = """<?xml version="1.0" encoding="UTF-8"?>
 </rss>"""
 
 
+# TODO remove this?
 @pytest.fixture(name="gcs_uploader_mock")
 def fixture_gcs_uploader_mock() -> GcsUploader:
     """Return a mock GcsUploader."""
@@ -52,21 +53,18 @@ def fixture_gcs_uploader_mock() -> GcsUploader:
 
 @pytest.fixture(name="backend")
 def fixture_backend(
-    statsd_mock,
-    mocker: MockerFixture,
+    statsd_mock, mocker: MockerFixture, gcs_storage_client, gcs_storage_bucket
 ) -> WikimediaPotdBackend:
     """Return a WikimediaPotdBackend instance for testing."""
-    mocker.patch(
-        "merino.providers.rss.wikimedia_potd.backends.wikimedia_potd.get_storage_client",
-        return_value=MagicMock(),
-    )
-
     return WikimediaPotdBackend(
         metrics_client=statsd_mock,
         http_client=mocker.AsyncMock(spec=AsyncClient),
-        bucket_name="test-bucket",
-        cdn_hostname="test-cdn",
         feed_url=FEED_URL,
+        gcs_uploader=GcsUploader(
+            destination_gcp_project=gcs_storage_client.project,
+            destination_bucket_name=gcs_storage_bucket.name,
+            destination_cdn_hostname="test-cdn-name",
+        ),
     )
 
 

--- a/tests/unit/providers/rss/wikimedia_potd/backends/test_wikimedia_potd_backend.py
+++ b/tests/unit/providers/rss/wikimedia_potd/backends/test_wikimedia_potd_backend.py
@@ -54,13 +54,18 @@ def fixture_gcs_uploader_mock() -> GcsUploader:
 def fixture_backend(
     statsd_mock,
     mocker: MockerFixture,
-    gcs_uploader_mock: GcsUploader,
 ) -> WikimediaPotdBackend:
     """Return a WikimediaPotdBackend instance for testing."""
+    mocker.patch(
+        "merino.providers.rss.wikimedia_potd.backends.wikimedia_potd.get_storage_client",
+        return_value=MagicMock(),
+    )
+
     return WikimediaPotdBackend(
         metrics_client=statsd_mock,
         http_client=mocker.AsyncMock(spec=AsyncClient),
-        gcs_uploader=gcs_uploader_mock,
+        bucket_name="test-bucket",
+        cdn_hostname="test-cdn",
         feed_url=FEED_URL,
     )
 

--- a/tests/unit/providers/rss/wikimedia_potd/backends/test_wikimedia_potd_backend.py
+++ b/tests/unit/providers/rss/wikimedia_potd/backends/test_wikimedia_potd_backend.py
@@ -6,7 +6,7 @@
 
 import logging
 from typing import Any, cast
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from httpx import AsyncClient, Request, Response
@@ -44,110 +44,115 @@ TEST_RSS_FEED_MISSING_FIELDS = """<?xml version="1.0" encoding="UTF-8"?>
 </rss>"""
 
 
+@pytest.fixture(name="gcs_uploader_mock")
+def fixture_gcs_uploader_mock() -> GcsUploader:
+    """Return a mock GcsUploader."""
+    return MagicMock(spec=GcsUploader)
+
+
 @pytest.fixture(name="backend")
-def fixture_backend(
-    statsd_mock, mocker: MockerFixture, gcs_storage_client, gcs_storage_bucket
-) -> WikimediaPotdBackend:
+def fixture_backend(statsd_mock, mocker: MockerFixture, gcs_uploader_mock) -> WikimediaPotdBackend:
     """Return a WikimediaPotdBackend instance for testing."""
     return WikimediaPotdBackend(
         metrics_client=statsd_mock,
         http_client=mocker.AsyncMock(spec=AsyncClient),
         feed_url=FEED_URL,
-        gcs_uploader=GcsUploader(
-            destination_gcp_project=gcs_storage_client.project,
-            destination_bucket_name=gcs_storage_bucket.name,
-            destination_cdn_hostname="test-cdn-name",
-        ),
+        gcs_uploader=gcs_uploader_mock,
     )
 
 
-@pytest.mark.asyncio
-async def test_get_pitcture_of_the_day_returns_correct_potd(backend: WikimediaPotdBackend) -> None:
-    """Test that get_picture_of_the_day method returns the correct potd instance."""
-    result = await backend.get_picture_of_the_day()
+class TestWikimediaPotdProvider:
+    """Tests for WikimediaPotd provider."""
 
-    assert result is not None
-    assert result.title == "Wikimedia Commons picture of the day"
-    assert result.published_date == "Mon, 13 Apr 2026 00:00:00 GMT"
-    assert result.description == "Sample Picture of the day description."
-    assert isinstance(result.thumbnail_image_url, HttpUrl)
-    assert isinstance(result.high_res_image_url, HttpUrl)
+    @pytest.mark.asyncio
+    async def test_get_pitcture_of_the_day_returns_correct_potd(
+        self, backend: WikimediaPotdBackend
+    ) -> None:
+        """Test that get_picture_of_the_day method returns the correct potd instance."""
+        result = await backend.get_picture_of_the_day()
 
+        assert result is not None
+        assert result.title == "Wikimedia Commons picture of the day"
+        assert result.published_date == "Mon, 13 Apr 2026 00:00:00 GMT"
+        assert result.description == "Sample Picture of the day description."
+        assert isinstance(result.thumbnail_image_url, HttpUrl)
+        assert isinstance(result.high_res_image_url, HttpUrl)
 
-@pytest.mark.asyncio
-async def test_fetch_potd_returns_entry_on_success(
-    backend: WikimediaPotdBackend,
-) -> None:
-    """Returns a FeedParserDict entry when the feed is fetched and parsed successfully."""
-    client_mock: AsyncMock = cast(AsyncMock, backend.http_client)
-    client_mock.get.return_value = Response(
-        status_code=200,
-        content=TEST_RSS_FEED.encode(),
-        request=Request(method="GET", url=FEED_URL),
-    )
+    @pytest.mark.asyncio
+    async def test_fetch_potd_returns_entry_on_success(
+        self,
+        backend: WikimediaPotdBackend,
+    ) -> None:
+        """Returns a FeedParserDict entry when the feed is fetched and parsed successfully."""
+        client_mock: AsyncMock = cast(AsyncMock, backend.http_client)
+        client_mock.get.return_value = Response(
+            status_code=200,
+            content=TEST_RSS_FEED.encode(),
+            request=Request(method="GET", url=FEED_URL),
+        )
 
-    result = await backend.fetch_picture_of_the_day()
+        result = await backend.fetch_picture_of_the_day()
 
-    assert result is not None
-    assert result["title"] == "Test POTD Title"
-    assert result["published"] == "Mon, 13 Apr 2026 00:00:00 GMT"
-    client_mock.get.assert_called_once_with(FEED_URL, headers=RSS_FETCH_REQUEST_HEADERS)
+        assert result is not None
+        assert result["title"] == "Test POTD Title"
+        assert result["published"] == "Mon, 13 Apr 2026 00:00:00 GMT"
+        client_mock.get.assert_called_once_with(FEED_URL, headers=RSS_FETCH_REQUEST_HEADERS)
 
+    @pytest.mark.asyncio
+    async def test_fetch_potd_returns_none_for_empty_content(
+        self,
+        backend: WikimediaPotdBackend,
+    ) -> None:
+        """Returns None when the HTTP response body is empty."""
+        client_mock: AsyncMock = cast(AsyncMock, backend.http_client)
+        client_mock.get.return_value = Response(
+            status_code=200,
+            content=b"",
+            request=Request(method="GET", url=FEED_URL),
+        )
 
-@pytest.mark.asyncio
-async def test_fetch_potd_returns_none_for_empty_content(
-    backend: WikimediaPotdBackend,
-) -> None:
-    """Returns None when the HTTP response body is empty."""
-    client_mock: AsyncMock = cast(AsyncMock, backend.http_client)
-    client_mock.get.return_value = Response(
-        status_code=200,
-        content=b"",
-        request=Request(method="GET", url=FEED_URL),
-    )
+        result = await backend.fetch_picture_of_the_day()
 
-    result = await backend.fetch_picture_of_the_day()
+        assert result is None
 
-    assert result is None
+    @pytest.mark.asyncio
+    async def test_fetch_potd_returns_none_and_logs_on_http_error(
+        self,
+        backend: WikimediaPotdBackend,
+        caplog: LogCaptureFixture,
+        filter_caplog: Any,
+    ) -> None:
+        """Returns None and logs an error when the HTTP request fails with a non-2xx status."""
+        client_mock: AsyncMock = cast(AsyncMock, backend.http_client)
+        client_mock.get.return_value = Response(
+            status_code=500,
+            request=Request(method="GET", url=FEED_URL),
+        )
 
+        caplog.set_level(logging.ERROR)
+        result = await backend.fetch_picture_of_the_day()
 
-@pytest.mark.asyncio
-async def test_fetch_potd_returns_none_and_logs_on_http_error(
-    backend: WikimediaPotdBackend,
-    caplog: LogCaptureFixture,
-    filter_caplog: Any,
-) -> None:
-    """Returns None and logs an error when the HTTP request fails with a non-2xx status."""
-    client_mock: AsyncMock = cast(AsyncMock, backend.http_client)
-    client_mock.get.return_value = Response(
-        status_code=500,
-        request=Request(method="GET", url=FEED_URL),
-    )
+        assert result is None
+        records = filter_caplog(
+            caplog.records,
+            "merino.providers.rss.wikimedia_potd.backends.wikimedia_potd",
+        )
+        assert len(records) == 1
+        assert "HTTP error occurred when fetching Wikimedia POTD feed" in records[0].message
 
-    caplog.set_level(logging.ERROR)
-    result = await backend.fetch_picture_of_the_day()
+    @pytest.mark.asyncio
+    async def test_fetch_potd_returns_none_when_feed_has_no_valid_entries(
+        self,
+        backend: WikimediaPotdBackend,
+    ) -> None:
+        """Returns None when the feed entries are missing required fields."""
+        client_mock: AsyncMock = cast(AsyncMock, backend.http_client)
+        client_mock.get.return_value = Response(
+            status_code=200,
+            content=TEST_RSS_FEED_MISSING_FIELDS.encode(),
+            request=Request(method="GET", url=FEED_URL),
+        )
 
-    assert result is None
-    records = filter_caplog(
-        caplog.records,
-        "merino.providers.rss.wikimedia_potd.backends.wikimedia_potd",
-    )
-    assert len(records) == 1
-    assert "HTTP error occurred when fetching Wikimedia POTD feed" in records[0].message
+        result = await backend.fetch_picture_of_the_day()
 
-
-@pytest.mark.asyncio
-async def test_fetch_potd_returns_none_when_feed_has_no_valid_entries(
-    backend: WikimediaPotdBackend,
-) -> None:
-    """Returns None when the feed entries are missing required fields."""
-    client_mock: AsyncMock = cast(AsyncMock, backend.http_client)
-    client_mock.get.return_value = Response(
-        status_code=200,
-        content=TEST_RSS_FEED_MISSING_FIELDS.encode(),
-        request=Request(method="GET", url=FEED_URL),
-    )
-
-    result = await backend.fetch_picture_of_the_day()
-
-    assert result is None
+        assert result is None


### PR DESCRIPTION
## References

JIRA: [HNT-2156](https://mozilla-hub.atlassian.net/browse/HNT-2156)

## Description
Adding methods to download and upload an image.

## PR Review Checklist
- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2380)


[HNT-2156]: https://mozilla-hub.atlassian.net/browse/HNT-2156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ