### PR TITLE
[AIMOD-1325] headlines no longer barred from popular_today, affects all locales

### DIFF
--- a/merino/curated_recommendations/protocol.py
+++ b/merino/curated_recommendations/protocol.py
@@ -312,11 +312,7 @@ class CuratedRecommendation(CorpusItem):
 
     def is_story_blocked_for_top_stories(self) -> bool:
         """Return true if the story should be blocked from most popular section."""
-        return (
-            self.in_experiment(ITEM_SUBTOPIC_FLAG)
-            or self.in_experiment(ITEM_HEADLINES_FLAG)
-            or self.topic == Topic.GAMING
-        )
+        return self.in_experiment(ITEM_SUBTOPIC_FLAG) or self.topic == Topic.GAMING
 
     @model_validator(mode="before")
     def set_tileId(cls, values):

--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -155,8 +155,7 @@ def map_corpus_section_to_section(
     is_headlines = corpus_section.externalId == HEADLINES_SECTION_KEY
     is_world_cup = corpus_section.externalId.startswith("worldcup")
     if is_headlines:
-        # Block headlines from Popular Today to avoid duplicate content with
-        # The Latest / Daily Briefing sections (HNT-2167).
+        # Preserve headlines provenance without treating it as a subtopic.
         item_flags.add(ITEM_HEADLINES_FLAG)
     elif is_world_cup:
         item_flags.add(ITEM_WORLD_CUP_FLAG)

--- a/tests/unit/curated_recommendations/test_rankers.py
+++ b/tests/unit/curated_recommendations/test_rankers.py
@@ -1214,13 +1214,13 @@ class TestTopStoriesArticleBalancer:
         """Test that blocked stories are identified correctly."""
         blocked_story1 = self._build_recommendation("1", Topic.GAMING)
         blocked_story2 = self._build_recommendation("1", Topic.ARTS, subtopic=True)
-        blocked_story3 = self._build_recommendation("1", Topic.BUSINESS, headlines=True)
+        headlines_story = self._build_recommendation("1", Topic.BUSINESS, headlines=True)
         allowed_story1 = self._build_recommendation("2", Topic.BUSINESS)
         allowed_story2 = self._build_recommendation("2", Topic.SPORTS)
 
         assert blocked_story1.is_story_blocked_for_top_stories() is True
         assert blocked_story2.is_story_blocked_for_top_stories() is True
-        assert blocked_story3.is_story_blocked_for_top_stories() is True
+        assert headlines_story.is_story_blocked_for_top_stories() is False
         assert allowed_story1.is_story_blocked_for_top_stories() is False
         assert allowed_story2.is_story_blocked_for_top_stories() is False
 

--- a/tests/unit/curated_recommendations/test_sections.py
+++ b/tests/unit/curated_recommendations/test_sections.py
@@ -711,7 +711,7 @@ class TestMapCorpusSectionToSection:
         assert [rec.receivedRank for rec in sec.recommendations] == [0, 1]
 
     def test_headlines_items_flagged_as_headlines(self):
-        """Headlines items should carry ITEM_HEADLINES_FLAG (HNT-2167)."""
+        """Headlines items should carry ITEM_HEADLINES_FLAG."""
         cs = CorpusSection(
             sectionItems=[generate_corpus_item("h1", "sched_h1")],
             title="Headlines",


### PR DESCRIPTION
## References

JIRA: [AIMOD-1325](https://mozilla-hub.atlassian.net/browse/AIMOD-1325)

## Description
Articles sourced from the section "headlines" could have similarity-dupes with items from other ML sections by design. When we didn't have similarity deduplication in merino, we would get dupes in Popular Today. Now that spindle is live, we can allow headlines in Popular Today.

Note: It might be better design to only allow headline articles into Popular Today iff spindle is alive and the backend is connected.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2403)


[AIMOD-1325]: https://mozilla-hub.atlassian.net/browse/AIMOD-1325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ