### PR TITLE
[DISCO-4320] fix(wcs/matches): set team.eliminated for all past matches

### DIFF
--- a/merino/providers/wcs/protocol.py
+++ b/merino/providers/wcs/protocol.py
@@ -126,8 +126,15 @@ class EventInfo(BaseModel):
     sport: str = Field(default="soccer", description="Sport identifier.")
 
     @classmethod
-    def from_event(cls, event: Event) -> "EventInfo":
-        """Build widget event info from a cached SportsData event."""
+    def from_event(cls, event: Event, eliminated_keys: set[str] | None = None) -> "EventInfo":
+        """Build widget event info from a cached SportsData event.
+
+        `eliminated_keys` carries the teams that no longer have a tournament
+        path; any side whose key is listed is marked eliminated regardless of
+        this match's result. It is unioned with the per-match knockout-loser
+        logic below so a team stays flagged across every match it appears in.
+        """
+        eliminated_keys = eliminated_keys or set()
         # In knockout stages, a completed match eliminates its loser. Group
         # Stage standings turn on points, not a single result, so they never
         # eliminate here. `is_final()` covers regulation, extra time, and
@@ -143,14 +150,18 @@ class EventInfo(BaseModel):
             None
             if is_tbd_event_team(event.home_team)
             else TeamInfo.from_event_team(
-                event.home_team, group=event.group, eliminated=home_eliminated
+                event.home_team,
+                group=event.group,
+                eliminated=home_eliminated or str(event.home_team["key"]) in eliminated_keys,
             )
         )
         away_team = (
             None
             if is_tbd_event_team(event.away_team)
             else TeamInfo.from_event_team(
-                event.away_team, group=event.group, eliminated=away_eliminated
+                event.away_team,
+                group=event.group,
+                eliminated=away_eliminated or str(event.away_team["key"]) in eliminated_keys,
             )
         )
         updated = event.updated or event.date

--- a/merino/providers/wcs/provider.py
+++ b/merino/providers/wcs/provider.py
@@ -100,8 +100,9 @@ class WcsProvider:
             self._record_cache_error("matches", ex)
             raise
 
+        eliminated_keys = await self._get_eliminated_team_keys()
         for event in sorted(events, key=lambda e: e.date):
-            event_info = EventInfo.from_event(event)
+            event_info = EventInfo.from_event(event, eliminated_keys)
             if _matches_team_filter(event_info, team_keys):
                 bucket = _bucket_for_event(event, reference_time)
                 if bucket == "previous":

--- a/tests/integration/api/v1/wcs/test_matches.py
+++ b/tests/integration/api/v1/wcs/test_matches.py
@@ -247,6 +247,7 @@ def test_open_circuit_breaker_returns_503(client: TestClient, mocker) -> None:
     with freezegun.freeze_time("2026-06-15T16:00:00Z") as freezer:
         sport = mocker.Mock()
         sport.get_events_by_date = mocker.AsyncMock(side_effect=CacheAdapterError("redis down"))
+        sport.get_eliminated_team_keys = mocker.AsyncMock(return_value=set())
         app.dependency_overrides[get_wcs_provider] = lambda: WcsProvider(sport=sport)
 
         # Trip the breaker

--- a/tests/unit/providers/wcs/test_protocol.py
+++ b/tests/unit/providers/wcs/test_protocol.py
@@ -308,6 +308,86 @@ def test_event_info_from_event_final_without_stage_eliminates_neither() -> None:
     assert info.away_team is not None and info.away_team.eliminated is False
 
 
+def test_event_info_from_event_marks_team_from_eliminated_keys() -> None:
+    """A side listed in `eliminated_keys` is eliminated even outside a knockout result."""
+    e = event(
+        event_id=20,
+        day_offset=-1,
+        hour=14,
+        home=("BRA", "Brazil", 90000001),
+        away=("ARG", "Argentina", 90000002),
+        status=GameStatus.Final,
+        home_score=2,
+        away_score=1,
+        stage="Group Stage",
+        winner="HomeTeam",
+    )
+
+    info = EventInfo.from_event(e, eliminated_keys={"ARG"})
+
+    assert info.home_team is not None and info.home_team.eliminated is False
+    assert info.away_team is not None and info.away_team.eliminated is True
+
+
+def test_event_info_from_event_unions_eliminated_keys_with_knockout_loser() -> None:
+    """Both the knockout loser and any key-listed side are eliminated together."""
+    e = event(
+        event_id=21,
+        day_offset=-1,
+        hour=14,
+        home=("BRA", "Brazil", 90000001),
+        away=("ARG", "Argentina", 90000002),
+        status=GameStatus.Final,
+        home_score=2,
+        away_score=1,
+        stage="Round of 16",
+        winner="HomeTeam",
+    )
+
+    # The away side loses this knockout match; the home side is independently
+    # listed as eliminated by the backend set.
+    info = EventInfo.from_event(e, eliminated_keys={"BRA"})
+
+    assert info.home_team is not None and info.home_team.eliminated is True
+    assert info.away_team is not None and info.away_team.eliminated is True
+
+
+def test_event_info_from_event_without_eliminated_keys_preserves_behavior() -> None:
+    """Omitting `eliminated_keys` keeps the prior knockout-only behavior."""
+    e = event(
+        event_id=22,
+        day_offset=0,
+        hour=14,
+        home=("BRA", "Brazil", 90000001),
+        away=("ARG", "Argentina", 90000002),
+        status=GameStatus.Scheduled,
+    )
+
+    info = EventInfo.from_event(e)
+
+    assert info.home_team is not None and info.home_team.eliminated is False
+    assert info.away_team is not None and info.away_team.eliminated is False
+
+
+def test_event_info_from_event_eliminated_keys_skip_tbd_side() -> None:
+    """A TBD bracket side stays null even when its placeholder key is not listed."""
+    e = event(
+        event_id=23,
+        day_offset=20,
+        hour=20,
+        home=("SWE", "Sweden", 90000001),
+        away=("TBD", "TBD", 0),
+        status=GameStatus.Scheduled,
+        original_date="2026-07-05T00:00:00",
+        stage="Quarterfinals",
+    )
+
+    info = EventInfo.from_event(e, eliminated_keys={"SWE"})
+
+    assert info.home_team is not None and info.home_team.eliminated is True
+    assert info.away_team is None
+
+
 def test_event_info_from_event_missing_period_and_clock_stay_null() -> None:
     """Scheduled matches without period or clock metadata serialize nulls."""
     e = event(

--- a/tests/unit/providers/wcs/test_provider.py
+++ b/tests/unit/providers/wcs/test_provider.py
@@ -318,6 +318,74 @@ async def test_teams_filter_matches_either_side() -> None:
 
 
 @pytest.mark.asyncio
+async def test_matches_reflect_eliminated_keys_across_buckets() -> None:
+    """A team in the eliminated set is flagged in every match it appears in."""
+    provider = build_provider(eliminated_team_keys={"ARG"})
+
+    response = await provider.get_matches(ANCHOR, limit=None, team_keys=None)
+    events = response.previous + response.current + response.next_
+
+    arg_sides = [
+        team
+        for event in events
+        for team in (event.home_team, event.away_team)
+        if team is not None and team.key == "ARG"
+    ]
+    other_sides = [
+        team
+        for event in events
+        for team in (event.home_team, event.away_team)
+        if team is not None and team.key != "ARG"
+    ]
+
+    assert len(arg_sides) >= 2  # ARG appears in both a previous and a next match
+    assert all(team.eliminated for team in arg_sides)
+    assert not any(team.eliminated for team in other_sides)
+
+
+@pytest.mark.asyncio
+@freezegun.freeze_time("2026-06-15T16:00:00Z")
+async def test_live_matches_ignore_eliminated_keys() -> None:
+    """The live endpoint does not apply the eliminated-keys set."""
+    provider = build_provider(eliminated_team_keys={"BRA"})
+
+    response = await provider.get_live_matches(team_keys=None)
+    sides = [
+        team
+        for event in response.matches
+        for team in (event.home_team, event.away_team)
+        if team is not None
+    ]
+
+    assert any(team.key == "BRA" for team in sides)
+    assert not any(team.eliminated for team in sides)
+
+
+@pytest.mark.asyncio
+async def test_matches_elimination_cache_error_leaves_teams_uneliminated(mocker) -> None:
+    """An elimination-cache error degrades to unflagged teams without dropping matches."""
+    sport = mocker.Mock()
+    sport.get_events_by_date = mocker.AsyncMock(return_value=build_events())
+    sport.get_eliminated_team_keys = mocker.AsyncMock(side_effect=CacheAdapterError("redis down"))
+    metrics_client = mocker.Mock()
+    sentry_capture = mocker.patch("merino.providers.wcs.provider.sentry_sdk.capture_exception")
+    provider = WcsProvider(sport=sport, metrics_client=metrics_client)
+
+    response = await provider.get_matches(ANCHOR, limit=None, team_keys=None)
+    events = response.previous + response.current + response.next_
+
+    assert events
+    assert not any(
+        team.eliminated
+        for event in events
+        for team in (event.home_team, event.away_team)
+        if team is not None
+    )
+    metrics_client.increment.assert_called_once_with("wcs.cache_error", tags={"endpoint": "teams"})
+    sentry_capture.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_response_is_deterministic_for_same_anchor() -> None:
     """Two calls with the same anchor produce identical payloads."""
     provider = build_provider()


### PR DESCRIPTION
## References

JIRA: [DISCO-4320](https://mozilla-hub.atlassian.net/browse/DISCO-4320)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->

Per Android team's request, they'd like Merino to flag `team.eliminated` for all the past matches for `wsc/matches` to reflect each team's status. Note that this doesn't affect the teams from `wcs/live`.
 
## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2438)


[DISCO-4320]: https://mozilla-hub.atlassian.net/browse/DISCO-4320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ