### PR TITLE
HNT-2673 feat: wire up particle green deploy roll-back functionality

### DIFF
--- a/merino/providers/games/particle/backends/filemanager.py
+++ b/merino/providers/games/particle/backends/filemanager.py
@@ -9,6 +9,7 @@ from json import JSONDecodeError
 from typing import Any
 
 from merino.providers.games.particle.backends.errors import ParticleFileManagerError
+from merino.providers.games.particle.backends.utils import GameFile
 from merino.utils.gcs.gcs_uploader import GcsUploader
 
 logger = logging.getLogger(__name__)
@@ -117,7 +118,12 @@ class ParticleRemoteFileManager:
             sentry_sdk.capture_exception(ParticleFileManagerError(str(ex)))
             return ""
 
-    async def empty_staging_folder(self) -> bool:
-        """Delete all contents of the GCS staging folder. Used when a channel staging fails, e.g. due to SHA validation or upload failure."""
-        # stub
-        return True
+    async def empty_staging_folder(self, files: list[GameFile]) -> None:
+        """Delete uploaded files in the GCS staging folder. Used when a channel staging deployment fails midway, e.g. due to SHA validation or upload failure."""
+        uploaded_files = [f for f in files if f.uploaded and hasattr(f, "gcs_staging_name")]
+
+        for f in uploaded_files:
+            try:
+                await asyncio.to_thread(self.gcs_client.delete_file_by_name, f.gcs_staging_name)
+            except Exception as ex:
+                sentry_sdk.capture_exception(ParticleFileManagerError(str(ex)))

--- a/merino/providers/games/particle/backends/particle.py
+++ b/merino/providers/games/particle/backends/particle.py
@@ -191,7 +191,7 @@ class ParticleBackend:
         # if some files were uploaded but not all, erase the partial green deployment
         # by clearing out the GCS "green" folder
         if any(f.uploaded for f in files) and not all(f.uploaded for f in files):
-            await self.remote_file_manager.empty_staging_folder()
+            await self.remote_file_manager.empty_staging_folder(files=files)
 
         # return set of files with sha_verified and uploaded properties
         # (potentially) updated

--- a/merino/utils/gcs/gcs_uploader.py
+++ b/merino/utils/gcs/gcs_uploader.py
@@ -144,3 +144,14 @@ class GcsUploader(BaseContentUploader):
             return most_recent
 
         return None
+
+    def delete_file_by_name(self, blob_name: str) -> None:
+        """Delete a file by name."""
+        bucket: Bucket = self.storage_client.get_bucket(self.bucket_name)
+        blob = bucket.blob(blob_name)
+
+        try:
+            blob.delete()
+        except Exception as e:
+            logger.error(f"Exception {e} occurred while deleting {blob_name}")
+            raise e

--- a/tests/integration/providers/games/particle/test_filemanager.py
+++ b/tests/integration/providers/games/particle/test_filemanager.py
@@ -12,6 +12,9 @@ from merino.providers.games.particle.backends.filemanager import (
 )
 
 
+GREEN_DEPLOYMENT_FOLDER = "green_deployment"
+
+
 @pytest.fixture(scope="function")
 def gcs_storage_bucket(gcs_storage_client) -> Bucket:
     """Return a test google storage bucket object to be used by all tests. Delete it
@@ -26,51 +29,43 @@ def gcs_storage_bucket(gcs_storage_client) -> Bucket:
     bucket.delete(force=True)
 
 
+@pytest.fixture
+def gcs_client(gcs_storage_client, gcs_storage_bucket) -> GcsUploader:
+    """Return a GcsUploader instance."""
+    return GcsUploader(
+        destination_gcp_project=gcs_storage_client.project,
+        destination_bucket_name=gcs_storage_bucket.name,
+        destination_cdn_hostname="test_cdn_hostname",
+    )
+
+
+@pytest.fixture
+def remote_filemanager(gcs_client) -> ParticleRemoteFileManager:
+    """Return a ParticleRemoteFileManager instance."""
+    return ParticleRemoteFileManager(
+        gcs_client=gcs_client,
+        manifest_file_name="test-manifest.json",
+        green_deployment_folder=GREEN_DEPLOYMENT_FOLDER,
+    )
+
+
 class TestRemoteFileManagerUploadFile:
     """Tests against the upload_file method of the ParticleRemoteFileManager."""
 
-    GREEN_DEPLOYMENT_FOLDER = "green_deployment"
-
     @pytest.mark.asyncio
-    async def test_successful_upload(self, gcs_storage_client, gcs_storage_bucket):
+    async def test_successful_upload(self, remote_filemanager):
         """Verify a successful upload."""
-        # create a GcsUploader instance
-        gcs_client = GcsUploader(
-            destination_gcp_project=gcs_storage_client.project,
-            destination_bucket_name=gcs_storage_bucket.name,
-            destination_cdn_hostname="test_cdn_hostname",
-        )
-
-        remote_filemanager = ParticleRemoteFileManager(
-            gcs_client=gcs_client,
-            manifest_file_name="test-manifest.json",
-            green_deployment_folder=self.GREEN_DEPLOYMENT_FOLDER,
-        )
-
         blob_name = await remote_filemanager.upload_file(
             file_name="image.jpg",
             file_path="tests/data/games/particle/image.jpg",
             content_type="image/jpeg",
         )
 
-        assert blob_name == f"{self.GREEN_DEPLOYMENT_FOLDER}/image.jpg"
+        assert blob_name == f"{GREEN_DEPLOYMENT_FOLDER}/image.jpg"
 
     @pytest.mark.asyncio
-    async def test_unsuccessful_upload(self, gcs_storage_client, gcs_storage_bucket):
+    async def test_unsuccessful_upload(self, remote_filemanager):
         """Verify an unsuccessful upload."""
-        # create a GcsUploader instance
-        gcs_client = GcsUploader(
-            destination_gcp_project=gcs_storage_client.project,
-            destination_bucket_name=gcs_storage_bucket.name,
-            destination_cdn_hostname="test_cdn_hostname",
-        )
-
-        remote_filemanager = ParticleRemoteFileManager(
-            gcs_client=gcs_client,
-            manifest_file_name="test-manifest.json",
-            green_deployment_folder=self.GREEN_DEPLOYMENT_FOLDER,
-        )
-
         with patch.object(
             remote_filemanager.gcs_client, "upload_from_filename", new_callable=AsyncMock
         ) as mock_upload_from_filename:

--- a/tests/integration/utils/test_gcs_uploader.py
+++ b/tests/integration/utils/test_gcs_uploader.py
@@ -21,17 +21,21 @@ def gcs_storage_bucket(gcs_storage_client) -> Bucket:
     bucket.delete(force=True)
 
 
+@pytest.fixture
+def gcs_client(gcs_storage_client, gcs_storage_bucket) -> GcsUploader:
+    """Return a GcsUploader instance."""
+    return GcsUploader(
+        destination_gcp_project=gcs_storage_client.project,
+        destination_bucket_name=gcs_storage_bucket.name,
+        destination_cdn_hostname="test_cdn_hostname",
+    )
+
+
 class TestGetFileByName:
     """Tests against get_file_by_name function."""
 
-    def test_success(self, gcs_storage_client, gcs_storage_bucket):
+    def test_success(self, gcs_client):
         """Verify a found blob returns said blob."""
-        gcs_client = GcsUploader(
-            destination_gcp_project=gcs_storage_client.project,
-            destination_bucket_name=gcs_storage_bucket.name,
-            destination_cdn_hostname="test_cdn_hostname",
-        )
-
         # put a blob in the bucket
         gcs_client.upload_from_filename(
             file_path="tests/data/games/particle/image.jpg",
@@ -44,38 +48,20 @@ class TestGetFileByName:
 
         assert blob
 
-    def test_missing_blob(self, gcs_storage_client, gcs_storage_bucket):
+    def test_missing_blob(self, gcs_client):
         """Verify a missing blob returns None."""
-        gcs_client = GcsUploader(
-            destination_gcp_project=gcs_storage_client.project,
-            destination_bucket_name=gcs_storage_bucket.name,
-            destination_cdn_hostname="test_cdn_hostname",
-        )
-
         assert not gcs_client.get_file_by_name("image.jpg")
 
-    def test_empty_blob_name_returns_none(self, gcs_storage_client, gcs_storage_bucket):
-        """Verify when given an empty string blob name, None is returned."""
-        gcs_client = GcsUploader(
-            destination_gcp_project=gcs_storage_client.project,
-            destination_bucket_name=gcs_storage_bucket.name,
-            destination_cdn_hostname="test_cdn_hostname",
-        )
-
+    def test_empty_blob_name_returns_none(self, gcs_client):
+        """Verify passing an empty string blob_name returns None."""
         assert not gcs_client.get_file_by_name("")
 
 
 class TestUploadFromFilename:
     """Tests against the upload_from_filename function."""
 
-    def test_success(self, gcs_storage_client, gcs_storage_bucket):
+    def test_success(self, gcs_client):
         """Verify success returns truthy (a blob)."""
-        gcs_client = GcsUploader(
-            destination_gcp_project=gcs_storage_client.project,
-            destination_bucket_name=gcs_storage_bucket.name,
-            destination_cdn_hostname="test_cdn_hostname",
-        )
-
         blob = gcs_client.upload_from_filename(
             file_path="tests/data/games/particle/image.jpg",
             destination_name="image.jpg",
@@ -84,10 +70,11 @@ class TestUploadFromFilename:
 
         assert blob.name == "image.jpg"
 
-    def test_failure(self, gcs_storage_client):
-        """Verify failure raises."""
+    def test_bucket_failure(self, gcs_storage_client):
+        """Verify bucket failure raises."""
         gcs_client = GcsUploader(
             destination_gcp_project=gcs_storage_client.project,
+            # invalid bucket name
             destination_bucket_name="invalidBucketName",
             destination_cdn_hostname="test_cdn_hostname",
         )
@@ -98,3 +85,57 @@ class TestUploadFromFilename:
                 destination_name="image.jpg",
                 content_type="image/jpeg",
             )
+
+    def test_file_path_failure(self, gcs_client):
+        """Verify invalid file path failure raises."""
+        with pytest.raises(Exception):
+            gcs_client.upload_from_filename(
+                # file path is invalid
+                file_path="tests/data/games/particle/missing.jpg",
+                destination_name="missing.jpg",
+                content_type="image/jpeg",
+            )
+
+
+class TestDeleteFileByName:
+    """Tests against the delete_file_by_name function."""
+
+    def test_success(self, gcs_client):
+        """Verify the blob is deleted."""
+        # put a file in the bucket to delete
+        gcs_client.upload_from_filename(
+            file_path="tests/data/games/particle/image.jpg",
+            destination_name="image.jpg",
+            content_type="image/jpeg",
+        )
+
+        # make sure the file exists
+        blob = gcs_client.get_file_by_name("image.jpg")
+
+        assert blob
+
+        # delete the file
+        gcs_client.delete_file_by_name("image.jpg")
+
+        # make sure the file doesn't exist
+        blob = gcs_client.get_file_by_name("image.jpg")
+
+        assert not blob
+
+    def test_failure(self, gcs_client):
+        """Verify the blob is not deleted when an exception occurs."""
+        # put a file in the bucket to delete
+        gcs_client.upload_from_filename(
+            file_path="tests/data/games/particle/image.jpg",
+            destination_name="image.jpg",
+            content_type="image/jpeg",
+        )
+
+        # make sure the file exists
+        blob = gcs_client.get_file_by_name("image.jpg")
+
+        assert blob
+
+        with pytest.raises(Exception):
+            # try to delete a file that doesn't exist
+            gcs_client.delete_file_by_name("notfound.jpg")

--- a/tests/unit/providers/games/particle/backends/test_filemanager.py
+++ b/tests/unit/providers/games/particle/backends/test_filemanager.py
@@ -16,7 +16,8 @@ from pytest import LogCaptureFixture
 from pytest_mock import MockerFixture
 from tests.types import FilterCaplogFixture
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest import mock
+from unittest.mock import call, MagicMock, patch
 
 from merino.configs import settings
 from merino.providers.games.particle.backends.filemanager import (
@@ -24,6 +25,7 @@ from merino.providers.games.particle.backends.filemanager import (
     ParticleLocalFileManager,
     ParticleRemoteFileManager,
 )
+from merino.providers.games.particle.backends.utils import GameFile
 from merino.utils.gcs.gcs_uploader import GcsUploader
 
 
@@ -82,64 +84,68 @@ class TestLocalFileManager:
             test_path.get_manifest_schema()
 
 
+@pytest.fixture(name="manifest_json")
+def fixture_manifest_json():
+    """Load manifest data from local file"""
+    with open("tests/data/games/particle/runtime-manifest.v1.json") as f:
+        return f.read()
+
+
+@pytest.fixture(name="manifest_gcs_blob_mock")
+def fixture_gcs_manifest_blob(mocker: MockerFixture, manifest_json: str) -> Any:
+    """Create a GCS Blob mock object for testing."""
+    mock_blob = mocker.MagicMock(spec=Blob)
+    mock_blob.name = "runtime-manifest.v1.json"
+    mock_blob.download_as_text.return_value = manifest_json
+
+    return mock_blob
+
+
+@pytest.fixture(name="gcs_uploader_mock")
+def fixture_gcs_uploader_mock(manifest_gcs_blob_mock) -> GcsUploader:
+    """Return a mock GcsUploader."""
+    mock = MagicMock(spec=GcsUploader)
+    mock.get_file_by_name.return_value = manifest_gcs_blob_mock
+
+    return mock
+
+
+@pytest.fixture(name="remote_filemanager_parameters")
+def fixture_remote_filemanager_parameters(gcs_uploader_mock) -> dict[str, Any]:
+    """Define ParticleRemoteFileManager parameters for test."""
+    return {
+        "gcs_client": gcs_uploader_mock,
+        "manifest_file_name": "test_manifest.json",
+        "green_deployment_folder": "green_deployment",
+    }
+
+
+@pytest.fixture(name="remote_filemanager")
+def fixture_remote_filemanager(
+    remote_filemanager_parameters: dict[str, Any],
+) -> ParticleRemoteFileManager:
+    """Create a ParticleRemoteFileManager object for test."""
+    with (
+        patch("google.auth.default") as mock_auth_default,
+    ):
+        creds = AnonymousCredentials()  # type: ignore
+        mock_auth_default.return_value = (creds, "test-project")
+        return ParticleRemoteFileManager(**remote_filemanager_parameters)
+
+
 class TestRemoteFileManager:
-    """Tests against Particle RemoteFileManager"""
-
-    @pytest.fixture(name="manifest_json")
-    def fixture_manifest_json(self):
-        """Load manifest data from local file"""
-        with open("tests/data/games/particle/runtime-manifest.v1.json") as f:
-            return f.read()
-
-    @pytest.fixture(name="manifest_gcs_blob_mock")
-    def fixture_gcs_manifest_blob(self, mocker: MockerFixture, manifest_json: str) -> Any:
-        """Create a GCS Blob mock object for testing."""
-        mock_blob = mocker.MagicMock(spec=Blob)
-        mock_blob.name = "runtime-manifest.v1.json"
-        mock_blob.download_as_text.return_value = manifest_json
-
-        return mock_blob
-
-    @pytest.fixture(name="gcs_uploader_mock")
-    def fixture_gcs_uploader_mock(self, manifest_gcs_blob_mock) -> GcsUploader:
-        """Return a mock GcsUploader."""
-        mock = MagicMock(spec=GcsUploader)
-        mock.get_file_by_name.return_value = manifest_gcs_blob_mock
-
-        return mock
-
-    @pytest.fixture(name="filemanager_parameters")
-    def fixture_filemanager_parameters(self, gcs_uploader_mock) -> dict[str, Any]:
-        """Define ParticleRemoteFileManager parameters for test."""
-        return {
-            "gcs_client": gcs_uploader_mock,
-            "manifest_file_name": "test_manifest.json",
-            "green_deployment_folder": "green_deployment",
-        }
-
-    @pytest.fixture(name="filemanager")
-    def fixture_particle_remote_filemanager(
-        self,
-        filemanager_parameters: dict[str, Any],
-    ) -> ParticleRemoteFileManager:
-        """Create a ParticleRemoteFileManager object for test."""
-        with (
-            patch("google.auth.default") as mock_auth_default,
-        ):
-            creds = AnonymousCredentials()  # type: ignore
-            mock_auth_default.return_value = (creds, "test-project")
-            return ParticleRemoteFileManager(**filemanager_parameters)
+    """Tests against Particle RemoteFileManager."""
 
     def test_get_manifest_file(
         self,
-        filemanager: ParticleRemoteFileManager,
+        remote_filemanager: ParticleRemoteFileManager,
         caplog: LogCaptureFixture,
         filter_caplog: FilterCaplogFixture,
     ) -> None:
         """Test that the Remote Filemanager get_manifest_file method returns manifest data."""
         caplog.set_level(logging.INFO)
 
-        result = filemanager.get_manifest_file()
+        result = remote_filemanager.get_manifest_file()
 
         records: list[LogRecord] = filter_caplog(
             caplog.records, "merino.providers.games.particle.backends.filemanager"
@@ -156,38 +162,136 @@ class TestRemoteFileManager:
 
     def test_get_manifest_file_empty(
         self,
-        filemanager: ParticleRemoteFileManager,
+        remote_filemanager: ParticleRemoteFileManager,
     ) -> None:
         """Test that the RemoteFileManager raises when the call to GCS returns None."""
-        filemanager.gcs_client = MagicMock()
-        filemanager.gcs_client.get_file_by_name.return_value = None
+        remote_filemanager.gcs_client = MagicMock()
+        remote_filemanager.gcs_client.get_file_by_name.return_value = None
 
         with pytest.raises(ParticleFileManagerError):
-            filemanager.get_manifest_file()
+            remote_filemanager.get_manifest_file()
 
     def test_get_manifest_file_invalid_json(
         self,
-        filemanager: ParticleRemoteFileManager,
+        remote_filemanager: ParticleRemoteFileManager,
     ) -> None:
         """Test that the RemoteFileManager raises when the call to GCS returns invalid JSON."""
-        filemanager.gcs_client = MagicMock()
-        filemanager.gcs_client.get_file_by_name.return_value = "invalid json"
+        remote_filemanager.gcs_client = MagicMock()
+        remote_filemanager.gcs_client.get_file_by_name.return_value = "invalid json"
 
         with pytest.raises(ParticleFileManagerError):
-            filemanager.get_manifest_file()
+            remote_filemanager.get_manifest_file()
 
     def test_get_manifest_file_error(
         self,
-        filemanager: ParticleRemoteFileManager,
+        remote_filemanager: ParticleRemoteFileManager,
     ) -> None:
         """Test that the RemoteFileManager raises when the call to GCS fails."""
-        filemanager.gcs_client = MagicMock()
-        filemanager.gcs_client.get_file_by_name.side_effect = Exception("Test error")
+        remote_filemanager.gcs_client = MagicMock()
+        remote_filemanager.gcs_client.get_file_by_name.side_effect = Exception("Test error")
 
         with pytest.raises(ParticleFileManagerError):
-            filemanager.get_manifest_file()
+            remote_filemanager.get_manifest_file()
+
+
+class TestRemoteFileManagerEmptyStagingFolder:
+    """Tests against the empty_staging_folder function of ParticleRemoteFileManager."""
 
     @pytest.mark.asyncio
-    async def test_empty_staging_folder(self, filemanager):
-        """Stub test."""
-        assert await filemanager.empty_staging_folder()
+    async def test_success(self, remote_filemanager):
+        """Verify the call succeeds."""
+        # simulate a partially staged fileset
+        files: list[GameFile] = [
+            GameFile(url="https://test.com/test.html", sha="1234abcd", content_type="text/html"),
+            GameFile(url="https://test.com/test.jpg", sha="1234abcd", content_type="image/jpeg"),
+            GameFile(url="https://test.com/test.png", sha="1234abcd", content_type="image/png"),
+            GameFile(
+                url="https://test.com/test.json", sha="1234abcd", content_type="application/json"
+            ),
+        ]
+
+        # only some of the files were successfully uploaded
+        files[0].uploaded = True
+        files[0].gcs_staging_name = "green/test.html"
+        files[1].uploaded = True
+        files[1].gcs_staging_name = "green/test.jpg"
+        files[3].uploaded = True
+        files[3].gcs_staging_name = "green/test.json"
+
+        with patch.object(remote_filemanager.gcs_client, "delete_file_by_name") as mock_delete:
+            await remote_filemanager.empty_staging_folder(files)
+
+            assert mock_delete.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_filters_files_correctly(self, remote_filemanager):
+        """Verify the call succeeds and filters files correctly."""
+        # simulate a partially staged fileset
+        files: list[GameFile] = [
+            GameFile(url="https://test.com/test.html", sha="1234abcd", content_type="text/html"),
+            GameFile(url="https://test.com/test.jpg", sha="1234abcd", content_type="image/jpeg"),
+            GameFile(url="https://test.com/test.png", sha="1234abcd", content_type="image/png"),
+            GameFile(
+                url="https://test.com/test.json", sha="1234abcd", content_type="application/json"
+            ),
+        ]
+
+        # only some of the files were successfully uploaded
+        files[0].uploaded = True
+        files[0].gcs_staging_name = "green/test.html"
+        # this file is in an invalid state - no gcs_staging_name set, so it
+        # shouldn't be processed
+        files[1].uploaded = True
+        files[3].uploaded = True
+        files[3].gcs_staging_name = "green/test.json"
+
+        with patch.object(remote_filemanager.gcs_client, "delete_file_by_name") as mock_delete:
+            await remote_filemanager.empty_staging_folder(files)
+
+            # should have only been called twice
+            assert mock_delete.call_count == 2
+
+            # should only have been called with files with a gcs_staging_name
+            calls = [call("green/test.html"), call("green/test.json")]
+
+            mock_delete.assert_has_calls(calls)
+
+    @pytest.mark.asyncio
+    async def test_failure(self, remote_filemanager, mocker):
+        """Verify sentry is called when the GCS client captures an exception."""
+        # simulate a partially staged fileset
+        files: list[GameFile] = [
+            GameFile(url="https://test.com/test.html", sha="1234abcd", content_type="text/html"),
+            GameFile(url="https://test.com/test.jpg", sha="1234abcd", content_type="image/jpeg"),
+            GameFile(url="https://test.com/test.png", sha="1234abcd", content_type="image/png"),
+            GameFile(
+                url="https://test.com/test.json", sha="1234abcd", content_type="application/json"
+            ),
+        ]
+
+        # only some of the files were successfully uploaded
+        files[0].uploaded = True
+        files[0].gcs_staging_name = "green/test.html"
+        files[1].uploaded = True
+        files[1].gcs_staging_name = "green/test.jpg"
+        files[3].uploaded = True
+        files[3].gcs_staging_name = "green/test.json"
+
+        sentry_capture = mocker.patch(
+            "merino.providers.games.particle.backends.filemanager.sentry_sdk.capture_exception"
+        )
+
+        with patch.object(remote_filemanager.gcs_client, "delete_file_by_name") as mock_delete:
+            mock_delete.side_effect = [
+                Exception("first delete fails"),
+                mock.DEFAULT,
+                Exception("third delete fails"),
+            ]
+
+            await remote_filemanager.empty_staging_folder(files)
+
+            # each file should be attempted to be deleted
+            assert mock_delete.call_count == 3
+
+            # two of the deletes should fail and send to sentry
+            assert sentry_capture.call_count == 2


### PR DESCRIPTION
## References

JIRA: [HNT-2673](https://mozilla-hub.atlassian.net/browse/HNT-2673)

## Description

wires up the rollback function called if a staging deploy partially fails.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2400)


[HNT-2673]: https://mozilla-hub.atlassian.net/browse/HNT-2673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ