### PR TITLE
[HNT-2767] feat: allow Latin-American Spanish locales (es-AR, es-CL, es-MX)

### DIFF
--- a/merino/curated_recommendations/protocol.py
+++ b/merino/curated_recommendations/protocol.py
@@ -51,6 +51,11 @@ class Locale(str, Enum):
     FR_FR = ("fr-FR",)
     ES = ("es",)
     ES_ES = ("es-ES",)
+    # Global Spanish markets (Firefox's Latin-American Spanish builds). Combined with the
+    # sections-in-global-spanish experiment, these route to NEW_TAB_ES_XA (see utils.py).
+    ES_AR = ("es-AR",)
+    ES_CL = ("es-CL",)
+    ES_MX = ("es-MX",)
     IT = ("it",)
     IT_IT = ("it-IT",)
     EN = ("en",)

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -782,6 +782,22 @@ class TestCuratedRecommendationsRequestParameters:
         data = response.json()
         assert data["surfaceId"] == surface_id
 
+    @pytest.mark.parametrize("locale", [Locale.ES_AR, Locale.ES_CL, Locale.ES_MX])
+    def test_global_spanish_locales_route_to_es_xa(self, locale, client: TestClient):
+        """Latin-American Spanish locales are accepted and, in the sections-in-global-spanish
+        treatment, route to the global Spanish surface (NEW_TAB_ES_XA).
+        """
+        response = client.post(
+            "/api/v1/curated-recommendations",
+            json={
+                "locale": locale,
+                "experimentName": "sections-in-global-spanish",
+                "experimentBranch": "treatment",
+            },
+        )
+        assert response.status_code == 200, f"{locale} resulted in {response.status_code}"
+        assert response.json()["surfaceId"] == SurfaceId.NEW_TAB_ES_XA
+
     @pytest.mark.parametrize(
         "locale",
         [


### PR DESCRIPTION
## References

- JIRA: [HNT-2781](https://mozilla-hub.atlassian.net/browse/HNT-2781)
- Follow-up to #1649
- [Experiment brief](https://docs.google.com/document/d/1ZucJUDI_MPVTtPkd3XuSD1XwZjIQvfffjyqzcPWE1Lc/edit?tab=t.0)

## Description

We want to experiment with a global Spanish feed.

Firefox ships four Spanish locales — `es-ES`, `es-AR`, `es-CL`, `es-MX` — but Merino's `Locale` enum only listed `es` and `es-ES`. So requests from Latin-American Spanish clients (`es-AR`/`es-CL`/`es-MX`) were rejected with **HTTP 400** before routing ever ran, which would block the `sections-in-global-spanish` experiment from reaching them.

This adds those three locales to the enum. Combined with the merged es-XA routing, an enrolled client with one of these locales now resolves to `NEW_TAB_ES_XA` (Spain still keeps `NEW_TAB_ES_ES`, and non-enrolled clients are unaffected).

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)

[HNT-2767]: https://mozilla-hub.atlassian.net/browse/HNT-2767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[HNT-2781]: https://mozilla-hub.atlassian.net/browse/HNT-2781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ