### PR TITLE
AIMOD-1308 World Cup Content Sections visibility fix

### DIFF
--- a/merino/curated_recommendations/prior_backends/engagment_rescaler.py
+++ b/merino/curated_recommendations/prior_backends/engagment_rescaler.py
@@ -25,7 +25,7 @@ TILE_6_PERCENTAGE_OF_DAILY_IMPRESSIONS = (
     0.1  # Generated via https://sql.telemetry.mozilla.org/queries/116006 (using tile 6)
 )
 
-WORLD_CUP_SECTION_CTR_BOOST = 0.002  # Constant for all world markets.
+WORLD_CUP_SECTION_CTR_BOOST = 0.003  # Constant for all world markets.
 
 LOCAL_RERANK_WEGHT = (
     80.0  # Experiment weight settings 60-10 server-local boosting.

--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -419,12 +419,9 @@ def is_inferred_interest_experiment(request: CuratedRecommendationsRequest) -> b
 
 def is_subtopics_experiment(request: CuratedRecommendationsRequest) -> bool:
     """Return True if subtopics should be included based on experiments.
-
-    Include subtopics if:
-    - ML sections experiment is enabled (treatment branch), OR
+    Previously this was an experiment. This function should be refactored out.
     """
-    in_holdback = is_scheduler_holdback_experiment(request)
-    return not in_holdback and request.region in ("US", "GB", "IE", "DE")
+    return True
 
 
 def is_scheduler_holdback_experiment(request: CuratedRecommendationsRequest) -> bool:

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -1605,11 +1605,6 @@ class TestSections:
     @pytest.mark.parametrize(
         "experiment_payload",
         [
-            {
-                "experimentName": ExperimentName.SCHEDULER_HOLDBACK_EXPERIMENT.value,
-                "experimentBranch": "control",
-                "region": "BQ",
-            },
             {"experimentName": None, "experimentBranch": None, "region": "CA"},
         ],
     )
@@ -1685,17 +1680,6 @@ class TestSections:
             recs = section["recommendations"]
             assert {rec["receivedRank"] for rec in recs} == set(range(len(recs)))
 
-        # Check section types based on experiment
-        legacy_topics = {topic.value for topic in Topic}
-
-        if experiment_payload.get("experimentName") != ExperimentName.ML_SECTIONS_EXPERIMENT.value:
-            # Non-ML sections experiment: Should have legacy topics and may have manually created sections
-            # but should not have ML subtopics
-            for sid in sections:
-                if sid != "top_stories_section" and sid not in legacy_topics:
-                    # Non-legacy sections should only be manually created sections
-                    assert is_manual_section(sid), f"Unexpected section type: {sid}"
-
         # Check the recs used in top_stories_section are removed from their original ML sections.
         top_story_ids = {
             rec["corpusItemId"] for rec in sections["top_stories_section"]["recommendations"]
@@ -1708,11 +1692,7 @@ class TestSections:
 
         # check editorial section with extra metadata is also returned along with ML subfeeds
         editorial_section_id = "042b10d6-4fab-4df6-8006-e73ae5fd021d"
-        if (
-            data["feeds"].get(editorial_section_id) is not None
-            and experiment_payload.get("experimentName")
-            == ExperimentName.ML_SECTIONS_EXPERIMENT.value
-        ):
+        if data["feeds"].get(editorial_section_id) is not None:
             assert data["feeds"][editorial_section_id]["title"] == "Amsterdam Tips"
             assert data["feeds"][editorial_section_id]["subtitle"] == "Travel tips in Amsterdam"
             assert (
@@ -2050,11 +2030,6 @@ class TestSections:
             {"region": "US"},
             {"region": "CA"},
             {
-                "experimentName": ExperimentName.SCHEDULER_HOLDBACK_EXPERIMENT.value,
-                "experimentBranch": "control",
-                "region": "US",
-            },
-            {
                 "experimentName": "other",
                 "experimentBranch": "other",
                 "region": "US",
@@ -2086,13 +2061,7 @@ class TestSections:
                 assert not sid.endswith("_crawl"), f"{sid} shouldn't have _crawl suffix"
 
         legacy_topics = {topic.value for topic in Topic}
-        experiment_name = experiment_payload.get("experimentName")
-        experiment_branch = experiment_payload.get("experimentBranch")
-        region = experiment_payload.get("region")
-        expect_subtopics = region == "US" and not (
-            experiment_name == ExperimentName.SCHEDULER_HOLDBACK_EXPERIMENT.value
-            and experiment_branch == "control"
-        )
+        expect_subtopics = True
 
         # Categorize non-legacy, non-top_stories sections
         non_legacy_section_ids = [
@@ -2775,8 +2744,6 @@ class TestSections:
         payload = {
             "locale": "en-US",
             "feeds": ["sections"],
-            "experimentName": ExperimentName.ML_SECTIONS_EXPERIMENT.value,
-            "experimentBranch": "treatment",
         }
 
         baseline_response = client.post("/api/v1/curated-recommendations", json=payload)
@@ -2812,7 +2779,9 @@ class TestSections:
             assert corpus_rec_id not in response_ids
             assert any("Excluding reported recommendation" in r.message for r in caplog.records)
         else:
-            assert corpus_rec_id in response_ids
+            # Rec was not taken down. We don't assert it reappears: section contents are
+            # chosen by Thompson sampling and vary between requests, so a non-removed rec
+            # can legitimately drop out of a second sampled response.
             assert not any(
                 "Excluding reported recommendation" in r.message for r in caplog.records
             )

--- a/tests/unit/curated_recommendations/test_sections.py
+++ b/tests/unit/curated_recommendations/test_sections.py
@@ -347,12 +347,12 @@ class TestMlSectionsExperiment:
     @pytest.mark.parametrize(
         "name,branch,region,expected",
         [
-            (ExperimentName.SCHEDULER_HOLDBACK_EXPERIMENT.value, "control", "US", False),
+            (ExperimentName.SCHEDULER_HOLDBACK_EXPERIMENT.value, "control", "US", True),
             (ExperimentName.SCHEDULER_HOLDBACK_EXPERIMENT.value, "other", "US", True),
-            (ExperimentName.SCHEDULER_HOLDBACK_EXPERIMENT.value, "other", "CA", False),
+            (ExperimentName.SCHEDULER_HOLDBACK_EXPERIMENT.value, "other", "CA", True),
             ("other", "treatment", "US", True),
             ("other", "treatment", "DE", True),
-            ("other", "treatment", "ZZ", False),
+            ("other", "treatment", "ZZ", True),
         ],
     )
     def test_flag_subtopics_experiment_logic(self, name, branch, region, expected):


### PR DESCRIPTION
## References

## Description
Some older logic filtered out subtopics, but the logic wasn't great in that it looked at the request region but not the derived region and filtered out some countries.

This is a short term fix. We should likely remove the is_stubtopic_experiment entirely.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2385)
