### PR TITLE
AIMOD-1240 Add german support for Spindle article deduplication

### DIFF
--- a/merino/curated_recommendations/ml_backends/spindle_backend.py
+++ b/merino/curated_recommendations/ml_backends/spindle_backend.py
@@ -30,10 +30,12 @@ LANGUAGE_FOR_SURFACE: dict[SurfaceId, str] = {
     SurfaceId.NEW_TAB_EN_CA: "en",
     SurfaceId.NEW_TAB_EN_GB: "en",
     SurfaceId.NEW_TAB_EN_IE: "en",
+    SurfaceId.NEW_TAB_DE_DE: "de",
 }
 
 LOCALE_FOR_SURFACE: dict[SurfaceId, str] = {
     SurfaceId.NEW_TAB_EN_US: "en_US",
+    SurfaceId.NEW_TAB_DE_DE: "de_DE",
 }
 
 METRIC_NAMESPACE = "recommendation.spindle"

--- a/tests/unit/curated_recommendations/ml_backends/test_spindle_backend.py
+++ b/tests/unit/curated_recommendations/ml_backends/test_spindle_backend.py
@@ -80,7 +80,7 @@ class TestSpindleBackendRefresh:
         http_client = MagicMock(spec=AsyncClient)
         http_client.post = AsyncMock()
         backend = _make_backend(http_client)
-        await backend.refresh_duplicate_item_info([_item("a")], SurfaceId.NEW_TAB_DE_DE)
+        await backend.refresh_duplicate_item_info([_item("a")], SurfaceId.NEW_TAB_FR_FR)
         http_client.post.assert_not_called()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## References

We've added multi-lingual support for the Spindle service.

To that end, we're enabling for the Germany in addition to the English locales. 

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2398)
