### PR TITLE
[HNT-1944] feat: Serve FR sections content in the legacy grid response

### DIFF
--- a/merino/curated_recommendations/localization.py
+++ b/merino/curated_recommendations/localization.py
@@ -28,6 +28,9 @@ LOCALIZED_SECTION_TITLES: LocalizedTopicSectionTitles = {
     SurfaceId.NEW_TAB_DE_DE: {
         "top-stories": "Meistgelesen",
     },
+    SurfaceId.NEW_TAB_FR_FR: {
+        "top-stories": "Tendances du jour",
+    },
     SurfaceId.NEW_TAB_PL_PL: {
         "top-stories": "Przegląd dnia",
     },

--- a/merino/curated_recommendations/utils.py
+++ b/merino/curated_recommendations/utils.py
@@ -16,6 +16,7 @@ ROLLED_OUT_SECTION_SURFACES: frozenset[SurfaceId] = frozenset(
         SurfaceId.NEW_TAB_EN_CA,
         SurfaceId.NEW_TAB_EN_IE,
         SurfaceId.NEW_TAB_DE_DE,
+        SurfaceId.NEW_TAB_FR_FR,
     }
 )
 

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -440,10 +440,10 @@ def fetch_en_us(client: TestClient) -> Response:
     )
 
 
-def fetch_fr_fr(client: TestClient) -> Response:
-    """Make a curated recommendations request with fr-FR locale (uses scheduled_surface backend)"""
+def fetch_es_es(client: TestClient) -> Response:
+    """Make a curated recommendations request with es-ES locale (uses scheduled_surface backend)"""
     return client.post(
-        "/api/v1/curated-recommendations", json={"locale": "fr-FR", "topics": [Topic.FOOD]}
+        "/api/v1/curated-recommendations", json={"locale": "es-ES", "topics": [Topic.FOOD]}
     )
 
 
@@ -511,14 +511,14 @@ class TestLegacyEndpoints:
     """Test the legacy curated recommendations endpoints (fx114 and fx115-129).
 
     These endpoints have two code paths:
-    - Rolled-out section surfaces (en-US, en-CA, en-GB, de-DE): use sections backend via get_legacy_recommendations_from_sections
-    - Other locales (fr-FR, es-ES, etc.): use scheduler backend via CuratedRecommendationsProvider
+    - Rolled-out section surfaces (en-US, en-CA, en-GB, de-DE, fr-FR): use sections backend via get_legacy_recommendations_from_sections
+    - Other locales (es-ES, it-IT, etc.): use scheduler backend via CuratedRecommendationsProvider
     """
 
     # Locales that use the sections backend (rolled-out section surfaces)
-    SECTIONS_BACKEND_LOCALES = ["en-US", "en-CA", "en-GB", "de-DE"]
+    SECTIONS_BACKEND_LOCALES = ["en-US", "en-CA", "en-GB", "de-DE", "fr-FR"]
     # Locales that use the scheduler backend (non-rolled-out)
-    SCHEDULER_BACKEND_LOCALES = ["fr-FR", "es-ES", "it-IT"]
+    SCHEDULER_BACKEND_LOCALES = ["es-ES", "it-IT"]
 
     @pytest.mark.parametrize(
         "locale",
@@ -1098,12 +1098,12 @@ class TestCuratedRecommendationsRequestParameters:
     ):
         """Test non-sections requests boost preferred topics to top positions.
 
-        Uses fr-FR locale (scheduler backend path) which supports topic boosting.
+        Uses es-ES locale (scheduler backend path) which supports topic boosting.
         Note: en-US non-sections requests intentionally do NOT apply topic boosting.
         """
         response = client.post(
             "/api/v1/curated-recommendations",
-            json={"locale": "fr-FR", "topics": preferred_topics},
+            json={"locale": "es-ES", "topics": preferred_topics},
         )
         data = response.json()
         corpus_items = data["data"]
@@ -1168,7 +1168,7 @@ class TestCuratedRecommendationsRequestParameters:
     ):
         """Test the curated recommendations endpoint ignores invalid topic in topics param.
         Should treat invalid topic as blank.
-        Uses fr-FR locale to test scheduled_surface backend behavior.
+        Uses es-ES locale to test scheduled_surface backend behavior.
         """
         caplog.set_level(logging.WARN)
         scheduled_surface_http_client.post.return_value = Response(
@@ -1177,7 +1177,7 @@ class TestCuratedRecommendationsRequestParameters:
             request=fixture_request_data,
         )
         response = client.post(
-            "/api/v1/curated-recommendations", json={"locale": "fr-FR", "topics": topics}
+            "/api/v1/curated-recommendations", json={"locale": "es-ES", "topics": topics}
         )
         data = response.json()
         corpus_items = data["data"]
@@ -1202,7 +1202,7 @@ class TestCuratedRecommendationsRequestParameters:
 
 class TestCorpusApiCaching:
     """Tests covering the caching behavior of the Corpus backend.
-    Uses fr-FR locale to test scheduled_surface backend caching (en-US uses sections backend).
+    Uses es-ES locale to test scheduled_surface backend caching (en-US uses sections backend).
     """
 
     @freezegun.freeze_time("2012-01-14 03:21:34", tz_offset=0)
@@ -1211,7 +1211,7 @@ class TestCorpusApiCaching:
     ):
         """Test that only a single request is made to the curated-corpus-api."""
         # Gather multiple fetch calls
-        results = [fetch_fr_fr(client) for _ in range(3)]
+        results = [fetch_es_es(client) for _ in range(3)]
         # Assert that recommendations were returned in each response.
         assert all(len(result.json()["data"]) > 0 for result in results)
 
@@ -1275,7 +1275,7 @@ class TestCorpusApiCaching:
         # Hit the endpoint until a 200 response is received or until timeout.
         while datetime.now() < start_time + timedelta(seconds=1):
             try:
-                result = fetch_fr_fr(client)
+                result = fetch_es_es(client)
                 if result.status_code == 200:
                     break
             except HTTPStatusError:
@@ -1299,11 +1299,11 @@ class TestCorpusApiCaching:
         client: TestClient,
     ):
         """Test that the cache expires, and subsequent requests return new data.
-        Uses fr-FR locale to test scheduled_surface backend caching.
+        Uses es-ES locale to test scheduled_surface backend caching.
         """
         with freezegun.freeze_time(tick=True) as frozen_datetime:
             # First fetch to populate cache
-            initial_response = fetch_fr_fr(client)
+            initial_response = fetch_es_es(client)
             initial_data = initial_response.json()
 
             for item in scheduled_surface_response_data["data"]["scheduledSurface"]["items"]:
@@ -1319,11 +1319,11 @@ class TestCorpusApiCaching:
             frozen_datetime.tick(delta=timedelta(seconds=1))
 
             # When the cache is expired, the first fetch may return stale data.
-            fetch_fr_fr(client)
+            fetch_es_es(client)
             await asyncio.sleep(0.01)  # Allow asyncio background task to make an API request
 
             # Next fetch should get the new data
-            new_response = fetch_fr_fr(client)
+            new_response = fetch_es_es(client)
             assert scheduled_surface_http_client.post.call_count == 2
             new_data = new_response.json()
             assert new_data["recommendedAt"] > initial_data["recommendedAt"]
@@ -1334,7 +1334,7 @@ class TestCorpusApiCaching:
     ):
         """Test that the cache does not cache error data even if expired & returns latest valid data from cache."""
         # First fetch to populate cache with good data
-        initial_response = fetch_fr_fr(client)
+        initial_response = fetch_es_es(client)
         initial_data = initial_response.json()
         assert initial_response.status_code == 200
         assert scheduled_surface_http_client.post.call_count == 1
@@ -1346,7 +1346,7 @@ class TestCorpusApiCaching:
         )
 
         # Try to fetch data when cache expired
-        new_response = fetch_fr_fr(client)
+        new_response = fetch_es_es(client)
         new_data = new_response.json()
 
         assert new_response.status_code == 200
@@ -1356,14 +1356,14 @@ class TestCorpusApiCaching:
 
 class TestCuratedRecommendationsMetrics:
     """Tests that the right metrics are recorded for curated-recommendations requests.
-    Uses fr-FR locale to test scheduled_surface backend metrics.
+    Uses es-ES locale to test scheduled_surface backend metrics.
     """
 
     def test_metrics_cache_miss(self, mocker: MockerFixture, client: TestClient) -> None:
         """Test that metrics are recorded when corpus api items are not yet cached."""
         report = mocker.patch.object(aiodogstatsd.Client, "_report")
 
-        fetch_fr_fr(client)
+        fetch_es_es(client)
 
         # TODO: Remove reliance on internal details of aiodogstatsd
         metric_keys: list[str] = [call.args[0] for call in report.call_args_list]
@@ -1378,11 +1378,11 @@ class TestCuratedRecommendationsMetrics:
     def test_metrics_cache_hit(self, mocker: MockerFixture, client: TestClient) -> None:
         """Test that metrics are recorded when corpus api items are cached."""
         # The first call populates the cache.
-        fetch_fr_fr(client)
+        fetch_es_es(client)
 
         # This test covers only the metrics emitted from the following cached call.
         report = mocker.patch.object(aiodogstatsd.Client, "_report")
-        fetch_fr_fr(client)
+        fetch_es_es(client)
 
         # TODO: Remove reliance on internal details of aiodogstatsd
         metric_keys: list[str] = [call.args[0] for call in report.call_args_list]
@@ -1419,7 +1419,7 @@ class TestCuratedRecommendationsMetrics:
 
         scheduled_surface_http_client.post = AsyncMock(side_effect=first_request_returns_error)
 
-        fetch_fr_fr(client)
+        fetch_es_es(client)
 
         # TODO: Remove reliance on internal details of aiodogstatsd
         metric_keys: list[str] = [call.args[0] for call in report.call_args_list]
@@ -2920,7 +2920,7 @@ def test_curated_recommendations_enriched_with_icons(
     client: TestClient,
 ):
     """Test the enrichment of a curated recommendation with an added icon-url.
-    Uses fr-FR locale to test scheduled_surface backend icon enrichment.
+    Uses es-ES locale to test scheduled_surface backend icon enrichment.
     """
     # Set up the manifest data first
     manifest_provider.manifest_data.domains = [
@@ -2944,7 +2944,7 @@ def test_curated_recommendations_enriched_with_icons(
                         "id": "scheduledSurfaceItemId-ABC",
                         "corpusItem": {
                             "id": "corpusItemId-XYZ",
-                            "url": "https://www.microsoft.com/some-article?utm_source=firefox-newtab-fr-fr",
+                            "url": "https://www.microsoft.com/some-article?utm_source=firefox-newtab-es-es",
                             "title": "Some MS Article",
                             "excerpt": "All about Microsoft something",
                             "topic": "tech",
@@ -2965,7 +2965,7 @@ def test_curated_recommendations_enriched_with_icons(
 
     response = client.post(
         "/api/v1/curated-recommendations",
-        json={"locale": "fr-FR"},
+        json={"locale": "es-ES"},
     )
     assert response.status_code == 200
 
@@ -2974,7 +2974,7 @@ def test_curated_recommendations_enriched_with_icons(
     assert len(items) == 1
 
     item = items[0]
-    assert item["url"] == "https://www.microsoft.com/some-article?utm_source=firefox-newtab-fr-fr"
+    assert item["url"] == "https://www.microsoft.com/some-article?utm_source=firefox-newtab-es-es"
 
     assert "iconUrl" in item
     assert (

--- a/tests/unit/curated_recommendations/test_localization.py
+++ b/tests/unit/curated_recommendations/test_localization.py
@@ -28,6 +28,12 @@ def test_get_translation_de_de():
     assert result == "Meistgelesen"
 
 
+def test_get_translation_fr_fr():
+    """Test that fr-FR surface has correct localized section title."""
+    result = get_translation(SurfaceId.NEW_TAB_FR_FR, "top-stories", "Default")
+    assert result == "Tendances du jour"
+
+
 def test_get_translation_pl_pl():
     """Test that pl-PL surface has correct localized section title."""
     result = get_translation(SurfaceId.NEW_TAB_PL_PL, "top-stories", "Default")


### PR DESCRIPTION
## References

JIRA: [HNT-1944](https://mozilla-hub.atlassian.net/browse/HNT-1944)

## Description

This graduates fr-FR to a fully rolled-out section surface, such that only sections content is served. If the client requests sections (e.g. via a Nimbus rollout) then sections are returned, otherwise sections content is served in the legacy grid schema.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)

[HNT-1944]: https://mozilla-hub.atlassian.net/browse/HNT-1944


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2441)
