### PR TITLE
[AIMOD-1362] Roll out Thompson Sampling Interest Ranker in US

### DIFF
--- a/merino/curated_recommendations/ml_backends/static_local_model.py
+++ b/merino/curated_recommendations/ml_backends/static_local_model.py
@@ -31,12 +31,9 @@ LOCAL_AND_SERVER_BRANCH_NAME = LOCAL_AND_SERVER_V1_MODEL_ID
 LOCAL_AND_SERVER_V3_BRANCH_NAME = "personalized-stories"
 LOCAL_AND_SERVER_V4_BRANCH_NAME = LOCAL_AND_SERVER_V3_BRANCH_NAME
 
-# InferredTimeZone experiment branches. Note: the TZ branch is currently
-# being repurposed to route requests to the LinTS InterestRanker (the original
-# TZ-context treatment underperformed; reusing its enrollment for the
-# InterestRanker rollout). See is_inferred_interest_experiment in sections.py.
+# InferredTimeZone experiment branches.
 CONTEXTUAL_RANKING_TREATMENT_TZ = "contextual-ranking-content-tz"
-# Ranking based on country only — the control branch (current production behavior).
+# Ranking based on country only — the control branch.
 CONTEXTUAL_RANKING_TREATMENT_COUNTRY = "contextual-ranking-content-country"
 
 CTR_TOPIC_MODEL_ID = "ctr_model_topic_1"

--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -395,27 +395,6 @@ def is_inferred_time_zone_experiment(request: CuratedRecommendationsRequest) -> 
     )
 
 
-def is_inferred_interest_experiment(request: CuratedRecommendationsRequest) -> bool:
-    """Return True if the user is enrolled in the InterestRanker treatment.
-
-    Reuses the InferredTimeZone experiment's TZ branch (originally a TZ-cohort
-    treatment that underperformed) — this avoids a fresh-experiment enrollment
-    ramp and gets the InterestRanker to traffic faster. Users on this branch
-    get the LinTS InterestRanker; users on the COUNTRY branch (control) stay
-    on the existing cohort path with TZ context disabled.
-
-    Gates the first tier of the ranker chain in get_sections: when this fires
-    and the LinTS backend is loaded, we rank with InterestRanker; otherwise
-    we fall through to the cohort ContextualRanker (or vanilla
-    ThompsonSamplingRanker).
-    """
-    return is_enrolled_in_experiment(
-        request,
-        ExperimentName.INFERRED_TIME_ZONE_EXPERIMENT.value,
-        CONTEXTUAL_RANKING_TREATMENT_TZ,
-    )
-
-
 def is_subtopics_experiment(request: CuratedRecommendationsRequest) -> bool:
     """Return True if subtopics should be included based on experiments.
     Previously this was an experiment. This function should be refactored out.
@@ -926,10 +905,9 @@ async def get_sections(
         and ml_backend is not None
         and ml_backend.is_valid(surface_id)
     )
-    # use interest ranker if we have interests available
+    # Use InterestRanker when the per-surface LinTS bundle is loaded and the request has interests.
     use_interest_ranker = (
-        is_inferred_interest_experiment(request)
-        and lints_interest_backend.is_valid(surface_id)
+        lints_interest_backend.is_valid(surface_id)
         and personal_interests is not None
         and bool(personal_interests.scores)
     )


### PR DESCRIPTION
## References

JIRA: [AIMOD-1362](https://mozilla-hub.atlassian.net/browse/AIMOD-1362)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->

This PR rolls out the Thompson Sampling interest ranker in US only. In the treatment branch, we've noticed a 2-3% improvement in ctr with this.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2442)


[AIMOD-1362]: https://mozilla-hub.atlassian.net/browse/AIMOD-1362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ