### PR TITLE
fix(requestHeader): Request to get images throws 403 without user-agent header

### DIFF
--- a/merino/providers/rss/wikimedia_potd/backends/wikimedia_potd.py
+++ b/merino/providers/rss/wikimedia_potd/backends/wikimedia_potd.py
@@ -124,7 +124,10 @@ class WikimediaPictureOfTheDayBackend:
             raise WikimediaPotdError(f"Invalid Wikimedia POTD image url: {url}")
 
         # set up request headers to only accept image content types
-        request_headers = {"accept": "image/jpeg,image/png,image/webp"}
+        request_headers = {
+            **RSS_FETCH_REQUEST_HEADERS,
+            "accept": "image/jpeg,image/png,image/webp",
+        }
         response: Response = await self.http_client.get(str(url), headers=request_headers)
         response.raise_for_status()
 


### PR DESCRIPTION
## References

N/A

## Description
Quick fix to add the `User-Agent` header to the image get request as well. This was an issue for the RSS feed get request in the past so just adding the same header for this request as well.



## PR Review Checklist
- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2456)
