### PR TITLE
[DISCO-4120] feat(codecov): add per-pr code coverage checks to actions

### DIFF
--- a/.github/actions/weave/action.yaml
+++ b/.github/actions/weave/action.yaml
@@ -4,20 +4,26 @@ inputs:
     description: "The directory path to store test results"
     required: true
     default: "workspace"
+  fetch-depth:
+    description: "Number of commits to fetch. 0 fetches full history (needed for diff-cover)."
+    required: false
+    default: "1"
 runs:
   using: "composite"
   steps:
     - uses: actions/checkout@v5
+      with:
+        fetch-depth: ${{ inputs.fetch-depth }}
     - name: Install uv
       uses: astral-sh/setup-uv@v5
       with:
-          enable-cache: true
+        enable-cache: true
     - uses: actions/setup-python@v6
       with:
         python-version-file: "pyproject.toml"
     - name: Install Build Dependencies
-    # Needed b/c various dependencies do not have prebuilt wheels
-    # and uv needs to build them from source.
+      # Needed b/c various dependencies do not have prebuilt wheels
+      # and uv needs to build them from source.
       run: |
         sudo apt-get update
         sudo apt-get install -y build-essential libxml2-dev libxslt-dev python3-dev libffi-dev

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -71,11 +71,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-        with:
-          # diff-cover needs origin/main and full history to compute the PR diff
-          fetch-depth: 0
       - name: Set up to run
         uses: ./.github/actions/weave
+        with:
+          # weave runs its own checkout; full history is required so diff-cover
+          # can find the merge base between origin/main and the PR head.
+          fetch-depth: 0
       - name: Download Test Results Artifacts
         uses: actions/download-artifact@v7
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -71,6 +71,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          # diff-cover needs origin/main and full history to compute the PR diff
+          fetch-depth: 0
       - name: Set up to run
         uses: ./.github/actions/weave
       - name: Download Test Results Artifacts
@@ -79,7 +82,12 @@ jobs:
           path: ${{ inputs.test_result_dir }}
           pattern: "*-test-results"
           merge-multiple: true
-      - name: Evaluate Minimum Test Coverage
+      - name: Evaluate Minimum Test Coverage (total)
         run: make test-coverage-check
+        env:
+          TEST_RESULTS_DIR: ${{ inputs.test_result_dir }}
+      # Uses the combined artifact from step above
+      - name: Evaluate Minimum Test Coverage (PR vs. main)
+        run: make diff-coverage-check
         env:
           TEST_RESULTS_DIR: ${{ inputs.test_result_dir }}

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ ES_IMAGE := merino-elasticsearch:local
 TEST_DIR := tests
 TEST_RESULTS_DIR ?= "workspace/test-results"
 COV_FAIL_UNDER := 95
+DIFF_COV_FAIL_UNDER := 95
+DIFF_COV_BRANCH ?= origin/main
+COMBINED_COVERAGE_XML := $(TEST_RESULTS_DIR)/coverage.xml
 COMMON_PACKAGE_DIR := merino-common/merino_common
 COMMON_TEST_DIR := merino-common/tests
 FLEECE_PACKAGE_DIR := merino-fleece/merino_fleece
@@ -95,6 +98,15 @@ test-coverage-check: $(INSTALL_STAMP)  ##  Evaluate combined unit and integratio
 	$(UV) run coverage report \
 	    --data-file=$(TEST_RESULTS_DIR)/.coverage \
 	    --fail-under=$(COV_FAIL_UNDER)
+
+.PHONY: diff-coverage-check
+diff-coverage-check: $(INSTALL_STAMP)  ##  Check coverage on lines changed vs DIFF_COV_BRANCH (default origin/main); run after `make test`
+	$(UV) run coverage xml \
+	    --data-file=$(TEST_RESULTS_DIR)/.coverage \
+	    -o $(COMBINED_COVERAGE_XML)
+	$(UV) run diff-cover $(COMBINED_COVERAGE_XML) \
+	    --compare-branch=$(DIFF_COV_BRANCH) \
+	    --fail-under=$(DIFF_COV_FAIL_UNDER)
 
 .PHONY: unit-tests
 unit-tests: $(INSTALL_STAMP)  ##  Run unit tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,7 @@ dev = [
     "opentelemetry-instrumentation-fastapi>=0.63b1",
     "opentelemetry-instrumentation-redis>=0.63b1",
     "opentelemetry-instrumentation-httpx>=0.63b1",
+    "diff-cover>=10.3.0",
 ]
 
 [tool.coverage.report]

--- a/uv.lock
+++ b/uv.lock
@@ -471,6 +471,21 @@ wheels = [
 ]
 
 [[package]]
+name = "diff-cover"
+version = "10.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "chardet" },
+    { name = "jinja2" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/35/21/057e816125c162662d2a2cc2ebcd72dd333e78e51678298d07dd3146011a/diff_cover-10.3.0.tar.gz", hash = "sha256:474dbc63e815fbb7567d7b7ca5b104123e96129f25426ebdbc9a1bdbb935b2c6", size = 106546, upload-time = "2026-05-30T14:17:14.32Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/0a/a96e57a7a3fca419cd5ceff0d13dee2166520fa67103fb82624ad64700fb/diff_cover-10.3.0-py3-none-any.whl", hash = "sha256:2e47d5ab3868d1e92131c11f364f3f4a8583c97123d3bbc6b6cc8ce0a4cc2202", size = 58989, upload-time = "2026-05-30T14:17:12.858Z" },
+]
+
+[[package]]
 name = "distlib"
 version = "0.3.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1410,6 +1425,7 @@ dependencies = [
 dev = [
     { name = "bandit" },
     { name = "coverage" },
+    { name = "diff-cover" },
     { name = "freezegun" },
     { name = "mypy" },
     { name = "opentelemetry-distro" },
@@ -1486,6 +1502,7 @@ requires-dist = [
 dev = [
     { name = "bandit", extras = ["toml"], specifier = ">=1.9.0,<2" },
     { name = "coverage", specifier = ">=7.13.5,<8" },
+    { name = "diff-cover", specifier = ">=10.3.0" },
     { name = "freezegun", specifier = ">=1.2.2,<2" },
     { name = "mypy", specifier = "==1.20.1" },
     { name = "opentelemetry-distro", specifier = ">=0.63b1" },


### PR DESCRIPTION
## References

JIRA: [DISCO-4210]

## Description
Use https://github.com/Bachmann1234/diff_cover tool for local and gha checks on code coverage. Local checks require that you run `make test` successfully first.

Ran it on an existing PR branch to test the action and it returned as expected: https://github.com/mozilla-services/merino-py/actions/runs/27234928635/job/80425039801

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-4210]: https://mozilla-hub.atlassian.net/browse/DISCO-4210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ