### PR TITLE
[DISCO-4276] Enable fleece pii detection in stage

### DIFF
--- a/merino/configs/flags/stage.toml
+++ b/merino/configs/flags/stage.toml
@@ -6,4 +6,4 @@ dynaconf_merge = true
 # Raise `enabled` to ramp the prototype in stage.
 [stage.flags.fleece-pii-detection]
 scheme = "random"
-enabled = 0.0
+enabled = 1.0


### PR DESCRIPTION
## References

JIRA: [DISCO-4276](https://mozilla-hub.atlassian.net/browse/DISCO-4276)

## Description
This PR sets the `fleece-pii-detection` feature flag to `enabled = 1.0`, turning the prototype on for 100% of stage suggest traffic.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2384)


[DISCO-4276]: https://mozilla-hub.atlassian.net/browse/DISCO-4276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ