### PR TITLE
[DISCO-4303] Emit pattern match metrics from suggest

### DIFF
--- a/merino/utils/query_processing/query_patterns.py
+++ b/merino/utils/query_processing/query_patterns.py
@@ -12,12 +12,23 @@ PRIVACY CONTRACT:
 """
 
 import logging
+import random
 import re
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Final, cast
 
+from opentelemetry import metrics
+
 logger = logging.getLogger(__name__)
+
+_meter = metrics.get_meter("merino.query_pattern")
+
+_match_counter = _meter.create_counter(
+    "merino.query_pattern.match",
+    description="Count of suggest queries matching a configured query pattern, "
+    "by pattern id and source",
+)
 
 # A pattern id is the only operator-supplied value that reaches metrics, so it is
 # constrained to a short, lowercase token to keep metric cardinality bounded and
@@ -125,3 +136,11 @@ def match_query(matcher: QueryPatternMatcher, query: str) -> tuple[str, ...]:
     if not query:
         return ()
     return tuple(p.id for p in matcher.patterns if p.regex.search(query))
+
+
+def emit_query_pattern_metrics(matcher: QueryPatternMatcher, query: str, source: str) -> None:
+    """Run the query pattern matcher and emit a metric for each matched pattern ID."""
+    if random.random() >= matcher.sample_rate:
+        return
+    for pattern_id in match_query(matcher, query):
+        _match_counter.add(1, {"pattern_id": pattern_id, "source": source})

--- a/merino/utils/query_processing/query_patterns.py
+++ b/merino/utils/query_processing/query_patterns.py
@@ -1,8 +1,8 @@
 """Query pattern matching for aggregate suggest metrics.
 
 PRIVACY CONTRACT:
-- Emits only ``merino.query_pattern.match`` (attributes ``pattern_id``, ``matched``,
-  ``source``) and ``merino.query_pattern.error`` (attribute ``source``).
+- Emits only ``merino_query_pattern_match`` (attributes ``pattern_id``, ``matched``,
+  ``source``) and ``merino_query_pattern_error`` (attribute ``source``).
 - Never emits raw query text, the matched substring, or the regex source.
 - ``pattern_id`` is operator-controlled and low-cardinality (``PATTERN_ID_RE``), so a
   metric series identifies a query *category*, never a search.
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 _meter = metrics.get_meter("merino.query_pattern")
 
 _match_counter = _meter.create_counter(
-    "merino.query_pattern.match",
+    "merino_query_pattern_match",
     description="Count of suggest queries matching a configured query pattern, "
     "by pattern id and source",
 )

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -71,6 +71,11 @@ from merino.utils.api.metrics import (
 )
 from merino.utils.featureflags import FeatureFlags
 from merino.utils.query_processing.fleece_client import get_fleece_client
+from merino.utils.query_processing.query_patterns import (
+    QueryPatternMatcher,
+    build_query_pattern_matcher,
+    emit_query_pattern_metrics,
+)
 from merino.utils.query_processing.pii_detect import pii_inspect, PIIType
 from merino.utils.query_processing.geo_params import (
     get_accepted_languages,
@@ -93,6 +98,13 @@ router = APIRouter()
 
 # Providers enabled for query normalization
 NORMALIZATION_PROVIDERS: frozenset[str] = frozenset(settings.query_normalization.providers)
+
+# Compiled query pattern matcher, or None when the feature is disabled.
+_QUERY_PATTERN_MATCHER: QueryPatternMatcher | None = build_query_pattern_matcher(
+    enabled=settings.query_pattern_matching.enabled,
+    sample_rate=settings.query_pattern_matching.sample_rate,
+    patterns=settings.query_pattern_matching.patterns,
+)
 
 # Param to capture all enabled_by_default=True providers.
 DEFAULT_PROVIDERS_PARAM_NAME: str = "default"
@@ -231,6 +243,10 @@ async def suggest(
     # feature_flags: FeatureFlags = request.scope[ScopeKey.FEATURE_FLAGS]
     metrics_client: Client = request.scope[ScopeKey.METRICS_CLIENT]
     user_agent: UserAgent = request.scope[ScopeKey.USER_AGENT]
+
+    # Emit query pattern match metrics
+    if _QUERY_PATTERN_MATCHER is not None:
+        emit_query_pattern_metrics(_QUERY_PATTERN_MATCHER, q, source)
 
     active_providers, default_providers = sources
     if providers is not None:

--- a/tests/integration/api/v1/suggest/test_suggest.py
+++ b/tests/integration/api/v1/suggest/test_suggest.py
@@ -17,6 +17,7 @@ from pytest_mock import MockerFixture
 
 from merino.configs import settings
 from merino.utils.log_data_creators import SuggestLogDataModel
+from merino.utils.query_processing.query_patterns import build_query_pattern_matcher
 from tests.integration.api.v1.fake_providers import FakeProviderFactory
 from tests.integration.api.v1.types import Providers
 from tests.types import FilterCaplogFixture
@@ -420,6 +421,76 @@ def test_suggest_fleece_not_called_for_empty_query(
 
     assert response.status_code == 200
     fleece_mock.detect_pii_safe.assert_not_called()
+
+
+@pytest.fixture()
+def sports_pattern_matcher() -> Any:
+    """Build a matcher for use in query pattern integration tests."""
+    return build_query_pattern_matcher(
+        enabled=True,
+        sample_rate=1.0,
+        patterns=[{"id": "sports_v1", "regex": r"\b(nba|nfl)\b"}],
+    )
+
+
+def test_query_pattern_metrics_emitted_before_email_pii_drop(
+    mocker: MockerFixture, client: TestClient, sports_pattern_matcher: Any
+) -> None:
+    """Test that pattern match metrics fire even when the email PII check drops the query."""
+    mocker.patch("merino.web.api_v1._QUERY_PATTERN_MATCHER", sports_pattern_matcher)
+    add = mocker.patch("merino.utils.query_processing.query_patterns._match_counter.add")
+
+    response = client.get("/api/v1/suggest?q=nba@example.com")
+
+    assert response.json()["suggestions"] == []
+    add.assert_called_once_with(1, {"pattern_id": "sports_v1", "source": "unknown"})
+
+    # raw query should never appear in any metric call.
+    assert "nba@example.com" not in str(add.call_args_list)
+
+
+def test_query_pattern_metrics_emitted_before_fleece_pii_drop(
+    mocker: MockerFixture, client: TestClient, sports_pattern_matcher: Any
+) -> None:
+    """Test that pattern match metrics fire even when fleece drops the query as PII."""
+    mocker.patch("merino.web.api_v1._QUERY_PATTERN_MATCHER", sports_pattern_matcher)
+    _patch_fleece(mocker, enabled=True, pii=True)
+    add = mocker.patch("merino.utils.query_processing.query_patterns._match_counter.add")
+
+    response = client.get("/api/v1/suggest?q=nba")
+
+    assert response.json()["suggestions"] == []
+    add.assert_called_once_with(1, {"pattern_id": "sports_v1", "source": "unknown"})
+
+
+def test_query_pattern_metrics_not_emitted_when_matcher_none(
+    mocker: MockerFixture, client: TestClient
+) -> None:
+    """Test that no query_pattern metrics are emitted when the matcher is disabled (None)."""
+    mocker.patch("merino.web.api_v1._QUERY_PATTERN_MATCHER", None)
+    add = mocker.patch("merino.utils.query_processing.query_patterns._match_counter.add")
+
+    client.get("/api/v1/suggest?q=nba")
+
+    add.assert_not_called()
+
+
+def test_query_pattern_metrics_not_emitted_outside_sample_rate(
+    mocker: MockerFixture, client: TestClient
+) -> None:
+    """Test that no metrics are emitted when the random roll falls outside the sample rate."""
+    low_rate_matcher = build_query_pattern_matcher(
+        enabled=True,
+        sample_rate=0.01,
+        patterns=[{"id": "sports_v1", "regex": r"\bnba\b"}],
+    )
+    mocker.patch("merino.web.api_v1._QUERY_PATTERN_MATCHER", low_rate_matcher)
+    mocker.patch("merino.utils.query_processing.query_patterns.random.random", return_value=0.5)
+    add = mocker.patch("merino.utils.query_processing.query_patterns._match_counter.add")
+
+    client.get("/api/v1/suggest?q=nba")
+
+    add.assert_not_called()
 
 
 def test_suggest_with_invalid_geolocation_ip(

--- a/tests/unit/utils/query_processing/test_query_patterns.py
+++ b/tests/unit/utils/query_processing/test_query_patterns.py
@@ -3,11 +3,14 @@
 import logging
 
 import pytest
+from pytest_mock import MockerFixture
 
+from merino.utils.query_processing import query_patterns
 from merino.utils.query_processing.query_patterns import (
     MAX_REGEX_LENGTH,
     QueryPatternMatcher,
     build_query_pattern_matcher,
+    emit_query_pattern_metrics,
     match_query,
 )
 
@@ -196,3 +199,73 @@ def test_match_query_returns_ids_not_query_text(
     assert all(isinstance(r, str) for r in result)
     assert "nba" not in result
     assert "scores" not in result
+
+
+@pytest.fixture()
+def sports_matcher() -> QueryPatternMatcher:
+    """Build a matcher with a single sports pattern."""
+    matcher = build_query_pattern_matcher(
+        enabled=True,
+        sample_rate=1.0,
+        patterns=[{"id": "sports_v1", "regex": r"\b(nba|nfl)\b"}],
+    )
+    assert matcher is not None
+    return matcher
+
+
+@pytest.fixture()
+def low_rate_matcher() -> QueryPatternMatcher:
+    """Build a sports matcher with a low sample rate for sampling gate tests."""
+    matcher = build_query_pattern_matcher(
+        enabled=True,
+        sample_rate=0.01,
+        patterns=[{"id": "sports_v1", "regex": r"\b(nba|nfl)\b"}],
+    )
+    assert matcher is not None
+    return matcher
+
+
+def test_emit_query_pattern_metrics_emits_for_match(
+    mocker: MockerFixture, sports_matcher: QueryPatternMatcher
+) -> None:
+    """Test that a matching query within the sample rate emits one metric per pattern."""
+    add = mocker.patch.object(query_patterns._match_counter, "add")
+
+    emit_query_pattern_metrics(sports_matcher, "nba scores", "urlbar")
+
+    add.assert_called_once_with(1, {"pattern_id": "sports_v1", "source": "urlbar"})
+
+
+def test_emit_query_pattern_metrics_no_match_emits_nothing(
+    mocker: MockerFixture, sports_matcher: QueryPatternMatcher
+) -> None:
+    """Test that a non-matching query emits no metrics."""
+    add = mocker.patch.object(query_patterns._match_counter, "add")
+
+    emit_query_pattern_metrics(sports_matcher, "weather in toronto", "urlbar")
+
+    add.assert_not_called()
+
+
+def test_emit_query_pattern_metrics_within_sample_rate_emits(
+    mocker: MockerFixture, sports_matcher: QueryPatternMatcher
+) -> None:
+    """Test that a roll below the sample rate still emits the match metric."""
+    add = mocker.patch.object(query_patterns._match_counter, "add")
+
+    mocker.patch.object(query_patterns.random, "random", return_value=0.99)
+    emit_query_pattern_metrics(sports_matcher, "nba", "urlbar")
+
+    add.assert_called_once()
+
+
+def test_emit_query_pattern_metrics_outside_sample_rate_emits_nothing(
+    mocker: MockerFixture, low_rate_matcher: QueryPatternMatcher
+) -> None:
+    """Test that a roll above the sample rate emits nothing."""
+    add = mocker.patch.object(query_patterns._match_counter, "add")
+
+    mocker.patch.object(query_patterns.random, "random", return_value=0.5)
+    emit_query_pattern_metrics(low_rate_matcher, "nba", "urlbar")
+
+    add.assert_not_called()


### PR DESCRIPTION
## References

JIRA: [DISCO-4303](https://mozilla-hub.atlassian.net/browse/DISCO-4303)

## Description
This PR wires the query pattern matcher into the `/api/v1/suggest` path and adds sampling support.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2452)


[DISCO-4303]: https://mozilla-hub.atlassian.net/browse/DISCO-4303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ