### PR TITLE
feat: particle k8s cron job entrypoint

### DIFF
--- a/docs/dev/dependencies.md
+++ b/docs/dev/dependencies.md
@@ -7,26 +7,32 @@ While you can use the vanilla virtualenv to set up the dev environment, we highl
 out [uv][1].
 
 To install `uv`, run:
+
 ```sh
 $ pipx install uv
 ```
+
 Or [install][2] via your preferred method.
 
 Feel free to browse the [pyproject.toml][3] file for a listing of dependencies
 and their versions.
 
 First, lets make sure you have a virtual environment set up with the right Python version. This service uses Python 3.13.
+
 ```sh
 $ uv venv
 ```
+
 See [more][4] about setting up virtual envs and Python version with uv.
 
 Once uv is installed, and a virtual environment is created with the correct Python version, install all the dependencies:
+
 ```sh
 $ uv sync --all-groups --all-packages
 ```
 
 Add packages to project via uv
+
 ```sh
 $ uv add <package_name>
 ```
@@ -38,6 +44,7 @@ $ uv run fastapi run merino/main.py --reload
 ```
 
 ## Moving from the Poetry & Pyenv Set up
+
 If you had your environment previously set up via poetry and pyenv, here are the steps to move to `uv`. This would be a nice clean up and reset.
 
 ```sh
@@ -50,7 +57,6 @@ rm -rf $(pyenv root)
 # or if you installed it via your OS package manager
 brew uninstall pyenv
 ```
-
 
 ## Service Dependencies
 
@@ -99,22 +105,22 @@ $ STORAGE_EMULATOR_HOST=http://localhost:4443 make run
 ```
 
 Optionally, you can create a GCS bucket and preload data into it. The preloaded
-data is located in `dev/local_data/gcs_emulator/`. Say if you want to preload
+data is located in `dev/local_setup/gcs/`. Say if you want to preload
 a JSON file `top_picks_latest.json` into a bucket `merino-images-prodpy`, you
-can create a new sub-directory `merino-images-prody` in `gcs_emulator` and then
+can create a new sub-directory `merino-images-prody` in `gcs` and then
 create or copy `top_picks_latest.json` into it. Then you can set Merino's
 configurations to use those artifacts in the GCS emulator.
 
 ```
 # File layout of the preloaded GCS data
 
-dev/local_data
-└── gcs_emulator
+dev/local_setup
+└── gcs
     └── merino-images-prodpy  <- GCS Bucket ID
         └── top_picks_latest.json  <- A preloaded GCS blob
 ```
 
-Note that `dev/local_data` will not be checked into the source control nor the
+Note that `dev/local_setup` will not be checked into the source control nor the
 docker image of Merino.
 
 ### Dev Helpers
@@ -124,7 +130,6 @@ development.
 
 - Redis Commander, http://localhost:8081 - Explore the Redis database started
   above.
-
 
 [1]: https://docs.astral.sh/uv/
 [2]: https://docs.astral.sh/uv/getting-started/installation/

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -1245,17 +1245,6 @@ manifest_gcs_file_name = "runtime-manifest.v1.json"
 # Timeout in seconds for establishing a connection to Particle endpoint.
 connect_timeout_sec = 3.0
 
-# MERINO_GAMES_PROVIDERS__PARTICLE__CRON_INTERVAL_SEC
-# The cron tick interval to try to get Particle data from the remote endpoint.
-# This is the error retry interval, and should be less than the
-# resync_interval_sec value below to allow for retries.
-cron_interval_sec = 600 # ten minutes
-
-# MERINO_GAMES_PROVIDERS__PARTICLE__RESYNC_INTERVAL_SEC
-# Time between re-syncs of Particle game data, in seconds.
-# Particle updates their files daily.
-resync_interval_sec = 86400 # one day
-
 
 [default.curated_recommendations.gcs]
 # MERINO__CURATED_RECOMMENDATIONS__GCS__BUCKET_NAME

--- a/merino/configs/development.toml
+++ b/merino/configs/development.toml
@@ -90,3 +90,16 @@ cdn_hostname = "localhost:4443"
 [development.contextual_interest]
 # disabled in dev so we don't fetch artifacts locally
 enabled = false
+
+[development.games_particle_gcs]
+# MERINO_GAMES_PARTICLE__GCS_PROJECT
+# GCS project name that contains domain data (GCP V2)
+gcs_project = ""
+
+# MERINO_GAMES_PARTICLE__GCS_BUCKET
+# GCS bucket that contains domain data files (GCP V2)
+gcs_bucket = "merino-games-particle-local"
+
+# MERINO_GAMES_PARTICLE__CDN_HOSTNAME
+# CDN hostname used for public URL (GCP V2)
+cdn_hostname = "localhost:4443"

--- a/merino/jobs/cli.py
+++ b/merino/jobs/cli.py
@@ -3,21 +3,22 @@
 import logging
 import typer
 
-from merino.configs import settings
 from merino_common.app_configs.config_logging import configure_logging
 from merino_common.app_configs.config_sentry import configure_sentry
+from merino.configs import settings
 from merino.jobs.amo_rs_uploader import amo_rs_uploader_cmd
 from merino.jobs.csv_rs_uploader import csv_rs_uploader_cmd
-from merino.jobs.geonames_uploader import geonames_uploader_cmd
-from merino.jobs.navigational_suggestions import navigational_suggestions_cmd
-from merino.jobs.relevancy_uploader import relevancy_csv_rs_uploader_cmd
-from merino.jobs.wikipedia_indexer import indexer_cmd
-from merino.jobs.wikipedia_offline_uploader import wiki_offline_uploader_cmd
-from merino.jobs.polygon import cli as polygon_ingestion_cmd
-from merino.jobs.flightaware import cli as flightaware_fetch_schedules_cmd
-from merino.jobs.sportsdata_jobs import cli as sportsdata_cmd
 from merino.jobs.engagement_model import cli as engagement_data_cmd
 from merino.jobs.engagement_model.amp_live_probe import cli as amp_live_probe_cmd
+from merino.jobs.flightaware import cli as flightaware_fetch_schedules_cmd
+from merino.jobs.geonames_uploader import geonames_uploader_cmd
+from merino.jobs.navigational_suggestions import navigational_suggestions_cmd
+from merino.jobs.games import cli as games_tasks_cmd
+from merino.jobs.polygon import cli as polygon_ingestion_cmd
+from merino.jobs.relevancy_uploader import relevancy_csv_rs_uploader_cmd
+from merino.jobs.sportsdata_jobs import cli as sportsdata_cmd
+from merino.jobs.wikipedia_indexer import indexer_cmd
+from merino.jobs.wikipedia_offline_uploader import wiki_offline_uploader_cmd
 
 # Include your new jobs module here.
 
@@ -56,6 +57,9 @@ cli.add_typer(engagement_data_cmd, no_args_is_help=True)
 
 # Add the AMP live dataset access probe subcommand
 cli.add_typer(amp_live_probe_cmd, no_args_is_help=True)
+
+# Add the games task runner subcommand
+cli.add_typer(games_tasks_cmd, no_args_is_help=True)
 
 
 @cli.callback()

--- a/merino/jobs/games/__init__.py
+++ b/merino/jobs/games/__init__.py
@@ -1,0 +1,28 @@
+"""CLI commands for the Particle updater job."""
+
+import asyncio
+import logging
+import typer
+
+from merino.providers import games
+
+logger = logging.getLogger(__name__)
+
+cli = typer.Typer(
+    name="games_tasks",
+    help="Commands to process data related to New Tab games.",
+)
+
+
+@cli.command("update-particle")
+def update_particle():  # pragma: no cover
+    """Initialize the Particle provider and execute the process to attempt to update the Particle game."""
+    games.init_particle()
+
+    provider = games.get_particle_provider()
+
+    logger.info("Beginning Particle update process...")
+
+    updated = asyncio.run(provider.run_update_process())
+
+    logger.info(f"Finished Particle update process. Files updated? {updated}")

--- a/merino/providers/games/__init__.py
+++ b/merino/providers/games/__init__.py
@@ -21,7 +21,6 @@ _particle_provider: Provider | None = None
 
 # Module-level variables as looking up from settings each time is expensive.
 _connect_timeout = settings.games_providers.particle.connect_timeout_sec
-_cron_interval_sec = settings.games_providers.particle.cron_interval_sec
 _enabled = settings.games_providers.particle.enabled
 _gcs_project = settings.games_particle_gcs.gcs_project
 _gcs_bucket = settings.games_particle_gcs.gcs_bucket
@@ -32,13 +31,17 @@ _manifest_schema_file_path = (
     f"{_app_root_dir}/{settings.games_providers.particle.manifest_schema_file_path}"
 )
 _manifest_schema_version = settings.games_providers.particle.manifest_schema_version
-_resync_interval_sec = settings.games_providers.particle.resync_interval_sec
 _url_root = settings.games_providers.particle.url_root
 _url_path_manifest = settings.games_providers.particle.url_path_manifest
 
 
 async def init_providers() -> None:
     """Initialize games providers - currently only Particle"""
+    init_particle()
+
+
+def init_particle() -> None:
+    """Initialize the Particle provider."""
     global _particle_provider
 
     gcs_uploader = GcsUploader(
@@ -72,16 +75,14 @@ async def init_providers() -> None:
 
     _particle_provider = Provider(
         backend=particle_backend,
-        cron_interval_sec=_cron_interval_sec,
         manifest_schema=local_file_manager.get_manifest_schema(),
         manifest_schema_version=_manifest_schema_version,
         metrics_client=metrics_client,
         name="Particle Provider",
-        resync_interval_sec=_resync_interval_sec,
         enabled=_enabled,
     )
 
-    await _particle_provider.initialize()
+    _particle_provider.initialize()
 
 
 def get_particle_provider() -> Provider:

--- a/merino/providers/games/particle/backends/particle.py
+++ b/merino/providers/games/particle/backends/particle.py
@@ -104,7 +104,7 @@ class ParticleBackend:
         return await asyncio.to_thread(self.remote_file_manager.get_manifest_file)
 
     async def update_channel_files(
-        self, manifest_remote: Json, manifest_gcs: Json, channel: RemoteChannelEnum
+        self, manifest_remote: Json, manifest_gcs: Json | None, channel: RemoteChannelEnum
     ) -> bool:
         """Attempt to update files for the given channel."""
         if remote_manifest_channel_is_updated(manifest_remote, manifest_gcs, channel):
@@ -198,7 +198,7 @@ class ParticleBackend:
         return all(f.sha_verified and f.uploaded for f in files), files
 
     async def deploy_channel_files(
-        self, files: list[GameFile], manifest_remote: Json, manifest_gcs: Json
+        self, files: list[GameFile], manifest_remote: Json, manifest_gcs: Json | None
     ) -> bool:
         """Deploy files from the 'green' folder in GCS to the root."""
         # stub

--- a/merino/providers/games/particle/backends/protocol.py
+++ b/merino/providers/games/particle/backends/protocol.py
@@ -52,7 +52,7 @@ class ParticleBackend(Protocol):
         ...
 
     async def update_channel_files(
-        self, manifest_remote: Json, manifest_gcs: Json, channel: RemoteChannelEnum
+        self, manifest_remote: Json, manifest_gcs: Json | None, channel: RemoteChannelEnum
     ) -> bool:
         """Attempt to update files in GCS for the given channel."""
         ...

--- a/merino/providers/games/particle/backends/utils.py
+++ b/merino/providers/games/particle/backends/utils.py
@@ -110,9 +110,13 @@ def validate_manifest_against_schema(manifest_json: Json, manifest_schema: Json)
 
 
 def remote_manifest_channel_is_updated(
-    manifest_remote: Json, manifest_gcs: Json, channel: RemoteChannelEnum
+    manifest_remote: Json, manifest_gcs: Json | None, channel: RemoteChannelEnum
 ) -> bool:
     """Determine if the JSON manifest from Particle has newer files for the given channel than the manifest we have stored in GCS."""
+    # if there is no manifest in GCS (cold start), channel needs to be updated
+    if manifest_gcs is None:
+        return True
+
     remote = manifest_remote["channels"][channel]["version"]
     gcs = manifest_gcs["channels"][channel]["version"]
 

--- a/merino/providers/games/particle/provider.py
+++ b/merino/providers/games/particle/provider.py
@@ -4,7 +4,6 @@ import aiodogstatsd
 import asyncio
 import logging
 import sentry_sdk
-import time
 
 from pydantic import Json
 from typing import Any
@@ -17,7 +16,6 @@ from merino.providers.games.particle.backends.utils import (
     ParticleManifestValidationError,
     RemoteChannelEnum,
 )
-from merino.utils import cron
 
 logger = logging.getLogger(__name__)
 
@@ -26,55 +24,34 @@ class Provider:
     """Particle provider for games."""
 
     backend: ParticleBackend
-    cron_interval_sec: float
-    last_successful_update_at: float
     manifest_schema: Json
     manifest_schema_version: int
     metrics_client: aiodogstatsd.Client
     cron_task: asyncio.Task
-    resync_interval_sec: float
 
     def __init__(
         self,
         backend: ParticleBackend,
-        cron_interval_sec: float,
         manifest_schema: Json,
         manifest_schema_version: int,
         metrics_client: aiodogstatsd.Client,
         name: str,
-        resync_interval_sec: float,
         enabled: bool = False,
         **kwargs: Any,
     ) -> None:
         self.backend = backend
-        self.cron_interval_sec = cron_interval_sec
-        self.last_successful_update_at = 0.0
         self.manifest_schema = manifest_schema
         self.manifest_schema_version = manifest_schema_version
         self.metrics_client = metrics_client
         self.name = name
-        self.resync_interval_sec = resync_interval_sec
         self._enabled = enabled
-        super().__init__(**kwargs)
 
-    async def initialize(self) -> None:
+    def initialize(self) -> None:
         """Initialize the provider."""
-        if self._enabled:
-            # create a cron job to update particle game files
-            cron_job = cron.Job(
-                name="update_particle_game_data",
-                interval=self.cron_interval_sec,
-                condition=self._should_fetch_data,
-                task=self._fetch_game_data,
-            )
+        pass
 
-            self.cron_task = asyncio.create_task(cron_job())
-
-    def _should_fetch_data(self) -> bool:
-        """Check if we should fetch Particle game data from the internet."""
-        return (time.time() - self.last_successful_update_at) >= self.resync_interval_sec
-
-    async def _fetch_game_data(self) -> None:
+    async def run_update_process(self) -> bool:
+        """Initiate the process to attempt to update Particle game files."""
         manifest_json: Json | None = None
 
         try:
@@ -89,19 +66,21 @@ class Provider:
 
         if manifest_json is None:
             logger.warning(
-                f"Particle game data fetch returned None - will retry on next cron tick ({self.cron_interval_sec} seconds)"
+                "Particle game data fetch returned None - will retry on next cron tick."
             )
-        else:
-            particle_updated = await self.process_remote_particle_data(manifest_json)
 
-            # only update the last success time if we actually updated some files
-            if particle_updated:
-                self.last_successful_update_at = time.time()
+            return False
+        else:
+            return await self.process_remote_particle_data(manifest_json)
 
     async def process_remote_particle_data(self, remote_manifest_json: Json) -> bool:
         """Orchestration function to validate and upload new Particle game data files to GCS.
         Returns True only if some files (puzzle runtime and/or daily puzzle) were updated.
         """
+        # default return values
+        puzzle_updated = False
+        runtime_updated = False
+
         # ensure the remote schema is valid
         # this will raise if the schema is invalid
         try:
@@ -135,11 +114,17 @@ class Provider:
             channel=RemoteChannelEnum.PUZZLE,
         )
 
+        if puzzle_updated:
+            logger.info("Particle daily files updated")
+
         runtime_updated = await self.backend.update_channel_files(
             manifest_remote=remote_manifest_json,
             manifest_gcs=gcs_manifest_json,
             channel=RemoteChannelEnum.RUNTIME,
         )
+
+        if runtime_updated:
+            logger.info("Particle runtime files updated")
 
         # if either set of files (daily puzzle or runtime) were updated, we can
         # consider this update successful

--- a/tests/integration/providers/games/particle/test_provider.py
+++ b/tests/integration/providers/games/particle/test_provider.py
@@ -69,32 +69,32 @@ def fixture_particle_provider(
 
     return Provider(
         backend=particle_backend,
-        cron_interval_sec=60,
         manifest_schema=manifest_validation_schema,
         manifest_schema_version=1,
         metrics_client=statsd_mock,
         name="particle",
-        resync_interval_sec=120,
         enabled=False,
     )
 
 
 @pytest.mark.asyncio
-async def test_fetch_game_data_successfully_processes_valid_remote_data(particle_provider) -> None:
+async def test_run_update_process_successfully_processes_valid_remote_data(
+    particle_provider,
+) -> None:
     """Test that fetching valid manifest data from particle succeeds"""
-    with patch.object(
-        particle_provider, "process_remote_particle_data", new=AsyncMock()
-    ) as mock_process_remote_data:
+    with (
+        patch.object(
+            particle_provider, "process_remote_particle_data", new_callable=AsyncMock
+        ) as mock_process_remote_data,
+        patch.object(
+            particle_provider.backend, "fetch_manifest_json_from_remote", new_callable=AsyncMock
+        ) as mock_fetch_manifest,
+    ):
         mock_process_remote_data.return_value = True
 
-        # verify last update is at the default value
-        assert particle_provider.last_successful_update_at == 0.0
-
-        await particle_provider._fetch_game_data()
-
-        # _fetch_game_data should have successfully run, updating the last update time
-        assert particle_provider.last_successful_update_at > 0.0
+        assert await particle_provider.run_update_process()
 
         # a successful fetch should result in process_remote_particle_data
         # being called
         mock_process_remote_data.assert_awaited_once()
+        mock_fetch_manifest.assert_awaited_once()

--- a/tests/unit/providers/games/particle/test_provider.py
+++ b/tests/unit/providers/games/particle/test_provider.py
@@ -4,7 +4,6 @@
 
 """Unit tests for the Particle games provider."""
 
-import asyncio
 import json
 import logging
 import pytest
@@ -54,12 +53,10 @@ def fixture_provider(
     """Return a Provider instance for testing."""
     return Provider(
         backend=backend_mock,
-        cron_interval_sec=60,
         manifest_schema=manifest_validation_schema,
         manifest_schema_version=1,
         metrics_client=statsd_mock,
         name="particle",
-        resync_interval_sec=120,
         enabled=False,
     )
 
@@ -120,33 +117,7 @@ class TestProvider:
     @pytest.mark.asyncio
     async def test_initialize(self, provider: Provider) -> None:
         """Test that initialize completes without error."""
-        await provider.initialize()
-
-    @pytest.mark.asyncio
-    async def test_initialize_runs_cron_when_provider_enabled(self, provider):
-        """Initialize should call _fetch_game_data and create cron job when provider is enabled."""
-        with (
-            patch.object(provider, "_enabled", True),
-            patch("asyncio.create_task", wraps=asyncio.create_task) as mock_create_task,
-            patch("merino.providers.games.particle.provider.cron.Job") as mock_cron_job,
-        ):
-            mock_job_instance = AsyncMock(name="mock_cron_job")
-            mock_cron_job.return_value = mock_job_instance
-
-            await provider.initialize()
-
-            mock_cron_job.assert_called_once_with(
-                name="update_particle_game_data",
-                interval=provider.cron_interval_sec,
-                condition=provider._should_fetch_data,
-                task=provider._fetch_game_data,
-            )
-
-            mock_create_task.assert_called_once()
-            args, _ = mock_create_task.call_args
-            called_arg = args[0]
-            assert asyncio.iscoroutine(called_arg)
-            assert hasattr(provider, "cron_task")
+        provider.initialize()
 
 
 class TestGetGameUrl:
@@ -176,69 +147,42 @@ class TestGetGameUrl:
         assert particle.url == test_game_url
 
 
-class TestShouldFetchData:
-    """Tests against should_fetch_data"""
-
-    def test_should_fetch_data_returns_true_when_interval_satsified(self, provider):
-        """_should_fetch_data should return True if the time interval condition is satisfied"""
-        with (
-            patch("merino.providers.games.particle.provider.time.time", side_effect=[100]),
-            patch.object(provider, "resync_interval_sec", 50),
-            patch.object(provider, "last_successful_update_at", 50),
-        ):
-            assert provider._should_fetch_data() is True
-
-    def test_should_fetch_data_returns_false_when_interval_not_satsified(self, provider):
-        """_should_fetch_data should return False if the time interval condition is not satisfied"""
-        with (
-            patch("merino.providers.games.particle.provider.time.time", side_effect=[100]),
-            patch.object(provider, "resync_interval_sec", 60),
-            patch.object(provider, "last_successful_update_at", 50),
-        ):
-            assert provider._should_fetch_data() is False
-
-
 class TestFetchGameData:
     """Tests against fetch_game_data"""
 
     @pytest.mark.asyncio
     async def test_happy_path(self, provider, valid_manifest_data):
-        """Test that _fetch_game_data retrieves remote json and updates as expected"""
+        """Test that run_update_process retrieves remote json and updates as expected"""
         with (
             patch.object(
                 provider.backend, "fetch_manifest_json_from_remote", new=AsyncMock()
             ) as mock_fetch_manifest,
             patch.object(provider, "process_remote_particle_data") as mock_process_data,
-            patch("merino.providers.games.particle.provider.time.time", side_effect=[100]),
         ):
             mock_fetch_manifest.return_value = valid_manifest_data
             mock_process_data.return_value = True
 
-            await provider._fetch_game_data()
+            assert await provider.run_update_process()
 
             mock_fetch_manifest.assert_awaited_once()
             mock_process_data.assert_called_once()
-            assert provider.last_successful_update_at == 100
 
     @pytest.mark.asyncio
     async def test_processing_remote_data_fails(self, provider, valid_manifest_data):
-        """Test that _fetch_game_data retrieves remote json but processing the json fails"""
+        """Test that run_update_process retrieves remote json but processing the json fails"""
         with (
             patch.object(
                 provider.backend, "fetch_manifest_json_from_remote", new=AsyncMock()
             ) as mock_fetch_manifest,
             patch.object(provider, "process_remote_particle_data") as mock_process_data,
-            patch.object(provider, "last_successful_update_at", 0.0),
-            patch("merino.providers.games.particle.provider.time.time", side_effect=[100]),
         ):
             mock_fetch_manifest.return_value = valid_manifest_data
             mock_process_data.return_value = False
 
-            await provider._fetch_game_data()
+            assert not await provider.run_update_process()
 
             mock_fetch_manifest.assert_awaited_once()
             mock_process_data.assert_called_once()
-            assert provider.last_successful_update_at == 0.0
 
     @pytest.mark.asyncio
     async def test_remote_fetch_fails(
@@ -247,26 +191,21 @@ class TestFetchGameData:
         caplog: LogCaptureFixture,
         filter_caplog: FilterCaplogFixture,
     ):
-        """Test that _fetch_game_data logs as expected if the remote fetch fails"""
+        """Test that run_update_process logs as expected if the remote fetch fails"""
         with (
             patch.object(
                 provider.backend, "fetch_manifest_json_from_remote", new=AsyncMock()
             ) as mock_fetch_manifest,
             patch.object(provider, "process_remote_particle_data") as mock_process_data,
-            patch.object(provider, "last_successful_update_at", 0.0),
-            patch("merino.providers.games.particle.provider.time.time", side_effect=[100]),
         ):
             caplog.set_level(logging.INFO)
 
             mock_fetch_manifest.side_effect = Exception("kaboom!")
 
-            await provider._fetch_game_data()
+            assert not await provider.run_update_process()
 
             mock_fetch_manifest.assert_awaited_once()
             mock_process_data.assert_not_awaited()
-
-            # ensure the last_successful_update_at value was not updated
-            assert provider.last_successful_update_at == 0.0
 
             records: list[LogRecord] = filter_caplog(
                 caplog.records, "merino.providers.games.particle.provider"


### PR DESCRIPTION
## References

JIRA: [HNT-2684](https://mozilla-hub.atlassian.net/browse/HNT-2684)

## Description

adds a CLI job to be run by k8s to initiate the game file update process.

- remove deprecated python "cron" schedule and related tests
- improve code to handle cold start (no files existing in GCS)
- update docs for local GCS buckets

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2416)


[HNT-2684]: https://mozilla-hub.atlassian.net/browse/HNT-2684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ