### PR TITLE
feat(wcs): long-running wcs etl option with configurable interval

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -556,6 +556,12 @@ retry_factor_sec=0.5
 # base_url.nfl="https://api.sportsdata.io/v3/nfl/scores/json"
 # base_url.ucl="https://api.sportsdata.io/v4/soccer/scores/json"
 
+[default.providers.sports.sportsdata.WCS]
+# MERINO_PROVIDERS__SPORTS__SPORTSDATA__WCS__GAMES_BY_DATE_TTL_SEC
+# Local-disk cache lifetime (seconds) for live `GamesByDate` score responses
+# before refetching from SportsData.io. 
+games_by_date_ttl_sec = 5
+
 [default.providers.wcs]
 # MERINO_PROVIDERS__WCS__LIVE_DATA_ENABLED
 # Serve Redis-backed in-progress matches for /wcs/live. Set to false to use

--- a/merino/jobs/sportsdata_jobs/__init__.py
+++ b/merino/jobs/sportsdata_jobs/__init__.py
@@ -22,6 +22,7 @@ hardcoded in the calling function for now, but is based on the file creation tim
 import asyncio
 import copy
 import logging
+import signal
 import typer
 import sys
 from time import monotonic, time
@@ -43,6 +44,9 @@ from merino.providers.suggest.sports.backends.sportsdata.common.data import Spor
 from merino.providers.suggest.sports.backends.sportsdata.common.elastic import (
     SportsDataStore,
     ElasticCredentials,
+)
+from merino.providers.suggest.sports.backends.sportsdata.common._metrics import (
+    wcs_job_state_counter,
 )
 from merino.providers.suggest.sports.backends.sportsdata.common.sports import (
     NFL,
@@ -273,6 +277,47 @@ class SportDataUpdater:
             finally:
                 await self.store.shutdown()
 
+    async def run_wcs_loop(self, interval_sec: float, stop_event: asyncio.Event) -> None:
+        """Continuously refresh WCS Elasticsearch data and widget cache.
+
+        Intended for a long-lived pod rather than a k8s CronJob: the store, cache,
+        and HTTP clients built in `__init__` are reused across every iteration
+        instead of being recreated per run. Each iteration is wrapped so a
+        transient provider error is logged and counted but does not stop the loop
+        (which would otherwise crash the pod). The loop exits cleanly once
+        `stop_event` is set, so callers can wire it to SIGTERM for rolling restarts.
+        """
+        logger = logging.getLogger(__name__)
+        # `startup()` is idempotent; open the store once and keep it for the
+        # lifetime of the loop rather than reconnecting every iteration.
+        await self.store.startup()
+        try:
+            while not stop_event.is_set():
+                started = monotonic()
+                wcs_job_state_counter.add(1, {"job_state": "started"})
+                try:
+                    # Widget data must be refreshed before event data; see the
+                    # ordering note on `update_and_cache_wcs`.
+                    await self.update_widget()
+                    await self.update_data()
+                    wcs_job_state_counter.add(1, {"job_state": "succeeded"})
+                except Exception as ex:
+                    logger.error(f"{LOGGING_TAG} WCS loop iteration failed: {ex}")
+                    wcs_job_state_counter.add(1, {"job_state": "failed"})
+                finally:
+                    logger.info(
+                        "wcs loop iteration finished",
+                        extra={"elapsed_sec": monotonic() - started},
+                    )
+                # Cancellable sleep: wake immediately if a shutdown signal arrives
+                # mid-gap rather than blocking for the full interval.
+                try:
+                    await asyncio.wait_for(stop_event.wait(), timeout=interval_sec)
+                except asyncio.TimeoutError:
+                    pass
+        finally:
+            await self.store.shutdown()
+
 
 logger = logging.getLogger(__name__)
 sports_settings = settings.providers.sports
@@ -389,6 +434,38 @@ def update_and_cache_wcs():  # pragma: no cover
             )
     else:
         logger.error("Sports provider unavailable.")
+
+
+@cli.command("run-wcs-loop")
+def run_wcs_loop(interval_sec: float = 60.0):  # pragma: no cover
+    """Continuously refresh WCS data on a long-lived pod (not a CronJob).
+
+    Builds the WCS updater once and loops until SIGTERM/SIGINT. Override the gap
+    between iterations with `--interval-sec`; otherwise `providers.sports.
+    wcs_loop_interval_sec` is used.
+    """
+    if not (store and cache):
+        logger.error("Sports provider unavailable.")
+        raise typer.Exit(code=1)
+    wcs_only_settings = copy.copy(sports_settings)
+    wcs_only_settings.sports = ["WCS"]
+    wcs_provider = SportDataUpdater(
+        settings=wcs_only_settings,
+        store=store,
+        cache=cache,
+        connect_timeout=sports_settings.get("connect_timeout"),
+        read_timeout=sports_settings.get("read_timeout"),
+    )
+
+    async def _main() -> None:
+        stop_event = asyncio.Event()
+        loop = asyncio.get_running_loop()
+        for sig in (signal.SIGTERM, signal.SIGINT):
+            loop.add_signal_handler(sig, stop_event.set)
+        logger.info("Starting WCS loop", extra={"interval_sec": interval_sec})
+        await wcs_provider.run_wcs_loop(interval_sec=interval_sec, stop_event=stop_event)
+
+    asyncio.run(_main())
 
 
 @cli.command("quick_update")

--- a/merino/providers/suggest/sports/backends/sportsdata/common/_metrics.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/_metrics.py
@@ -11,3 +11,8 @@ last_synced_at = _meter.create_gauge(
     unit="s",
     description="Unix timestamp when sportsdata endpoint was last synced successfully",
 )
+# Job state tracking for world cup etl
+wcs_job_state_counter = _meter.create_counter(
+    "merino.sports.sportsdata.endpoint.wcs_job_state",
+    description="Job history (failed/succeeded) for WCS polls",
+)

--- a/merino/providers/suggest/sports/backends/sportsdata/common/sports.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/sports.py
@@ -46,7 +46,6 @@ from merino.providers.suggest.sports.backends.sportsdata.common.wcs_elimination 
 FORCE_IMPORT = ""
 _SEASON_TYPE_POSTSEASON = 3
 _WCS_LIVE_REFRESH_WINDOW_DAYS = 1
-_WCS_GAMES_BY_DATE_TTL = timedelta(minutes=2)
 
 # When creating a new sport class, add its entry to SPORT_CATEGORY_MAP below.
 # The key must match the class name, as that is what is stored in the `Event.sport` field.
@@ -677,6 +676,9 @@ class WCS(Sport):
 
     season: str | None = None
     cache_prefix: str = "sport:wcs:v1"  # Unique prefix for Redis
+    # Local-disk cache lifetime for live `GamesByDate` score fetches. Lower this
+    # (via config) to refresh scores faster, e.g. for the continuous WCS ETL loop.
+    games_by_date_ttl: timedelta
     _lock: asyncio.Lock
     teams: dict[int, Team] = {}
     rounds: dict[int, str] = {}
@@ -725,6 +727,8 @@ class WCS(Sport):
         )
         self._lock = asyncio.Lock()
         self.cache = cache
+        games_by_date_ttl_sec = sport_settings.get("games_by_date_ttl_sec")
+        self.games_by_date_ttl = timedelta(seconds=games_by_date_ttl_sec)
         self.normalized_terms.update(
             {
                 SportTerms.GAME_ID: "GlobalGameId",
@@ -1239,7 +1243,7 @@ class WCS(Sport):
                 response = await get_data(
                     client=client,
                     url=url,
-                    ttl=_WCS_GAMES_BY_DATE_TTL,
+                    ttl=self.games_by_date_ttl,
                     cache_dir=self.cache_dir,
                     headers=self.api_headers(),
                 )

--- a/tests/unit/jobs/sports/test_sportsdata.py
+++ b/tests/unit/jobs/sports/test_sportsdata.py
@@ -4,6 +4,7 @@
 
 """Unit tests for fetch_schedules.py module."""
 
+import asyncio
 from contextlib import nullcontext
 from datetime import datetime, timedelta, timezone
 from typing import Any, cast
@@ -149,4 +150,66 @@ async def test_update_and_cache_wcs_closes_store_on_error(
     with pytest.raises(SportsDataError):
         await updater.update_and_cache_wcs()
 
+    shutdown.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_run_wcs_loop_runs_until_stopped(
+    sport_data_store: SportsDataStore,
+    mocker: MockerFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The WCS loop refreshes widget then event data once per iteration."""
+    monkeypatch.setattr(settings.providers.sports, "sports", ["WCS"])
+    updater = SportDataUpdater(settings=settings.providers.sports, store=sport_data_store)
+    stop_event = asyncio.Event()
+    startup = mocker.AsyncMock()
+    shutdown = mocker.AsyncMock()
+    cast(Any, updater.store).startup = startup
+    cast(Any, updater.store).shutdown = shutdown
+    cast(Any, updater).update_widget = mocker.AsyncMock()
+
+    # Stop the loop as part of the first iteration so it runs exactly once.
+    async def _update_data(*args: Any, **kwargs: Any) -> None:
+        stop_event.set()
+
+    cast(Any, updater).update_data = mocker.AsyncMock(side_effect=_update_data)
+    counter = mocker.patch("merino.jobs.sportsdata_jobs.wcs_job_state_counter")
+
+    await updater.run_wcs_loop(interval_sec=0, stop_event=stop_event)
+
+    startup.assert_awaited_once()
+    cast(Any, updater).update_widget.assert_awaited_once()
+    cast(Any, updater).update_data.assert_awaited_once()
+    counter.add.assert_any_call(1, {"job_state": "started"})
+    counter.add.assert_any_call(1, {"job_state": "succeeded"})
+    shutdown.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_run_wcs_loop_isolates_iteration_errors(
+    sport_data_store: SportsDataStore,
+    mocker: MockerFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failing iteration is logged/counted but does not stop the loop or raise."""
+    monkeypatch.setattr(settings.providers.sports, "sports", ["WCS"])
+    updater = SportDataUpdater(settings=settings.providers.sports, store=sport_data_store)
+    stop_event = asyncio.Event()
+    shutdown = mocker.AsyncMock()
+    cast(Any, updater.store).startup = mocker.AsyncMock()
+    cast(Any, updater.store).shutdown = shutdown
+
+    # update_widget runs first; use it to stop the loop after one failing iteration.
+    async def _update_widget(*args: Any, **kwargs: Any) -> None:
+        stop_event.set()
+
+    cast(Any, updater).update_widget = mocker.AsyncMock(side_effect=_update_widget)
+    cast(Any, updater).update_data = mocker.AsyncMock(side_effect=SportsDataError("provider down"))
+    counter = mocker.patch("merino.jobs.sportsdata_jobs.wcs_job_state_counter")
+
+    # Must not raise despite the iteration failing.
+    await updater.run_wcs_loop(interval_sec=0, stop_event=stop_event)
+
+    counter.add.assert_any_call(1, {"job_state": "failed"})
     shutdown.assert_awaited_once()

--- a/tests/unit/providers/suggest/sports/backends/common/test_sports.py
+++ b/tests/unit/providers/suggest/sports/backends/common/test_sports.py
@@ -2018,6 +2018,13 @@ async def test_ucl_update_events(
     assert "/SchedulesBasic/UCL/2025" in get_data.call_args_list[0].kwargs["url"]
 
 
+def test_wcs_games_by_date_ttl_from_config() -> None:
+    """The live GamesByDate cache TTL is read from config and stored as a timedelta."""
+    expected_sec = settings.providers.sports.sportsdata.WCS.games_by_date_ttl_sec
+    sport = WCS(settings=settings.providers.sports)
+    assert sport.games_by_date_ttl == timedelta(seconds=expected_sec)
+
+
 @pytest.mark.asyncio
 async def test_wcs_load_areas(mock_client: AsyncClient, mocker: MockerFixture) -> None:
     """Test WCS load areas (widget)"""
@@ -2563,7 +2570,7 @@ async def test_wcs_update_events_fetches_games_by_date_for_live_relevant_days(
         "https://api.sportsdata.io/v4/soccer/scores/json/SchedulesBasic/fifa/2026",
         expected_games_by_date_url,
     ]
-    assert get_data.call_args_list[1].kwargs["ttl"] == timedelta(minutes=2)
+    assert get_data.call_args_list[1].kwargs["ttl"] == timedelta(seconds=5)
 
     if expected_status == GameStatus.InProgress:
         assert event.period == "1"


### PR DESCRIPTION


## References

JIRA: https://mozilla-hub.atlassian.net/browse/DISCO-4289

## Description
Option for looping frequently (below 1 minute limits on k8s) on a continuously running pod.

This can be safely merged without impacting prod at all, because it's just a job config. It runs locally as expected.
