### PR TITLE
[DISCO-4325] fix(wcs): ensure images are served through cdn

### DIFF
--- a/merino/providers/wcs/protocol.py
+++ b/merino/providers/wcs/protocol.py
@@ -10,23 +10,12 @@ from merino.providers.suggest.sports.backends.sportsdata.common.sports import WC
 from merino.providers.suggest.sports.backends.sportsdata.common.tbd import is_tbd_event_team
 from merino.providers.suggest.sports.backends.sportsdata.protocol import build_query
 from merino.providers.wcs.utils import get_team_colours
-from merino.utils.logos import LogoCategory, load_manifest
-
-
-# Stage does not always provide a CDN host override for the nations logo bucket.
-# Pin WCS flag URLs to the production image bucket so stage and prod render the
-# same assets.
-_LOGO_HOST = "https://storage.googleapis.com/merino-images-prod"
+from merino.utils.logos import LogoCategory, get_logo_url
 
 
 def _icon(key: str) -> HttpUrl | None:
     """Return the nations flag URL for `key`, preferring SVG over PNG."""
-    entry = load_manifest().get(LogoCategory.Nations, key)
-    if not entry:
-        return None
-    if entry.svg:
-        return HttpUrl(f"{_LOGO_HOST}/{entry.svg}")
-    return HttpUrl(f"{_LOGO_HOST}/{entry.url}")
+    return get_logo_url(LogoCategory.Nations, key, format="svg")
 
 
 def _public_status(event: Event) -> str:

--- a/merino/utils/logos.py
+++ b/merino/utils/logos.py
@@ -60,7 +60,7 @@ def load_manifest() -> LogoManifest:
     return LogoManifest.model_validate(orjson.loads(manifest_path.read_bytes()))
 
 
-def get_logo_url(category: LogoCategory, key: str) -> Optional[HttpUrl]:
+def get_logo_url(category: LogoCategory, key: str, format: str | None = None) -> Optional[HttpUrl]:
     """Logo lookup for suggest providers.
 
     The process for creating suggestions is currently manual,
@@ -72,6 +72,10 @@ def get_logo_url(category: LogoCategory, key: str) -> Optional[HttpUrl]:
     For sports teams, it corresponds to the "key" field in the
     `merino.providers.suggest.sports.backends.sportsdata.common.Team`
     model.
+
+    When `format` is set, will look for an entry with the specified
+    format (e.g. "svg", "png") otherwise will fall back to the
+    default URL entry in the manifest.
     """
     logo = load_manifest().get(category, key)
     if logo is None:
@@ -85,4 +89,5 @@ def get_logo_url(category: LogoCategory, key: str) -> Optional[HttpUrl]:
             tags={"name": f"logos.{category}", "key": normalized_key, "result": "miss"},
         )
         return None
-    return HttpUrl(urljoin(CDN_ROOT_URL, logo.url))
+    path = (format and getattr(logo, format.lower(), None)) or logo.url
+    return HttpUrl(urljoin(CDN_ROOT_URL, path))

--- a/tests/integration/api/v1/wcs/test_live.py
+++ b/tests/integration/api/v1/wcs/test_live.py
@@ -85,8 +85,9 @@ def test_unknown_team_returns_empty_list(client: TestClient) -> None:
     assert response.json() == {"matches": []}
 
 
+@pytest.mark.restore_load_manifest
 def test_team_icons_are_svg(client: TestClient) -> None:
-    """Live match team flags serve SVG from the production GCS bucket."""
+    """Live match team flags serve SVG through the configured image CDN host."""
     matches = client.get(_PATH).json()["matches"]
 
     assert matches
@@ -96,7 +97,7 @@ def test_team_icons_are_svg(client: TestClient) -> None:
         team["icon_url"] for match in matches for team in (match["home_team"], match["away_team"])
     ]
 
-    expected_prefix = "https://storage.googleapis.com/merino-images-prod/logos/nations/svg/"
+    expected_prefix = "https://test-cdn.mozilla.net/logos/nations/svg/"
     assert all(icon.startswith(expected_prefix) for icon in icons)
 
 

--- a/tests/integration/api/v1/wcs/test_matches.py
+++ b/tests/integration/api/v1/wcs/test_matches.py
@@ -266,8 +266,9 @@ def test_open_circuit_breaker_returns_503(client: TestClient, mocker) -> None:
         client.get(_PATH)
 
 
-def test_team_icons_pinned_to_prod_logo_bucket(client: TestClient) -> None:
-    """Stage lacks a CDN host override, so icons hardcode the prod GCS bucket."""
+@pytest.mark.restore_load_manifest
+def test_team_icons_served_through_configured_cdn(client: TestClient) -> None:
+    """Team flag icons are served through the configured image CDN host."""
     body = client.get(_PATH, params={"date": _ANCHOR}).json()
     events = body["previous"] + body["current"] + body["next"]
 
@@ -275,5 +276,5 @@ def test_team_icons_pinned_to_prod_logo_bucket(client: TestClient) -> None:
     icons = [e["home_team"]["icon_url"] for e in events] + [
         e["away_team"]["icon_url"] for e in events
     ]
-    expected_prefix = "https://storage.googleapis.com/merino-images-prod/logos/nations/svg/"
+    expected_prefix = "https://test-cdn.mozilla.net/logos/nations/svg/"
     assert all(icon and icon.startswith(expected_prefix) for icon in icons)

--- a/tests/integration/api/v1/wcs/test_teams.py
+++ b/tests/integration/api/v1/wcs/test_teams.py
@@ -64,14 +64,15 @@ def test_success_sets_short_public_cache_control(client: TestClient) -> None:
     )
 
 
-def test_team_icons_are_svg_from_prod_logo_bucket(client: TestClient) -> None:
-    """All team flags serve SVG from the hardcoded production GCS bucket."""
+@pytest.mark.restore_load_manifest
+def test_team_icons_are_svg_from_configured_cdn(client: TestClient) -> None:
+    """All team flags serve SVG through the configured image CDN host."""
     body = client.get(_PATH).json()
 
     icons = [team["icon_url"] for team in body["teams"] if team["icon_url"] is not None]
 
     assert icons
-    expected_prefix = "https://storage.googleapis.com/merino-images-prod/logos/nations/svg/"
+    expected_prefix = "https://test-cdn.mozilla.net/logos/nations/svg/"
     assert all(icon.startswith(expected_prefix) for icon in icons)
 
 

--- a/tests/unit/providers/wcs/test_protocol.py
+++ b/tests/unit/providers/wcs/test_protocol.py
@@ -60,7 +60,7 @@ def test_team_info_icon_url_can_be_none_when_logo_is_missing(
     make_manifest: MakeManifest,
 ) -> None:
     """Teams without a manifest logo serialize icon_url=None."""
-    mocker.patch("merino.providers.wcs.protocol.load_manifest", return_value=make_manifest())
+    mocker.patch("merino.utils.logos.load_manifest", return_value=make_manifest())
 
     info = TeamInfo.from_event_team({"key": "ZZZ", "id": 1, "name": "Unknown"})
 
@@ -73,7 +73,7 @@ def test_team_info_icon_url_uses_png_when_svg_is_missing(
 ) -> None:
     """Manifest entries without SVGs fall back to their PNG URL."""
     mocker.patch(
-        "merino.providers.wcs.protocol.load_manifest",
+        "merino.utils.logos.load_manifest",
         return_value=make_manifest((LogoCategory.Nations, "ZZZ")),
     )
 


### PR DESCRIPTION



## References

JIRA:  [DISCO-4325]

## Description
Previously hard-coded for direct object access, which during periods of load resulted in images not rendering on client widgets. Running through LB+CDN should solve issue.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2448)


[DISCO-4325]: https://mozilla-hub.atlassian.net/browse/DISCO-4325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ