### PR TITLE
fix(wcs) DISCO-4323 Keep InProgress during extra time and penalties

### DIFF
--- a/merino/providers/wcs/protocol.py
+++ b/merino/providers/wcs/protocol.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, HttpUrl
 
+from merino.providers.suggest.sports.backends.sportsdata.common import GameStatus
 from merino.providers.suggest.sports.backends.sportsdata.common.data import Event, Team
 from merino.providers.suggest.sports.backends.sportsdata.common.tbd import is_tbd_event_team
 from merino.providers.suggest.sports.backends.sportsdata.protocol import build_query
@@ -25,6 +26,24 @@ def _icon(key: str) -> HttpUrl | None:
     if entry.svg:
         return HttpUrl(f"{_LOGO_HOST}/{entry.svg}")
     return HttpUrl(f"{_LOGO_HOST}/{entry.url}")
+
+
+def _public_status(event: Event) -> str:
+    """Return the client-facing status string for a WCS event."""
+    if event.status == GameStatus.Break and _is_post_regulation_period(event.period):
+        return GameStatus.InProgress.as_str()
+    return event.status.as_str()
+
+
+def _is_post_regulation_period(period: str | None) -> bool:
+    """Return whether `period` describes extra time or penalties."""
+    normalized = "".join(char for char in (period or "").lower() if char.isalnum())
+    return (
+        normalized.startswith("et")
+        or "extra" in normalized
+        or "penalty" in normalized
+        or normalized in {"p", "pen"}
+    )
 
 
 class TeamInfo(BaseModel):
@@ -180,7 +199,7 @@ class EventInfo(BaseModel):
             clock=event.clock,
             updated=int(updated.timestamp()),
             stage=event.stage or "",
-            status=event.status.as_str(),
+            status=_public_status(event),
             status_type=event.status.as_ui_status(),
             query=build_query(event.model_dump(mode="json")),
         )

--- a/tests/unit/providers/wcs/test_protocol.py
+++ b/tests/unit/providers/wcs/test_protocol.py
@@ -6,6 +6,7 @@
 
 from collections.abc import Callable
 
+import pytest
 from pytest_mock import MockerFixture
 
 from merino.providers.suggest.sports.backends.sportsdata.common import GameStatus
@@ -403,6 +404,62 @@ def test_event_info_from_event_missing_period_and_clock_stay_null() -> None:
 
     assert info.period is None
     assert info.clock is None
+
+
+@pytest.mark.parametrize(
+    ("period", "expected_status"),
+    [
+        pytest.param("HT", "Break", id="halftime"),
+        pytest.param("Regular", "Break", id="regular"),
+        pytest.param("1", "Break", id="first-half"),
+        pytest.param("2", "Break", id="second-half"),
+        pytest.param(None, "Break", id="missing-period"),
+        pytest.param("ExtraTime", "In Progress", id="extra-time"),
+        pytest.param("Extra Time", "In Progress", id="extra-time-spaced"),
+        pytest.param("ET", "In Progress", id="et"),
+        pytest.param("ETHT", "In Progress", id="extra-time-halftime"),
+        pytest.param("PenaltyShootout", "In Progress", id="penalty-shootout"),
+        pytest.param("P", "In Progress", id="penalty-short"),
+    ],
+)
+def test_event_info_from_event_masks_non_halftime_break_status(
+    period: str | None, expected_status: str
+) -> None:
+    """Only regulation halftime is exposed as Break to WCS clients."""
+    e = event(
+        event_id=17,
+        day_offset=0,
+        hour=14,
+        home=("BRA", "Brazil", 90000001),
+        away=("ARG", "Argentina", 90000002),
+        status=GameStatus.Break,
+        period=period,
+    )
+
+    info = EventInfo.from_event(e)
+
+    assert info.status == expected_status
+    assert info.status_type == "live"
+    assert info.period == period
+
+
+def test_event_info_from_event_keeps_non_break_extra_time_status() -> None:
+    """The extra-time workaround only rewrites Break statuses."""
+    e = event(
+        event_id=18,
+        day_offset=0,
+        hour=14,
+        home=("BRA", "Brazil", 90000001),
+        away=("ARG", "Argentina", 90000002),
+        status=GameStatus.InProgress,
+        period="ExtraTime",
+    )
+
+    info = EventInfo.from_event(e)
+
+    assert info.status == "In Progress"
+    assert info.status_type == "live"
+    assert info.period == "ExtraTime"
 
 
 def test_event_info_from_event_propagates_group_to_both_teams() -> None:


### PR DESCRIPTION
## References

JIRA: [DISCO-4323](https://mozilla-hub.atlassian.net/browse/DISCO-4323)

## Description
Change the client facing status during extra time and penalties. Keep `InProgress` instead of `Break`.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2444)


[DISCO-4323]: https://mozilla-hub.atlassian.net/browse/DISCO-4323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ