### PR TITLE
[DISCO-4292] test(wcs): add time freeze for more wcs failing tests

### DIFF
--- a/tests/integration/api/v1/wcs/test_matches.py
+++ b/tests/integration/api/v1/wcs/test_matches.py
@@ -59,6 +59,7 @@ def test_explicit_date_is_deterministic(client: TestClient) -> None:
     assert a == b
 
 
+@freezegun.freeze_time("2026-06-15T16:00:00Z")
 def test_matches_per_bucket(client: TestClient) -> None:
     """Each of `previous`, `current`, `next` has at least one event sharing a status."""
     body = client.get(_PATH, params={"date": _ANCHOR}).json()

--- a/tests/unit/providers/wcs/test_provider.py
+++ b/tests/unit/providers/wcs/test_provider.py
@@ -328,6 +328,7 @@ async def test_response_is_deterministic_for_same_anchor() -> None:
 
 
 @pytest.mark.asyncio
+@freezegun.freeze_time("2026-06-15T16:00:00Z")
 async def test_six_records_two_per_status_type() -> None:
     """The stub set has at least two past, two live, and two scheduled matches
     assuming a window >= 7 days.


### PR DESCRIPTION
## References

JIRA: [DISCO-4292](https://mozilla-hub.atlassian.net/browse/DISCO-4292)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->

Fixed a couple of more.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2407)


[DISCO-4292]: https://mozilla-hub.atlassian.net/browse/DISCO-4292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ