### PR TITLE
[AIMOD-1296] Add more flight trigger words for improved coverage

### DIFF
--- a/merino/providers/suggest/flightaware/backends/utils.py
+++ b/merino/providers/suggest/flightaware/backends/utils.py
@@ -38,6 +38,42 @@ FLIGHT_KEYWORD_PATTERN = pattern = re.compile(
 )
 # matches 1-5 words, followed by 1-5 digits e.g united airlines 100, air canada 250
 
+# Phrases that may accompany a flight number and still indicate flight intent.
+# Text around the flight number is accepted if it is empty or a prefix of one of
+# these phrases; the prefix rule also handles per-keystroke typing.
+FLIGHT_TRIGGER_PHRASES: tuple[str, ...] = (
+    "flight status",
+    "flight tracker",
+    "flight tracking",
+    "track flight",
+    "flight number",
+    "track",
+    "tracker",
+    "tracking",
+    "status",
+    "status of",
+    "number",
+    "arrival",
+    "arrivals",
+    "arriving",
+    "departure",
+    "departures",
+    "departing",
+    "live",
+    "eta",
+    "delay",
+    "delayed",
+    "cancelled",
+    "canceled",
+)
+
+
+def is_flight_trigger_context(remaining: str) -> bool:
+    """Return True if the text around a flight number indicates flight intent."""
+    if not remaining:
+        return True
+    return any(phrase.startswith(remaining) for phrase in FLIGHT_TRIGGER_PHRASES)
+
 
 def derive_flight_status(flight: dict) -> FlightStatus:
     """Derive a stable, backend-calculated flight status from AeroAPI fields.
@@ -288,7 +324,7 @@ def get_flight_number_from_query_if_valid(query: str) -> str | None:
         after = query[match.end() :].strip()
         remaining = " ".join(f"{before} {after}".split())
 
-        if not remaining or "flight status".startswith(remaining):
+        if is_flight_trigger_context(remaining):
             return matched_part.replace(" ", "").upper()
 
     # if not a flight number pattern, check if the query is a valid keyword

--- a/tests/unit/providers/suggest/flightaware/backend/test_utils.py
+++ b/tests/unit/providers/suggest/flightaware/backend/test_utils.py
@@ -26,6 +26,7 @@ from merino.providers.suggest.flightaware.backends.utils import (
     get_flight_number_from_query_if_valid,
     get_live_url,
     is_delayed,
+    is_flight_trigger_context,
     is_valid_flight_keyword_pattern,
     is_valid_flight_number_pattern,
     is_within_one_hour,
@@ -901,6 +902,10 @@ def test_is_valid_flight_keyword_pattern(description, query, expected):
         ("flight status after number", "ac100 flight status", {}, "AC100"),
         ("flight status before number", "flight status ac100", {}, "AC100"),
         ("embedded in sentence", "my flight is ua123 today", {}, None),
+        ("track trigger before number", "track ac100", {}, "AC100"),
+        ("tracker trigger after number", "ac100 tracker", {}, "AC100"),
+        ("arrival trigger after number", "ac100 arrival", {}, "AC100"),
+        ("non-trigger word after number", "ac100 recipe", {}, None),
     ],
 )
 def test_get_flight_number_from_query_if_valid(description, query, mapping, expected):
@@ -911,6 +916,25 @@ def test_get_flight_number_from_query_if_valid(description, query, mapping, expe
     ):
         result = get_flight_number_from_query_if_valid(query)
         assert result == expected, f"Failed: {description} (input: '{query}')"
+
+
+@pytest.mark.parametrize(
+    "description, remaining, expected",
+    [
+        ("empty is always allowed", "", True),
+        ("full trigger phrase", "track", True),
+        ("prefix of a phrase (incremental typing)", "trac", True),
+        ("existing flight status still works", "flight status", True),
+        ("prefix of flight status", "flight", True),
+        ("new trigger: arrival", "arrival", True),
+        ("new trigger: cancelled", "cancelled", True),
+        ("non-trigger word rejected", "essay", False),
+        ("trigger embedded in longer text rejected", "track my", False),
+    ],
+)
+def test_is_flight_trigger_context(description, remaining, expected):
+    """Trigger context accepts empty/prefix-of-phrase text and rejects unrelated text."""
+    assert is_flight_trigger_context(remaining) == expected, f"Failed: {description}"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## References

JIRA: [AIMOD-1296](https://mozilla-hub.atlassian.net/browse/AIMOD-1296)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->
Adds extra flight trigger words. 

ATM, there are `~2,528 sessions` for the `flight status` trigger over a period of two weeks. The breakdown below shows the extra potential sessions for the new keywords:

For the first row for example, something like `track ua 123` or `ua 123 tracker` should now trigger.

BQ sql [link](https://console.cloud.google.com/bigquery?ws=!1m8!1m7!12m5!1m3!1smozdata!2sus-central1!3sfc1fb872-782a-4365-afb4-f12479dd361f!2e1!23sWS_URL_PARAM&project=mozdata)

| Keyword | New-only sessions |
|---|---:|
| track / tracker / tracking | 4,098 |
| cancelled / canceled | 2,001 |
| flight number / number | 1,005 |
| delay / delayed | 678 |
| arrival(s) / arriving / arrived | 365 |
| departure(s) / departing / departed | 246 |
| live | 212 |
| status | 170 |
| gate | 148 |
| eta | 17 |

Will do a test on staging first before doing a prod push.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[AIMOD-1296]: https://mozilla-hub.atlassian.net/browse/AIMOD-1296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ