### PR TITLE
chore(wcs): DISCO-4286 Grace period for live games

### DIFF
--- a/merino/providers/wcs/provider.py
+++ b/merino/providers/wcs/provider.py
@@ -29,6 +29,7 @@ from merino.providers.wcs.utils import resolve_other_regions, resolve_watch_link
 from merino.utils.metrics import get_metrics_client
 
 _WINDOW = timedelta(days=21)
+_SCHEDULED_MATCH_POST_KICKOFF_GRACE = timedelta(minutes=30)
 _LIVE_MATCH_LOOKBACK = timedelta(hours=6)
 _LIVE_MATCH_LOOKAHEAD = timedelta(hours=2)
 _CACHE_ERROR_METRIC = "wcs.cache_error"
@@ -78,10 +79,11 @@ class WcsProvider:
         """Return matches in a +/- _WINDOW day window around `target_date`.
 
         Events are sorted ascending by event date, then bucketed by match state
-        at request time: completed/past matches in `previous`, active matches in
-        `current`, and scheduled future matches in `next`. `limit` keeps the
-        entries closest to `target_date` in each bucket; `team_keys` restricts
-        results to matches involving any of the listed teams.
+        at request time: completed/past matches in `previous`, active or
+        just-started scheduled matches in `current`, and scheduled future matches
+        in `next`. `limit` keeps the entries closest to `target_date` in each
+        bucket; `team_keys` restricts results to matches involving any of the
+        listed teams.
         """
         previous: list[EventInfo] = []
         current: list[EventInfo] = []
@@ -244,6 +246,10 @@ def _bucket_for_event(event: Event, reference_time: datetime) -> _MatchBucket:
     event_datetime = _event_datetime(event)
     if event_datetime > reference_time:
         return "next"
+    if event.status.is_scheduled():
+        time_since_kickoff = reference_time - event_datetime
+        if time_since_kickoff <= _SCHEDULED_MATCH_POST_KICKOFF_GRACE:
+            return "current"
     return "previous"
 
 

--- a/merino/web/api_v1_wcs.py
+++ b/merino/web/api_v1_wcs.py
@@ -57,7 +57,8 @@ async def get_wcs_matches(
     """Return matches grouped into `previous`, `current`, and `next`.
 
     The window is around `date`. `previous` holds completed or old matches,
-    `current` holds active matches, and `next` holds upcoming matches. Each
+    `current` holds active matches and scheduled matches during the short
+    post-kickoff feed-lag grace period, and `next` holds upcoming matches. Each
     bucket is sorted ascending by event date.
     """
     target_date = date or datetime.now(UTC).date()

--- a/tests/integration/api/v1/wcs/test_matches.py
+++ b/tests/integration/api/v1/wcs/test_matches.py
@@ -93,6 +93,29 @@ def test_same_day_scheduled_match_is_next_until_kickoff(client: TestClient) -> N
     assert [event["global_event_id"] for event in body["next"]] == [90086908]
 
 
+@freezegun.freeze_time("2026-06-15T19:01:00Z")
+def test_scheduled_match_is_current_during_post_kickoff_grace(client: TestClient) -> None:
+    """A same-day scheduled match remains current shortly after kickoff."""
+    app.dependency_overrides[get_wcs_provider] = lambda: build_provider(
+        events=[
+            build_event(
+                90086908,
+                0,
+                19,
+                ("MEX", "Mexico", 90000868),
+                ("RSA", "South Africa", 90001083),
+                GameStatus.Scheduled,
+            )
+        ]
+    )
+
+    body = client.get(_PATH, params={"date": _ANCHOR}).json()
+
+    assert body["previous"] == []
+    assert [event["global_event_id"] for event in body["current"]] == [90086908]
+    assert body["next"] == []
+
+
 @freezegun.freeze_time("2026-06-11T12:00:00Z")
 def test_explicit_date_keeps_upcoming_match_next_until_kickoff(client: TestClient) -> None:
     """The date parameter anchors the window, not the match-state reference time."""

--- a/tests/unit/providers/wcs/test_provider.py
+++ b/tests/unit/providers/wcs/test_provider.py
@@ -20,6 +20,7 @@ from merino.providers.wcs.provider import (
     WcsProvider,
     _LIVE_MATCH_LOOKAHEAD,
     _LIVE_MATCH_LOOKBACK,
+    _SCHEDULED_MATCH_POST_KICKOFF_GRACE,
     _WINDOW,
 )
 from tests.wcs.factories import (
@@ -87,8 +88,32 @@ async def test_same_day_scheduled_match_stays_next_until_kickoff() -> None:
 
 @pytest.mark.asyncio
 @freezegun.freeze_time("2026-06-15T19:01:00Z")
-async def test_scheduled_match_moves_previous_after_kickoff_until_status_updates() -> None:
-    """After kickoff, a still-scheduled match is past until the feed marks it live."""
+async def test_scheduled_match_stays_current_during_post_kickoff_grace() -> None:
+    """After kickoff, a still-scheduled match remains current while the feed catches up."""
+    scheduled = build_event(
+        90086908,
+        0,
+        19,
+        ("MEX", "Mexico", 90000868),
+        ("RSA", "South Africa", 90001083),
+        GameStatus.Scheduled,
+    )
+
+    response = await build_provider(events=[scheduled]).get_matches(
+        ANCHOR,
+        limit=None,
+        team_keys=None,
+    )
+
+    assert response.previous == []
+    assert [event.global_event_id for event in response.current] == [90086908]
+    assert response.next_ == []
+
+
+@pytest.mark.asyncio
+@freezegun.freeze_time("2026-06-15T19:31:00Z")
+async def test_scheduled_match_moves_previous_after_post_kickoff_grace() -> None:
+    """A still-scheduled match moves previous after the feed-lag grace window."""
     scheduled = build_event(
         90086908,
         0,
@@ -106,6 +131,31 @@ async def test_scheduled_match_moves_previous_after_kickoff_until_status_updates
 
     assert [event.global_event_id for event in response.previous] == [90086908]
     assert response.current == []
+    assert response.next_ == []
+
+
+@pytest.mark.asyncio
+@freezegun.freeze_time("2026-06-15T19:30:00Z")
+async def test_scheduled_match_grace_includes_boundary() -> None:
+    """Scheduled matches remain current through the configured grace duration."""
+    scheduled = build_event(
+        90086908,
+        0,
+        19,
+        ("MEX", "Mexico", 90000868),
+        ("RSA", "South Africa", 90001083),
+        GameStatus.Scheduled,
+    )
+
+    response = await build_provider(events=[scheduled]).get_matches(
+        ANCHOR,
+        limit=None,
+        team_keys=None,
+    )
+
+    assert _SCHEDULED_MATCH_POST_KICKOFF_GRACE == timedelta(minutes=30)
+    assert response.previous == []
+    assert [event.global_event_id for event in response.current] == [90086908]
     assert response.next_ == []
 
 


### PR DESCRIPTION
## References

JIRA: [DISCO-4286](https://mozilla-hub.atlassian.net/browse/DISCO-4286O)

## Description
Add a 30 minute grace period for live games to start


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2395)


[DISCO-4286]: https://mozilla-hub.atlassian.net/browse/DISCO-4286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ