### PR TITLE
chore(wcs): DISCO-4282 Count break as in-progress status

### DIFF
--- a/merino/providers/suggest/sports/backends/sportsdata/common/__init__.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/__init__.py
@@ -16,6 +16,7 @@ class GameStatus(StrEnum):
     Delayed = "delayed"  # equivalent to "scheduled"
     Postponed = "postponed"  # equivalent to "scheduled"
     InProgress = "inprogress"
+    Break = "break"  # equivalent to "inprogress" during soccer intervals
     Suspended = "suspended"  # equivalent to "inprogress"
     Canceled = "canceled"
     Final = "final"
@@ -55,7 +56,7 @@ class GameStatus(StrEnum):
 
     def is_in_progress(self) -> bool:
         """Return if the game is currently in progress in some form"""
-        return self in [GameStatus.InProgress, GameStatus.Suspended]
+        return self in [GameStatus.InProgress, GameStatus.Break, GameStatus.Suspended]
 
     def status_type(self) -> GameStatus:
         """Return a simplified status for this event.

--- a/tests/unit/providers/suggest/sports/backends/test_sports_backend.py
+++ b/tests/unit/providers/suggest/sports/backends/test_sports_backend.py
@@ -256,6 +256,7 @@ async def test_gamestatus():
     """Test the GameStatus enum"""
     assert GameStatus.parse("final") == GameStatus.Final
     assert GameStatus.parse("in progress") == GameStatus.InProgress
+    assert GameStatus.parse("break") == GameStatus.Break
     assert GameStatus.parse("final - over time") == GameStatus.F_OT
     assert GameStatus.parse("final - shoot out") == GameStatus.F_SO
     assert GameStatus.parse("not necessary") == GameStatus.NotNecessary
@@ -263,6 +264,7 @@ async def test_gamestatus():
 
     assert GameStatus.Final.is_final()
     assert GameStatus.parse("scheduled").is_scheduled()
+    assert GameStatus.parse("break").is_in_progress()
     assert GameStatus.parse("suspended").is_in_progress()
     assert GameStatus.parse("In Progress").status_type() == GameStatus.InProgress
     assert GameStatus.NotNecessary.as_str() == "Not Necessary"
@@ -272,6 +274,7 @@ async def test_gamestatus():
 
     assert GameStatus.Final.as_ui_status() == "past"
     assert GameStatus.InProgress.as_ui_status() == "live"
+    assert GameStatus.Break.as_ui_status() == "live"
     assert GameStatus.Scheduled.as_ui_status() == "scheduled"
     assert GameStatus.Unknown.as_ui_status() == "unknown"
 

--- a/tests/unit/providers/wcs/test_provider.py
+++ b/tests/unit/providers/wcs/test_provider.py
@@ -110,6 +110,67 @@ async def test_scheduled_match_moves_previous_after_kickoff_until_status_updates
 
 
 @pytest.mark.asyncio
+@freezegun.freeze_time("2026-06-15T19:45:00Z")
+async def test_break_match_stays_current_after_kickoff() -> None:
+    """SportsData uses Break for halftime, which remains a current live match."""
+    halftime = build_event(
+        90086910,
+        0,
+        19,
+        ("MEX", "Mexico", 90000868),
+        ("RSA", "South Africa", 90001083),
+        GameStatus.Break,
+        home_score=1,
+        away_score=1,
+        period="HT",
+        clock="45",
+    )
+
+    response = await build_provider(events=[halftime]).get_matches(
+        ANCHOR,
+        limit=None,
+        team_keys=None,
+    )
+
+    assert response.previous == []
+    assert [event.global_event_id for event in response.current] == [90086910]
+    assert response.next_ == []
+    assert response.current[0].status == "Break"
+    assert response.current[0].status_type == "live"
+
+
+@pytest.mark.asyncio
+@freezegun.freeze_time("2026-06-15T21:10:00Z")
+async def test_penalty_shootout_match_stays_current_until_final() -> None:
+    """A live penalty shootout remains current until SportsData marks it final."""
+    penalties = build_event(
+        90086911,
+        0,
+        19,
+        ("MEX", "Mexico", 90000868),
+        ("RSA", "South Africa", 90001083),
+        GameStatus.InProgress,
+        home_score=2,
+        away_score=2,
+        home_penalty=2,
+        away_penalty=1,
+        period="PenaltyShootout",
+        clock="120",
+    )
+
+    response = await build_provider(events=[penalties]).get_matches(
+        ANCHOR,
+        limit=None,
+        team_keys=None,
+    )
+
+    assert response.previous == []
+    assert [event.global_event_id for event in response.current] == [90086911]
+    assert response.next_ == []
+    assert response.current[0].period == "PenaltyShootout"
+
+
+@pytest.mark.asyncio
 @freezegun.freeze_time("2026-06-11T12:00:00Z")
 async def test_explicit_date_does_not_promote_upcoming_previous_day_match() -> None:
     """A future `date` window does not make an upcoming scheduled match current."""
@@ -359,11 +420,24 @@ async def test_live_mock_path_does_not_touch_redis(mocker) -> None:
 @freezegun.freeze_time("2026-06-15T16:00:00Z")
 async def test_live_returns_only_in_progress_cached_events() -> None:
     """`get_live_matches` reads Redis-backed events and keeps live matches only."""
-    response = await build_provider().get_live_matches(team_keys=None)
+    halftime = build_event(
+        90086910,
+        0,
+        15,
+        ("MEX", "Mexico", 90000868),
+        ("RSA", "South Africa", 90001083),
+        GameStatus.Break,
+        period="HT",
+        clock="45",
+    )
 
-    assert len(response.matches) == 2
-    assert {event.global_event_id for event in response.matches} == {1003, 1004}
-    assert {event.status for event in response.matches} == {"In Progress"}
+    response = await build_provider(events=[*build_events(), halftime]).get_live_matches(
+        team_keys=None
+    )
+
+    assert len(response.matches) == 3
+    assert {event.global_event_id for event in response.matches} == {1003, 1004, 90086910}
+    assert {event.status for event in response.matches} == {"In Progress", "Break"}
     assert {event.status_type for event in response.matches} == {"live"}
 
 


### PR DESCRIPTION
## References

JIRA: [DISCO-4282](https://mozilla-hub.atlassian.net/browse/DISCO-4282)

## Description
In case sportsdata.io returns a `break` status in-between half times, we want to count that to `in_progress` overall status.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2392)


[DISCO-4282]: https://mozilla-hub.atlassian.net/browse/DISCO-4282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ