### PR TITLE
[DISCO-4321] fix(wcs): apply region code remapping to matches and live and matches endpoints

### DIFF
--- a/merino/providers/wcs/protocol.py
+++ b/merino/providers/wcs/protocol.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, ConfigDict, Field, HttpUrl
 
 from merino.providers.suggest.sports.backends.sportsdata.common import GameStatus
 from merino.providers.suggest.sports.backends.sportsdata.common.data import Event, Team
+from merino.providers.suggest.sports.backends.sportsdata.common.sports import WCS
 from merino.providers.suggest.sports.backends.sportsdata.common.tbd import is_tbd_event_team
 from merino.providers.suggest.sports.backends.sportsdata.protocol import build_query
 from merino.providers.wcs.utils import get_team_colours
@@ -99,11 +100,16 @@ class TeamInfo(BaseModel):
         """
         key = str(team["key"])
         raw_icon_url = team.get("icon_url")
+        # SportsData.io returns the wrong official ISO3 for a few countries; remap
+        # through WCS.ISO_alias so the region surfaces the correct code, leaving
+        # codes that are not aliased unchanged.
+        region = str(team.get("region") or team.get("country") or key)
+        region = WCS.ISO_alias.get(region, region)
         return cls(
             key=key,
             global_team_id=int(team["id"]),
             name=str(team["name"]),
-            region=str(team.get("region") or team.get("country") or key),
+            region=region,
             colors=get_team_colours(key),
             icon_url=HttpUrl(raw_icon_url) if raw_icon_url else _icon(key),
             group=team.get("group") or group,

--- a/tests/unit/providers/wcs/test_protocol.py
+++ b/tests/unit/providers/wcs/test_protocol.py
@@ -82,6 +82,71 @@ def test_team_info_icon_url_uses_png_when_svg_is_missing(
     assert str(info.icon_url).endswith("/logos/nations/nations_zzz.png")
 
 
+@pytest.mark.parametrize(
+    ("key", "expected_region"),
+    [
+        pytest.param("CDR", "COD", id="cdr-aliased-to-cod"),
+        pytest.param("CVI", "CPV", id="cvi-aliased-to-cpv"),
+        pytest.param("BRA", "BRA", id="unlisted-code-unchanged"),
+    ],
+)
+def test_team_info_from_event_team_remaps_region_through_iso_alias(
+    key: str, expected_region: str
+) -> None:
+    """SportsData's wrong ISO3 codes are remapped; unlisted codes pass through."""
+    info = TeamInfo.from_event_team({"key": key, "id": 1, "name": "Team"})
+
+    assert info.region == expected_region
+
+
+def test_team_info_from_event_team_remaps_region_from_country() -> None:
+    """An explicit country field is remapped when it is an aliased ISO3 code."""
+    info = TeamInfo.from_event_team({"key": "ZZZ", "id": 1, "name": "Team", "country": "CDR"})
+
+    assert info.region == "COD"
+
+
+@pytest.mark.parametrize(
+    ("home", "away", "expected_home_region", "expected_away_region"),
+    [
+        pytest.param(
+            ("CDR", "Congo DR", 90000091),
+            ("CVI", "Cape Verde", 90000092),
+            "COD",
+            "CPV",
+            id="both-sides-aliased",
+        ),
+        pytest.param(
+            ("CDR", "Congo DR", 90000091),
+            ("BRA", "Brazil", 90000001),
+            "COD",
+            "BRA",
+            id="one-side-aliased",
+        ),
+    ],
+)
+def test_event_info_from_event_remaps_team_regions(
+    home: tuple[str, str, int],
+    away: tuple[str, str, int],
+    expected_home_region: str,
+    expected_away_region: str,
+) -> None:
+    """Both home and away regions are remapped through WCS.ISO_alias end-to-end."""
+    e = event(
+        event_id=30,
+        day_offset=0,
+        hour=14,
+        home=home,
+        away=away,
+        status=GameStatus.Scheduled,
+    )
+
+    info = EventInfo.from_event(e)
+
+    assert info.home_team is not None and info.home_team.region == expected_home_region
+    assert info.away_team is not None and info.away_team.region == expected_away_region
+
+
 def test_is_tbd_event_team_ignores_malformed_placeholder_id() -> None:
     """A malformed placeholder id is not treated as an undecided bracket side."""
     assert is_tbd_event_team({"key": TBD_TEAM_KEY, "id": "bad"}) is False


### PR DESCRIPTION
## References

JIRA: [DISCO-4321](https://mozilla-hub.atlassian.net/browse/DISCO-4321)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->

Apply country code remapping to /matches and /live.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2445)


[DISCO-4321]: https://mozilla-hub.atlassian.net/browse/DISCO-4321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ