### PR TITLE
[HNT-2775] Add cli command for wikimedia potd update job

### DIFF
--- a/merino/jobs/cli.py
+++ b/merino/jobs/cli.py
@@ -19,6 +19,7 @@ from merino.jobs.relevancy_uploader import relevancy_csv_rs_uploader_cmd
 from merino.jobs.sportsdata_jobs import cli as sportsdata_cmd
 from merino.jobs.wikipedia_indexer import indexer_cmd
 from merino.jobs.wikipedia_offline_uploader import wiki_offline_uploader_cmd
+from merino.jobs.pitcture_of_the_day import cli as picture_of_the_day_upload_cmd
 
 # Include your new jobs module here.
 
@@ -60,6 +61,9 @@ cli.add_typer(amp_live_probe_cmd, no_args_is_help=True)
 
 # Add the games task runner subcommand
 cli.add_typer(games_tasks_cmd, no_args_is_help=True)
+
+# Add the picture of the day task runner subcommand
+cli.add_typer(picture_of_the_day_upload_cmd, no_args_is_help=True)
 
 
 @cli.callback()

--- a/merino/jobs/cli.py
+++ b/merino/jobs/cli.py
@@ -19,7 +19,7 @@ from merino.jobs.relevancy_uploader import relevancy_csv_rs_uploader_cmd
 from merino.jobs.sportsdata_jobs import cli as sportsdata_cmd
 from merino.jobs.wikipedia_indexer import indexer_cmd
 from merino.jobs.wikipedia_offline_uploader import wiki_offline_uploader_cmd
-from merino.jobs.pitcture_of_the_day import cli as picture_of_the_day_upload_cmd
+from merino.jobs.picture_of_the_day import cli as picture_of_the_day_upload_cmd
 
 # Include your new jobs module here.
 

--- a/merino/jobs/picture_of_the_day/__init__.py
+++ b/merino/jobs/picture_of_the_day/__init__.py
@@ -1,5 +1,6 @@
 """CLI commands for the Wikimedia Picture of the Day updater job."""
 
+import asyncio
 import logging
 import typer
 from merino.providers.rss import get_wikimedia_potd_provider, init_providers
@@ -12,14 +13,18 @@ cli = typer.Typer(
 )
 
 
+async def _potd_update_job() -> bool:
+    """Get the provider and call the method to upload potd."""
+    await init_providers()
+    provider = get_wikimedia_potd_provider()
+    return await provider.upload_picture_of_the_day()
+
+
 @cli.command("update-wikimedia-potd")
-async def update_wikimedia_potd():  # pragma: no cover
+def update_wikimedia_potd():  # pragma: no cover
     """Execute the process to attempt to update the Wikimedia Picture of the Day."""
     logger.info("Beginning wikimedia potd update process...")
 
-    # TODO @herraj refactor this to not init all future rss providers
-    await init_providers()
-    provider = get_wikimedia_potd_provider()
-    await provider.upload_picture_of_the_day()
+    success = asyncio.run(_potd_update_job())
 
-    logger.info("Finished wikimedia potd update.")
+    logger.info("Wikimedia potd update job finished", extra={"success": success})

--- a/merino/jobs/picture_of_the_day/__init__.py
+++ b/merino/jobs/picture_of_the_day/__init__.py
@@ -13,7 +13,7 @@ cli = typer.Typer(
 )
 
 
-async def _potd_update_job() -> bool:
+async def _potd_update_job() -> bool:  # pragma: no cover
     """Get the provider and call the method to upload potd."""
     await init_providers()
     provider = get_wikimedia_potd_provider()

--- a/merino/jobs/pitcture_of_the_day/__init__.py
+++ b/merino/jobs/pitcture_of_the_day/__init__.py
@@ -1,0 +1,26 @@
+"""CLI commands for the Wikimedia Picture of the Day updater job."""
+
+import asyncio
+import logging
+import typer
+from merino.providers.rss import get_wikimedia_potd_provider
+
+logger = logging.getLogger(__name__)
+
+
+provider = get_wikimedia_potd_provider()
+
+cli = typer.Typer(
+    name="wikimedia_potd_updater",
+    help="Commands to process and update data related to Picture of the Day widget on New Tab.",
+)
+
+
+@cli.command("update-wikimedia-potd")
+async def update_wikimedia_potd():  # pragma: no cover
+    """Execute the process to attempt to update the Wikimedia Picture of the Day."""
+    logger.info("Beginning wikimedia potd update process...")
+
+    await provider.upload_picture_of_the_day()
+
+    logger.info("Finished wikimedia potd update.")

--- a/merino/jobs/pitcture_of_the_day/__init__.py
+++ b/merino/jobs/pitcture_of_the_day/__init__.py
@@ -1,6 +1,5 @@
 """CLI commands for the Wikimedia Picture of the Day updater job."""
 
-import asyncio
 import logging
 import typer
 from merino.providers.rss import get_wikimedia_potd_provider

--- a/merino/jobs/pitcture_of_the_day/__init__.py
+++ b/merino/jobs/pitcture_of_the_day/__init__.py
@@ -2,12 +2,9 @@
 
 import logging
 import typer
-from merino.providers.rss import get_wikimedia_potd_provider
+from merino.providers.rss import get_wikimedia_potd_provider, init_providers
 
 logger = logging.getLogger(__name__)
-
-
-provider = get_wikimedia_potd_provider()
 
 cli = typer.Typer(
     name="wikimedia_potd_updater",
@@ -20,6 +17,9 @@ async def update_wikimedia_potd():  # pragma: no cover
     """Execute the process to attempt to update the Wikimedia Picture of the Day."""
     logger.info("Beginning wikimedia potd update process...")
 
+    # TODO @herraj refactor this to not init all future rss providers
+    await init_providers()
+    provider = get_wikimedia_potd_provider()
     await provider.upload_picture_of_the_day()
 
     logger.info("Finished wikimedia potd update.")


### PR DESCRIPTION
## References

JIRA: [HNT-2775](https://mozilla-hub.atlassian.net/browse/HNT-2775)

## Description
Adding a cli command to run the job that calls the upload method to update the Wikimedia potd.

Depends on this change: https://github.com/mozilla-services/merino-py/pull/1625 

k8s `cronJob` change: https://github.com/mozilla/webservices-infra/pull/11684



## PR Review Checklist
- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2453)


[HNT-2775]: https://mozilla-hub.atlassian.net/browse/HNT-2775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ