### PR TITLE
[HNT-2204] feat: Serve Polish (PL) content on New Tab

### DIFF
--- a/merino/curated_recommendations/corpus_backends/protocol.py
+++ b/merino/curated_recommendations/corpus_backends/protocol.py
@@ -49,6 +49,7 @@ class SurfaceId(str, Enum):
     NEW_TAB_ES_ES = "NEW_TAB_ES_ES"
     NEW_TAB_FR_FR = "NEW_TAB_FR_FR"
     NEW_TAB_IT_IT = "NEW_TAB_IT_IT"
+    NEW_TAB_PL_PL = "NEW_TAB_PL_PL"
 
 
 class CreateSource(str, Enum):

--- a/merino/curated_recommendations/corpus_backends/scheduled_surface_backend.py
+++ b/merino/curated_recommendations/corpus_backends/scheduled_surface_backend.py
@@ -86,6 +86,7 @@ class ScheduledSurfaceBackend(ScheduledSurfaceProtocol):
             SurfaceId.NEW_TAB_ES_ES: "Europe/Madrid",
             SurfaceId.NEW_TAB_FR_FR: "Europe/Paris",
             SurfaceId.NEW_TAB_IT_IT: "Europe/Rome",
+            SurfaceId.NEW_TAB_PL_PL: "Europe/Warsaw",
         }
 
         try:

--- a/merino/curated_recommendations/corpus_backends/utils.py
+++ b/merino/curated_recommendations/corpus_backends/utils.py
@@ -47,6 +47,7 @@ def get_utm_source(surface_id: SurfaceId) -> str | None:
         SurfaceId.NEW_TAB_ES_ES: "firefox-newtab-es-es",
         SurfaceId.NEW_TAB_FR_FR: "firefox-newtab-fr-fr",
         SurfaceId.NEW_TAB_IT_IT: "firefox-newtab-it-it",
+        SurfaceId.NEW_TAB_PL_PL: "firefox-newtab-pl-pl",
     }
     return utm_mapping.get(surface_id)
 

--- a/merino/curated_recommendations/localization.py
+++ b/merino/curated_recommendations/localization.py
@@ -28,6 +28,9 @@ LOCALIZED_SECTION_TITLES: LocalizedTopicSectionTitles = {
     SurfaceId.NEW_TAB_DE_DE: {
         "top-stories": "Meistgelesen",
     },
+    SurfaceId.NEW_TAB_PL_PL: {
+        "top-stories": "Przegląd dnia",
+    },
 }
 
 

--- a/merino/curated_recommendations/protocol.py
+++ b/merino/curated_recommendations/protocol.py
@@ -62,6 +62,8 @@ class Locale(str, Enum):
     DE_DE = ("de-DE",)
     DE_AT = ("de-AT",)
     DE_CH = ("de-CH",)
+    PL = ("pl",)
+    PL_PL = ("pl-PL",)
 
     @staticmethod
     def values():

--- a/merino/curated_recommendations/utils.py
+++ b/merino/curated_recommendations/utils.py
@@ -42,6 +42,8 @@ def get_recommendation_surface_id(
 
     if language == "de":
         return SurfaceId.NEW_TAB_DE_DE
+    elif language == "pl":
+        return SurfaceId.NEW_TAB_PL_PL
     elif language == "es":
         return SurfaceId.NEW_TAB_ES_ES
     elif language == "fr":

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -765,6 +765,8 @@ class TestCuratedRecommendationsRequestParameters:
             (Locale.ES_ES, SurfaceId.NEW_TAB_ES_ES),
             (Locale.IT, SurfaceId.NEW_TAB_IT_IT),
             (Locale.IT_IT, SurfaceId.NEW_TAB_IT_IT),
+            (Locale.PL, SurfaceId.NEW_TAB_PL_PL),
+            (Locale.PL_PL, SurfaceId.NEW_TAB_PL_PL),
         ],
     )
     def test_curated_recommendations_locales(self, locale, surface_id, client: TestClient):
@@ -1529,6 +1531,7 @@ class TestSections:
         [
             SurfaceId.NEW_TAB_EN_US,
             SurfaceId.NEW_TAB_EN_GB,
+            SurfaceId.NEW_TAB_PL_PL,
         ],
     )
     def test_section_translations(self, surface_id):

--- a/tests/unit/curated_recommendations/corpus_backends/test_scheduled_corpus_backend.py
+++ b/tests/unit/curated_recommendations/corpus_backends/test_scheduled_corpus_backend.py
@@ -21,6 +21,7 @@ from pytest import LogCaptureFixture
         (SurfaceId.NEW_TAB_ES_ES, "Europe/Madrid"),
         (SurfaceId.NEW_TAB_FR_FR, "Europe/Paris"),
         (SurfaceId.NEW_TAB_IT_IT, "Europe/Rome"),
+        (SurfaceId.NEW_TAB_PL_PL, "Europe/Warsaw"),
     ],
 )
 def test_get_surface_timezone(surface_id, timezone_str, caplog: LogCaptureFixture):

--- a/tests/unit/curated_recommendations/corpus_backends/test_utils.py
+++ b/tests/unit/curated_recommendations/corpus_backends/test_utils.py
@@ -65,6 +65,7 @@ def test_get_utm_source_return_none(scheduled_surface_id):
         (SurfaceId.NEW_TAB_ES_ES, "firefox-newtab-es-es"),
         (SurfaceId.NEW_TAB_FR_FR, "firefox-newtab-fr-fr"),
         (SurfaceId.NEW_TAB_IT_IT, "firefox-newtab-it-it"),
+        (SurfaceId.NEW_TAB_PL_PL, "firefox-newtab-pl-pl"),
     ],
 )
 def test_get_utm_source(scheduled_surface_id, expected_utm_source):

--- a/tests/unit/curated_recommendations/test_localization.py
+++ b/tests/unit/curated_recommendations/test_localization.py
@@ -28,6 +28,12 @@ def test_get_translation_de_de():
     assert result == "Meistgelesen"
 
 
+def test_get_translation_pl_pl():
+    """Test that pl-PL surface has correct localized section title."""
+    result = get_translation(SurfaceId.NEW_TAB_PL_PL, "top-stories", "Default")
+    assert result == "Przegląd dnia"
+
+
 def test_get_translation_non_existing_locale(caplog):
     """Test logs error and falls back to default when locale translations do not exist."""
     result = get_translation(SurfaceId.NEW_TAB_IT_IT, "business", "Default")

--- a/tests/unit/curated_recommendations/test_provider.py
+++ b/tests/unit/curated_recommendations/test_provider.py
@@ -3,7 +3,10 @@
 import pytest
 from pydantic import HttpUrl
 
-from merino.curated_recommendations.corpus_backends.protocol import SurfaceId, Topic
+from merino.curated_recommendations.corpus_backends.protocol import (
+    SurfaceId,
+    Topic,
+)
 from merino.curated_recommendations.provider import CuratedRecommendationsProvider
 from merino.curated_recommendations.protocol import (
     MAX_TILE_ID,
@@ -75,6 +78,13 @@ class TestIsSectionsExperiment:
     """Unit tests for CuratedRecommendationsProvider.is_sections_experiment."""
 
     @pytest.mark.parametrize(
+        "locale, surface_id",
+        [
+            ("de-DE", SurfaceId.NEW_TAB_DE_DE),
+            ("pl-PL", SurfaceId.NEW_TAB_PL_PL),
+        ],
+    )
+    @pytest.mark.parametrize(
         "experiment_name, experiment_branch",
         [
             (None, None),
@@ -86,36 +96,36 @@ class TestIsSectionsExperiment:
             ("some-unrelated-experiment", "treatment"),
         ],
     )
-    def test_de_with_sections_feed_returns_true_regardless_of_enrollment(
-        self, experiment_name, experiment_branch
+    def test_with_sections_feed_returns_true_for_supported_surfaces_regardless_of_enrollment(
+        self, locale, surface_id, experiment_name, experiment_branch
     ):
-        """DE clients that request the sections feed get sections, regardless of Nimbus enrollment.
+        """Clients that request the sections feed get sections, regardless of Nimbus enrollment.
 
         Gating sections response on enrollment caused the Ireland incident where an experiment
-        gate was forgotten and clients kept receiving the wrong treatment. Sections branches in
-        sections-in-germany-v2 are differentiated from control by what the client requests, not
-        by a backend gate.
+        gate was forgotten and clients kept receiving the wrong treatment. Sections branches are
+        differentiated from control by what the client requests, not by a backend gate.
         """
         request = CuratedRecommendationsRequest(
-            locale="de-DE",
+            locale=locale,
             feeds=["sections"],
             experimentName=experiment_name,
             experimentBranch=experiment_branch,
         )
-        assert (
-            CuratedRecommendationsProvider.is_sections_experiment(request, SurfaceId.NEW_TAB_DE_DE)
-            is True
-        )
+        assert CuratedRecommendationsProvider.is_sections_experiment(request, surface_id) is True
 
-    def test_de_without_sections_feed_returns_false(self):
+    @pytest.mark.parametrize(
+        "locale, surface_id",
+        [
+            ("de-DE", SurfaceId.NEW_TAB_DE_DE),
+            ("pl-PL", SurfaceId.NEW_TAB_PL_PL),
+        ],
+    )
+    def test_without_sections_feed_returns_false(self, locale, surface_id):
         """If the client does not request sections, the response is not sections."""
         request = CuratedRecommendationsRequest(
-            locale="de-DE",
+            locale=locale,
             feeds=None,
             experimentName="sections-in-germany-v2",
             experimentBranch="content-only",
         )
-        assert (
-            CuratedRecommendationsProvider.is_sections_experiment(request, SurfaceId.NEW_TAB_DE_DE)
-            is False
-        )
+        assert CuratedRecommendationsProvider.is_sections_experiment(request, surface_id) is False

--- a/tests/unit/curated_recommendations/test_utils.py
+++ b/tests/unit/curated_recommendations/test_utils.py
@@ -131,6 +131,11 @@ class TestCuratedRecommendationsProviderGetRecommendationSurfaceId:
             ("fr", "FR", SurfaceId.NEW_TAB_FR_FR),
             ("it", "IT", SurfaceId.NEW_TAB_IT_IT),
             ("es", "ES", SurfaceId.NEW_TAB_ES_ES),
+            ("pl", "PL", SurfaceId.NEW_TAB_PL_PL),
+            ("pl-PL", "PL", SurfaceId.NEW_TAB_PL_PL),
+            # Polish locale primarily determines the market, even without a region.
+            ("pl", None, SurfaceId.NEW_TAB_PL_PL),
+            ("pl-PL", None, SurfaceId.NEW_TAB_PL_PL),
             ("en-CA", "IN", SurfaceId.NEW_TAB_EN_INTL),
             ("en-GB", "IN", SurfaceId.NEW_TAB_EN_INTL),
             ("en-US", "IN", SurfaceId.NEW_TAB_EN_INTL),


### PR DESCRIPTION
## References

JIRA: [HNT-2204](https://mozilla-hub.atlassian.net/browse/HNT-2204)

## Description
Experimentally launch Polish content on New Tab for the Poland content/widgets experiment.

- Content-feed branches request `feeds=["sections"]` and receive Polish content from the new `NEW_TAB_PL_PL` surface.
- Control and widgets-only branches do not request sections and receive no content feed.

Merging this PR will not deliver Polish content to users; first we will perform QA internally. Two gates prevent Polish content from reaching users:
1. Firefox by default does not request Polish content. This requires a Nimbus flag override.
2. All sections are currently disabled in our curation admin tooling.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[HNT-2204]: https://mozilla-hub.atlassian.net/browse/HNT-2204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ