### PR TITLE
[HNT-2657] Include sponsored content stories in additional sections

### DIFF
--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -329,7 +329,7 @@ def exclude_recommendations_from_blocked_sections(
 def adjust_ads_in_sections(sections: dict[str, Section]) -> None:
     """Disable ads based on section rank position and the allowAds flag.
 
-    Ads are allowed in sections at ranks {0, 1, 2, 4, 6, 8} only.
+    Ads are allowed in sections at ranks {0, 1, 2, 4, 6, 8, 10, 12, 14, 16, 18} only.
     Sections with allowAds=False have all ad tiles disabled regardless of rank.
 
     Args:
@@ -338,7 +338,7 @@ def adjust_ads_in_sections(sections: dict[str, Section]) -> None:
     Returns:
         None. Mutates tile.hasAd flags in-place.
     """
-    allowed_ranks = {0, 1, 2, 4, 6, 8}
+    allowed_ranks = {0, 1, 2, 4, 6, 8, 10, 12, 14, 16, 18}
     for sec in sections.values():
         if not sec.allowAds or sec.receivedFeedRank not in allowed_ranks:
             for rl in sec.layout.responsiveLayouts:

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -1955,8 +1955,8 @@ class TestSections:
         # Assert layouts are cycled
         assert_section_layouts_are_cycled(sections)
 
-        # Assert only sections 1,2,3,5,7,9 (ranks: 0,1,2,4,6,8) have ads
-        expected_section_ranks_with_ads = {0, 1, 2, 4, 6, 8}
+        # Assert only sections 1,2,3,5,7,9,11,13,15,17,19 (ranks: 0,1,2,4,6,8,10,12,14,16,18) have ads
+        expected_section_ranks_with_ads = {0, 1, 2, 4, 6, 8, 10, 12, 14, 16, 18}
         for section in sections.values():
             tiles_with_ads = [
                 tile

--- a/tests/unit/curated_recommendations/test_sections.py
+++ b/tests/unit/curated_recommendations/test_sections.py
@@ -217,7 +217,7 @@ class TestAdjustAdsInSections:
     @pytest.mark.parametrize(
         "section_count, expected_section_ranks_with_ads",
         [
-            (11, {0, 1, 2, 4, 6, 8}),  # All 6 expected sections (1,2,3,5,7,9) to have ads
+            (20, {0, 1, 2, 4, 6, 8, 10, 12, 14, 16, 18}),  # All 11 expected sections (1,2,3,5,7,9,11,13,15,17,19) to have ads
             (4, {0, 1, 2}),  # Partially expected sections to have ads
         ],
         ids=["all-allowed-ranks", "partial-allowed-ranks"],

--- a/tests/unit/curated_recommendations/test_sections.py
+++ b/tests/unit/curated_recommendations/test_sections.py
@@ -217,7 +217,10 @@ class TestAdjustAdsInSections:
     @pytest.mark.parametrize(
         "section_count, expected_section_ranks_with_ads",
         [
-            (20, {0, 1, 2, 4, 6, 8, 10, 12, 14, 16, 18}),  # All 11 expected sections (1,2,3,5,7,9,11,13,15,17,19) to have ads
+            (
+                20,
+                {0, 1, 2, 4, 6, 8, 10, 12, 14, 16, 18},
+            ),  # All 11 expected sections (1,2,3,5,7,9,11,13,15,17,19) to have ads
             (4, {0, 1, 2}),  # Partially expected sections to have ads
         ],
         ids=["all-allowed-ranks", "partial-allowed-ranks"],


### PR DESCRIPTION
## References

JIRA: [HNT-2657](https://mozilla-hub.atlassian.net/browse/HNT-2657)

## Description
We want to include the ability to have sponsored content stories in more of the sections further down the page. This increases possible inventory and we see much better click through rates in sections lower in the page. The current logic is to display sponsored content stories in sections 1,2,3,5,7,9. This would extend that to 1,2,3,5,7,9,11,13,15,17,19. This is a light weight and low impact change and will sections will function if there are sponsored content stories returned for a given section or not. 

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2383)


[HNT-2657]: https://mozilla-hub.atlassian.net/browse/HNT-2657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ