### PR TITLE
[AIMOD-1297] Enable Query Normalization for Finance & Sports

### DIFF
--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -287,7 +287,7 @@ async def suggest(
     # Query normalization (sports and finance only)
     pipeline = get_pipeline()
     use_normalization = pipeline is not None
-    if use_normalization:
+    if pipeline is not None:
         with metrics_client.timeit("normalization.experiment.timing"):
             q_normalized = pipeline.normalize(q)
     else:

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -91,8 +91,7 @@ from merino.providers.games.particle.provider import Provider as ParticleProvide
 logger = logging.getLogger(__name__)
 router = APIRouter()
 
-# Query normalization experiment
-NORMALIZATION_CLIENT_VARIANT: str = "query_norm_treatment"
+# Providers enabled for query normalization
 NORMALIZATION_PROVIDERS: frozenset[str] = frozenset(settings.query_normalization.providers)
 
 # Param to capture all enabled_by_default=True providers.
@@ -285,12 +284,10 @@ async def suggest(
     geolocation = refine_geolocation_for_suggestion(request, city, region, country)
     client_variants_list = client_variants.split(",") if client_variants else []
 
-    # Query normalization experiment (Phase 1: sports + finance only)
+    # Query normalization (sports and finance only)
     pipeline = get_pipeline()
-    use_normalization = (
-        pipeline is not None and NORMALIZATION_CLIENT_VARIANT in client_variants_list
-    )
-    if use_normalization and pipeline:
+    use_normalization = pipeline is not None
+    if use_normalization:
         with metrics_client.timeit("normalization.experiment.timing"):
             q_normalized = pipeline.normalize(q)
     else:


### PR DESCRIPTION
## References

JIRA: [AIMOD-1297](https://mozilla-hub.atlassian.net/browse/AIMOD-1297)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->
This pr enables the query normalization pipeline for "Sports" and "Finance" providers. Other providers still go through the regular flow.

There's a current feature gate `settings.query_normalization.enabled` that can be turned off if needed. There's also `settings.query_normalization.providers` which allows query normalization only for the sports and finance providers.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2422)


[AIMOD-1297]: https://mozilla-hub.atlassian.net/browse/AIMOD-1297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ