### PR TITLE
[DISCO-4319] fix(wcs/matches): set eliminated when a knockout stage game is completed

### DIFF
--- a/merino/providers/wcs/protocol.py
+++ b/merino/providers/wcs/protocol.py
@@ -68,12 +68,15 @@ class TeamInfo(BaseModel):
         team: dict[str, Any],
         *,
         group: str | None = None,
+        eliminated: bool = False,
     ) -> "TeamInfo":
         """Build widget team info from the compact team dict stored on events.
 
         The `group` argument is plumbed in from the parent event because the
         compact team dict does not carry a group of its own; the World Cup
-        group is a per-event attribute.
+        group is a per-event attribute. The `eliminated` argument lets the
+        caller mark the losing side of a completed knockout match, which the
+        compact team dict does not record either.
         """
         key = str(team["key"])
         raw_icon_url = team.get("icon_url")
@@ -85,7 +88,7 @@ class TeamInfo(BaseModel):
             colors=get_team_colours(key),
             icon_url=HttpUrl(raw_icon_url) if raw_icon_url else _icon(key),
             group=team.get("group") or group,
-            eliminated=bool(team.get("eliminated", False)),
+            eliminated=eliminated or bool(team.get("eliminated", False)),
         )
 
 
@@ -125,15 +128,30 @@ class EventInfo(BaseModel):
     @classmethod
     def from_event(cls, event: Event) -> "EventInfo":
         """Build widget event info from a cached SportsData event."""
+        # In knockout stages, a completed match eliminates its loser. Group
+        # Stage standings turn on points, not a single result, so they never
+        # eliminate here. `is_final()` covers regulation, extra time, and
+        # shootout finishes.
+        eliminates_loser = (
+            event.status.is_final() and bool(event.stage) and event.stage != "Group Stage"
+        )
+        winner = (event.winner or "").lower()
+        home_eliminated = eliminates_loser and winner == "awayteam"
+        away_eliminated = eliminates_loser and winner == "hometeam"
+
         home_team = (
             None
             if is_tbd_event_team(event.home_team)
-            else TeamInfo.from_event_team(event.home_team, group=event.group)
+            else TeamInfo.from_event_team(
+                event.home_team, group=event.group, eliminated=home_eliminated
+            )
         )
         away_team = (
             None
             if is_tbd_event_team(event.away_team)
-            else TeamInfo.from_event_team(event.away_team, group=event.group)
+            else TeamInfo.from_event_team(
+                event.away_team, group=event.group, eliminated=away_eliminated
+            )
         )
         updated = event.updated or event.date
         return cls(

--- a/tests/integration/api/v1/wcs/test_matches.py
+++ b/tests/integration/api/v1/wcs/test_matches.py
@@ -207,6 +207,35 @@ def test_matches_returns_nullable_tbd_sides(client: TestClient) -> None:
     assert body["next"][0]["query"] == "Quarterfinals World Cup 2026"
 
 
+@freezegun.freeze_time("2026-07-05T16:00:00Z")
+def test_completed_knockout_match_marks_losing_team_eliminated(client: TestClient) -> None:
+    """A finished knockout match serializes the loser as eliminated and the winner as not."""
+    app.dependency_overrides[get_wcs_provider] = lambda: build_provider(
+        events=[
+            build_event(
+                90086997,
+                0,
+                14,
+                ("BRA", "Brazil", 90000868),
+                ("ARG", "Argentina", 90001083),
+                GameStatus.Final,
+                home_score=2,
+                away_score=1,
+                stage="Round of 16",
+                round_id=1617,
+                season_type=3,
+                winner="HomeTeam",
+            )
+        ]
+    )
+
+    body = client.get(_PATH, params={"date": "2026-07-05"}).json()
+
+    match = body["previous"][0]
+    assert match["home_team"]["eliminated"] is False
+    assert match["away_team"]["eliminated"] is True
+
+
 def test_invalid_date_returns_400(client: TestClient) -> None:
     """Merino's validation handler in main.py converts FastAPI's 422 to 400."""
     response = client.get(_PATH, params={"date": "not-a-date"})

--- a/tests/unit/providers/wcs/test_protocol.py
+++ b/tests/unit/providers/wcs/test_protocol.py
@@ -160,6 +160,154 @@ def test_event_info_from_event_stage_defaults_to_empty_string() -> None:
     assert info.stage == ""
 
 
+def test_event_info_from_event_eliminates_knockout_loser_home_wins() -> None:
+    """A completed knockout match marks the away (losing) side eliminated."""
+    e = event(
+        event_id=10,
+        day_offset=-1,
+        hour=14,
+        home=("BRA", "Brazil", 90000001),
+        away=("ARG", "Argentina", 90000002),
+        status=GameStatus.Final,
+        home_score=2,
+        away_score=1,
+        stage="Round of 16",
+        winner="HomeTeam",
+    )
+
+    info = EventInfo.from_event(e)
+
+    assert info.home_team is not None and info.home_team.eliminated is False
+    assert info.away_team is not None and info.away_team.eliminated is True
+
+
+def test_event_info_from_event_eliminates_knockout_loser_away_wins() -> None:
+    """A completed knockout match marks the home (losing) side eliminated."""
+    e = event(
+        event_id=11,
+        day_offset=-1,
+        hour=14,
+        home=("BRA", "Brazil", 90000001),
+        away=("ARG", "Argentina", 90000002),
+        status=GameStatus.Final,
+        home_score=0,
+        away_score=3,
+        stage="Round of 16",
+        winner="AwayTeam",
+    )
+
+    info = EventInfo.from_event(e)
+
+    assert info.home_team is not None and info.home_team.eliminated is True
+    assert info.away_team is not None and info.away_team.eliminated is False
+
+
+def test_event_info_from_event_group_stage_final_eliminates_neither() -> None:
+    """Group Stage standings turn on points, so a single result eliminates no one."""
+    e = event(
+        event_id=12,
+        day_offset=-1,
+        hour=14,
+        home=("BRA", "Brazil", 90000001),
+        away=("ARG", "Argentina", 90000002),
+        status=GameStatus.Final,
+        home_score=2,
+        away_score=1,
+        stage="Group Stage",
+        winner="HomeTeam",
+    )
+
+    info = EventInfo.from_event(e)
+
+    assert info.home_team is not None and info.home_team.eliminated is False
+    assert info.away_team is not None and info.away_team.eliminated is False
+
+
+def test_event_info_from_event_eliminates_loser_after_shootout() -> None:
+    """A shootout (F_SO) knockout finish still eliminates the loser."""
+    e = event(
+        event_id=13,
+        day_offset=-1,
+        hour=14,
+        home=("GER", "Germany", 90000003),
+        away=("FRA", "France", 90000004),
+        status=GameStatus.F_SO,
+        home_score=1,
+        away_score=1,
+        home_penalty=5,
+        away_penalty=4,
+        stage="Quarterfinals",
+        winner="HomeTeam",
+    )
+
+    info = EventInfo.from_event(e)
+
+    assert info.home_team is not None and info.home_team.eliminated is False
+    assert info.away_team is not None and info.away_team.eliminated is True
+
+
+def test_event_info_from_event_in_progress_knockout_eliminates_neither() -> None:
+    """A knockout match still in progress eliminates no one."""
+    e = event(
+        event_id=14,
+        day_offset=0,
+        hour=14,
+        home=("BRA", "Brazil", 90000001),
+        away=("ARG", "Argentina", 90000002),
+        status=GameStatus.InProgress,
+        home_score=1,
+        away_score=0,
+        stage="Round of 16",
+        winner="HomeTeam",
+    )
+
+    info = EventInfo.from_event(e)
+
+    assert info.home_team is not None and info.home_team.eliminated is False
+    assert info.away_team is not None and info.away_team.eliminated is False
+
+
+def test_event_info_from_event_final_without_winner_eliminates_neither() -> None:
+    """A final knockout match with no declared winner eliminates no one."""
+    e = event(
+        event_id=15,
+        day_offset=-1,
+        hour=14,
+        home=("BRA", "Brazil", 90000001),
+        away=("ARG", "Argentina", 90000002),
+        status=GameStatus.Final,
+        home_score=1,
+        away_score=1,
+        stage="Round of 16",
+        winner=None,
+    )
+
+    info = EventInfo.from_event(e)
+
+    assert info.home_team is not None and info.home_team.eliminated is False
+    assert info.away_team is not None and info.away_team.eliminated is False
+
+
+def test_event_info_from_event_final_without_stage_eliminates_neither() -> None:
+    """A final match with no cached stage eliminates no one (missing-stage guard)."""
+    e = event(
+        event_id=16,
+        day_offset=-1,
+        hour=14,
+        home=("BRA", "Brazil", 90000001),
+        away=("ARG", "Argentina", 90000002),
+        status=GameStatus.Final,
+        home_score=2,
+        away_score=1,
+        winner="HomeTeam",
+    )
+
+    info = EventInfo.from_event(e)
+
+    assert info.home_team is not None and info.home_team.eliminated is False
+    assert info.away_team is not None and info.away_team.eliminated is False
+
+
 def test_event_info_from_event_missing_period_and_clock_stay_null() -> None:
     """Scheduled matches without period or clock metadata serialize nulls."""
     e = event(


### PR DESCRIPTION
## References

JIRA: [DISCO-4319](https://mozilla-hub.atlassian.net/browse/DISCO-4319)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->

The `wcs/matches` response is built in `EventInfo.from_event()`. It builds each side via `TeamInfo.from_event_team()`, which sets `eliminated=bool(team.get("eliminated", False))`. The compact team dicts stored on cached `Event`s never carry an `eliminated` key, so the loser of a completed knockout match is always serialized as `eliminated: false`.

This is a hotfix, there could be a better fix if time allows.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2437)


[DISCO-4319]: https://mozilla-hub.atlassian.net/browse/DISCO-4319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ