### PR TITLE
[HNT-1746] feat: Serve DE sections content in the legacy grid response

### DIFF
--- a/merino/curated_recommendations/prior_backends/engagment_rescaler.py
+++ b/merino/curated_recommendations/prior_backends/engagment_rescaler.py
@@ -150,31 +150,6 @@ class CrawledContentPinnedFreshRescaler(CrawledContentRescaler):
         return round(impressions_for_tile_for_period * scale)
 
 
-DE_EXPERIMENT_TREATMENT_PERCENT = 0.30
-
-
-class DECrawledContentRescaler(CrawledContentRescaler):
-    """Rescaler for DE sections experiments — scales engagement up by 1/p
-    to compensate for the fraction p of DE traffic that generates
-    sections-backend engagement data.
-
-    p = 0.30 reflects three disjoint 10% slices of DE traffic that route
-    through the sections backend: sections-in-germany `sections` branch (v1),
-    sections-in-germany-v2 `sections` branch, and sections-in-germany-v2
-    `content-only` branch (grid layout served from the same backend).
-    """
-
-    def __init__(self, **data: Any):
-        super().__init__(**data)
-
-    def rescale(self, rec: CuratedRecommendation, opens: float, no_opens: float):
-        """Apply parent scaling (blocked-from-most-popular 5x), then divide by
-        treatment percentage to compensate for small experiment size.
-        """
-        opens, no_opens = super().rescale(rec, opens, no_opens)
-        return opens / DE_EXPERIMENT_TREATMENT_PERCENT, no_opens / DE_EXPERIMENT_TREATMENT_PERCENT
-
-
 class SchedulerHoldbackRescaler(EngagementRescaler):
     """Scales experiment based content on relative size of experiment, as a fractional percentage"""
 

--- a/merino/curated_recommendations/protocol.py
+++ b/merino/curated_recommendations/protocol.py
@@ -118,9 +118,6 @@ class ExperimentName(str, Enum):
     INFERRED_LOCAL_EXPERIMENT_V3 = "new-tab-automated-personalization-v3"
     INFERRED_LOCAL_EXPERIMENT_V4 = "new-tab-automated-personalization-v4"
 
-    # Second German sections experiment (3-arm: control / content-only / sections), pre-World Cup.
-    SECTIONS_IN_GERMANY_V2 = "sections-in-germany-v2"
-
 
 class DailyBriefingBranch(str, Enum):
     """Treatment branches for the Daily Briefing experiment."""
@@ -136,17 +133,6 @@ class EditorialSectionsBranch(str, Enum):
 
     # Remove editorial (manually curated) sections; keep ML sections + Popular Today.
     NO_EDITORIAL_SECTIONS = "no-editorial-sections"
-
-
-class SectionsInGermanyV2Branch(str, Enum):
-    """Treatment branches for the sections-in-germany-v2 experiment."""
-
-    # Scheduled-surface content in the legacy (non-sections) response.
-    CONTROL = "control"
-    # Sections-backend content delivered in the legacy (grid) response.
-    CONTENT_ONLY = "content-only"
-    # Sections-backend content delivered in the sections response.
-    SECTIONS = "sections"
 
 
 # Maximum tileId that Firefox can support. Firefox uses Javascript to store this value. The max

--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -23,14 +23,12 @@ from merino.curated_recommendations.corpus_backends.protocol import (
 from merino.curated_recommendations.engagement_backends.protocol import EngagementBackend
 from merino.curated_recommendations.interest_picker import create_interest_picker
 from merino.curated_recommendations.localization import LOCALIZED_SECTION_TITLES
-from merino.curated_recommendations.prior_backends.protocol import EngagementRescaler, PriorBackend
+from merino.curated_recommendations.prior_backends.protocol import PriorBackend
 from merino.curated_recommendations.protocol import (
     CuratedRecommendation,
     CuratedRecommendationsRequest,
     CuratedRecommendationsResponse,
-    ExperimentName,
     ProcessedInterests,
-    SectionsInGermanyV2Branch,
 )
 
 from merino.curated_recommendations.rankers import (
@@ -43,7 +41,6 @@ from merino.curated_recommendations.legacy.sections_adapter import (
 )
 from merino.curated_recommendations.prior_backends.engagment_rescaler import (
     CrawledContentRescaler,
-    DECrawledContentRescaler,
 )
 from merino.curated_recommendations.sections import get_sections
 from merino.curated_recommendations.utils import (
@@ -51,7 +48,6 @@ from merino.curated_recommendations.utils import (
     get_recommendation_surface_id,
     get_millisecond_epoch_time,
     derive_region,
-    is_enrolled_in_experiment,
 )
 
 logger = logging.getLogger(__name__)
@@ -181,7 +177,6 @@ class CuratedRecommendationsProvider:
             )
         elif surface_id in ROLLED_OUT_SECTION_SURFACES:
             # Rolled-out section surfaces: fetch from sections backend instead of scheduler
-            rescaler: EngagementRescaler | None = None
             rescaler = CrawledContentRescaler()
             general_feed = await get_legacy_recommendations_from_sections(
                 sections_backend=self.sections_backend,
@@ -191,22 +186,6 @@ class CuratedRecommendationsProvider:
                 count=request.count,
                 region=derive_region(request.locale, request.region),
                 rescaler=rescaler,
-            )
-        elif surface_id == SurfaceId.NEW_TAB_DE_DE and is_enrolled_in_experiment(
-            request,
-            ExperimentName.SECTIONS_IN_GERMANY_V2.value,
-            SectionsInGermanyV2Branch.CONTENT_ONLY.value,
-        ):
-            # sections-in-germany-v2 content-only branch: sections-backend content
-            # delivered in the legacy (grid) response.
-            general_feed = await get_legacy_recommendations_from_sections(
-                sections_backend=self.sections_backend,
-                engagement_backend=self.engagement_backend,
-                prior_backend=self.prior_backend,
-                surface_id=surface_id,
-                count=request.count,
-                region=derive_region(request.locale, request.region),
-                rescaler=DECrawledContentRescaler(),
             )
         else:
             # Other markets: fetch from scheduled surface backend

--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -37,7 +37,6 @@ from merino.curated_recommendations.rankers.interest_ranker import InterestRanke
 from merino.curated_recommendations.prior_backends.engagment_rescaler import (
     CrawledContentPinnedFreshRescaler,
     CrawledContentRescaler,
-    DECrawledContentRescaler,
     SchedulerHoldbackRescaler,
 )
 from merino.curated_recommendations.prior_backends.protocol import (
@@ -58,7 +57,6 @@ from merino.curated_recommendations.protocol import (
     DailyBriefingBranch,
     ProcessedInterests,
     Layout,
-    SectionsInGermanyV2Branch,
 )
 from merino.curated_recommendations.article_balancer_configs import (
     ArticleBalancerConfig,
@@ -458,21 +456,12 @@ def get_ranking_rescaler_for_branch(
     if is_scheduler_holdback_experiment(request):
         return SchedulerHoldbackRescaler()
 
-    if surface_id == SurfaceId.NEW_TAB_EN_GB:
-        return CrawledContentRescaler()
-
-    if surface_id == SurfaceId.NEW_TAB_EN_IE:
-        return CrawledContentRescaler()
-
-    if surface_id == SurfaceId.NEW_TAB_DE_DE and (
-        is_enrolled_in_experiment(request, "sections-in-germany", "sections")
-        or is_enrolled_in_experiment(
-            request,
-            ExperimentName.SECTIONS_IN_GERMANY_V2.value,
-            SectionsInGermanyV2Branch.SECTIONS.value,
-        )
+    if surface_id in (
+        SurfaceId.NEW_TAB_EN_GB,
+        SurfaceId.NEW_TAB_EN_IE,
+        SurfaceId.NEW_TAB_DE_DE,
     ):
-        return DECrawledContentRescaler()
+        return CrawledContentRescaler()
 
     if surface_id == SurfaceId.NEW_TAB_EN_CA:
         if request.inferredInterests is None:

--- a/merino/curated_recommendations/utils.py
+++ b/merino/curated_recommendations/utils.py
@@ -15,6 +15,7 @@ ROLLED_OUT_SECTION_SURFACES: frozenset[SurfaceId] = frozenset(
         SurfaceId.NEW_TAB_EN_GB,
         SurfaceId.NEW_TAB_EN_CA,
         SurfaceId.NEW_TAB_EN_IE,
+        SurfaceId.NEW_TAB_DE_DE,
     }
 )
 

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -440,10 +440,10 @@ def fetch_en_us(client: TestClient) -> Response:
     )
 
 
-def fetch_de_de(client: TestClient) -> Response:
-    """Make a curated recommendations request with de-DE locale (uses scheduled_surface backend)"""
+def fetch_fr_fr(client: TestClient) -> Response:
+    """Make a curated recommendations request with fr-FR locale (uses scheduled_surface backend)"""
     return client.post(
-        "/api/v1/curated-recommendations", json={"locale": "de-DE", "topics": [Topic.FOOD]}
+        "/api/v1/curated-recommendations", json={"locale": "fr-FR", "topics": [Topic.FOOD]}
     )
 
 
@@ -511,14 +511,14 @@ class TestLegacyEndpoints:
     """Test the legacy curated recommendations endpoints (fx114 and fx115-129).
 
     These endpoints have two code paths:
-    - US/CA/GB locales (en-US, en-CA, en-GB): use sections backend via get_legacy_recommendations_from_sections
-    - Other locales (de-DE, fr-FR, etc.): use scheduler backend via CuratedRecommendationsProvider
+    - Rolled-out section surfaces (en-US, en-CA, en-GB, de-DE): use sections backend via get_legacy_recommendations_from_sections
+    - Other locales (fr-FR, es-ES, etc.): use scheduler backend via CuratedRecommendationsProvider
     """
 
-    # Locales that use the sections backend (US/CA/GB)
-    SECTIONS_BACKEND_LOCALES = ["en-US", "en-CA", "en-GB"]
-    # Locales that use the scheduler backend (non-US/CA/GB)
-    SCHEDULER_BACKEND_LOCALES = ["de-DE", "fr-FR", "es-ES", "it-IT"]
+    # Locales that use the sections backend (rolled-out section surfaces)
+    SECTIONS_BACKEND_LOCALES = ["en-US", "en-CA", "en-GB", "de-DE"]
+    # Locales that use the scheduler backend (non-rolled-out)
+    SCHEDULER_BACKEND_LOCALES = ["fr-FR", "es-ES", "it-IT"]
 
     @pytest.mark.parametrize(
         "locale",
@@ -1098,12 +1098,12 @@ class TestCuratedRecommendationsRequestParameters:
     ):
         """Test non-sections requests boost preferred topics to top positions.
 
-        Uses de-DE locale (scheduler backend path) which supports topic boosting.
+        Uses fr-FR locale (scheduler backend path) which supports topic boosting.
         Note: en-US non-sections requests intentionally do NOT apply topic boosting.
         """
         response = client.post(
             "/api/v1/curated-recommendations",
-            json={"locale": "de-DE", "topics": preferred_topics},
+            json={"locale": "fr-FR", "topics": preferred_topics},
         )
         data = response.json()
         corpus_items = data["data"]
@@ -1168,7 +1168,7 @@ class TestCuratedRecommendationsRequestParameters:
     ):
         """Test the curated recommendations endpoint ignores invalid topic in topics param.
         Should treat invalid topic as blank.
-        Uses de-DE locale to test scheduled_surface backend behavior.
+        Uses fr-FR locale to test scheduled_surface backend behavior.
         """
         caplog.set_level(logging.WARN)
         scheduled_surface_http_client.post.return_value = Response(
@@ -1177,7 +1177,7 @@ class TestCuratedRecommendationsRequestParameters:
             request=fixture_request_data,
         )
         response = client.post(
-            "/api/v1/curated-recommendations", json={"locale": "de-DE", "topics": topics}
+            "/api/v1/curated-recommendations", json={"locale": "fr-FR", "topics": topics}
         )
         data = response.json()
         corpus_items = data["data"]
@@ -1202,7 +1202,7 @@ class TestCuratedRecommendationsRequestParameters:
 
 class TestCorpusApiCaching:
     """Tests covering the caching behavior of the Corpus backend.
-    Uses de-DE locale to test scheduled_surface backend caching (en-US uses sections backend).
+    Uses fr-FR locale to test scheduled_surface backend caching (en-US uses sections backend).
     """
 
     @freezegun.freeze_time("2012-01-14 03:21:34", tz_offset=0)
@@ -1211,7 +1211,7 @@ class TestCorpusApiCaching:
     ):
         """Test that only a single request is made to the curated-corpus-api."""
         # Gather multiple fetch calls
-        results = [fetch_de_de(client) for _ in range(3)]
+        results = [fetch_fr_fr(client) for _ in range(3)]
         # Assert that recommendations were returned in each response.
         assert all(len(result.json()["data"]) > 0 for result in results)
 
@@ -1275,7 +1275,7 @@ class TestCorpusApiCaching:
         # Hit the endpoint until a 200 response is received or until timeout.
         while datetime.now() < start_time + timedelta(seconds=1):
             try:
-                result = fetch_de_de(client)
+                result = fetch_fr_fr(client)
                 if result.status_code == 200:
                     break
             except HTTPStatusError:
@@ -1299,11 +1299,11 @@ class TestCorpusApiCaching:
         client: TestClient,
     ):
         """Test that the cache expires, and subsequent requests return new data.
-        Uses de-DE locale to test scheduled_surface backend caching.
+        Uses fr-FR locale to test scheduled_surface backend caching.
         """
         with freezegun.freeze_time(tick=True) as frozen_datetime:
             # First fetch to populate cache
-            initial_response = fetch_de_de(client)
+            initial_response = fetch_fr_fr(client)
             initial_data = initial_response.json()
 
             for item in scheduled_surface_response_data["data"]["scheduledSurface"]["items"]:
@@ -1319,11 +1319,11 @@ class TestCorpusApiCaching:
             frozen_datetime.tick(delta=timedelta(seconds=1))
 
             # When the cache is expired, the first fetch may return stale data.
-            fetch_de_de(client)
+            fetch_fr_fr(client)
             await asyncio.sleep(0.01)  # Allow asyncio background task to make an API request
 
             # Next fetch should get the new data
-            new_response = fetch_de_de(client)
+            new_response = fetch_fr_fr(client)
             assert scheduled_surface_http_client.post.call_count == 2
             new_data = new_response.json()
             assert new_data["recommendedAt"] > initial_data["recommendedAt"]
@@ -1334,7 +1334,7 @@ class TestCorpusApiCaching:
     ):
         """Test that the cache does not cache error data even if expired & returns latest valid data from cache."""
         # First fetch to populate cache with good data
-        initial_response = fetch_de_de(client)
+        initial_response = fetch_fr_fr(client)
         initial_data = initial_response.json()
         assert initial_response.status_code == 200
         assert scheduled_surface_http_client.post.call_count == 1
@@ -1346,7 +1346,7 @@ class TestCorpusApiCaching:
         )
 
         # Try to fetch data when cache expired
-        new_response = fetch_de_de(client)
+        new_response = fetch_fr_fr(client)
         new_data = new_response.json()
 
         assert new_response.status_code == 200
@@ -1356,14 +1356,14 @@ class TestCorpusApiCaching:
 
 class TestCuratedRecommendationsMetrics:
     """Tests that the right metrics are recorded for curated-recommendations requests.
-    Uses de-DE locale to test scheduled_surface backend metrics.
+    Uses fr-FR locale to test scheduled_surface backend metrics.
     """
 
     def test_metrics_cache_miss(self, mocker: MockerFixture, client: TestClient) -> None:
         """Test that metrics are recorded when corpus api items are not yet cached."""
         report = mocker.patch.object(aiodogstatsd.Client, "_report")
 
-        fetch_de_de(client)
+        fetch_fr_fr(client)
 
         # TODO: Remove reliance on internal details of aiodogstatsd
         metric_keys: list[str] = [call.args[0] for call in report.call_args_list]
@@ -1378,11 +1378,11 @@ class TestCuratedRecommendationsMetrics:
     def test_metrics_cache_hit(self, mocker: MockerFixture, client: TestClient) -> None:
         """Test that metrics are recorded when corpus api items are cached."""
         # The first call populates the cache.
-        fetch_de_de(client)
+        fetch_fr_fr(client)
 
         # This test covers only the metrics emitted from the following cached call.
         report = mocker.patch.object(aiodogstatsd.Client, "_report")
-        fetch_de_de(client)
+        fetch_fr_fr(client)
 
         # TODO: Remove reliance on internal details of aiodogstatsd
         metric_keys: list[str] = [call.args[0] for call in report.call_args_list]
@@ -1419,7 +1419,7 @@ class TestCuratedRecommendationsMetrics:
 
         scheduled_surface_http_client.post = AsyncMock(side_effect=first_request_returns_error)
 
-        fetch_de_de(client)
+        fetch_fr_fr(client)
 
         # TODO: Remove reliance on internal details of aiodogstatsd
         metric_keys: list[str] = [call.args[0] for call in report.call_args_list]
@@ -2920,7 +2920,7 @@ def test_curated_recommendations_enriched_with_icons(
     client: TestClient,
 ):
     """Test the enrichment of a curated recommendation with an added icon-url.
-    Uses de-DE locale to test scheduled_surface backend icon enrichment.
+    Uses fr-FR locale to test scheduled_surface backend icon enrichment.
     """
     # Set up the manifest data first
     manifest_provider.manifest_data.domains = [
@@ -2944,7 +2944,7 @@ def test_curated_recommendations_enriched_with_icons(
                         "id": "scheduledSurfaceItemId-ABC",
                         "corpusItem": {
                             "id": "corpusItemId-XYZ",
-                            "url": "https://www.microsoft.com/some-article?utm_source=firefox-newtab-de-de",
+                            "url": "https://www.microsoft.com/some-article?utm_source=firefox-newtab-fr-fr",
                             "title": "Some MS Article",
                             "excerpt": "All about Microsoft something",
                             "topic": "tech",
@@ -2965,7 +2965,7 @@ def test_curated_recommendations_enriched_with_icons(
 
     response = client.post(
         "/api/v1/curated-recommendations",
-        json={"locale": "de-DE"},
+        json={"locale": "fr-FR"},
     )
     assert response.status_code == 200
 
@@ -2974,7 +2974,7 @@ def test_curated_recommendations_enriched_with_icons(
     assert len(items) == 1
 
     item = items[0]
-    assert item["url"] == "https://www.microsoft.com/some-article?utm_source=firefox-newtab-de-de"
+    assert item["url"] == "https://www.microsoft.com/some-article?utm_source=firefox-newtab-fr-fr"
 
     assert "iconUrl" in item
     assert (

--- a/tests/unit/curated_recommendations/test_provider.py
+++ b/tests/unit/curated_recommendations/test_provider.py
@@ -88,11 +88,6 @@ class TestIsSectionsExperiment:
         "experiment_name, experiment_branch",
         [
             (None, None),
-            ("sections-in-germany", "control"),
-            ("sections-in-germany", "sections"),
-            ("sections-in-germany-v2", "control"),
-            ("sections-in-germany-v2", "content-only"),
-            ("sections-in-germany-v2", "sections"),
             ("some-unrelated-experiment", "treatment"),
         ],
     )
@@ -125,7 +120,7 @@ class TestIsSectionsExperiment:
         request = CuratedRecommendationsRequest(
             locale=locale,
             feeds=None,
-            experimentName="sections-in-germany-v2",
-            experimentBranch="content-only",
+            experimentName="some-unrelated-experiment",
+            experimentBranch="treatment",
         )
         assert CuratedRecommendationsProvider.is_sections_experiment(request, surface_id) is False

--- a/tests/unit/curated_recommendations/test_sections.py
+++ b/tests/unit/curated_recommendations/test_sections.py
@@ -30,7 +30,6 @@ from merino.curated_recommendations.prior_backends.constant_prior import Constan
 from merino.curated_recommendations.prior_backends.engagment_rescaler import (
     CrawledContentPinnedFreshRescaler,
     CrawledContentRescaler,
-    DECrawledContentRescaler,
     SchedulerHoldbackRescaler,
 )
 from merino.curated_recommendations.prior_backends.protocol import Prior
@@ -490,32 +489,8 @@ class TestFilterSectionsByExperiment:
                 SurfaceId.NEW_TAB_EN_CA,
                 CrawledContentRescaler,
             ),
-            # DE with sections branch gets DECrawledContentRescaler
-            (
-                "sections-in-germany",
-                "sections",
-                "DE",
-                SurfaceId.NEW_TAB_DE_DE,
-                DECrawledContentRescaler,
-            ),
-            # DE with wrong branch falls through to CrawledContentPinnedFreshRescaler
-            (
-                "sections-in-germany",
-                "control",
-                "DE",
-                SurfaceId.NEW_TAB_DE_DE,
-                CrawledContentPinnedFreshRescaler,
-            ),
-            # DE v2 sections branch gets DECrawledContentRescaler
-            (
-                "sections-in-germany-v2",
-                "sections",
-                "DE",
-                SurfaceId.NEW_TAB_DE_DE,
-                DECrawledContentRescaler,
-            ),
-            # DE surface without experiment falls through to CrawledContentPinnedFreshRescaler
-            (None, None, "DE", SurfaceId.NEW_TAB_DE_DE, CrawledContentPinnedFreshRescaler),
+            # DE surface gets CrawledContentRescaler (no experiment gating)
+            (None, None, "DE", SurfaceId.NEW_TAB_DE_DE, CrawledContentRescaler),
         ],
     )
     def test_get_ranking_rescaler_for_branch(
@@ -533,6 +508,22 @@ class TestFilterSectionsByExperiment:
             )
         else:
             assert get_ranking_rescaler_for_branch(req) is None
+
+    def test_de_de_uses_plain_crawled_content_rescaler(self):
+        """de-DE is a rolled-out surface and must use the plain CrawledContentRescaler.
+
+        Asserts the exact type rather than isinstance: CrawledContentPinnedFreshRescaler
+        subclasses CrawledContentRescaler, so an isinstance check would not catch a
+        regression that dropped DE from get_ranking_rescaler_for_branch and let it fall
+        through to the pinned-fresh default.
+        """
+        from merino.curated_recommendations.sections import get_ranking_rescaler_for_branch
+
+        req = SimpleNamespace(
+            experimentName=None, experimentBranch=None, region="DE", inferredInterests=None
+        )
+        rescaler = get_ranking_rescaler_for_branch(req, surface_id=SurfaceId.NEW_TAB_DE_DE)
+        assert type(rescaler) is CrawledContentRescaler
 
     def test_filter_sections_includes_both_manual_and_ml(self):
         """Test that filter_sections_by_experiment includes both MANUAL and ML sections"""

--- a/tests/unit/prior_backends/test_engagement_rescaler.py
+++ b/tests/unit/prior_backends/test_engagement_rescaler.py
@@ -11,8 +11,6 @@ from merino.curated_recommendations.prior_backends.engagment_rescaler import (
     US_UTC_RELATIVE_IMPRESSIONS_NORM,
     CrawledContentPinnedFreshRescaler,
     CrawledContentRescaler,
-    DE_EXPERIMENT_TREATMENT_PERCENT,
-    DECrawledContentRescaler,
     SchedulerHoldbackRescaler,
     PESSIMISTIC_PRIOR_ALPHA_SCALE,
     PESSIMISTIC_PRIOR_ALPHA_SCALE_SUBTOPIC,
@@ -155,52 +153,6 @@ class TestCrawledContentPinnedFreshRescaler:
             )
             < 2.5 * estimated_impression_per_tile_per_cycle
         )
-
-
-class TestDECrawledContentRescaler:
-    """Test Rig for the DE experiment rescaler"""
-
-    def setup_method(self):
-        """Set up test"""
-        self.rescaler = DECrawledContentRescaler()
-
-    def test_rescale_regular_item(self):
-        """Test that regular items are scaled up by 1/0.10 = 10x for experiment size"""
-        rec = Mock()
-        rec.in_experiment.return_value = False
-        rec.is_story_blocked_for_top_stories.return_value = False
-
-        opens, no_opens = self.rescaler.rescale(rec, 100, 50)
-        assert opens == 100 / DE_EXPERIMENT_TREATMENT_PERCENT
-        assert no_opens == 50 / DE_EXPERIMENT_TREATMENT_PERCENT
-
-    def test_rescale_blocked_item(self):
-        """Test that blocked items get parent 5x scaling then 10x experiment scaling"""
-        rec = Mock()
-        rec.in_experiment.return_value = False
-        rec.topic = Topic.GAMING
-        rec.is_story_blocked_for_top_stories.return_value = True
-
-        opens, no_opens = self.rescaler.rescale(rec, 100, 50)
-        assert opens == 100 * BLOCKED_FROM_MOST_POPULAR_SCALER / DE_EXPERIMENT_TREATMENT_PERCENT
-        assert no_opens == 50 * BLOCKED_FROM_MOST_POPULAR_SCALER / DE_EXPERIMENT_TREATMENT_PERCENT
-
-    def test_rescale_prior_inherits_parent(self):
-        """Test that prior rescaling is inherited from CrawledContentRescaler"""
-        rec = Mock()
-        rec.in_experiment.return_value = True
-        rec.isTimeSensitive = False
-        rec.is_story_blocked_for_top_stories.return_value = False
-
-        alpha, beta = self.rescaler.rescale_prior(rec, 10, 20)
-        assert alpha == 10 * PESSIMISTIC_PRIOR_ALPHA_SCALE_SUBTOPIC
-        assert beta == 20
-
-    def test_fresh_items_settings_inherited(self):
-        """Test that fresh item settings are inherited from parent"""
-        assert self.rescaler.fresh_items_max == 0
-        assert self.rescaler.fresh_items_section_ranking_max_percentage > 0
-        assert self.rescaler.fresh_items_limit_prior_threshold_multiplier > 0
 
 
 class TestSchedulerHoldbackRescaler:


### PR DESCRIPTION
## Problem

Germany (de-DE) currently serves sections content only behind the `sections-in-germany-v2` experiment. Older / non-sections Firefox clients in DE fall through to the scheduled-surface backend and so do not see the ML sections content in their legacy grid layout.

This graduates de-DE to a **fully rolled-out section surface** — mirroring how en-GB / en-CA / en-IE were rolled out (see #1525, "Clean up IE sections experiment") — and closes out the German sections experiments.

Jira: [HNT-1746](https://mozilla-hub.atlassian.net/browse/HNT-1746) — *Ensure older clients' content grid layouts can be populated by ML content post-rollout* (in the [Germany (DE) Expansion](https://mozilla-hub.atlassian.net/browse/HNT-1462) epic).

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2435)


[HNT-1746]: https://mozilla-hub.atlassian.net/browse/HNT-1746?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ