### PR TITLE
chore: send specific deployment error to sentry on deployment error

### DIFF
--- a/merino/providers/games/particle/backends/errors.py
+++ b/merino/providers/games/particle/backends/errors.py
@@ -13,3 +13,7 @@ class ParticleRemoteFileProcessError(Exception):
 
 class ParticleFileManagerError(FilemanagerError):
     """Error loading local Particle manifest schema validator file."""
+
+
+class ParticleDeploymentError(Exception):
+    """Error during deployment of Particle files."""

--- a/merino/providers/games/particle/backends/filemanager.py
+++ b/merino/providers/games/particle/backends/filemanager.py
@@ -10,7 +10,10 @@ from json import JSONDecodeError
 from pydantic import Json
 from typing import Any
 
-from merino.providers.games.particle.backends.errors import ParticleFileManagerError
+from merino.providers.games.particle.backends.errors import (
+    ParticleDeploymentError,
+    ParticleFileManagerError,
+)
 from merino.providers.games.particle.backends.utils import GameFile
 from merino.utils.gcs.gcs_uploader import GcsUploader
 
@@ -168,7 +171,7 @@ class ParticleRemoteFileManager:
                 # this exception should be treated as critical, as the game may
                 # be in a broken state. sentry should be configured to alert to
                 # slack on every error captured here.
-                sentry_sdk.capture_exception(ParticleFileManagerError(str(ex)))
+                sentry_sdk.capture_exception(ParticleDeploymentError(str(ex)))
 
                 # mark the process as a failure if any file move fails
                 success = False


### PR DESCRIPTION
## References

JIRA: HNT-2730

## Description

for easier sentry filtering, send specific deployment error to sentry if/when particle deployment encounters an error.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2434)
