### PR TITLE
[DISCO-4277] fix(fleece): use a threadpool executor for pii detection

### DIFF
--- a/merino-fleece/merino_fleece/api/v1/pii.py
+++ b/merino-fleece/merino_fleece/api/v1/pii.py
@@ -1,12 +1,14 @@
 """PII / NER detection endpoint."""
 
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
 
 from merino_fleece.configs import settings
-from merino_fleece.pii import get_detector
+from merino_fleece.pii import get_detector, get_executor
 from merino_fleece.pii.detector import PiiDetector
 from merino_fleece.utils.metrics import get_metrics_client
 
@@ -33,8 +35,14 @@ async def detect_pii(
         Query(min_length=1, max_length=QUERY_CHARACTER_MAX, description="Text to scan for PII."),
     ],
     detector: PiiDetector = Depends(get_detector),
+    executor: ThreadPoolExecutor = Depends(get_executor),
 ) -> PiiResponse:
-    """Return whether `q` contains a PERSON named entity."""
+    """Return whether `q` contains a PERSON named entity.
+
+    SpaCy NER is CPU-bound and synchronous; it runs in the shared thread pool so
+    it does not block the event loop and stall other concurrent requests.
+    """
+    loop = asyncio.get_running_loop()
     with get_metrics_client().timeit("pii.detect_duration"):
-        pii = detector.is_person(q)
+        pii = await loop.run_in_executor(executor, detector.is_person, q)
     return PiiResponse(pii=pii)

--- a/merino-fleece/merino_fleece/app.py
+++ b/merino-fleece/merino_fleece/app.py
@@ -10,13 +10,18 @@ from merino_common.routers import dockerflow
 
 from merino_fleece.api.v1 import router as v1_router
 from merino_fleece.configs import settings
-from merino_fleece.pii import init_detector, shutdown_detector
+from merino_fleece.pii import (
+    init_detector,
+    init_executor,
+    shutdown_detector,
+    shutdown_executor,
+)
 from merino_fleece.utils.metrics import configure_metrics
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
-    """Initialize logging, Sentry, and load the SpaCy model on startup."""
+    """Initialize logging, Sentry, metrics, the SpaCy model, and the PII detection thread pool."""
     configure_logging(
         log_format=settings.logging.format,
         level=settings.logging.level,
@@ -32,9 +37,11 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     )
     await configure_metrics()
     init_detector()
+    init_executor()
     try:
         yield
     finally:
+        shutdown_executor()
         shutdown_detector()
 
 

--- a/merino-fleece/merino_fleece/configs/__init__.py
+++ b/merino-fleece/merino_fleece/configs/__init__.py
@@ -33,6 +33,12 @@ def _build_validators() -> list[Validator]:
             must_exist=True,
         ),
         Validator(
+            "pii.executor_max_workers",
+            is_type_of=int,
+            gt=0,
+            must_exist=True,
+        ),
+        Validator(
             "logging.format",
             is_in=["mozlog", "pretty"],
             must_exist=True,

--- a/merino-fleece/merino_fleece/configs/default.toml
+++ b/merino-fleece/merino_fleece/configs/default.toml
@@ -17,6 +17,12 @@ excluded_components = ["tok2vec", "tagger", "parser", "attribute_ruler", "lemmat
 # Maximum allowed length of the `q` query parameter.
 query_character_max = 500
 
+# MERINO_FLEECE_PII__EXECUTOR_MAX_WORKERS
+# Size of the thread pool that runs CPU-bound SpaCy NER off the event loop.
+# Roughly match the number of CPU cores available to each worker process; a
+# bounded pool avoids GIL thrashing under load.
+executor_max_workers = 1
+
 [default.sentry]
 # MERINO_FLEECE_SENTRY__MODE
 # One of "disabled", "release", "debug". When "disabled", no Sentry client is initialized.

--- a/merino-fleece/merino_fleece/pii/__init__.py
+++ b/merino-fleece/merino_fleece/pii/__init__.py
@@ -1,11 +1,19 @@
-"""PII / NER detection. Owns the singleton PiiDetector instance.
+"""PII / NER detection. Owns the singleton PiiDetector and its thread pool.
 
 The detector is initialized once at app startup via :func:`init_detector` and
 served to request handlers through :func:`get_detector` (used with FastAPI
 ``Depends``).
+
+SpaCy NER is CPU-bound and synchronous, so running it directly in an ``async``
+handler would block the event loop and stall every concurrent request. The
+shared :class:`~concurrent.futures.ThreadPoolExecutor` created by
+:func:`init_executor` lets handlers offload that work off the loop. A thread
+pool (rather than a process pool) keeps the single loaded model shared and
+benefits from SpaCy releasing the GIL during its numeric work.
 """
 
 import logging
+from concurrent.futures import ThreadPoolExecutor
 
 from merino_fleece.configs import settings
 from merino_fleece.pii.detector import PiiDetector, build_detector
@@ -13,6 +21,7 @@ from merino_fleece.pii.detector import PiiDetector, build_detector
 logger = logging.getLogger(__name__)
 
 _detector: PiiDetector | None = None
+_executor: ThreadPoolExecutor | None = None
 
 
 def init_detector() -> None:
@@ -32,3 +41,27 @@ def get_detector() -> PiiDetector:
     if _detector is None:
         raise RuntimeError("PiiDetector is not initialized; init_detector() must run first")
     return _detector
+
+
+def init_executor() -> None:
+    """Create the shared NER thread pool from settings. Call once at startup."""
+    global _executor
+    _executor = ThreadPoolExecutor(
+        max_workers=settings.pii.executor_max_workers,
+        thread_name_prefix="pii-detect",
+    )
+
+
+def shutdown_executor() -> None:
+    """Shut down the NER thread pool, waiting for in-flight work. Call once at shutdown."""
+    global _executor
+    if _executor is not None:
+        _executor.shutdown(wait=True)
+        _executor = None
+
+
+def get_executor() -> ThreadPoolExecutor:
+    """Return the NER thread pool. Intended for use with ``fastapi.Depends``."""
+    if _executor is None:
+        raise RuntimeError("PII executor is not initialized; init_executor() must run first")
+    return _executor

--- a/merino-fleece/tests/unit/api/v1/test_pii.py
+++ b/merino-fleece/tests/unit/api/v1/test_pii.py
@@ -1,6 +1,7 @@
 """Tests for the FastAPI /api/v1/pii endpoint with a dependency-overridden detector."""
 
 from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 from pytest_mock import MockerFixture
@@ -10,7 +11,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from merino_fleece.app import create_app
-from merino_fleece.pii import get_detector
+from merino_fleece.pii import get_detector, get_executor
 
 
 class StubDetector:
@@ -27,21 +28,24 @@ class StubDetector:
 
 @pytest.fixture
 def make_client() -> Iterator:
-    """Yield a factory that builds a TestClient with get_detector overridden."""
+    """Yield a factory that builds a TestClient with the detector and executor overridden."""
     apps: list[FastAPI] = []
+    executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="test-pii-detect")
 
     def _factory(verdict: bool) -> TestClient:
         app = create_app()
         app.dependency_overrides[get_detector] = lambda: StubDetector(verdict)
+        app.dependency_overrides[get_executor] = lambda: executor
         apps.append(app)
-        # No `with` / lifespan needed: the dependency override skips the real
-        # detector and the route does not touch app state.
+        # No `with` / lifespan needed: the dependency overrides supply the
+        # detector and executor, so the route does not touch app state.
         return TestClient(app)
 
     yield _factory
 
     for app in apps:
         app.dependency_overrides.clear()
+    executor.shutdown(wait=True)
 
 
 def test_pii_true(make_client) -> None:

--- a/merino-fleece/tests/unit/configs/test_validators.py
+++ b/merino-fleece/tests/unit/configs/test_validators.py
@@ -40,6 +40,7 @@ def test_valid_models_accepted(model: str) -> None:
             "model": model,
             "excluded_components": ["tok2vec"],
             "query_character_max": 100,
+            "executor_max_workers": 4,
         },
         LOGGING={"format": "mozlog", "level": "INFO", "can_propagate": False},
         SENTRY={"mode": "disabled", "dsn": "", "env": "dev", "traces_sample_rate": 0.0},

--- a/merino-fleece/tests/unit/pii/test_init.py
+++ b/merino-fleece/tests/unit/pii/test_init.py
@@ -1,0 +1,71 @@
+"""Unit tests for the merino_fleece.pii package lifecycle helpers."""
+
+from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+from pytest_mock import MockerFixture
+
+import merino_fleece.pii as pii
+from merino_fleece.pii import (
+    get_detector,
+    get_executor,
+    init_detector,
+    init_executor,
+    shutdown_detector,
+    shutdown_executor,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_singletons() -> Iterator[None]:
+    """Ensure the module-level detector/executor globals are reset around each test."""
+    pii._detector = None
+    pii._executor = None
+    yield
+    shutdown_executor()
+    pii._detector = None
+
+
+def test_get_detector_uninitialized_raises() -> None:
+    """get_detector raises until init_detector has run."""
+    with pytest.raises(RuntimeError, match="not initialized"):
+        get_detector()
+
+
+def test_init_and_shutdown_detector(mocker: MockerFixture) -> None:
+    """init_detector builds the singleton; shutdown_detector drops it."""
+    sentinel = object()
+    mocker.patch("merino_fleece.pii.build_detector", return_value=sentinel)
+
+    init_detector()
+    assert get_detector() is sentinel
+
+    shutdown_detector()
+    with pytest.raises(RuntimeError, match="not initialized"):
+        get_detector()
+
+
+def test_get_executor_uninitialized_raises() -> None:
+    """get_executor raises until init_executor has run."""
+    with pytest.raises(RuntimeError, match="not initialized"):
+        get_executor()
+
+
+def test_init_executor_uses_configured_max_workers() -> None:
+    """init_executor sizes the pool from settings.pii.executor_max_workers."""
+    init_executor()
+    executor = get_executor()
+
+    assert isinstance(executor, ThreadPoolExecutor)
+    assert executor._max_workers == pii.settings.pii.executor_max_workers
+
+
+def test_shutdown_executor_is_idempotent() -> None:
+    """shutdown_executor tolerates being called when no executor exists."""
+    init_executor()
+    shutdown_executor()
+    shutdown_executor()  # second call is a no-op, must not raise
+
+    with pytest.raises(RuntimeError, match="not initialized"):
+        get_executor()


### PR DESCRIPTION
## References

JIRA: [DISCO-4277](https://mozilla-hub.atlassian.net/browse/DISCO-4277)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->

The test results in staging show higher than expected latency results, then the local benchmark suggest the PII detection code could slow Fleece down as it's CPU-bound and sync. This PR offloads that onto a threadpool executor to mitigate that. 

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2387)


[DISCO-4277]: https://mozilla-hub.atlassian.net/browse/DISCO-4277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ