### PR TITLE
HNT-264 fix: fix bug in stage.toml for particle provider

### DIFF
--- a/merino/configs/stage.toml
+++ b/merino/configs/stage.toml
@@ -45,7 +45,7 @@ gcs_bucket = "merino-images-stagepy"
 # carries the same content as prod.
 cdn_hostname = "prod-images.merino.prod.webservices.mozgcp.net"
 
-[stage.games_particle.gcs]
+[stage.games_particle_gcs]
 # MERINO_GAMES_PARTICLE_GCS__GCS_PROJECT (GCP V2)
 gcs_project = "moz-fx-merino-nonprod-db57"
 


### PR DESCRIPTION
## References

JIRA: [HNT-2684](https://mozilla-hub.atlassian.net/browse/HNT-2684)

## Description

fixes a typo in the stage.toml file related to the particle games provider.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2425)


[HNT-2684]: https://mozilla-hub.atlassian.net/browse/HNT-2684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ