### PR TITLE
chore(wcs): freeze time in date-dependent match tests

### DIFF
--- a/tests/integration/api/v1/wcs/test_matches.py
+++ b/tests/integration/api/v1/wcs/test_matches.py
@@ -180,6 +180,7 @@ def test_teams_filter(client: TestClient) -> None:
         assert "BRA" in {event["home_team"]["key"], event["away_team"]["key"]}
 
 
+@freezegun.freeze_time("2026-07-05T16:00:00Z")
 def test_matches_returns_nullable_tbd_sides(client: TestClient) -> None:
     """Knockout placeholders serialize null team objects for Mobile."""
     app.dependency_overrides[get_wcs_provider] = lambda: build_provider(

--- a/tests/unit/providers/wcs/test_provider.py
+++ b/tests/unit/providers/wcs/test_provider.py
@@ -450,6 +450,7 @@ async def test_public_sport_identifier_is_soccer() -> None:
 
 
 @pytest.mark.asyncio
+@freezegun.freeze_time("2026-07-05T16:00:00Z")
 async def test_matches_include_nullable_tbd_teams() -> None:
     """The matches endpoint can return scheduled bracket slots with null teams."""
     placeholder = build_event(


### PR DESCRIPTION
## References

Failure was discovered in an unrelated PR https://github.com/mozilla-services/merino-py/pull/1649

## Description

`test_matches_include_nullable_tbd_teams` (unit) and `test_matches_returns_nullable_tbd_sides` (integration) inject a fixed-date placeholder match (`2026-07-05T20:00Z`) and assert it lands in the `next` bucket, but omit the `@freezegun.freeze_time` decorator — so they bucket against the real wall clock. Once that date passed, the match moved to `current`/`previous` and `next` emptied, so `assert len(next) == 1` / `next[0]` began failing (`2026-07-05T20:00Z` onward) and now blocks CI.

This is a test-hermeticity defect, not a product bug: `get_matches` buckets by live match state against `datetime.now(UTC)` by design (correct for a live widget), and production runs on real match data, not this fixture.

Most WCS tests correctly have no `freeze_time` — they assert time-independent behavior (response shape, bucket ordering, team filtering, validation, determinism) or operate on already-past fixtures. These two are the only ones that assert a fixed **future-dated** fixture lands in `next` without freezing the clock; they were also the only fixtures using a hardcoded future `original_date`, so there are no other latent date bombs.

Fix: freeze both to `2026-07-05T16:00Z` (before the match's 20:00 kickoff → stays `next`), matching sibling bucket-content tests such as `test_completed_knockout_match_marks_losing_team_eliminated`.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)
