### PR TITLE
AIMOD-1331 update world cup boosting to something lower

### DIFF
--- a/merino/curated_recommendations/prior_backends/engagment_rescaler.py
+++ b/merino/curated_recommendations/prior_backends/engagment_rescaler.py
@@ -25,7 +25,7 @@ TILE_6_PERCENTAGE_OF_DAILY_IMPRESSIONS = (
     0.1  # Generated via https://sql.telemetry.mozilla.org/queries/116006 (using tile 6)
 )
 
-WORLD_CUP_SECTION_CTR_BOOST = 0.008  # Constant for all world markets.
+WORLD_CUP_SECTION_CTR_BOOST = 0.004  # Constant for all world markets.
 
 LOCAL_RERANK_WEGHT = (
     80.0  # Experiment weight settings 60-10 server-local boosting.


### PR DESCRIPTION
## References

https://mozilla-hub.atlassian.net/browse/AIMOD-1331

## Description
It is 99% of the time the top section in Germany and 90% in the US and Canada. 
https://sql.telemetry.mozilla.org/queries/121518?p_country=CA

In the meantime our Politics impressions in top stories have gone down quite a bit, likely because of discoverability by not having that the 2nd section.

I’m reducing the boost by 50% which will keep it high but not always on top.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2411)
