### PR TITLE
AIMOD-1240 turn on spindle ML service - enable deduplication

### DIFF
--- a/merino/configs/production.toml
+++ b/merino/configs/production.toml
@@ -57,11 +57,6 @@ cdn_hostname = "prod-games-particle.merino.prod.webservices.mozgcp.net"
 # MERINO_SPINDLE__API__BASE_URL
 base_url = "http://spindle-prod.llm-proxy.prod.dataservices.mozgcp.net"
 
-# MERINO_SPINDLE__API__MAX_WAIT_TIME_SECONDS
-# Wait time when calling the api
-# A zero value disables the service. We are testing only on staging.
-max_wait_time_seconds = 0
-
 
 [production.engagement]
 # MERINO_ENGAGEMENT__GCS_STORAGE_BUCKET


### PR DESCRIPTION
## References

JIRA: https://mozilla-hub.atlassian.net/browse/AIMOD-1240

## Description
I have been testing on staging for a day and it seems to be working well.
Disabling the timeout 0 override turns the service on

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2386)
