### PR TITLE
chore: bump up feature flag ratio for pii detection

### DIFF
--- a/merino/configs/flags/production.toml
+++ b/merino/configs/flags/production.toml
@@ -6,4 +6,4 @@ dynaconf_merge = true
 # Raise `enabled` to ramp the prototype in production.
 [production.flags.fleece-pii-detection]
 scheme = "random"
-enabled = 0.001
+enabled = 0.03


### PR DESCRIPTION
## References

JIRA: [DISCO-4290](https://mozilla-hub.atlassian.net/browse/DISCO-4290)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->

Bump up the feature flag for pii detection to 3%.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2405)


[DISCO-4290]: https://mozilla-hub.atlassian.net/browse/DISCO-4290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ