### PR TITLE
hotfix(wcs): add penalty clock hint workaround

### DIFF
--- a/merino/providers/suggest/sports/backends/sportsdata/common/sports.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/sports.py
@@ -23,7 +23,7 @@ from merino.cache.none import NoCacheAdapter
 from merino.providers.suggest.sports import LOGGING_TAG, utc_time_from_now
 from merino.providers.suggest.sports.backends.sportsdata.common.error import SportsDataError
 from merino.providers.suggest.sports.backends import get_data
-from merino.providers.suggest.sports.backends.sportsdata.common import SportCategory
+from merino.providers.suggest.sports.backends.sportsdata.common import GameStatus, SportCategory
 from merino.providers.suggest.sports.backends.sportsdata.common.data import (
     Sport,
     SportTerms,
@@ -745,17 +745,33 @@ class WCS(Sport):
         )
         self.default_metric_attributes = {"sport": self.__class__.__name__}
 
+    @staticmethod
+    def _clock_or_penalty_hint(clock: Any, period: Any, status: GameStatus) -> str | None:
+        """Return a clock hint, substituting "PEN" during a live penalty shootout.
+
+        Workaround for a client bug on iOS and Desktop: when the feed reports a
+        penalty shootout the period alone is not enough for the clients to show
+        penalty time, so surface "PEN" in the clock field for them to display.
+
+        The feed keeps `Period` as "PenaltyShootout" after the match ends, so we
+        gate on a live status to avoid showing "PEN" on a completed game.
+        """
+        if period == "PenaltyShootout" and status.is_in_progress():
+            return "PEN"
+        return str(clock) if clock is not None else None
+
     def event_details(self, event_description: dict[str, Any]) -> dict[str, Any]:
         """Return soccer score details used by the WCS widget."""
         clock = event_description.get("ClockDisplay") or event_description.get("Clock")
         round_id = event_description.get("RoundId")
+        status = GameStatus.parse(event_description.get("Status") or "")
         return {
             "period": event_description.get("Period"),
             "home_extra": event_description.get("HomeTeamScoreExtraTime"),
             "away_extra": event_description.get("AwayTeamScoreExtraTime"),
             "home_penalty": event_description.get("HomeTeamScorePenalty"),
             "away_penalty": event_description.get("AwayTeamScorePenalty"),
-            "clock": str(clock) if clock is not None else None,
+            "clock": WCS._clock_or_penalty_hint(clock, event_description.get("Period"), status),
             "stage": self.rounds.get(round_id) if round_id is not None else None,
             "round_id": round_id,
             "season_type": event_description.get("SeasonType"),

--- a/tests/unit/providers/suggest/sports/backends/common/test_sports.py
+++ b/tests/unit/providers/suggest/sports/backends/common/test_sports.py
@@ -2391,6 +2391,62 @@ def test_wcs_event_details_no_rounds_returns_none_stage() -> None:
     assert details["stage"] is None
 
 
+@pytest.mark.parametrize(
+    ("clock", "period", "status", "expected"),
+    [
+        pytest.param("90+3", "PenaltyShootout", GameStatus.InProgress, "PEN", id="live-penalty"),
+        pytest.param(None, "PenaltyShootout", GameStatus.InProgress, "PEN", id="live-no-clock"),
+        pytest.param("90+3", "PenaltyShootout", GameStatus.F_SO, "90+3", id="completed-shootout"),
+        pytest.param("90+3", "PenaltyShootout", GameStatus.Scheduled, "90+3", id="not-yet-live"),
+        pytest.param("45", "Regular", GameStatus.InProgress, "45", id="non-penalty"),
+        pytest.param(90, "ExtraTime", GameStatus.InProgress, "90", id="non-str-clock-coerced"),
+        pytest.param(None, "Regular", GameStatus.InProgress, None, id="no-clock"),
+    ],
+)
+def test_wcs_clock_or_penalty_hint(
+    clock: Any, period: Any, status: GameStatus, expected: str | None
+) -> None:
+    """Surface PEN only for a live penalty shootout; otherwise pass the clock through."""
+    assert WCS._clock_or_penalty_hint(clock, period, status) == expected
+
+
+@pytest.mark.parametrize(
+    ("row", "expected_clock"),
+    [
+        pytest.param(
+            {"Period": "PenaltyShootout", "Status": "InProgress", "ClockDisplay": "90+3"},
+            "PEN",
+            id="live-shootout-gets-pen",
+        ),
+        pytest.param(
+            {"Period": "PenaltyShootout", "Status": "Final", "ClockDisplay": "90+3"},
+            "90+3",
+            id="completed-shootout-keeps-clock",
+        ),
+        pytest.param(
+            # Missing Status normalizes to a non-live status, so no PEN hint.
+            {"Period": "PenaltyShootout", "ClockDisplay": "90+3"},
+            "90+3",
+            id="missing-status-keeps-clock",
+        ),
+        pytest.param(
+            {"Period": "Regular", "Status": "InProgress", "ClockDisplay": "45"},
+            "45",
+            id="non-penalty-keeps-clock",
+        ),
+    ],
+)
+def test_wcs_event_details_clock(row: dict[str, Any], expected_clock: str | None) -> None:
+    """event_details wires Status/Period/clock into the penalty-shootout hint.
+
+    Both `/matches` and `/live` reach this through `event_from_row` and
+    `apply_score_update`, so covering the chokepoint covers both endpoints.
+    """
+    sport = WCS(settings=settings.providers.sports)
+
+    assert sport.event_details(row)["clock"] == expected_clock
+
+
 @freezegun.freeze_time("2026-06-10T00:00:00", tz_offset=0)
 @pytest.mark.asyncio
 async def test_wcs_update_events_loads_rounds_when_empty(


### PR DESCRIPTION


## References

JIRA: [DISCO-TODO](https://mozilla-hub.atlassian.net/browse/DISCO-TODO)

## Description
hotfix(wcs): add penalty clock hint workaround for ios and desktop widgets


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2443)
