### PR TITLE
HNT-2729 fix: local docker GCS volume mount

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,6 @@ local_data/
 
 # Local data for development
 dev/local_data/
+dev/local_setup/gcs
+# Don't ignore files we need in source control for tests
+!dev/local_setup/gcs/logos

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -32,7 +32,6 @@ services:
     ports:
       - 4443:4443
     volumes:
-      - ./local_data/gcs_emulator:/data
       - ./local_setup/gcs/:/data
     command: -port=4443 -public-host=localhost:4443 -scheme=http
 

--- a/docs/dev/dependencies.md
+++ b/docs/dev/dependencies.md
@@ -7,26 +7,32 @@ While you can use the vanilla virtualenv to set up the dev environment, we highl
 out [uv][1].
 
 To install `uv`, run:
+
 ```sh
 $ pipx install uv
 ```
+
 Or [install][2] via your preferred method.
 
 Feel free to browse the [pyproject.toml][3] file for a listing of dependencies
 and their versions.
 
 First, lets make sure you have a virtual environment set up with the right Python version. This service uses Python 3.13.
+
 ```sh
 $ uv venv
 ```
+
 See [more][4] about setting up virtual envs and Python version with uv.
 
 Once uv is installed, and a virtual environment is created with the correct Python version, install all the dependencies:
+
 ```sh
 $ uv sync --all-groups --all-packages
 ```
 
 Add packages to project via uv
+
 ```sh
 $ uv add <package_name>
 ```
@@ -38,6 +44,7 @@ $ uv run fastapi run merino/main.py --reload
 ```
 
 ## Moving from the Poetry & Pyenv Set up
+
 If you had your environment previously set up via poetry and pyenv, here are the steps to move to `uv`. This would be a nice clean up and reset.
 
 ```sh
@@ -50,7 +57,6 @@ rm -rf $(pyenv root)
 # or if you installed it via your OS package manager
 brew uninstall pyenv
 ```
-
 
 ## Service Dependencies
 
@@ -99,23 +105,24 @@ $ STORAGE_EMULATOR_HOST=http://localhost:4443 make run
 ```
 
 Optionally, you can create a GCS bucket and preload data into it. The preloaded
-data is located in `dev/local_data/gcs_emulator/`. Say if you want to preload
+data is located in `dev/local_setup/gcs/`. Say if you want to preload
 a JSON file `top_picks_latest.json` into a bucket `merino-images-prodpy`, you
-can create a new sub-directory `merino-images-prody` in `gcs_emulator` and then
+can create a new sub-directory `merino-images-prody` in `gcs` and then
 create or copy `top_picks_latest.json` into it. Then you can set Merino's
 configurations to use those artifacts in the GCS emulator.
 
 ```
 # File layout of the preloaded GCS data
 
-dev/local_data
-└── gcs_emulator
+dev/local_setup
+└── gcs
     └── merino-images-prodpy  <- GCS Bucket ID
         └── top_picks_latest.json  <- A preloaded GCS blob
 ```
 
-Note that `dev/local_data` will not be checked into the source control nor the
-docker image of Merino.
+Note that any contents in `dev/local_setup/gcs` will not be checked into the source control nor the
+docker image of Merino. (There are exceptions to this, e.g. logos necessary for tests. These
+exceptions are managed in the root `.gitignore` file.)
 
 ### Dev Helpers
 
@@ -124,7 +131,6 @@ development.
 
 - Redis Commander, http://localhost:8081 - Explore the Redis database started
   above.
-
 
 [1]: https://docs.astral.sh/uv/
 [2]: https://docs.astral.sh/uv/getting-started/installation/


### PR DESCRIPTION
## References

JIRA: [HNT-2729](https://mozilla-hub.atlassian.net/browse/HNT-2729)

## Description

fix double volume mount bug in `docker-compose.yaml`. only one volume can be mounted to a destination dir in the container.

approach is the simplest i could think of to retain necessary GCS seed files while being able to ignore those that are added for any purely local testing as described in the docs.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2436)


[HNT-2729]: https://mozilla-hub.atlassian.net/browse/HNT-2729?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ