### PR TITLE
[DISCO-4279] feat(wcs): add cache-control headers to /teams, /matches, and /live

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -566,6 +566,9 @@ circuit_breaker_recover_timeout_sec = 30
 # MERINO_PROVIDERS__WCS__WATCH_LINKS_CACHE_CONTROL_TTL
 # TTL value for the cache-control header set on the /wcs/watch-links endpoint response.
 watch_links_cache_control_ttl = 3600 # 1 hour
+# MERINO_PROVIDERS__WCS__DEFAULT_CACHE_CONTROL_TTL
+# TTL value for the cache-control header if cacheable and no other more specific TTL exists
+default_cache_control_ttl = 15 # seconds
 # MERINO_PROVIDERS__WCS__CIRCUIT_BREAKER_RETRY_AFTER_SEC
 # Value for the `Retry-After` header on 503 responses when the breaker is open.
 circuit_breaker_retry_after_sec = 90

--- a/merino/web/api_v1_wcs.py
+++ b/merino/web/api_v1_wcs.py
@@ -65,7 +65,7 @@ async def get_wcs_matches(
     try:
         matches: MatchesResponse = await provider.get_matches(target_date, limit, team_keys)
         response.headers["Cache-Control"] = (
-            f"public, s-maxage={DEFAULT_CACHE_CONTROL_TTL}, max-age={DEFAULT_CACHE_CONTROL_TTL}"
+            f"public, s-maxage={DEFAULT_CACHE_CONTROL_TTL}, max-age={DEFAULT_CACHE_CONTROL_TTL}, stale-while-revalidate={DEFAULT_CACHE_CONTROL_TTL}"
         )
         return matches
     except CircuitBreakerError:
@@ -96,7 +96,7 @@ async def get_wcs_live(
             _parse_team_keys(teams)
         )
         response.headers["Cache-Control"] = (
-            f"public, s-maxage={DEFAULT_CACHE_CONTROL_TTL}, max-age={DEFAULT_CACHE_CONTROL_TTL}"
+            f"public, s-maxage={DEFAULT_CACHE_CONTROL_TTL}, max-age={DEFAULT_CACHE_CONTROL_TTL}, stale-while-revalidate={DEFAULT_CACHE_CONTROL_TTL}"
         )
         return live_matches
     except CircuitBreakerError:
@@ -144,7 +144,7 @@ async def get_wcs_teams(
     try:
         teams: TeamsResponse = await provider.get_teams()
         response.headers["Cache-Control"] = (
-            f"public, s-maxage={DEFAULT_CACHE_CONTROL_TTL}, max-age={DEFAULT_CACHE_CONTROL_TTL}"
+            f"public, s-maxage={DEFAULT_CACHE_CONTROL_TTL}, max-age={DEFAULT_CACHE_CONTROL_TTL}, stale-while-revalidate={DEFAULT_CACHE_CONTROL_TTL}"
         )
         return teams
     except CircuitBreakerError:

--- a/merino/web/api_v1_wcs.py
+++ b/merino/web/api_v1_wcs.py
@@ -4,7 +4,7 @@ from datetime import UTC, datetime
 from datetime import date as Date
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, Header
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Header, Response
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
 
@@ -29,6 +29,9 @@ router = APIRouter()
 
 HEADER_CHARACTER_MAX = settings.web.api.v1.header_character_max
 WATCH_LINKS_CACHE_CONTROL_TTL = settings.providers.wcs.watch_links_cache_control_ttl
+# All game/team data is refreshed on a 3 minute schedule; add a short cache
+# to reduce some requests to the server while not compromising freshness
+DEFAULT_CACHE_CONTROL_TTL = settings.providers.wcs.default_cache_control_ttl
 _RETRY_AFTER = str(settings.providers.wcs.circuit_breaker_retry_after_sec)
 
 
@@ -40,6 +43,7 @@ _RETRY_AFTER = str(settings.providers.wcs.circuit_breaker_retry_after_sec)
     response_model_by_alias=True,
 )
 async def get_wcs_matches(
+    response: Response,
     date: Annotated[
         Date | None, Query(description="RFC date YYYY-MM-DD; defaults to today UTC.")
     ] = None,
@@ -60,6 +64,9 @@ async def get_wcs_matches(
     team_keys = _parse_team_keys(teams)
     try:
         matches: MatchesResponse = await provider.get_matches(target_date, limit, team_keys)
+        response.headers["Cache-Control"] = (
+            f"public, s-maxage={DEFAULT_CACHE_CONTROL_TTL}, max-age={DEFAULT_CACHE_CONTROL_TTL}"
+        )
         return matches
     except CircuitBreakerError:
         raise HTTPException(
@@ -76,6 +83,7 @@ async def get_wcs_matches(
     response_model=LiveMatchesResponse,
 )
 async def get_wcs_live(
+    response: Response,
     teams: Annotated[
         str | None,
         Query(description="Comma-separated 3-letter team keys, e.g. 'BRA,ARG'."),
@@ -86,6 +94,9 @@ async def get_wcs_live(
     try:
         live_matches: LiveMatchesResponse = await provider.get_live_matches(
             _parse_team_keys(teams)
+        )
+        response.headers["Cache-Control"] = (
+            f"public, s-maxage={DEFAULT_CACHE_CONTROL_TTL}, max-age={DEFAULT_CACHE_CONTROL_TTL}"
         )
         return live_matches
     except CircuitBreakerError:
@@ -115,7 +126,7 @@ async def get_wcs_watch_links(
 
     return JSONResponse(
         content=jsonable_encoder(watch_links),
-        headers={"Cache-Control": (f"private, max-age={WATCH_LINKS_CACHE_CONTROL_TTL}")},
+        headers={"Cache-Control": f"private, max-age={WATCH_LINKS_CACHE_CONTROL_TTL}"},
     )
 
 
@@ -126,11 +137,15 @@ async def get_wcs_watch_links(
     response_model=TeamsResponse,
 )
 async def get_wcs_teams(
+    response: Response,
     provider: WcsProvider = Depends(get_wcs_provider),
 ) -> TeamsResponse:
     """Return all teams participating in the World Cup."""
     try:
         teams: TeamsResponse = await provider.get_teams()
+        response.headers["Cache-Control"] = (
+            f"public, s-maxage={DEFAULT_CACHE_CONTROL_TTL}, max-age={DEFAULT_CACHE_CONTROL_TTL}"
+        )
         return teams
     except CircuitBreakerError:
         raise HTTPException(

--- a/tests/integration/api/v1/wcs/test_live.py
+++ b/tests/integration/api/v1/wcs/test_live.py
@@ -40,6 +40,14 @@ def test_returns_matches_envelope(client: TestClient) -> None:
     assert {event["status"] for event in body["matches"]} == {"In Progress"}
 
 
+def test_success_sets_short_public_cache_control(client: TestClient) -> None:
+    """Successful live responses are publicly cacheable for the default TTL."""
+    response = client.get(_PATH)
+    assert response.status_code == 200
+    ttl = settings.providers.wcs.default_cache_control_ttl
+    assert response.headers["cache-control"] == f"public, s-maxage={ttl}, max-age={ttl}"
+
+
 def test_matches_sorted_ascending_by_date(client: TestClient) -> None:
     """Live matches come back ordered by event start time."""
     matches = client.get(_PATH).json()["matches"]
@@ -106,6 +114,8 @@ def test_open_circuit_breaker_returns_503(client: TestClient, mocker) -> None:
         assert response.status_code == 503
         assert response.json() == {"detail": "WCS temporarily unavailable"}
         assert response.headers["retry-after"] == "5"
+        # 503s are not cached, so a recovered backend is served immediately.
+        assert "cache-control" not in response.headers
 
         freezer.tick(settings.providers.wcs.circuit_breaker_recover_timeout_sec + 1)
         sport.get_events_by_date = mocker.AsyncMock(return_value=[])

--- a/tests/integration/api/v1/wcs/test_live.py
+++ b/tests/integration/api/v1/wcs/test_live.py
@@ -45,7 +45,10 @@ def test_success_sets_short_public_cache_control(client: TestClient) -> None:
     response = client.get(_PATH)
     assert response.status_code == 200
     ttl = settings.providers.wcs.default_cache_control_ttl
-    assert response.headers["cache-control"] == f"public, s-maxage={ttl}, max-age={ttl}"
+    assert (
+        response.headers["cache-control"]
+        == f"public, s-maxage={ttl}, max-age={ttl}, stale-while-revalidate={ttl}"
+    )
 
 
 def test_matches_sorted_ascending_by_date(client: TestClient) -> None:

--- a/tests/integration/api/v1/wcs/test_matches.py
+++ b/tests/integration/api/v1/wcs/test_matches.py
@@ -34,6 +34,14 @@ def test_default_date_returns_three_buckets(client: TestClient) -> None:
     assert isinstance(body["next"], list)
 
 
+def test_success_sets_short_public_cache_control(client: TestClient) -> None:
+    """Successful matches responses are publicly cacheable for the default TTL."""
+    response = client.get(_PATH)
+    assert response.status_code == 200
+    ttl = settings.providers.wcs.default_cache_control_ttl
+    assert response.headers["cache-control"] == f"public, s-maxage={ttl}, max-age={ttl}"
+
+
 def test_response_uses_alias_next(client: TestClient) -> None:
     """The JSON key must be `next`, not the Python `next_` field name."""
     body = client.get(_PATH).json()
@@ -138,6 +146,8 @@ def test_open_circuit_breaker_returns_503(client: TestClient, mocker) -> None:
         assert response.status_code == 503
         assert response.json() == {"detail": "WCS temporarily unavailable"}
         assert response.headers["retry-after"] == "5"
+        # 503s are not cached, so a recovered backend is served immediately.
+        assert "cache-control" not in response.headers
 
         freezer.tick(settings.providers.wcs.circuit_breaker_recover_timeout_sec + 1)
         sport.get_events_by_date = mocker.AsyncMock(return_value=[])

--- a/tests/integration/api/v1/wcs/test_matches.py
+++ b/tests/integration/api/v1/wcs/test_matches.py
@@ -39,7 +39,10 @@ def test_success_sets_short_public_cache_control(client: TestClient) -> None:
     response = client.get(_PATH)
     assert response.status_code == 200
     ttl = settings.providers.wcs.default_cache_control_ttl
-    assert response.headers["cache-control"] == f"public, s-maxage={ttl}, max-age={ttl}"
+    assert (
+        response.headers["cache-control"]
+        == f"public, s-maxage={ttl}, max-age={ttl}, stale-while-revalidate={ttl}"
+    )
 
 
 def test_response_uses_alias_next(client: TestClient) -> None:

--- a/tests/integration/api/v1/wcs/test_teams.py
+++ b/tests/integration/api/v1/wcs/test_teams.py
@@ -53,6 +53,14 @@ def test_teams_endpoint_returns_correct_list_of_teams(client: TestClient) -> Non
     assert fra["group"] == "Group I"
 
 
+def test_success_sets_short_public_cache_control(client: TestClient) -> None:
+    """Successful teams responses are publicly cacheable for the default TTL."""
+    response = client.get(_PATH)
+    assert response.status_code == 200
+    ttl = settings.providers.wcs.default_cache_control_ttl
+    assert response.headers["cache-control"] == f"public, s-maxage={ttl}, max-age={ttl}"
+
+
 def test_team_icons_are_svg_from_prod_logo_bucket(client: TestClient) -> None:
     """All team flags serve SVG from the hardcoded production GCS bucket."""
     body = client.get(_PATH).json()
@@ -80,6 +88,8 @@ def test_open_circuit_breaker_returns_503(client: TestClient, mocker) -> None:
         assert response.status_code == 503
         assert response.json() == {"detail": "WCS temporarily unavailable"}
         assert response.headers["retry-after"] == "5"
+        # 503s are not cached, so a recovered backend is served immediately.
+        assert "cache-control" not in response.headers
 
         freezer.tick(settings.providers.wcs.circuit_breaker_recover_timeout_sec + 1)
         sport.get_all_teams = mocker.AsyncMock(return_value={})

--- a/tests/integration/api/v1/wcs/test_teams.py
+++ b/tests/integration/api/v1/wcs/test_teams.py
@@ -58,7 +58,10 @@ def test_success_sets_short_public_cache_control(client: TestClient) -> None:
     response = client.get(_PATH)
     assert response.status_code == 200
     ttl = settings.providers.wcs.default_cache_control_ttl
-    assert response.headers["cache-control"] == f"public, s-maxage={ttl}, max-age={ttl}"
+    assert (
+        response.headers["cache-control"]
+        == f"public, s-maxage={ttl}, max-age={ttl}, stale-while-revalidate={ttl}"
+    )
 
 
 def test_team_icons_are_svg_from_prod_logo_bucket(client: TestClient) -> None:


### PR DESCRIPTION
## References

JIRA: [DISCO-4279]

## Description
Add cache-control headers to /teams, /matches, and /live

Data in these endpoints are refreshed on a 3 minute schedule. Add a short cache to reduce some requests to the origin without compromising too much on freshness (team eliminated status is dynamic, and some clients use /matches for in-progress game data

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2389)


[DISCO-4279]: https://mozilla-hub.atlassian.net/browse/DISCO-4279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ