### PR TITLE
fix(wcs): [DISCO-4281] Fix WCS upcoming match bucketing

### DIFF
--- a/merino/providers/wcs/protocol.py
+++ b/merino/providers/wcs/protocol.py
@@ -160,8 +160,8 @@ class EventInfo(BaseModel):
 class MatchesResponse(BaseModel):
     """Response payload for `GET /api/v1/wcs/matches`.
 
-    Each bucket is sorted by `EventInfo.date` ascending. `next_` is aliased to
-    `next` on the wire; populate by either name in Python.
+    Buckets are grouped by match state and sorted by `EventInfo.date` ascending.
+    `next_` is aliased to `next` on the wire; populate by either name in Python.
     """
 
     model_config = ConfigDict(populate_by_name=True)

--- a/merino/providers/wcs/provider.py
+++ b/merino/providers/wcs/provider.py
@@ -2,7 +2,7 @@
 
 from datetime import UTC, date, datetime, time, timedelta
 import logging
-from typing import Protocol
+from typing import Literal, Protocol
 
 from aiodogstatsd import Client
 import sentry_sdk
@@ -32,6 +32,7 @@ _WINDOW = timedelta(days=21)
 _LIVE_MATCH_LOOKBACK = timedelta(hours=6)
 _LIVE_MATCH_LOOKAHEAD = timedelta(hours=2)
 _CACHE_ERROR_METRIC = "wcs.cache_error"
+_MatchBucket = Literal["previous", "current", "next"]
 logger = logging.getLogger(__name__)
 
 
@@ -76,16 +77,18 @@ class WcsProvider:
     ) -> MatchesResponse:
         """Return matches in a +/- _WINDOW day window around `target_date`.
 
-        Events are bucketed into `previous`, `current`, and `next` relative to
-        `target_date` and sorted ascending by event date. `limit` keeps the
-        entries closest to `target_date` in each bucket; `team_keys` restricts
-        results to matches involving any of the listed teams.
+        Events are sorted ascending by event date, then bucketed by match state:
+        completed/old matches in `previous`, active matches in `current`, and
+        scheduled future matches in `next`. `limit` keeps the entries closest
+        to `target_date` in each bucket; `team_keys` restricts results to
+        matches involving any of the listed teams.
         """
         previous: list[EventInfo] = []
         current: list[EventInfo] = []
         next_: list[EventInfo] = []
 
         target_day = _target_day(target_date)
+        reference_time = _reference_datetime(target_date)
         window_start = datetime.combine(target_day - _WINDOW, time.min, tzinfo=UTC)
         window_end = datetime.combine(target_day + _WINDOW, time.max, tzinfo=UTC)
         try:
@@ -96,11 +99,11 @@ class WcsProvider:
 
         for event in sorted(events, key=lambda e: e.date):
             event_info = EventInfo.from_event(event)
-            event_date = _event_date(event)
             if _matches_team_filter(event_info, team_keys):
-                if event_date < target_day:
+                bucket = _bucket_for_event(event, reference_time)
+                if bucket == "previous":
                     previous.append(event_info)
-                elif event_date == target_day:
+                elif bucket == "current":
                     current.append(event_info)
                 else:
                     next_.append(event_info)
@@ -218,12 +221,36 @@ def _target_day(target_date: date) -> date:
     return target_date
 
 
-def _event_date(event: Event) -> date:
-    """Return the UTC calendar date of `event`."""
+def _reference_datetime(target_date: date) -> datetime:
+    """Return the UTC time used for status-aware match bucketing."""
+    target_day = _target_day(target_date)
+    now = datetime.now(UTC)
+    if target_day == now.date():
+        return now
+    return datetime.combine(target_day, time.min, tzinfo=UTC)
+
+
+def _event_datetime(event: Event) -> datetime:
+    """Return the UTC datetime of `event`."""
     event_datetime = event.date
     if event_datetime.tzinfo is None:
         event_datetime = event_datetime.replace(tzinfo=UTC)
-    return event_datetime.astimezone(UTC).date()
+    return event_datetime.astimezone(UTC)
+
+
+def _bucket_for_event(event: Event, reference_time: datetime) -> _MatchBucket:
+    """Return the matches response bucket for `event` at `reference_time`."""
+    if event.status.is_final():
+        return "previous"
+    if event.status.is_in_progress():
+        return "current"
+
+    event_datetime = _event_datetime(event)
+    if event_datetime > reference_time:
+        return "next"
+    if event.status.is_scheduled() and event_datetime >= reference_time - _LIVE_MATCH_LOOKBACK:
+        return "current"
+    return "previous"
 
 
 def _has_team(event: EventInfo, team_keys: frozenset[str]) -> bool:

--- a/merino/providers/wcs/provider.py
+++ b/merino/providers/wcs/provider.py
@@ -78,7 +78,7 @@ class WcsProvider:
         """Return matches in a +/- _WINDOW day window around `target_date`.
 
         Events are sorted ascending by event date, then bucketed by match state
-        at request time: completed/old matches in `previous`, active matches in
+        at request time: completed/past matches in `previous`, active matches in
         `current`, and scheduled future matches in `next`. `limit` keeps the
         entries closest to `target_date` in each bucket; `team_keys` restricts
         results to matches involving any of the listed teams.
@@ -244,8 +244,6 @@ def _bucket_for_event(event: Event, reference_time: datetime) -> _MatchBucket:
     event_datetime = _event_datetime(event)
     if event_datetime > reference_time:
         return "next"
-    if event.status.is_scheduled() and event_datetime >= reference_time - _LIVE_MATCH_LOOKBACK:
-        return "current"
     return "previous"
 
 

--- a/merino/providers/wcs/provider.py
+++ b/merino/providers/wcs/provider.py
@@ -77,18 +77,18 @@ class WcsProvider:
     ) -> MatchesResponse:
         """Return matches in a +/- _WINDOW day window around `target_date`.
 
-        Events are sorted ascending by event date, then bucketed by match state:
-        completed/old matches in `previous`, active matches in `current`, and
-        scheduled future matches in `next`. `limit` keeps the entries closest
-        to `target_date` in each bucket; `team_keys` restricts results to
-        matches involving any of the listed teams.
+        Events are sorted ascending by event date, then bucketed by match state
+        at request time: completed/old matches in `previous`, active matches in
+        `current`, and scheduled future matches in `next`. `limit` keeps the
+        entries closest to `target_date` in each bucket; `team_keys` restricts
+        results to matches involving any of the listed teams.
         """
         previous: list[EventInfo] = []
         current: list[EventInfo] = []
         next_: list[EventInfo] = []
 
         target_day = _target_day(target_date)
-        reference_time = _reference_datetime(target_date)
+        reference_time = _reference_datetime()
         window_start = datetime.combine(target_day - _WINDOW, time.min, tzinfo=UTC)
         window_end = datetime.combine(target_day + _WINDOW, time.max, tzinfo=UTC)
         try:
@@ -221,13 +221,9 @@ def _target_day(target_date: date) -> date:
     return target_date
 
 
-def _reference_datetime(target_date: date) -> datetime:
+def _reference_datetime() -> datetime:
     """Return the UTC time used for status-aware match bucketing."""
-    target_day = _target_day(target_date)
-    now = datetime.now(UTC)
-    if target_day == now.date():
-        return now
-    return datetime.combine(target_day, time.min, tzinfo=UTC)
+    return datetime.now(UTC)
 
 
 def _event_datetime(event: Event) -> datetime:

--- a/merino/web/api_v1_wcs.py
+++ b/merino/web/api_v1_wcs.py
@@ -38,7 +38,7 @@ _RETRY_AFTER = str(settings.providers.wcs.circuit_breaker_retry_after_sec)
 @router.get(
     "/wcs/matches",
     tags=["wcs"],
-    summary="World Cup Soccer matches in the +/- 7 day window around `date`",
+    summary="World Cup Soccer matches near `date`, grouped by match state",
     response_model=MatchesResponse,
     response_model_by_alias=True,
 )
@@ -56,9 +56,9 @@ async def get_wcs_matches(
 ) -> MatchesResponse:
     """Return matches grouped into `previous`, `current`, and `next`.
 
-    The window is `+/- 7 days` around `date`. `current` holds matches on `date`,
-    `previous` is older, `next` is newer. Each bucket is sorted ascending by
-    event date.
+    The window is around `date`. `previous` holds completed or old matches,
+    `current` holds active matches, and `next` holds upcoming matches. Each
+    bucket is sorted ascending by event date.
     """
     target_date = date or datetime.now(UTC).date()
     team_keys = _parse_team_keys(teams)

--- a/tests/integration/api/v1/wcs/test_matches.py
+++ b/tests/integration/api/v1/wcs/test_matches.py
@@ -70,6 +70,29 @@ def test_matches_per_bucket(client: TestClient) -> None:
     assert all(e["status"] == "Scheduled" for e in body["next"])
 
 
+@freezegun.freeze_time("2026-06-15T12:00:00Z")
+def test_same_day_scheduled_match_is_next_until_kickoff(client: TestClient) -> None:
+    """A same-day scheduled match remains upcoming until kickoff."""
+    app.dependency_overrides[get_wcs_provider] = lambda: build_provider(
+        events=[
+            build_event(
+                90086908,
+                0,
+                19,
+                ("MEX", "Mexico", 90000868),
+                ("RSA", "South Africa", 90001083),
+                GameStatus.Scheduled,
+            )
+        ]
+    )
+
+    body = client.get(_PATH, params={"date": _ANCHOR}).json()
+
+    assert body["previous"] == []
+    assert body["current"] == []
+    assert [event["global_event_id"] for event in body["next"]] == [90086908]
+
+
 def test_event_contract_required_fields_are_non_null(client: TestClient) -> None:
     """Event fields Mobile branches on are always present and non-null."""
     body = client.get(_PATH, params={"date": _ANCHOR}).json()
@@ -122,10 +145,10 @@ def test_matches_returns_nullable_tbd_sides(client: TestClient) -> None:
 
     body = client.get(_PATH, params={"date": "2026-07-05"}).json()
 
-    assert body["current"][0]["home_team"] is None
-    assert body["current"][0]["away_team"] is None
-    assert body["current"][0]["stage"] == "Quarterfinals"
-    assert body["current"][0]["query"] == "Quarterfinals World Cup 2026"
+    assert body["next"][0]["home_team"] is None
+    assert body["next"][0]["away_team"] is None
+    assert body["next"][0]["stage"] == "Quarterfinals"
+    assert body["next"][0]["query"] == "Quarterfinals World Cup 2026"
 
 
 def test_invalid_date_returns_400(client: TestClient) -> None:

--- a/tests/integration/api/v1/wcs/test_matches.py
+++ b/tests/integration/api/v1/wcs/test_matches.py
@@ -93,6 +93,29 @@ def test_same_day_scheduled_match_is_next_until_kickoff(client: TestClient) -> N
     assert [event["global_event_id"] for event in body["next"]] == [90086908]
 
 
+@freezegun.freeze_time("2026-06-11T12:00:00Z")
+def test_explicit_date_keeps_upcoming_match_next_until_kickoff(client: TestClient) -> None:
+    """The date parameter anchors the window, not the match-state reference time."""
+    app.dependency_overrides[get_wcs_provider] = lambda: build_provider(
+        events=[
+            build_event(
+                90086908,
+                -4,
+                19,
+                ("MEX", "Mexico", 90000868),
+                ("RSA", "South Africa", 90001083),
+                GameStatus.Scheduled,
+            )
+        ]
+    )
+
+    body = client.get(_PATH, params={"date": "2026-06-12"}).json()
+
+    assert body["previous"] == []
+    assert body["current"] == []
+    assert [event["global_event_id"] for event in body["next"]] == [90086908]
+
+
 def test_event_contract_required_fields_are_non_null(client: TestClient) -> None:
     """Event fields Mobile branches on are always present and non-null."""
     body = client.get(_PATH, params={"date": _ANCHOR}).json()

--- a/tests/unit/providers/wcs/test_provider.py
+++ b/tests/unit/providers/wcs/test_provider.py
@@ -86,9 +86,9 @@ async def test_same_day_scheduled_match_stays_next_until_kickoff() -> None:
 
 
 @pytest.mark.asyncio
-@freezegun.freeze_time("2026-06-15T19:00:00Z")
-async def test_scheduled_match_moves_current_at_kickoff_if_status_lags() -> None:
-    """At kickoff, a scheduled match is active even before the feed status flips."""
+@freezegun.freeze_time("2026-06-15T19:01:00Z")
+async def test_scheduled_match_moves_previous_after_kickoff_until_status_updates() -> None:
+    """After kickoff, a still-scheduled match is past until the feed marks it live."""
     scheduled = build_event(
         90086908,
         0,
@@ -104,8 +104,8 @@ async def test_scheduled_match_moves_current_at_kickoff_if_status_lags() -> None
         team_keys=None,
     )
 
-    assert response.previous == []
-    assert [event.global_event_id for event in response.current] == [90086908]
+    assert [event.global_event_id for event in response.previous] == [90086908]
+    assert response.current == []
     assert response.next_ == []
 
 

--- a/tests/unit/providers/wcs/test_provider.py
+++ b/tests/unit/providers/wcs/test_provider.py
@@ -110,6 +110,54 @@ async def test_scheduled_match_moves_current_at_kickoff_if_status_lags() -> None
 
 
 @pytest.mark.asyncio
+@freezegun.freeze_time("2026-06-11T12:00:00Z")
+async def test_explicit_date_does_not_promote_upcoming_previous_day_match() -> None:
+    """A future `date` window does not make an upcoming scheduled match current."""
+    scheduled = build_event(
+        90086908,
+        -4,
+        19,
+        ("MEX", "Mexico", 90000868),
+        ("RSA", "South Africa", 90001083),
+        GameStatus.Scheduled,
+    )
+
+    response = await build_provider(events=[scheduled]).get_matches(
+        date(2026, 6, 12),
+        limit=None,
+        team_keys=None,
+    )
+
+    assert response.previous == []
+    assert response.current == []
+    assert [event.global_event_id for event in response.next_] == [90086908]
+
+
+@pytest.mark.asyncio
+@freezegun.freeze_time("2026-06-11T12:00:00Z")
+async def test_future_midnight_kickoff_stays_next_until_real_kickoff() -> None:
+    """A future 00:00Z scheduled match is not current before its kickoff time."""
+    scheduled = build_event(
+        90086909,
+        -3,
+        0,
+        ("KOR", "Korea Republic", 90001209),
+        ("CZE", "Czechia", 90000945),
+        GameStatus.Scheduled,
+    )
+
+    response = await build_provider(events=[scheduled]).get_matches(
+        date(2026, 6, 12),
+        limit=None,
+        team_keys=None,
+    )
+
+    assert response.previous == []
+    assert response.current == []
+    assert [event.global_event_id for event in response.next_] == [90086909]
+
+
+@pytest.mark.asyncio
 async def test_window_excludes_outside_range() -> None:
     """No event lands more than WINDOW days from the anchor."""
     response = await build_provider().get_matches(ANCHOR, limit=None, team_keys=None)

--- a/tests/unit/providers/wcs/test_provider.py
+++ b/tests/unit/providers/wcs/test_provider.py
@@ -5,7 +5,6 @@
 """Unit tests for the WCS matches provider."""
 
 from datetime import UTC, date, datetime, timedelta
-from typing import Any
 
 import freezegun
 import pytest
@@ -62,18 +61,52 @@ def test_cache_uses_wcs_redis_settings(mocker) -> None:
     redis_adapter.assert_called_once_with("primary", "replica")
 
 
-def _dates(events: list[Any]) -> list[date]:
-    return [datetime.fromisoformat(e.date).date() for e in events]
+@pytest.mark.asyncio
+@freezegun.freeze_time("2026-06-15T12:00:00Z")
+async def test_same_day_scheduled_match_stays_next_until_kickoff() -> None:
+    """A scheduled match later on `target_date` remains in the upcoming bucket."""
+    scheduled = build_event(
+        90086908,
+        0,
+        19,
+        ("MEX", "Mexico", 90000868),
+        ("RSA", "South Africa", 90001083),
+        GameStatus.Scheduled,
+    )
+
+    response = await build_provider(events=[scheduled]).get_matches(
+        ANCHOR,
+        limit=None,
+        team_keys=None,
+    )
+
+    assert response.previous == []
+    assert response.current == []
+    assert [event.global_event_id for event in response.next_] == [90086908]
 
 
 @pytest.mark.asyncio
-async def test_buckets_split_by_date() -> None:
-    """Each bucket holds events on the correct side of `target_date`."""
-    response = await build_provider().get_matches(ANCHOR, limit=None, team_keys=None)
+@freezegun.freeze_time("2026-06-15T19:00:00Z")
+async def test_scheduled_match_moves_current_at_kickoff_if_status_lags() -> None:
+    """At kickoff, a scheduled match is active even before the feed status flips."""
+    scheduled = build_event(
+        90086908,
+        0,
+        19,
+        ("MEX", "Mexico", 90000868),
+        ("RSA", "South Africa", 90001083),
+        GameStatus.Scheduled,
+    )
 
-    assert all(d < ANCHOR for d in _dates(response.previous))
-    assert all(d == ANCHOR for d in _dates(response.current))
-    assert all(d > ANCHOR for d in _dates(response.next_))
+    response = await build_provider(events=[scheduled]).get_matches(
+        ANCHOR,
+        limit=None,
+        team_keys=None,
+    )
+
+    assert response.previous == []
+    assert [event.global_event_id for event in response.current] == [90086908]
+    assert response.next_ == []
 
 
 @pytest.mark.asyncio
@@ -181,8 +214,8 @@ async def test_matches_include_nullable_tbd_teams() -> None:
         team_keys=None,
     )
 
-    assert len(response.current) == 1
-    event = response.current[0]
+    assert len(response.next_) == 1
+    event = response.next_[0]
     assert event.home_team is None
     assert event.away_team is None
     assert event.stage == "Quarterfinals"
@@ -221,7 +254,7 @@ async def test_match_team_group_comes_from_cached_event_group() -> None:
     response = await build_provider(events=[grouped_event]).get_matches(
         ANCHOR, limit=None, team_keys=None
     )
-    event = response.current[0]
+    event = response.next_[0]
 
     assert event.home_team is not None
     assert event.away_team is not None


### PR DESCRIPTION
## References

JIRA: [DISCO-4281](https://mozilla-hub.atlassian.net/browse/DISCO-4281)

## Description

* Removed the 6-hour grace period. iOS flattens the match arrays and groups by date, so it does not depend on current meaning “today.”
* Matches now move into current only when their status is InProgress or Suspended.
* Scheduled matches stay in next even when match day is today, until they actually become live.
* Once kickoff time is in the past, a non-live/non-final match falls into previous.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2391)


[DISCO-4281]: https://mozilla-hub.atlassian.net/browse/DISCO-4281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ