### PR TITLE
HNT-2690 feat: clean up old particle files after green deployment

### DIFF
--- a/merino/providers/games/particle/backends/filemanager.py
+++ b/merino/providers/games/particle/backends/filemanager.py
@@ -178,3 +178,10 @@ class ParticleRemoteFileManager:
                 success = False
 
         return success
+
+    async def delete_file(self, file_name: str) -> None:
+        """Delete the given file from GCS."""
+        try:
+            await asyncio.to_thread(self.gcs_client.delete_file_by_name, file_name)
+        except Exception as ex:
+            sentry_sdk.capture_exception(ParticleFileManagerError(str(ex)))

--- a/merino/providers/games/particle/backends/particle.py
+++ b/merino/providers/games/particle/backends/particle.py
@@ -17,6 +17,7 @@ from merino.providers.games.particle.backends.filemanager import ParticleRemoteF
 from merino.providers.games.particle.backends.utils import (
     download_remote_file,
     GameFile,
+    get_files_for_cleanup_for_channel,
     get_files_from_manifest_for_channel,
     RemoteChannelEnum,
     remote_manifest_channel_is_updated,
@@ -220,7 +221,11 @@ class ParticleBackend:
 
     async def cleanup_old_files_for_channel(
         self, manifest_remote: Json, manifest_gcs: Json, channel: RemoteChannelEnum
-    ) -> bool:
+    ) -> None:
         """Clean up any outdated files for the given channel. Run after a channel deploy has succeeded."""
-        # stub
-        return True
+        files_to_delete: list[str] = get_files_for_cleanup_for_channel(
+            manifest_remote=manifest_remote, manifest_gcs=manifest_gcs, channel=channel
+        )
+
+        for f in files_to_delete:
+            await self.remote_file_manager.delete_file(f)

--- a/merino/providers/games/particle/backends/protocol.py
+++ b/merino/providers/games/particle/backends/protocol.py
@@ -78,6 +78,6 @@ class ParticleBackend(Protocol):
 
     async def cleanup_old_files_for_channel(
         self, manifest_remote: Json, manifest_gcs: Json, channel: RemoteChannelEnum
-    ) -> bool:
+    ) -> None:
         """Clean up any outdated files for the given channel. Run after a channel deploy has succeeded."""
         ...

--- a/merino/providers/games/particle/backends/utils.py
+++ b/merino/providers/games/particle/backends/utils.py
@@ -136,6 +136,35 @@ def get_files_from_manifest_for_channel(
     return game_files
 
 
+def get_files_for_cleanup_for_channel(
+    manifest_remote: Json, manifest_gcs: Json, channel: RemoteChannelEnum
+) -> list[str]:
+    """Get a list of string file names/paths from the old deployment that should be deleted from GCS."""
+    # get files from remote manifest for channel - this is the "green"
+    # deploy that was just released
+    green_files: list[GameFile] = get_files_from_manifest_for_channel(manifest_remote, channel)
+
+    # get files from the previous GCS manifest - this is the "blue"
+    # deployment that is no longer in release
+    blue_files: list[GameFile] = get_files_from_manifest_for_channel(manifest_gcs, channel)
+
+    # get a list of files present in the "blue" deploy that are not present
+    # in the "green" deploy - these files were not overwritten by the
+    # "green" deployment and are now orphaned/unused and should be deleted
+
+    # the only comparison we need to do is on the remote_path attribute, as
+    # that's the file name in GCS.
+    green_file_paths = set([f.remote_path for f in green_files])
+
+    # special casing for HTML file - we'll never need to clean it up, as the
+    # file name always stays consistent.
+    return [
+        f.remote_path
+        for f in blue_files
+        if f.remote_path not in green_file_paths and not f.remote_path.lower().endswith(".html")
+    ]
+
+
 def download_remote_file(url: str, destination_path: str) -> None:
     """Download a remote Particle file."""
     response = requests.get(url)  # nosec

--- a/tests/integration/providers/games/particle/test_filemanager.py
+++ b/tests/integration/providers/games/particle/test_filemanager.py
@@ -21,7 +21,7 @@ def gcs_storage_bucket(gcs_storage_client) -> Bucket:
     """Return a test google storage bucket object to be used by all tests. Delete it
     after each test run to ensure isolation
     """
-    bucket: Bucket = gcs_storage_client.create_bucket("test_gcp_uploader_bucket")
+    bucket: Bucket = gcs_storage_client.create_bucket("merino-images-local")
 
     # Yield the bucket object for the test to use
     yield bucket
@@ -88,7 +88,7 @@ class TestRemoteFileManagerUploadFile:
             assert blob_name == ""
 
 
-class TestUploadManifest:
+class TestRemoteFileManagerUploadManifest:
     """Tests against the upload_manifest method of ParticleRemoteFileManager."""
 
     @pytest.mark.asyncio
@@ -109,3 +109,37 @@ class TestUploadManifest:
             )
 
             assert not await remote_filemanager.upload_manifest(remote_manifest_json)
+
+
+class TestRemoteFileManagerDeleteFile:
+    """Tests against the delete_file method of ParticleRemoteFileManager."""
+
+    @pytest.mark.asyncio
+    async def test_success(self, remote_filemanager, mocker):
+        """Test success scenario."""
+        sentry_capture = mocker.patch(
+            "merino.providers.games.particle.backends.filemanager.sentry_sdk.capture_exception"
+        )
+
+        # put a file in GCS to be deleted
+        remote_filemanager.gcs_client.upload_from_filename(
+            "tests/data/games/particle/image.jpg", "images/image.jpg", "image/jpeg"
+        )
+
+        # delete should execute without error
+        await remote_filemanager.delete_file("images/image.jpg")
+
+        # sentry should not be called
+        sentry_capture.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_failure(self, remote_filemanager, mocker):
+        """Test failure scenario."""
+        sentry_capture = mocker.patch(
+            "merino.providers.games.particle.backends.filemanager.sentry_sdk.capture_exception"
+        )
+
+        # file doesn't exist - should send to sentry
+        await remote_filemanager.delete_file("images/image.jpg")
+
+        sentry_capture.assert_called_once()

--- a/tests/integration/providers/games/particle/test_filemanager.py
+++ b/tests/integration/providers/games/particle/test_filemanager.py
@@ -109,37 +109,3 @@ class TestRemoteFileManagerUploadManifest:
             )
 
             assert not await remote_filemanager.upload_manifest(remote_manifest_json)
-
-
-class TestRemoteFileManagerDeleteFile:
-    """Tests against the delete_file method of ParticleRemoteFileManager."""
-
-    @pytest.mark.asyncio
-    async def test_success(self, remote_filemanager, mocker):
-        """Test success scenario."""
-        sentry_capture = mocker.patch(
-            "merino.providers.games.particle.backends.filemanager.sentry_sdk.capture_exception"
-        )
-
-        # put a file in GCS to be deleted
-        remote_filemanager.gcs_client.upload_from_filename(
-            "tests/data/games/particle/image.jpg", "images/image.jpg", "image/jpeg"
-        )
-
-        # delete should execute without error
-        await remote_filemanager.delete_file("images/image.jpg")
-
-        # sentry should not be called
-        sentry_capture.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_failure(self, remote_filemanager, mocker):
-        """Test failure scenario."""
-        sentry_capture = mocker.patch(
-            "merino.providers.games.particle.backends.filemanager.sentry_sdk.capture_exception"
-        )
-
-        # file doesn't exist - should send to sentry
-        await remote_filemanager.delete_file("images/image.jpg")
-
-        sentry_capture.assert_called_once()

--- a/tests/unit/providers/games/particle/backends/test_filemanager.py
+++ b/tests/unit/providers/games/particle/backends/test_filemanager.py
@@ -426,3 +426,31 @@ class TestRemoteFileManagerUploadManifest:
             )
 
             assert sentry_capture.call_count == 1
+
+
+class TestRemoteFileManagerDeleteFile:
+    """Tests against the delete_file method of ParticleRemoteFileManager."""
+
+    @pytest.mark.asyncio
+    async def test_success(self, remote_filemanager):
+        """Verify success behavior."""
+        with patch.object(remote_filemanager.gcs_client, "delete_file_by_name") as mock_delete:
+            await remote_filemanager.delete_file("assets/index.js")
+
+            mock_delete.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_failure(self, remote_filemanager, mocker):
+        """Verify failure behavior."""
+        sentry_capture = mocker.patch(
+            "merino.providers.games.particle.backends.filemanager.sentry_sdk.capture_exception"
+        )
+
+        with patch.object(remote_filemanager.gcs_client, "delete_file_by_name") as mock_delete:
+            mock_delete.side_effect = [Exception("forced error")]
+
+            await remote_filemanager.delete_file("assets/index.js")
+
+            sentry_capture.assert_called_once()
+
+            mock_delete.assert_called_once()

--- a/tests/unit/providers/games/particle/backends/test_particle_backend.py
+++ b/tests/unit/providers/games/particle/backends/test_particle_backend.py
@@ -187,6 +187,15 @@ def mock_particle_game_file():
         return f.read()
 
 
+@pytest.fixture()
+def mock_get_files_for_cleanup_for_channel():
+    """Return a mocked version of the get_files_for_cleanup_for_channel utils function."""
+    with patch(
+        "merino.providers.games.particle.backends.particle.get_files_for_cleanup_for_channel"
+    ) as mock_get_files_for_cleanup_for_channel:
+        yield mock_get_files_for_cleanup_for_channel
+
+
 # END FIXTURES
 
 
@@ -817,3 +826,22 @@ class TestDeployChannelFiles:
             assert success == deploy_success
 
             mock_deploy.assert_awaited_once_with(self.mock_game_files)
+
+
+class TestCleanupOldFilesForChannel:
+    """Tests against the cleanup_old_files_for_channel function."""
+
+    @pytest.mark.asyncio
+    async def test_success(self, backend, mock_get_files_for_cleanup_for_channel):
+        """Test success scenario."""
+        mock_get_files_for_cleanup_for_channel.return_value = [
+            "assets/index.js",
+            "assets/index.css",
+        ]
+
+        with patch.object(
+            backend.remote_file_manager, "delete_file", new_callable=AsyncMock
+        ) as mock_delete:
+            await backend.cleanup_old_files_for_channel("{}", "{}", RemoteChannelEnum.PUZZLE)
+
+            assert mock_delete.await_count == 2

--- a/tests/unit/providers/games/particle/backends/test_utils.py
+++ b/tests/unit/providers/games/particle/backends/test_utils.py
@@ -12,11 +12,13 @@ from contextlib import nullcontext as does_not_raise
 from pydantic import Json
 from pytest import LogCaptureFixture
 from typing import Any
+from unittest.mock import patch
 
 from merino.configs import settings
 from merino.providers.games.particle.backends.errors import ParticleManifestValidationError
 from merino.providers.games.particle.backends.utils import (
     GameFile,
+    get_files_for_cleanup_for_channel,
     get_files_from_manifest_for_channel,
     RemoteChannelEnum,
     remote_manifest_channel_is_updated,
@@ -247,3 +249,76 @@ class TestGameFile:
         assert gf.name == "file.jpg"
         assert gf.content_type == content_type
         assert not gf.sha_verified
+
+
+class TestGetFilesForCleanupForChannel:
+    """Tests against the get_files_for_cleanup_for_channel function."""
+
+    def test_manifests_with_differences(
+        self, valid_manifest_data_remote_updated, valid_manifest_data
+    ):
+        """Verify manifests with differences return the expected list of GameFiles, omitting the .html file."""
+        daily_files = get_files_for_cleanup_for_channel(
+            manifest_remote=valid_manifest_data_remote_updated,
+            manifest_gcs=valid_manifest_data,
+            channel=RemoteChannelEnum.PUZZLE,
+        )
+        runtime_files = get_files_for_cleanup_for_channel(
+            manifest_remote=valid_manifest_data_remote_updated,
+            manifest_gcs=valid_manifest_data,
+            channel=RemoteChannelEnum.RUNTIME,
+        )
+
+        assert len(daily_files) == 2
+
+        assert (
+            daily_files[0]
+            == "assets/cluster-images/42a376c9467b635c6c31c997020ec3f68ee8365992d4fb93e1a61e54712cde74.jpg"
+        )
+        assert (
+            daily_files[1]
+            == "assets/cluster-images/5060e2ba850a7032b2a4a606b2b59781cc85cb7a20833c12aa5c5c7d8d654d58.jpg"
+        )
+
+        # in the manifest data used for this test, there is an HTML file
+        # properly filtered out of this list - see test below
+        assert len(runtime_files) == 2
+
+        assert runtime_files[0] == "assets/index-7wt06ylr.css"
+        assert runtime_files[1] == "assets/index-rc_Uh052.js"
+
+    def test_filters_out_html_file(self):
+        """Test that any HTML files are skipped."""
+        with patch(
+            "merino.providers.games.particle.backends.utils.get_files_from_manifest_for_channel"
+        ) as mock_get_files:
+            # the newly deployed files
+            green_files = [
+                GameFile(url="assets/a.jpg", sha="123", content_type="image/jpeg"),
+                GameFile(url="assets/a.png", sha="123", content_type="image/png"),
+                GameFile(url="runtime/index-1234.html", sha="123", content_type="text/html"),
+            ]
+
+            # the previously deployed files - two are different from green:
+            # - assets/b.jpg
+            # - runtime/index-5678.html
+            blue_files = [
+                GameFile(url="assets/b.jpg", sha="123", content_type="image/jpeg"),
+                GameFile(url="assets/a.png", sha="123", content_type="image/png"),
+                GameFile(url="runtime/index-5678.html", sha="123", content_type="text/html"),
+            ]
+
+            mock_get_files.side_effect = [green_files, blue_files]
+
+            # this calls mock_get_files twice, returning the lists above, which
+            # are used to determine which files need to be deleted
+            runtime_files = get_files_for_cleanup_for_channel(
+                manifest_remote={},
+                manifest_gcs={},
+                channel=RemoteChannelEnum.RUNTIME,
+            )
+
+            # get_files_for_cleanup_for_channel should skip html files, meaning
+            # only assets/b.jpg is marked as old and needing to be deleted
+            assert len(runtime_files) == 1
+            assert runtime_files[0] == "assets/b.jpg"


### PR DESCRIPTION
## References

JIRA: [HNT-2690](https://mozilla-hub.atlassian.net/browse/HNT-2690)

## Description

adds functionality to particle update process the clean up old "blue" deployment files post deploy.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2418)


[HNT-2690]: https://mozilla-hub.atlassian.net/browse/HNT-2690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ