### PR TITLE
[DISCO-4345] fix(wcs): update Switzerland mapping from CHE -> SUI

### DIFF
--- a/merino/providers/suggest/sports/backends/sportsdata/common/sports.py
+++ b/merino/providers/suggest/sports/backends/sportsdata/common/sports.py
@@ -702,6 +702,7 @@ class WCS(Sport):
     ISO_alias = {
         "CDR": "COD",
         "CVI": "CPV",
+        "CHE": "SUI",
     }
 
     def __init__(

--- a/tests/unit/providers/wcs/test_protocol.py
+++ b/tests/unit/providers/wcs/test_protocol.py
@@ -87,6 +87,7 @@ def test_team_info_icon_url_uses_png_when_svg_is_missing(
     [
         pytest.param("CDR", "COD", id="cdr-aliased-to-cod"),
         pytest.param("CVI", "CPV", id="cvi-aliased-to-cpv"),
+        pytest.param("CHE", "SUI", id="che-aliased-to-sui"),
         pytest.param("BRA", "BRA", id="unlisted-code-unchanged"),
     ],
 )


### PR DESCRIPTION


## References

JIRA: [DISCO-4345]

## Description
Update Switzerland mapping from CHE to SUI (the ISO3 code to the FIFA standings code)





[DISCO-4345]: https://mozilla-hub.atlassian.net/browse/DISCO-4345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ