### PR TITLE
HNT-2684 feat: particle k8s cron job entrypoint

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -1245,17 +1245,6 @@ manifest_gcs_file_name = "runtime-manifest.v1.json"
 # Timeout in seconds for establishing a connection to Particle endpoint.
 connect_timeout_sec = 3.0
 
-# MERINO_GAMES_PROVIDERS__PARTICLE__CRON_INTERVAL_SEC
-# The cron tick interval to try to get Particle data from the remote endpoint.
-# This is the error retry interval, and should be less than the
-# resync_interval_sec value below to allow for retries.
-cron_interval_sec = 600 # ten minutes
-
-# MERINO_GAMES_PROVIDERS__PARTICLE__RESYNC_INTERVAL_SEC
-# Time between re-syncs of Particle game data, in seconds.
-# Particle updates their files daily.
-resync_interval_sec = 86400 # one day
-
 
 [default.curated_recommendations.gcs]
 # MERINO__CURATED_RECOMMENDATIONS__GCS__BUCKET_NAME

--- a/merino/configs/development.toml
+++ b/merino/configs/development.toml
@@ -90,3 +90,16 @@ cdn_hostname = "localhost:4443"
 [development.contextual_interest]
 # disabled in dev so we don't fetch artifacts locally
 enabled = false
+
+[development.games_particle_gcs]
+# MERINO_GAMES_PARTICLE__GCS_PROJECT
+# GCS project name that contains domain data (GCP V2)
+gcs_project = ""
+
+# MERINO_GAMES_PARTICLE__GCS_BUCKET
+# GCS bucket that contains domain data files (GCP V2)
+gcs_bucket = "merino-games-particle-local"
+
+# MERINO_GAMES_PARTICLE__CDN_HOSTNAME
+# CDN hostname used for public URL (GCP V2)
+cdn_hostname = "localhost:4443"

--- a/merino/configs/stage.toml
+++ b/merino/configs/stage.toml
@@ -54,6 +54,23 @@ gcs_project = "moz-fx-merino-nonprod-db57"
 # Set to `true` in production and `false` in staging or development.
 gcs_enabled = false
 
+# MERINO_GAMES_PARTICLE__GCS_BUCKET
+# GCS bucket that contains domain data files (GCP V2)
+gcs_bucket = "merino-games-particle-stage"
+
+# MERINO_GAMES_PARTICLE__CDN_HOSTNAME
+# CDN hostname used for public URL (GCP V2)
+cdn_hostname = "stage-games-particle.merino.nonprod.webservices.mozgcp.net"
+
+[stage.games_providers.particle]
+# MERINO_GAMES_PROVIDERS__PARTICLE__ENABLED
+# Whether or not the provider's cron runs to regularly update game files.
+enabled = true
+
+# MERINO_GAMES_PROVIDERS__PARTICLE__GAME_URL
+# The URL pointing to the game hosted in GCP (GCS)
+game_url = "https://stage-games-particle.merino.nonprod.webservices.mozgcp.net/index.html"
+
 [stage.providers.top_picks]
 # MERINO_PROVIDERS__TOP_PICKS__DOMAIN_DATA_SOURCE
 domain_data_source = "remote"

--- a/merino/jobs/cli.py
+++ b/merino/jobs/cli.py
@@ -3,21 +3,22 @@
 import logging
 import typer
 
-from merino.configs import settings
 from merino_common.app_configs.config_logging import configure_logging
 from merino_common.app_configs.config_sentry import configure_sentry
+from merino.configs import settings
 from merino.jobs.amo_rs_uploader import amo_rs_uploader_cmd
 from merino.jobs.csv_rs_uploader import csv_rs_uploader_cmd
-from merino.jobs.geonames_uploader import geonames_uploader_cmd
-from merino.jobs.navigational_suggestions import navigational_suggestions_cmd
-from merino.jobs.relevancy_uploader import relevancy_csv_rs_uploader_cmd
-from merino.jobs.wikipedia_indexer import indexer_cmd
-from merino.jobs.wikipedia_offline_uploader import wiki_offline_uploader_cmd
-from merino.jobs.polygon import cli as polygon_ingestion_cmd
-from merino.jobs.flightaware import cli as flightaware_fetch_schedules_cmd
-from merino.jobs.sportsdata_jobs import cli as sportsdata_cmd
 from merino.jobs.engagement_model import cli as engagement_data_cmd
 from merino.jobs.engagement_model.amp_live_probe import cli as amp_live_probe_cmd
+from merino.jobs.flightaware import cli as flightaware_fetch_schedules_cmd
+from merino.jobs.geonames_uploader import geonames_uploader_cmd
+from merino.jobs.navigational_suggestions import navigational_suggestions_cmd
+from merino.jobs.games import cli as games_tasks_cmd
+from merino.jobs.polygon import cli as polygon_ingestion_cmd
+from merino.jobs.relevancy_uploader import relevancy_csv_rs_uploader_cmd
+from merino.jobs.sportsdata_jobs import cli as sportsdata_cmd
+from merino.jobs.wikipedia_indexer import indexer_cmd
+from merino.jobs.wikipedia_offline_uploader import wiki_offline_uploader_cmd
 
 # Include your new jobs module here.
 
@@ -56,6 +57,9 @@ cli.add_typer(engagement_data_cmd, no_args_is_help=True)
 
 # Add the AMP live dataset access probe subcommand
 cli.add_typer(amp_live_probe_cmd, no_args_is_help=True)
+
+# Add the games task runner subcommand
+cli.add_typer(games_tasks_cmd, no_args_is_help=True)
 
 
 @cli.callback()

--- a/merino/jobs/games/__init__.py
+++ b/merino/jobs/games/__init__.py
@@ -1,0 +1,28 @@
+"""CLI commands for the Particle updater job."""
+
+import asyncio
+import logging
+import typer
+
+from merino.providers import games
+
+logger = logging.getLogger(__name__)
+
+cli = typer.Typer(
+    name="games_tasks",
+    help="Commands to process data related to New Tab games.",
+)
+
+
+@cli.command("update-particle")
+def update_particle():  # pragma: no cover
+    """Initialize the Particle provider and execute the process to attempt to update the Particle game."""
+    games.init_particle()
+
+    provider = games.get_particle_provider()
+
+    logger.info("Beginning Particle update process...")
+
+    updated = asyncio.run(provider.run_update_process())
+
+    logger.info(f"Finished Particle update process. Files updated? {updated}")

--- a/merino/providers/games/__init__.py
+++ b/merino/providers/games/__init__.py
@@ -21,7 +21,6 @@ _particle_provider: Provider | None = None
 
 # Module-level variables as looking up from settings each time is expensive.
 _connect_timeout = settings.games_providers.particle.connect_timeout_sec
-_cron_interval_sec = settings.games_providers.particle.cron_interval_sec
 _enabled = settings.games_providers.particle.enabled
 _gcs_project = settings.games_particle_gcs.gcs_project
 _gcs_bucket = settings.games_particle_gcs.gcs_bucket
@@ -32,13 +31,17 @@ _manifest_schema_file_path = (
     f"{_app_root_dir}/{settings.games_providers.particle.manifest_schema_file_path}"
 )
 _manifest_schema_version = settings.games_providers.particle.manifest_schema_version
-_resync_interval_sec = settings.games_providers.particle.resync_interval_sec
 _url_root = settings.games_providers.particle.url_root
 _url_path_manifest = settings.games_providers.particle.url_path_manifest
 
 
 async def init_providers() -> None:
     """Initialize games providers - currently only Particle"""
+    init_particle()
+
+
+def init_particle() -> None:
+    """Initialize the Particle provider."""
     global _particle_provider
 
     gcs_uploader = GcsUploader(
@@ -72,16 +75,12 @@ async def init_providers() -> None:
 
     _particle_provider = Provider(
         backend=particle_backend,
-        cron_interval_sec=_cron_interval_sec,
         manifest_schema=local_file_manager.get_manifest_schema(),
         manifest_schema_version=_manifest_schema_version,
         metrics_client=metrics_client,
         name="Particle Provider",
-        resync_interval_sec=_resync_interval_sec,
         enabled=_enabled,
     )
-
-    await _particle_provider.initialize()
 
 
 def get_particle_provider() -> Provider:

--- a/merino/providers/games/particle/backends/filemanager.py
+++ b/merino/providers/games/particle/backends/filemanager.py
@@ -65,7 +65,7 @@ class ParticleRemoteFileManager:
         self.green_deployment_folder = green_deployment_folder
         self.manifest_file_name = manifest_file_name
 
-    def get_manifest_file(self) -> dict[str, Any]:
+    def get_manifest_file(self) -> dict[str, Any] | None:
         """Read remote manifest file from GCS.
 
         Raises:
@@ -91,11 +91,7 @@ class ParticleRemoteFileManager:
 
             raise ParticleFileManagerError(error_msg) from ex
 
-        # if manifest is still None, the blob in GCS was empty, so we need to raise
-        if manifest is None:
-            raise ParticleFileManagerError("GCS manifest file is empty.")
-
-        # if the manifest was retrieved and converted to JSON, return it
+        # return json, or None if the blob wasn't found in GCS (cold start)
         return manifest
 
     async def upload_file(self, file_name: str, file_path: str, content_type: str) -> str:

--- a/merino/providers/games/particle/backends/particle.py
+++ b/merino/providers/games/particle/backends/particle.py
@@ -105,10 +105,12 @@ class ParticleBackend:
         return await asyncio.to_thread(self.remote_file_manager.get_manifest_file)
 
     async def update_channel_files(
-        self, manifest_remote: Json, manifest_gcs: Json, channel: RemoteChannelEnum
+        self, manifest_remote: Json, manifest_gcs: Json | None, channel: RemoteChannelEnum
     ) -> bool:
         """Attempt to update files for the given channel."""
-        if remote_manifest_channel_is_updated(manifest_remote, manifest_gcs, channel):
+        if manifest_gcs is None or remote_manifest_channel_is_updated(
+            manifest_remote, manifest_gcs, channel
+        ):
             # get the files for the given channel from the remote manifest
             files: list[GameFile] = get_files_from_manifest_for_channel(manifest_remote, channel)
 
@@ -120,7 +122,7 @@ class ParticleBackend:
                 # if no files were found, exit early
                 sentry_sdk.capture_exception(
                     ParticleRemoteFileProcessError(
-                        f"No files found in remote manifest for {channel} channel."
+                        f"No files found in remote manifest for {channel.value} channel."
                     )
                 )
                 return False
@@ -220,7 +222,7 @@ class ParticleBackend:
         return await self.remote_file_manager.upload_manifest(manifest=manifest)
 
     async def cleanup_old_files_for_channel(
-        self, manifest_remote: Json, manifest_gcs: Json, channel: RemoteChannelEnum
+        self, manifest_remote: Json, manifest_gcs: Json | None, channel: RemoteChannelEnum
     ) -> None:
         """Clean up any outdated files for the given channel. Run after a channel deploy has succeeded."""
         files_to_delete: list[str] = get_files_for_cleanup_for_channel(

--- a/merino/providers/games/particle/backends/protocol.py
+++ b/merino/providers/games/particle/backends/protocol.py
@@ -52,7 +52,7 @@ class ParticleBackend(Protocol):
         ...
 
     async def update_channel_files(
-        self, manifest_remote: Json, manifest_gcs: Json, channel: RemoteChannelEnum
+        self, manifest_remote: Json, manifest_gcs: Json | None, channel: RemoteChannelEnum
     ) -> bool:
         """Attempt to update files in GCS for the given channel."""
         ...

--- a/merino/providers/games/particle/backends/utils.py
+++ b/merino/providers/games/particle/backends/utils.py
@@ -106,11 +106,15 @@ def validate_manifest_against_schema(manifest_json: Json, manifest_schema: Json)
 
 
 def remote_manifest_channel_is_updated(
-    manifest_remote: Json, manifest_gcs: Json, channel: RemoteChannelEnum
+    manifest_remote: Json, manifest_gcs: Json | None, channel: RemoteChannelEnum
 ) -> bool:
     """Determine if the JSON manifest from Particle has newer files for the given channel than the manifest we have stored in GCS."""
-    remote = manifest_remote["channels"][channel]["version"]
-    gcs = manifest_gcs["channels"][channel]["version"]
+    # if there is no manifest in GCS (cold start), channel needs to be updated
+    if manifest_gcs is None:
+        return True
+
+    remote = manifest_remote["channels"][channel.value]["version"]
+    gcs = manifest_gcs["channels"][channel.value]["version"]
 
     return bool(remote != gcs)
 
@@ -122,7 +126,7 @@ def get_files_from_manifest_for_channel(
     game_files = []
 
     try:
-        files = manifest["channels"][channel]["files"]
+        files = manifest["channels"][channel.value]["files"]
     except KeyError as ex:
         files = []
 
@@ -137,7 +141,7 @@ def get_files_from_manifest_for_channel(
 
 
 def get_files_for_cleanup_for_channel(
-    manifest_remote: Json, manifest_gcs: Json, channel: RemoteChannelEnum
+    manifest_remote: Json, manifest_gcs: Json | None, channel: RemoteChannelEnum
 ) -> list[str]:
     """Get a list of string file names/paths from the old deployment that should be deleted from GCS."""
     # get files from remote manifest for channel - this is the "green"
@@ -145,8 +149,13 @@ def get_files_for_cleanup_for_channel(
     green_files: list[GameFile] = get_files_from_manifest_for_channel(manifest_remote, channel)
 
     # get files from the previous GCS manifest - this is the "blue"
-    # deployment that is no longer in release
-    blue_files: list[GameFile] = get_files_from_manifest_for_channel(manifest_gcs, channel)
+    # deployment that is no longer in release.
+    # on a cold start, this list is empty.
+    blue_files: list[GameFile] = (
+        get_files_from_manifest_for_channel(manifest_gcs, channel)
+        if manifest_gcs is not None
+        else []
+    )
 
     # get a list of files present in the "blue" deploy that are not present
     # in the "green" deploy - these files were not overwritten by the

--- a/merino/providers/games/particle/provider.py
+++ b/merino/providers/games/particle/provider.py
@@ -1,10 +1,8 @@
 """Particle integration."""
 
 import aiodogstatsd
-import asyncio
 import logging
 import sentry_sdk
-import time
 
 from pydantic import Json
 from typing import Any
@@ -17,7 +15,6 @@ from merino.providers.games.particle.backends.utils import (
     ParticleManifestValidationError,
     RemoteChannelEnum,
 )
-from merino.utils import cron
 
 logger = logging.getLogger(__name__)
 
@@ -26,55 +23,33 @@ class Provider:
     """Particle provider for games."""
 
     backend: ParticleBackend
-    cron_interval_sec: float
-    last_successful_update_at: float
     manifest_schema: Json
     manifest_schema_version: int
     metrics_client: aiodogstatsd.Client
-    cron_task: asyncio.Task
-    resync_interval_sec: float
 
     def __init__(
         self,
         backend: ParticleBackend,
-        cron_interval_sec: float,
         manifest_schema: Json,
         manifest_schema_version: int,
         metrics_client: aiodogstatsd.Client,
         name: str,
-        resync_interval_sec: float,
         enabled: bool = False,
         **kwargs: Any,
     ) -> None:
         self.backend = backend
-        self.cron_interval_sec = cron_interval_sec
-        self.last_successful_update_at = 0.0
         self.manifest_schema = manifest_schema
         self.manifest_schema_version = manifest_schema_version
         self.metrics_client = metrics_client
         self.name = name
-        self.resync_interval_sec = resync_interval_sec
         self._enabled = enabled
-        super().__init__(**kwargs)
 
-    async def initialize(self) -> None:
-        """Initialize the provider."""
-        if self._enabled:
-            # create a cron job to update particle game files
-            cron_job = cron.Job(
-                name="update_particle_game_data",
-                interval=self.cron_interval_sec,
-                condition=self._should_fetch_data,
-                task=self._fetch_game_data,
-            )
+    async def run_update_process(self) -> bool:
+        """Initiate the process to attempt to update Particle game files."""
+        # return early if the provider is not enabled
+        if not self._enabled:
+            return False
 
-            self.cron_task = asyncio.create_task(cron_job())
-
-    def _should_fetch_data(self) -> bool:
-        """Check if we should fetch Particle game data from the internet."""
-        return (time.time() - self.last_successful_update_at) >= self.resync_interval_sec
-
-    async def _fetch_game_data(self) -> None:
         manifest_json: Json | None = None
 
         try:
@@ -88,15 +63,11 @@ class Provider:
             sentry_sdk.capture_exception(ex)
 
         if manifest_json is None:
-            logger.warning(
-                f"Particle game data fetch returned None - will retry on next cron tick ({self.cron_interval_sec} seconds)"
-            )
-        else:
-            particle_updated = await self.process_remote_particle_data(manifest_json)
+            logger.warning("Particle game data fetch returned None - will retry on next cron run.")
 
-            # only update the last success time if we actually updated some files
-            if particle_updated:
-                self.last_successful_update_at = time.time()
+            return False
+        else:
+            return await self.process_remote_particle_data(manifest_json)
 
     async def process_remote_particle_data(self, remote_manifest_json: Json) -> bool:
         """Orchestration function to validate and upload new Particle game data files to GCS.
@@ -135,11 +106,17 @@ class Provider:
             channel=RemoteChannelEnum.PUZZLE,
         )
 
+        if puzzle_updated:
+            logger.info("Particle daily files updated")
+
         runtime_updated = await self.backend.update_channel_files(
             manifest_remote=remote_manifest_json,
             manifest_gcs=gcs_manifest_json,
             channel=RemoteChannelEnum.RUNTIME,
         )
+
+        if runtime_updated:
+            logger.info("Particle runtime files updated")
 
         manifest_updated = False
 

--- a/tests/integration/providers/games/particle/test_provider.py
+++ b/tests/integration/providers/games/particle/test_provider.py
@@ -69,32 +69,32 @@ def fixture_particle_provider(
 
     return Provider(
         backend=particle_backend,
-        cron_interval_sec=60,
         manifest_schema=manifest_validation_schema,
         manifest_schema_version=1,
         metrics_client=statsd_mock,
         name="particle",
-        resync_interval_sec=120,
-        enabled=False,
+        enabled=True,
     )
 
 
 @pytest.mark.asyncio
-async def test_fetch_game_data_successfully_processes_valid_remote_data(particle_provider) -> None:
+async def test_run_update_process_successfully_processes_valid_remote_data(
+    particle_provider,
+) -> None:
     """Test that fetching valid manifest data from particle succeeds"""
-    with patch.object(
-        particle_provider, "process_remote_particle_data", new=AsyncMock()
-    ) as mock_process_remote_data:
+    with (
+        patch.object(
+            particle_provider, "process_remote_particle_data", new_callable=AsyncMock
+        ) as mock_process_remote_data,
+        patch.object(
+            particle_provider.backend, "fetch_manifest_json_from_remote", new_callable=AsyncMock
+        ) as mock_fetch_manifest,
+    ):
         mock_process_remote_data.return_value = True
 
-        # verify last update is at the default value
-        assert particle_provider.last_successful_update_at == 0.0
-
-        await particle_provider._fetch_game_data()
-
-        # _fetch_game_data should have successfully run, updating the last update time
-        assert particle_provider.last_successful_update_at > 0.0
+        assert await particle_provider.run_update_process()
 
         # a successful fetch should result in process_remote_particle_data
         # being called
         mock_process_remote_data.assert_awaited_once()
+        mock_fetch_manifest.assert_awaited_once()

--- a/tests/unit/providers/games/particle/backends/test_filemanager.py
+++ b/tests/unit/providers/games/particle/backends/test_filemanager.py
@@ -173,12 +173,11 @@ class TestRemoteFileManager:
         self,
         remote_filemanager: ParticleRemoteFileManager,
     ) -> None:
-        """Test that the RemoteFileManager raises when the call to GCS returns None."""
+        """Test that the RemoteFileManager returns None when the call to GCS returns None."""
         remote_filemanager.gcs_client = MagicMock()
         remote_filemanager.gcs_client.get_file_by_name.return_value = None
 
-        with pytest.raises(ParticleFileManagerError):
-            remote_filemanager.get_manifest_file()
+        assert remote_filemanager.get_manifest_file() is None
 
     def test_get_manifest_file_invalid_json(
         self,

--- a/tests/unit/providers/games/particle/backends/test_particle_backend.py
+++ b/tests/unit/providers/games/particle/backends/test_particle_backend.py
@@ -331,6 +331,35 @@ class TestUpdateChannelFiles:
 
     @pytest.mark.parametrize("channel", test_params)
     @pytest.mark.asyncio
+    async def test_is_updated_with_no_gcs_manifest_cold_start(
+        self,
+        backend,
+        valid_manifest_data_json,
+        mock_remote_manifest_channel_is_updated,
+        mock_stage_channel_files,
+        mock_deploy_channel_files,
+        mock_cleanup_old_files_for_channel,
+        mock_successfully_updated_game_files,
+        mock_get_files_from_manifest_for_channel,
+        channel,
+    ):
+        """Test that channel is marked as updated when GCS manifest is missing (cold start), channel files are found, and staging deployment was successful (happy path)."""
+        # set up mocks for happy path
+        mock_get_files_from_manifest_for_channel.return_value = self.mock_game_files
+        mock_stage_channel_files.side_effect = [(True, mock_successfully_updated_game_files)]
+        mock_deploy_channel_files.side_effect = [True]
+
+        assert await backend.update_channel_files(valid_manifest_data_json, None, channel)
+
+        # ensure all inner functions were called as expected
+        mock_remote_manifest_channel_is_updated.assert_not_called()
+        mock_get_files_from_manifest_for_channel.assert_called_once()
+        mock_stage_channel_files.assert_awaited_once()
+        mock_deploy_channel_files.assert_awaited_once()
+        mock_cleanup_old_files_for_channel.assert_awaited_once()
+
+    @pytest.mark.parametrize("channel", test_params)
+    @pytest.mark.asyncio
     async def test_not_updated_if_manifest_versions_match(
         self,
         backend,

--- a/tests/unit/providers/games/particle/backends/test_utils.py
+++ b/tests/unit/providers/games/particle/backends/test_utils.py
@@ -180,6 +180,15 @@ class TestRemoteManifestChannelIsUpdated:
         )
 
     @pytest.mark.parametrize("channel", test_params)
+    def test_was_updated_no_gcs_manifest_cold_start(
+        self, valid_manifest_data_remote_updated, channel
+    ):
+        """Test that a missing GCS manifest results in an updated signal"""
+        assert remote_manifest_channel_is_updated(
+            valid_manifest_data_remote_updated, None, channel
+        )
+
+    @pytest.mark.parametrize("channel", test_params)
     def test_was_not_updated(self, valid_manifest_data, channel):
         """Test that comparing the same manifest results in a not updated signal"""
         assert not remote_manifest_channel_is_updated(
@@ -313,8 +322,8 @@ class TestGetFilesForCleanupForChannel:
             # this calls mock_get_files twice, returning the lists above, which
             # are used to determine which files need to be deleted
             runtime_files = get_files_for_cleanup_for_channel(
-                manifest_remote={},
-                manifest_gcs={},
+                manifest_remote="{}",  # these values don't matter, as the file lists are dictated by the mocks above
+                manifest_gcs="{}",
                 channel=RemoteChannelEnum.RUNTIME,
             )
 
@@ -322,3 +331,27 @@ class TestGetFilesForCleanupForChannel:
             # only assets/b.jpg is marked as old and needing to be deleted
             assert len(runtime_files) == 1
             assert runtime_files[0] == "assets/b.jpg"
+
+    def test_no_gcs_manifest_cold_start(self):
+        """Test that no files are marked for cleanup if the GCS manifest is missing (cold start)."""
+        with patch(
+            "merino.providers.games.particle.backends.utils.get_files_from_manifest_for_channel"
+        ) as mock_get_files:
+            # the newly deployed files
+            green_files = [
+                GameFile(url="assets/a.jpg", sha="123", content_type="image/jpeg"),
+                GameFile(url="assets/a.png", sha="123", content_type="image/png"),
+                GameFile(url="runtime/index-1234.html", sha="123", content_type="text/html"),
+            ]
+
+            mock_get_files.side_effect = [green_files]
+
+            # as manifest_gcs is None, there is no base list of files to cleanup
+            assert (
+                get_files_for_cleanup_for_channel(
+                    manifest_remote="{}",
+                    manifest_gcs=None,
+                    channel=RemoteChannelEnum.RUNTIME,
+                )
+                == []
+            )

--- a/tests/unit/providers/games/particle/test_provider.py
+++ b/tests/unit/providers/games/particle/test_provider.py
@@ -4,7 +4,6 @@
 
 """Unit tests for the Particle games provider."""
 
-import asyncio
 import json
 import logging
 import pytest
@@ -54,13 +53,11 @@ def fixture_provider(
     """Return a Provider instance for testing."""
     return Provider(
         backend=backend_mock,
-        cron_interval_sec=60,
         manifest_schema=manifest_validation_schema,
         manifest_schema_version=1,
         metrics_client=statsd_mock,
         name="particle",
-        resync_interval_sec=120,
-        enabled=False,
+        enabled=True,
     )
 
 
@@ -124,38 +121,7 @@ class TestProvider:
 
     def test_enabled(self, provider: Provider) -> None:
         """Test that enabled is set correctly."""
-        assert provider._enabled is False
-
-    @pytest.mark.asyncio
-    async def test_initialize(self, provider: Provider) -> None:
-        """Test that initialize completes without error."""
-        await provider.initialize()
-
-    @pytest.mark.asyncio
-    async def test_initialize_runs_cron_when_provider_enabled(self, provider):
-        """Initialize should call _fetch_game_data and create cron job when provider is enabled."""
-        with (
-            patch.object(provider, "_enabled", True),
-            patch("asyncio.create_task", wraps=asyncio.create_task) as mock_create_task,
-            patch("merino.providers.games.particle.provider.cron.Job") as mock_cron_job,
-        ):
-            mock_job_instance = AsyncMock(name="mock_cron_job")
-            mock_cron_job.return_value = mock_job_instance
-
-            await provider.initialize()
-
-            mock_cron_job.assert_called_once_with(
-                name="update_particle_game_data",
-                interval=provider.cron_interval_sec,
-                condition=provider._should_fetch_data,
-                task=provider._fetch_game_data,
-            )
-
-            mock_create_task.assert_called_once()
-            args, _ = mock_create_task.call_args
-            called_arg = args[0]
-            assert asyncio.iscoroutine(called_arg)
-            assert hasattr(provider, "cron_task")
+        assert provider._enabled is True
 
 
 class TestGetGameUrl:
@@ -185,69 +151,42 @@ class TestGetGameUrl:
         assert particle.url == test_game_url
 
 
-class TestShouldFetchData:
-    """Tests against should_fetch_data"""
-
-    def test_should_fetch_data_returns_true_when_interval_satsified(self, provider):
-        """_should_fetch_data should return True if the time interval condition is satisfied"""
-        with (
-            patch("merino.providers.games.particle.provider.time.time", side_effect=[100]),
-            patch.object(provider, "resync_interval_sec", 50),
-            patch.object(provider, "last_successful_update_at", 50),
-        ):
-            assert provider._should_fetch_data() is True
-
-    def test_should_fetch_data_returns_false_when_interval_not_satsified(self, provider):
-        """_should_fetch_data should return False if the time interval condition is not satisfied"""
-        with (
-            patch("merino.providers.games.particle.provider.time.time", side_effect=[100]),
-            patch.object(provider, "resync_interval_sec", 60),
-            patch.object(provider, "last_successful_update_at", 50),
-        ):
-            assert provider._should_fetch_data() is False
-
-
 class TestFetchGameData:
     """Tests against fetch_game_data"""
 
     @pytest.mark.asyncio
     async def test_happy_path(self, provider, valid_manifest_data):
-        """Test that _fetch_game_data retrieves remote json and updates as expected"""
+        """Test that run_update_process retrieves remote json and updates as expected"""
         with (
             patch.object(
                 provider.backend, "fetch_manifest_json_from_remote", new=AsyncMock()
             ) as mock_fetch_manifest,
             patch.object(provider, "process_remote_particle_data") as mock_process_data,
-            patch("merino.providers.games.particle.provider.time.time", side_effect=[100]),
         ):
             mock_fetch_manifest.return_value = valid_manifest_data
             mock_process_data.return_value = True
 
-            await provider._fetch_game_data()
+            assert await provider.run_update_process()
 
             mock_fetch_manifest.assert_awaited_once()
             mock_process_data.assert_called_once()
-            assert provider.last_successful_update_at == 100
 
     @pytest.mark.asyncio
     async def test_processing_remote_data_fails(self, provider, valid_manifest_data):
-        """Test that _fetch_game_data retrieves remote json but processing the json fails"""
+        """Test that run_update_process retrieves remote json but processing the json fails"""
         with (
             patch.object(
                 provider.backend, "fetch_manifest_json_from_remote", new=AsyncMock()
             ) as mock_fetch_manifest,
             patch.object(provider, "process_remote_particle_data") as mock_process_data,
-            patch.object(provider, "last_successful_update_at", 0.0),
-            patch("merino.providers.games.particle.provider.time.time", side_effect=[100]),
         ):
             mock_fetch_manifest.return_value = valid_manifest_data
             mock_process_data.return_value = False
 
-            await provider._fetch_game_data()
+            assert not await provider.run_update_process()
 
             mock_fetch_manifest.assert_awaited_once()
             mock_process_data.assert_called_once()
-            assert provider.last_successful_update_at == 0.0
 
     @pytest.mark.asyncio
     async def test_remote_fetch_fails(
@@ -256,26 +195,21 @@ class TestFetchGameData:
         caplog: LogCaptureFixture,
         filter_caplog: FilterCaplogFixture,
     ):
-        """Test that _fetch_game_data logs as expected if the remote fetch fails"""
+        """Test that run_update_process logs as expected if the remote fetch fails"""
         with (
             patch.object(
                 provider.backend, "fetch_manifest_json_from_remote", new=AsyncMock()
             ) as mock_fetch_manifest,
             patch.object(provider, "process_remote_particle_data") as mock_process_data,
-            patch.object(provider, "last_successful_update_at", 0.0),
-            patch("merino.providers.games.particle.provider.time.time", side_effect=[100]),
         ):
             caplog.set_level(logging.INFO)
 
             mock_fetch_manifest.side_effect = Exception("kaboom!")
 
-            await provider._fetch_game_data()
+            assert not await provider.run_update_process()
 
             mock_fetch_manifest.assert_awaited_once()
             mock_process_data.assert_not_awaited()
-
-            # ensure the last_successful_update_at value was not updated
-            assert provider.last_successful_update_at == 0.0
 
             records: list[LogRecord] = filter_caplog(
                 caplog.records, "merino.providers.games.particle.provider"
@@ -287,7 +221,7 @@ class TestFetchGameData:
                 "Failed to fetch Particle game data from remote endpoint"
             )
             assert records[1].message.startswith(
-                "Particle game data fetch returned None - will retry on next cron tick"
+                "Particle game data fetch returned None - will retry on next cron run."
             )
 
 


### PR DESCRIPTION
## References

JIRA: [HNT-2684](https://mozilla-hub.atlassian.net/browse/HNT-2684)

## Description
create a CLI job for K8s cron to execute. replaces old python based "cron", which means a fair amount of code deletion.

also refactors the process to handle a cold start, meaning no manifest data found in GCS.

enables the provider in stage so we can run the update process/cron in that env for testing.

cron enablement in https://github.com/mozilla/webservices-infra/pull/11478

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2421)


[HNT-2684]: https://mozilla-hub.atlassian.net/browse/HNT-2684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ