### PR TITLE
AIMOD-1308 World cup section boost worldwide

### DIFF
--- a/merino/curated_recommendations/prior_backends/engagment_rescaler.py
+++ b/merino/curated_recommendations/prior_backends/engagment_rescaler.py
@@ -25,7 +25,7 @@ TILE_6_PERCENTAGE_OF_DAILY_IMPRESSIONS = (
     0.1  # Generated via https://sql.telemetry.mozilla.org/queries/116006 (using tile 6)
 )
 
-WORLD_CUP_SECTION_CTR_BOOST = 0.0008
+WORLD_CUP_SECTION_CTR_BOOST = 0.002  # Constant for all world markets.
 
 LOCAL_RERANK_WEGHT = (
     80.0  # Experiment weight settings 60-10 server-local boosting.

--- a/merino/curated_recommendations/prior_backends/engagment_rescaler.py
+++ b/merino/curated_recommendations/prior_backends/engagment_rescaler.py
@@ -25,6 +25,8 @@ TILE_6_PERCENTAGE_OF_DAILY_IMPRESSIONS = (
     0.1  # Generated via https://sql.telemetry.mozilla.org/queries/116006 (using tile 6)
 )
 
+WORLD_CUP_SECTION_CTR_BOOST = 0.0008
+
 LOCAL_RERANK_WEGHT = (
     80.0  # Experiment weight settings 60-10 server-local boosting.
     # Given high ctr item 0.005 and interest of 0.5 that would
@@ -95,6 +97,12 @@ class CrawledContentRescaler(EngagementRescaler):
             opens = opens * BLOCKED_FROM_MOST_POPULAR_SCALER
             no_opens = no_opens * BLOCKED_FROM_MOST_POPULAR_SCALER
         return opens, no_opens
+
+    def boost_section(self, section_id: str) -> float:
+        """Return ctr boost score for section for special event such as World Cup"""
+        if section_id.startswith("worldcup"):
+            return WORLD_CUP_SECTION_CTR_BOOST
+        return 0.0
 
     def rescale_prior(self, rec: CuratedRecommendation, alpha, beta):
         """Update priors values based on whether item is unique to the experiment.

--- a/merino/curated_recommendations/prior_backends/protocol.py
+++ b/merino/curated_recommendations/prior_backends/protocol.py
@@ -75,6 +75,10 @@ class EngagementRescaler(BaseModel):
         """Update priors values based on whether item is unique to the experiment."""
         return alpha, beta
 
+    def boost_section(self, section_id: str) -> float:
+        """Return ctr boost score for section for special event such as World Cup"""
+        return 0.0
+
     def compute_estimated_fresh_per_cycle(self, prior: Prior) -> int:
         """Compute the estimated number of impressions that a single top stories tile gets in a content refresh cycle
         based on total impressions and normalized by hour.

--- a/merino/curated_recommendations/protocol.py
+++ b/merino/curated_recommendations/protocol.py
@@ -279,6 +279,7 @@ class RankingData(BaseModel):
 # Flags for in_experiment flags. Note that the name in_experiment is historical and should be migrated to a new name
 ITEM_SUBTOPIC_FLAG = "SUBTOPICS"
 ITEM_HEADLINES_FLAG = "HEADLINES"
+ITEM_WORLD_CUP_FLAG = "WORLDCUP"
 
 
 class CuratedRecommendation(CorpusItem):

--- a/merino/curated_recommendations/rankers/contextual_ranker.py
+++ b/merino/curated_recommendations/rankers/contextual_ranker.py
@@ -188,6 +188,7 @@ class ContextualRanker(Ranker):
 
             # Get any special boost for a particular section
             boost_amount = rescaler.boost_section(section_id) if rescaler is not None else 0.0
+
             return (total_score / n_scores if n_scores > 0 else 0.0) + boost_amount
 
         ordered = sorted(sections.items(), key=lambda kv: sample_score(kv[0], kv[1]), reverse=True)

--- a/merino/curated_recommendations/rankers/contextual_ranker.py
+++ b/merino/curated_recommendations/rankers/contextual_ranker.py
@@ -169,7 +169,7 @@ class ContextualRanker(Ranker):
     ) -> dict[str, Section]:
         """Re-rank sections using average score of top items."""
 
-        def sample_score(sec: Section) -> float:
+        def sample_score(section_id: str, sec: Section) -> float:
             """Create score based on top items in section"""
             fresh_retain_likelyhood = (
                 rescaler.fresh_items_section_ranking_max_percentage
@@ -186,7 +186,9 @@ class ContextualRanker(Ranker):
                     total_score += rec.ranking_data.score
                     n_scores += 1
 
-            return total_score / n_scores if n_scores > 0 else 0.0
+            # Get any special boost for a particular section
+            boost_amount = rescaler.boost_section(section_id) if rescaler is not None else 0.0
+            return (total_score / n_scores if n_scores > 0 else 0.0) + boost_amount
 
-        ordered = sorted(sections.items(), key=lambda kv: sample_score(kv[1]), reverse=True)
+        ordered = sorted(sections.items(), key=lambda kv: sample_score(kv[0], kv[1]), reverse=True)
         return renumber_sections(ordered)

--- a/merino/curated_recommendations/rankers/t_sampling.py
+++ b/merino/curated_recommendations/rankers/t_sampling.py
@@ -127,7 +127,7 @@ class ThompsonSamplingRanker(Ranker):
         [thompson-sampling]: https://en.wikipedia.org/wiki/Thompson_sampling
         """
 
-        def sample_score(sec: Section) -> float:
+        def sample_score(section_id: str, sec: Section) -> float:
             """Sample beta distribution for the combined engagement of the top _n_ items."""
             # sum clicks and impressions over top_n items
 
@@ -169,9 +169,12 @@ class ThompsonSamplingRanker(Ranker):
             # Sum engagement and priors.
             opens = max(total_clicks + a_prior_total, 1.0)
             no_opens = max(total_imps - total_clicks + b_prior_total, 1.0)
+
+            boost_amount = rescaler.boost_section(section_id) if rescaler is not None else 0.0
+
             # Sample distribution
-            return float(beta.rvs(opens, no_opens))
+            return float(beta.rvs(opens, no_opens)) + boost_amount
 
         # sort sections by sampled score, highest first
-        ordered = sorted(sections.items(), key=lambda kv: sample_score(kv[1]), reverse=True)
+        ordered = sorted(sections.items(), key=lambda kv: sample_score(kv[0], kv[1]), reverse=True)
         return renumber_sections(ordered)

--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -47,6 +47,7 @@ from merino.curated_recommendations.prior_backends.protocol import (
 from merino.curated_recommendations.protocol import (
     ITEM_HEADLINES_FLAG,
     ITEM_SUBTOPIC_FLAG,
+    ITEM_WORLD_CUP_FLAG,
     CuratedRecommendationsRequest,
     CuratedRecommendation,
     Section,
@@ -151,10 +152,13 @@ def map_corpus_section_to_section(
     item_flags = set()
     is_manual_section = corpus_section.createSource == CreateSource.MANUAL
     is_headlines = corpus_section.externalId == HEADLINES_SECTION_KEY
+    is_world_cup = corpus_section.externalId.startswith("worldcup")
     if is_headlines:
         # Block headlines from Popular Today to avoid duplicate content with
         # The Latest / Daily Briefing sections (HNT-2167).
         item_flags.add(ITEM_HEADLINES_FLAG)
+    elif is_world_cup:
+        item_flags.add(ITEM_WORLD_CUP_FLAG)
     elif not is_legacy_section and not is_manual_section:
         item_flags.add(ITEM_SUBTOPIC_FLAG)
     seen_ids: set[str] = set()

--- a/tests/unit/curated_recommendations/test_sections.py
+++ b/tests/unit/curated_recommendations/test_sections.py
@@ -37,6 +37,7 @@ from merino.curated_recommendations.prior_backends.protocol import Prior
 from merino.curated_recommendations.protocol import (
     ITEM_HEADLINES_FLAG,
     ITEM_SUBTOPIC_FLAG,
+    ITEM_WORLD_CUP_FLAG,
     Section,
     SectionConfiguration,
     EditorialSectionsBranch,
@@ -728,6 +729,18 @@ class TestMapCorpusSectionToSection:
         )
         sec = map_corpus_section_to_section(cs, 0, is_legacy_section=False)
         assert sec.recommendations[0].in_experiment(ITEM_SUBTOPIC_FLAG)
+
+    def test_world_cup_items_flagged_as_world_cup(self):
+        """Items in a worldcup section should carry ITEM_WORLD_CUP_FLAG, not ITEM_SUBTOPIC_FLAG."""
+        cs = CorpusSection(
+            sectionItems=[generate_corpus_item("wc1", "sched_wc1")],
+            title="World Cup",
+            externalId="worldcup-2026",
+            createSource=CreateSource.ML,
+        )
+        sec = map_corpus_section_to_section(cs, 0, is_legacy_section=False)
+        assert sec.recommendations[0].in_experiment(ITEM_WORLD_CUP_FLAG)
+        assert not sec.recommendations[0].in_experiment(ITEM_SUBTOPIC_FLAG)
 
     @pytest.mark.parametrize(
         "followable,allow_ads",

--- a/tests/unit/prior_backends/test_engagement_rescaler.py
+++ b/tests/unit/prior_backends/test_engagement_rescaler.py
@@ -16,6 +16,7 @@ from merino.curated_recommendations.prior_backends.engagment_rescaler import (
     SchedulerHoldbackRescaler,
     PESSIMISTIC_PRIOR_ALPHA_SCALE,
     PESSIMISTIC_PRIOR_ALPHA_SCALE_SUBTOPIC,
+    WORLD_CUP_SECTION_CTR_BOOST,
 )
 from merino.curated_recommendations.prior_backends.protocol import Prior
 from merino.curated_recommendations.protocol import ITEM_SUBTOPIC_FLAG
@@ -125,6 +126,13 @@ class TestCrawledContentRescaler:
         alpha, beta = self.rescaler.rescale_prior(rec, 10, 20)
         assert alpha == 10 * PESSIMISTIC_PRIOR_ALPHA_SCALE
         assert beta == 20
+
+    def test_boost_section_world_cup(self):
+        """World Cup sections get a CTR boost, while other sections get none."""
+        assert self.rescaler.boost_section("worldcup__lFR_BE") == WORLD_CUP_SECTION_CTR_BOOST
+        assert self.rescaler.boost_section("worldcup") == WORLD_CUP_SECTION_CTR_BOOST
+        assert self.rescaler.boost_section("nfl") == 0.0
+        assert self.rescaler.boost_section("headlines") == 0.0
 
 
 class TestCrawledContentPinnedFreshRescaler:


### PR DESCRIPTION
## References

JIRA: https://mozilla-hub.atlassian.net/browse/AIMOD-1308

## Description
Boosts world cup section position for all section based markets.

World cup articles are no longer blocked from top stories.

Current boost constant brings section to spot #3 and US. Future work can make it a dynamic constant based on the per-country CTR priors that we compute. I think that can be left as a future ticket, as this is likely a reasonable boost for all markets.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2381)
