### PR TITLE
HNT-2723 chore: enable particle provider updater process in production

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -1207,7 +1207,8 @@ feed_url = "https://commons.wikimedia.org/w/api.php?action=featuredfeed&feed=pot
 type = "particle"
 
 # MERINO_GAMES_PROVIDERS__PARTICLE__ENABLED
-# Whether or not the provider's cron runs to regularly update game files.
+# Enable/disable execution of the Particle file update process
+# Schedule is managed by K8s cron job
 enabled = false
 
 # MERINO_GAMES_PROVIDERS__PARTICLE__CACHE_TTL

--- a/merino/configs/production.toml
+++ b/merino/configs/production.toml
@@ -39,6 +39,12 @@ gcs_bucket = "merino-images-prodpy"
 # CDN hostname used for public URLs of stored images
 cdn_hostname = "merino-images.services.mozilla.com"
 
+[production.games_providers.particle]
+# MERINO_GAMES_PROVIDERS__PARTICLE__ENABLED
+# Enable/disable execution of the Particle file update process
+# Schedule is managed by K8s cron job
+enabled = true
+
 [production.games_particle_gcs]
 # MERINO_GAMES_PARTICLE__GCS_PROJECT
 # GCS project name that contains domain data (GCP V2)

--- a/merino/configs/stage.toml
+++ b/merino/configs/stage.toml
@@ -64,7 +64,8 @@ cdn_hostname = "stage-games-particle.merino.nonprod.webservices.mozgcp.net"
 
 [stage.games_providers.particle]
 # MERINO_GAMES_PROVIDERS__PARTICLE__ENABLED
-# Whether or not the provider's cron runs to regularly update game files.
+# Enable/disable execution of the Particle file update process
+# Schedule is managed by K8s cron job
 enabled = true
 
 # MERINO_GAMES_PROVIDERS__PARTICLE__GAME_URL


### PR DESCRIPTION
## References

JIRA: [HNT-2723](https://mozilla-hub.atlassian.net/browse/HNT-2723)

## Description

enable the particle provider updater process in production.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2433)


[HNT-2723]: https://mozilla-hub.atlassian.net/browse/HNT-2723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ