### PR TITLE
fix(watch_links): Fix Germany location users not seeing watch links if browser language not de

### DIFF
--- a/merino/providers/wcs/watch_links.py
+++ b/merino/providers/wcs/watch_links.py
@@ -352,7 +352,7 @@ WATCH_LINKS: dict[str, CountryEntry] = {
     },
     "DE": {
         "langs": {
-            "de": [
+            "*": [
                 _build_fifa_watch_link(),
                 build_watch_link(
                     "ZDF",

--- a/tests/integration/api/v1/wcs/test_watch_links.py
+++ b/tests/integration/api/v1/wcs/test_watch_links.py
@@ -163,3 +163,26 @@ def test_watch_links_de_de(
         len(country["streams"]) for country in body["other_regions"]
     )
     assert total_links == 76
+
+
+def test_watch_links_de_en(
+    client: TestClient,
+    inject_de_location: None,
+) -> None:
+    """German users with a non-German browser language still see all five German streams.
+
+    All DE streams are country-wide ('*') so the Accept-Language header does not
+    gate them out.
+    """
+    response = client.get(_PATH, headers={"Accept-Language": "en-US"})
+
+    assert response.status_code == 200
+    body = response.json()
+
+    your_region_names = [s["product_name"] for s in body["your_region"]]
+    assert "FIFA+ (DAZN)" in your_region_names
+    assert "ZDF" in your_region_names
+    assert "ARD" in your_region_names
+    assert "SPORTSCHAU" in your_region_names
+    assert "MagentaTV" in your_region_names
+    assert len(body["your_region"]) == 5


### PR DESCRIPTION
## References



## Description
Fix watch links to show all Germany users all of the links regardless of browser language.



## PR Review Checklist
- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2396)
