### PR TITLE
fix(wcs): DISCO-4287 Return previous matches from newest to oldest

### DIFF
--- a/merino/providers/wcs/protocol.py
+++ b/merino/providers/wcs/protocol.py
@@ -160,7 +160,8 @@ class EventInfo(BaseModel):
 class MatchesResponse(BaseModel):
     """Response payload for `GET /api/v1/wcs/matches`.
 
-    Buckets are grouped by match state and sorted by `EventInfo.date` ascending.
+    Buckets are grouped by match state. `previous` is sorted by `EventInfo.date`
+    descending; `current` and `next` are sorted by `EventInfo.date` ascending.
     `next_` is aliased to `next` on the wire; populate by either name in Python.
     """
 

--- a/merino/providers/wcs/provider.py
+++ b/merino/providers/wcs/provider.py
@@ -81,9 +81,10 @@ class WcsProvider:
         Events are sorted ascending by event date, then bucketed by match state
         at request time: completed/past matches in `previous`, active or
         just-started scheduled matches in `current`, and scheduled future matches
-        in `next`. `limit` keeps the entries closest to `target_date` in each
-        bucket; `team_keys` restricts results to matches involving any of the
-        listed teams.
+        in `next`. The `previous` bucket is returned newest-first while `current`
+        and `next` remain chronological. `limit` keeps the entries closest to
+        `target_date` in each bucket; `team_keys` restricts results to matches
+        involving any of the listed teams.
         """
         previous: list[EventInfo] = []
         current: list[EventInfo] = []
@@ -113,6 +114,7 @@ class WcsProvider:
         if limit is not None:
             previous, current, next_ = previous[-limit:], current[:limit], next_[:limit]
 
+        previous.reverse()
         return MatchesResponse(previous=previous, current=current, next_=next_)
 
     @WCSCircuitBreaker(name="wcs_live_matches")

--- a/merino/web/api_v1_wcs.py
+++ b/merino/web/api_v1_wcs.py
@@ -58,8 +58,8 @@ async def get_wcs_matches(
 
     The window is around `date`. `previous` holds completed or old matches,
     `current` holds active matches and scheduled matches during the short
-    post-kickoff feed-lag grace period, and `next` holds upcoming matches. Each
-    bucket is sorted ascending by event date.
+    post-kickoff feed-lag grace period, and `next` holds upcoming matches.
+    `previous` is newest-first; `current` and `next` are chronological.
     """
     target_date = date or datetime.now(UTC).date()
     team_keys = _parse_team_keys(teams)

--- a/tests/integration/api/v1/wcs/test_matches.py
+++ b/tests/integration/api/v1/wcs/test_matches.py
@@ -70,6 +70,15 @@ def test_matches_per_bucket(client: TestClient) -> None:
     assert all(e["status"] == "Scheduled" for e in body["next"])
 
 
+def test_buckets_are_sorted_for_display(client: TestClient) -> None:
+    """Results are newest-first while current and upcoming stay chronological."""
+    body = client.get(_PATH, params={"date": _ANCHOR}).json()
+
+    assert body["previous"] == sorted(body["previous"], key=lambda e: e["date"], reverse=True)
+    assert body["current"] == sorted(body["current"], key=lambda e: e["date"])
+    assert body["next"] == sorted(body["next"], key=lambda e: e["date"])
+
+
 @freezegun.freeze_time("2026-06-15T12:00:00Z")
 def test_same_day_scheduled_match_is_next_until_kickoff(client: TestClient) -> None:
     """A same-day scheduled match remains upcoming until kickoff."""

--- a/tests/unit/providers/wcs/test_provider.py
+++ b/tests/unit/providers/wcs/test_provider.py
@@ -279,11 +279,12 @@ async def test_window_excludes_outside_range() -> None:
 
 
 @pytest.mark.asyncio
-async def test_buckets_sorted_ascending_by_date() -> None:
-    """Each bucket is sorted by event date ascending."""
+async def test_buckets_sorted_by_display_order() -> None:
+    """Previous is newest-first; current and next remain chronological."""
     response = await build_provider().get_matches(ANCHOR, limit=None, team_keys=None)
 
-    for bucket in (response.previous, response.current, response.next_):
+    assert response.previous == sorted(response.previous, key=lambda e: e.date, reverse=True)
+    for bucket in (response.current, response.next_):
         assert bucket == sorted(bucket, key=lambda e: e.date)
 
 
@@ -298,7 +299,7 @@ async def test_limit_keeps_closest_to_target_date() -> None:
     assert len(limited.current) <= 1
     assert len(limited.next_) <= 1
     if full.previous and limited.previous:
-        assert limited.previous[-1].date == full.previous[-1].date
+        assert limited.previous[0].date == full.previous[0].date
     if full.next_ and limited.next_:
         assert limited.next_[0].date == full.next_[0].date
 


### PR DESCRIPTION
## References

JIRA: [DISCO-4287](https://mozilla-hub.atlassian.net/browse/DISCO-4287)

## Description
Change the order of the games in the `previous` bucket from newest to oldest.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2399)


[DISCO-4287]: https://mozilla-hub.atlassian.net/browse/DISCO-4287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ