### PR TITLE
fix(sports): DISCO-4298 Gracefully handle non-key teams

### DIFF
--- a/merino/providers/suggest/sports/backends/sportsdata/common/data.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/data.py
@@ -141,7 +141,10 @@ class Team(BaseModel):
         country = None
         if areas:
             country = areas.get(team_data.get(normalized_terms.get("AreaId", "AreaId"), 9999))
-        raw_key = team_data["Key"]
+        raw_key = team_data.get("Key")
+        if not isinstance(raw_key, str) or not raw_key:
+            logger.warning(f"{LOGGING_TAG}: No valid key found for team {team_data}")
+            raise SportsDataError(f"No Key found for {fullname}")
         if country and country.get("aliases"):
             terms.add(country.get("aliases"))
         return cls(

--- a/tests/unit/providers/suggest/sports/backends/common/test_data.py
+++ b/tests/unit/providers/suggest/sports/backends/common/test_data.py
@@ -16,6 +16,7 @@ from merino.providers.suggest.sports.backends.sportsdata.common.data import (
     SPORTSDATA_US_EASTERN,
     sportsdata_day_slug,
 )
+from merino.providers.suggest.sports.backends.sportsdata.common.error import SportsDataError
 from merino.providers.suggest.sports.backends.sportsdata.common.sports import (
     NFL,
     NHL,
@@ -462,7 +463,11 @@ def test_load_teams_from_source(
 
 
 @freezegun.freeze_time("2025-09-22T00:00:00", tz_offset=0)
-@pytest.mark.parametrize("sport_cls", [NFL, NHL, NBA], ids=["NFL", "NHL", "NBA"])
+@pytest.mark.parametrize(
+    "sport_cls",
+    [NFL, NHL, NBA, MLB, UCL],
+    ids=["NFL", "NHL", "NBA", "MLB", "UCL"],
+)
 def test_load_bad_teams_from_source(
     sport_cls: type[Sport],
     events_response: list[dict],
@@ -478,6 +483,38 @@ def test_load_bad_teams_from_source(
     teams_data = sport.load_teams_from_source(teams)
 
     assert set(teams_data.keys()) == {456}
+
+
+@freezegun.freeze_time("2025-09-22T00:00:00", tz_offset=0)
+@pytest.mark.parametrize(
+    "sport_cls",
+    [NFL, NHL, NBA, MLB, UCL],
+    ids=["NFL", "NHL", "NBA", "MLB", "UCL"],
+)
+def test_load_teams_from_source_skips_team_without_key(
+    sport_cls: type[Sport],
+    teams: list[dict],
+):
+    """Ensure teams with missing provider keys are not loaded."""
+    sport = sport_cls(settings=settings.providers.sports, name="", base_url="")
+    teams[0]["Key"] = None
+
+    teams_data = sport.load_teams_from_source(teams)
+
+    assert set(teams_data.keys()) == {456}
+
+
+def test_from_data_requires_key(teams: list[dict]) -> None:
+    """Verify a missing team key raises the loader's expected provider error."""
+    teams[0]["Key"] = None
+
+    with pytest.raises(SportsDataError, match="No Key found"):
+        Team.from_data(
+            teams[0],
+            term_filter=[],
+            team_ttl=timedelta(weeks=1),
+            normalized_terms=SportNormalizedTerms,
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## References

JIRA: [DISCO-4298O](https://mozilla-hub.atlassian.net/browse/DISCO-4298)

## Description
ports job is failing due to the UCL getTeams call returns a team which has a team with no key:

```bash
curl --request GET \
  --url 'https://api.sportsdata.io/v4/soccer/scores/json/Teams/ucl?key='
```

returns with
```json
{
    "TeamId": 5324,
    "AreaId": null,
    "VenueId": null,
    "Key": null,
    "Name": "Mjällby AIF",
    "FullName": null,
    "Active": true,
```

The fix: `raise SportsDataError(f"No Key found for {fullname}")` when key is not a string. Which means this team is being skipped.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2420)
