### PR TITLE
[DISCO-4288] (fix): do not send empty query to fleece

### DIFF
--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -267,7 +267,8 @@ async def suggest(
     # optionally run PII detection via merino-fleece, behind the `fleece-pii-detection` flag.
     fleece_client = get_fleece_client()
     if (
-        fleece_client is not None
+        q
+        and fleece_client is not None
         and FeatureFlags().is_enabled("fleece-pii-detection")
         and await fleece_client.detect_pii_safe(q, metrics_client)
     ):

--- a/tests/integration/api/v1/suggest/test_suggest.py
+++ b/tests/integration/api/v1/suggest/test_suggest.py
@@ -410,6 +410,18 @@ def test_suggest_fleece_not_called_when_flag_off(
     fleece_mock.detect_pii_safe.assert_not_called()
 
 
+def test_suggest_fleece_not_called_for_empty_query(
+    mocker: MockerFixture, client: TestClient
+) -> None:
+    """Test that an empty query is not sent to fleece"""
+    fleece_mock = _patch_fleece(mocker, enabled=True, pii=True)
+
+    response = client.get("/api/v1/suggest?q=")
+
+    assert response.status_code == 200
+    fleece_mock.detect_pii_safe.assert_not_called()
+
+
 def test_suggest_with_invalid_geolocation_ip(
     mocker: MockerFixture,
     caplog: LogCaptureFixture,
@@ -442,11 +454,19 @@ def test_suggest_with_invalid_geolocation_ip(
                 ("get.api.v1.suggest.timing", None),
                 (
                     "get.api.v1.suggest.status_codes.200",
-                    {"browser": "Firefox(103.0)", "form_factor": "desktop", "os_family": "macos"},
+                    {
+                        "browser": "Firefox(103.0)",
+                        "form_factor": "desktop",
+                        "os_family": "macos",
+                    },
                 ),
                 (
                     "response.status_codes.200",
-                    {"browser": "Firefox(103.0)", "form_factor": "desktop", "os_family": "macos"},
+                    {
+                        "browser": "Firefox(103.0)",
+                        "form_factor": "desktop",
+                        "os_family": "macos",
+                    },
                 ),
             ],
         ),
@@ -457,11 +477,19 @@ def test_suggest_with_invalid_geolocation_ip(
                 ("get.api.v1.suggest.timing", None),
                 (
                     "get.api.v1.suggest.status_codes.200",
-                    {"browser": "Firefox(103.0)", "form_factor": "desktop", "os_family": "macos"},
+                    {
+                        "browser": "Firefox(103.0)",
+                        "form_factor": "desktop",
+                        "os_family": "macos",
+                    },
                 ),
                 (
                     "response.status_codes.200",
-                    {"browser": "Firefox(103.0)", "form_factor": "desktop", "os_family": "macos"},
+                    {
+                        "browser": "Firefox(103.0)",
+                        "form_factor": "desktop",
+                        "os_family": "macos",
+                    },
                 ),
             ],
         ),
@@ -484,11 +512,19 @@ def test_suggest_with_invalid_geolocation_ip(
                 ("get.api.v1.suggest.timing", None),
                 (
                     "get.api.v1.suggest.status_codes.200",
-                    {"browser": "Firefox(103.0)", "form_factor": "desktop", "os_family": "macos"},
+                    {
+                        "browser": "Firefox(103.0)",
+                        "form_factor": "desktop",
+                        "os_family": "macos",
+                    },
                 ),
                 (
                     "response.status_codes.200",
-                    {"browser": "Firefox(103.0)", "form_factor": "desktop", "os_family": "macos"},
+                    {
+                        "browser": "Firefox(103.0)",
+                        "form_factor": "desktop",
+                        "os_family": "macos",
+                    },
                 ),
             ],
         ),
@@ -498,16 +534,29 @@ def test_suggest_with_invalid_geolocation_ip(
                 ("get.api.v1.suggest.timing", None),
                 (
                     "get.api.v1.suggest.status_codes.400",
-                    {"browser": "Firefox(103.0)", "form_factor": "desktop", "os_family": "macos"},
+                    {
+                        "browser": "Firefox(103.0)",
+                        "form_factor": "desktop",
+                        "os_family": "macos",
+                    },
                 ),
                 (
                     "response.status_codes.400",
-                    {"browser": "Firefox(103.0)", "form_factor": "desktop", "os_family": "macos"},
+                    {
+                        "browser": "Firefox(103.0)",
+                        "form_factor": "desktop",
+                        "os_family": "macos",
+                    },
                 ),
             ],
         ),
     ],
-    ids=["status_code_200", "status_code_200_pii", "status_code_200_soft_pii", "status_code_400"],
+    ids=[
+        "status_code_200",
+        "status_code_200_pii",
+        "status_code_200_soft_pii",
+        "status_code_400",
+    ],
 )
 def test_suggest_metrics(
     mocker: MockerFixture,


### PR DESCRIPTION
## References

JIRA: [DISCO-4288](https://mozilla-hub.atlassian.net/browse/DISCO-4288)

## Description
Fix for the 422 error - we shouldn't sanitize empty queries so we are skipping pii detection for empty queries



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2402)


[DISCO-4288]: https://mozilla-hub.atlassian.net/browse/DISCO-4288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ