### PR TITLE
AIMOD-1240 Reduce load on spindle by limiting to US only

### DIFF
--- a/merino/curated_recommendations/ml_backends/spindle_backend.py
+++ b/merino/curated_recommendations/ml_backends/spindle_backend.py
@@ -34,9 +34,6 @@ LANGUAGE_FOR_SURFACE: dict[SurfaceId, str] = {
 
 LOCALE_FOR_SURFACE: dict[SurfaceId, str] = {
     SurfaceId.NEW_TAB_EN_US: "en_US",
-    SurfaceId.NEW_TAB_EN_CA: "en_CA",
-    SurfaceId.NEW_TAB_EN_GB: "en_GB",
-    SurfaceId.NEW_TAB_EN_IE: "en_IE",
 }
 
 METRIC_NAMESPACE = "recommendation.spindle"


### PR DESCRIPTION
## References

JIRA: https://mozilla-hub.atlassian.net/browse/AIMOD-1240

## Description
The service is released but the load seems high on the spindle server.
Reducing use of the service to just the US locale for the time being to reduce the number of requests.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2393)
