### PR TITLE
Revert "Revert "[DISCO-4294] chore(fleece): use POST on the pii detection endpoint""

### DIFF
--- a/merino-fleece/README.md
+++ b/merino-fleece/README.md
@@ -8,7 +8,7 @@ Search term sanitization looks for most commonly occurring personally identifiab
 
 ## PII / NER endpoint
 
-`GET /api/v1/pii?q=<text>` — returns `{"pii": true}` when the input text contains a SpaCy `PERSON` named entity, otherwise `{"pii": false}`.
+`POST /api/v1/pii` with a JSON body `{"q": "<text>"}` — returns `{"pii": true}` when the input text contains a SpaCy `PERSON` named entity, otherwise `{"pii": false}`.
 
 ## Running locally
 

--- a/merino-fleece/merino_fleece/api/v1/pii.py
+++ b/merino-fleece/merino_fleece/api/v1/pii.py
@@ -5,7 +5,7 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, Query
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from merino_fleece.configs import settings
 from merino_fleece.pii import get_detector, get_executor
@@ -17,26 +17,21 @@ QUERY_CHARACTER_MAX = settings.pii.query_character_max
 router = APIRouter(tags=["pii"])
 
 
+class PiiRequest(BaseModel):
+    """Request body for the PII endpoint."""
+
+    q: str = Field(
+        min_length=1, max_length=QUERY_CHARACTER_MAX, description="Text to scan for PII."
+    )
+
+
 class PiiResponse(BaseModel):
     """Response for the PII endpoint."""
 
     pii: bool
 
 
-@router.get(
-    "/pii",
-    tags=["pii"],
-    summary="Merino-fleece PII endpoint",
-    response_model=PiiResponse,
-)
-async def detect_pii(
-    q: Annotated[
-        str,
-        Query(min_length=1, max_length=QUERY_CHARACTER_MAX, description="Text to scan for PII."),
-    ],
-    detector: PiiDetector = Depends(get_detector),
-    executor: ThreadPoolExecutor = Depends(get_executor),
-) -> PiiResponse:
+async def _detect_pii(q: str, detector: PiiDetector, executor: ThreadPoolExecutor) -> PiiResponse:
     """Return whether `q` contains a PERSON named entity.
 
     SpaCy NER is CPU-bound and synchronous; it runs in the shared thread pool so
@@ -46,3 +41,40 @@ async def detect_pii(
     with get_metrics_client().timeit("pii.detect_duration"):
         pii = await loop.run_in_executor(executor, detector.is_person, q)
     return PiiResponse(pii=pii)
+
+
+@router.post(
+    "/pii",
+    tags=["pii"],
+    summary="Merino-fleece PII endpoint",
+    response_model=PiiResponse,
+)
+async def detect_pii(
+    body: PiiRequest,
+    detector: PiiDetector = Depends(get_detector),
+    executor: ThreadPoolExecutor = Depends(get_executor),
+) -> PiiResponse:
+    """Return whether `body.q` contains a PERSON named entity."""
+    return await _detect_pii(body.q, detector, executor)
+
+
+@router.get(
+    "/pii",
+    tags=["pii"],
+    summary="Merino-fleece PII endpoint (deprecated; use POST)",
+    response_model=PiiResponse,
+    deprecated=True,
+)
+async def detect_pii_get(
+    q: Annotated[
+        str,
+        Query(min_length=1, max_length=QUERY_CHARACTER_MAX, description="Text to scan for PII."),
+    ],
+    detector: PiiDetector = Depends(get_detector),
+    executor: ThreadPoolExecutor = Depends(get_executor),
+) -> PiiResponse:
+    """Return whether `q` contains a PERSON named entity.
+
+    Retained for backwards compatibility; prefer the POST endpoint.
+    """
+    return await _detect_pii(q, detector, executor)

--- a/merino-fleece/tests/unit/api/v1/test_pii.py
+++ b/merino-fleece/tests/unit/api/v1/test_pii.py
@@ -51,7 +51,7 @@ def make_client() -> Iterator:
 def test_pii_true(make_client) -> None:
     """Detector reporting PERSON returns pii=true."""
     client = make_client(True)
-    resp = client.get("/api/v1/pii", params={"q": "Alice Bob"})
+    resp = client.post("/api/v1/pii", json={"q": "Alice Bob"})
     assert resp.status_code == 200
     assert resp.json() == {"pii": True}
 
@@ -59,22 +59,22 @@ def test_pii_true(make_client) -> None:
 def test_pii_false(make_client) -> None:
     """Detector reporting no PERSON returns pii=false."""
     client = make_client(False)
-    resp = client.get("/api/v1/pii", params={"q": "the weather is nice"})
+    resp = client.post("/api/v1/pii", json={"q": "the weather is nice"})
     assert resp.status_code == 200
     assert resp.json() == {"pii": False}
 
 
 def test_missing_query(make_client) -> None:
-    """A missing `q` parameter is rejected with 422."""
+    """A missing `q` field is rejected with 422."""
     client = make_client(False)
-    resp = client.get("/api/v1/pii")
+    resp = client.post("/api/v1/pii", json={})
     assert resp.status_code == 422
 
 
 def test_query_too_long(make_client) -> None:
     """A `q` exceeding the configured max length is rejected with 422."""
     client = make_client(False)
-    resp = client.get("/api/v1/pii", params={"q": "x" * 501})
+    resp = client.post("/api/v1/pii", json={"q": "x" * 501})
     assert resp.status_code == 422
 
 
@@ -86,7 +86,7 @@ def test_pii_metrics(
     report = mocker.patch.object(aiodogstatsd.Client, "_report")
 
     client = make_client(True)
-    client.get("/api/v1/pii", params={"q": "Alice Bob"})
+    client.post("/api/v1/pii", json={"q": "Alice Bob"})
 
     report.assert_called_once()
     assert report.call_args[0][0] == "pii.detect_duration"

--- a/merino/utils/query_processing/fleece_client.py
+++ b/merino/utils/query_processing/fleece_client.py
@@ -24,7 +24,7 @@ class FleeceClient:
 
     async def detect_pii(self, query: str) -> bool:
         """Return whether merino-fleece flags `query` as containing PII."""
-        response = await self.http_client.get(self.pii_path, params={"q": query})
+        response = await self.http_client.post(self.pii_path, json={"q": query})
         response.raise_for_status()
         return bool(response.json()["pii"])
 

--- a/tests/unit/utils/query_processing/test_fleece_client.py
+++ b/tests/unit/utils/query_processing/test_fleece_client.py
@@ -31,7 +31,7 @@ def _response(json_body: Any, status_code: int = 200) -> httpx.Response:
     return httpx.Response(
         status_code=status_code,
         json=json_body,
-        request=httpx.Request("GET", "http://test-fleece/api/v1/pii?q=test"),
+        request=httpx.Request("POST", "http://test-fleece/api/v1/pii"),
     )
 
 
@@ -41,7 +41,7 @@ async def test_detect_pii_parses_flag(
     mocker: MockerFixture, fleece: FleeceClient, pii: bool, expected: bool
 ) -> None:
     """Test that detect_pii returns the boolean `pii` field from the fleece response."""
-    mocker.patch.object(httpx.AsyncClient, "get", return_value=_response({"pii": pii}))
+    mocker.patch.object(httpx.AsyncClient, "post", return_value=_response({"pii": pii}))
 
     assert await fleece.detect_pii("barack obama") is expected
     await fleece.shutdown()
@@ -52,7 +52,7 @@ async def test_detect_pii_safe_returns_result_and_times(
     mocker: MockerFixture, fleece: FleeceClient, statsd_mock: Any
 ) -> None:
     """Test that detect_pii_safe returns the detected value and records the duration metric."""
-    mocker.patch.object(httpx.AsyncClient, "get", return_value=_response({"pii": True}))
+    mocker.patch.object(httpx.AsyncClient, "post", return_value=_response({"pii": True}))
 
     assert await fleece.detect_pii_safe("barack obama", statsd_mock) is True
     statsd_mock.timeit.assert_called_once_with("fleece.pii.detect_duration")
@@ -68,7 +68,7 @@ async def test_detect_pii_safe_fails_open_on_http_error(
 ) -> None:
     """Test that http error returns False and emits an error metric."""
     mocker.patch.object(
-        httpx.AsyncClient, "get", side_effect=httpx.ConnectError("connection refused")
+        httpx.AsyncClient, "post", side_effect=httpx.ConnectError("connection refused")
     )
 
     assert await fleece.detect_pii_safe("barack obama", statsd_mock) is False
@@ -82,7 +82,7 @@ async def test_detect_pii_safe_fails_open_on_bad_response(
     mocker: MockerFixture, fleece: FleeceClient, statsd_mock: Any
 ) -> None:
     """Test that a response missing the `pii` key returns False and emits a response error metric."""
-    mocker.patch.object(httpx.AsyncClient, "get", return_value=_response({"unexpected": 1}))
+    mocker.patch.object(httpx.AsyncClient, "post", return_value=_response({"unexpected": 1}))
 
     assert await fleece.detect_pii_safe("barack obama", statsd_mock) is False
     statsd_mock.increment.assert_called_once_with("fleece.pii.error", tags={"reason": "response"})


### PR DESCRIPTION
Reverts mozilla-services/merino-py#1610 (re-enable)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2424)
