### PR TITLE
[DISCO-4326] feat(storage): update image cache control headers

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -391,6 +391,8 @@ favicons_root = "favicons"
 max_size = 16777216 # 16MB
 # HTTP timeout for favicon downloads (in seconds)
 http_timeout = 5
+# Cache control headers (12 hrs)
+cache_control = "public, max-age=43200"
 
 [default.query_normalization]
 # MERINO_QUERY_NORMALIZATION__ENABLED
@@ -1032,9 +1034,12 @@ circuit_breaker_failure_threshold = 10
 # The circuit breaker will stay open for this period of time until the next recovery attempt.
 circuit_breaker_recover_timeout_sec = 30
 
+# MERINO_PROVIDERS__POLYGON__IMAGE_CACHE_CONTROL
+# Cache control headers for ticker images
+image_cache_control = "public, max-age=43200"
+
 [default.providers.polygon.cache_ttls]
 # Cache TTLs for Polygon ticker snapshots.
-
 # MERINO_PROVIDERS__POLYGON__CACHE_TTLS__TICKER_TTL_SEC
 ticker_ttl_sec = 300 # 5 minutes
 
@@ -1219,6 +1224,10 @@ query_timeout_sec = 1.0
 # MERINO_RSS_PROVIDERS__WIKIMEDIA_POTD__FEED_URL
 # URL for the Wikimedia Picture of the Day RSS feed.
 feed_url = "https://commons.wikimedia.org/w/api.php?action=featuredfeed&feed=potd&feedformat=rss"
+
+# MERINO_RSS_PROVIDERS__WIKIMEDIA_POTD__CACHE_CONTROL
+# Cache control headers for stored images in the bucket (1hr)
+cache_control = "public, max-age=3600"
 
 [default.games_providers.particle]
 # MERINO_GAMES_PROVIDERS__PARTICLE__TYPE
@@ -1501,6 +1510,10 @@ force_upload = false
 # MERINO_JOBS__NAVIGATIONAL_SUGGESTIONS__MIN_FAVICON_WIDTH
 # Minimum width of the domain favicon required for it to be a part of domain metadata
 min_favicon_width = 48
+
+# MERINO_JOBS__NAVIGATIONAL_SUGGESTIONS__CACHE_CONTROL  
+# cache control headers for uploaded favicons (12 hrs)
+cache_control = "public, max-age=43200"
 
 
 [default.jobs.amo_rs_uploader]

--- a/merino/jobs/navigational_suggestions/favicon/favicon_processor.py
+++ b/merino/jobs/navigational_suggestions/favicon/favicon_processor.py
@@ -23,9 +23,11 @@ class FaviconProcessor:
         self,
         favicon_downloader: AsyncFaviconDownloader,
         base_url: str = "",
+        cache_control: str | None = None,
     ) -> None:
         self.favicon_downloader = favicon_downloader
         self.base_url = base_url
+        self.cache_control = cache_control
 
     async def process_and_upload_best_favicon(
         self,
@@ -135,7 +137,12 @@ class FaviconProcessor:
                     # Upload and return immediately - SVGs are top priority
                     dst_favicon_name = uploader.destination_favicon_name(image)
                     try:
-                        result = uploader.upload_image(image, dst_favicon_name, forced_upload=True)
+                        result = uploader.upload_image(
+                            image,
+                            dst_favicon_name,
+                            forced_upload=True,
+                            cache_control=self.cache_control,
+                        )
                         return str(result)
                     except Exception as e:
                         logger.warning(f"Failed to upload SVG favicon: {e}")
@@ -207,7 +214,10 @@ class FaviconProcessor:
                                     try:
                                         dst_favicon_name = uploader.destination_favicon_name(image)
                                         result = uploader.upload_image(
-                                            image, dst_favicon_name, forced_upload=True
+                                            image,
+                                            dst_favicon_name,
+                                            forced_upload=True,
+                                            cache_control=self.cache_control,
                                         )
                                         return str(result), min_width, failed_image_validations
                                     except Exception as svg_err:
@@ -230,7 +240,10 @@ class FaviconProcessor:
                                 try:
                                     dst_favicon_name = uploader.destination_favicon_name(image)
                                     favicon_url = uploader.upload_image(
-                                        image, dst_favicon_name, forced_upload=True
+                                        image,
+                                        dst_favicon_name,
+                                        forced_upload=True,
+                                        cache_control=self.cache_control,
                                     )
                                     best_favicon_url = favicon_url
                                     best_favicon_width = width_val

--- a/merino/jobs/navigational_suggestions/io/domain_metadata_uploader.py
+++ b/merino/jobs/navigational_suggestions/io/domain_metadata_uploader.py
@@ -8,11 +8,14 @@ from datetime import datetime
 
 from google.cloud.storage import Blob
 
+from merino.configs import settings
 from merino.utils.gcs.gcs_uploader import GcsUploader
 from merino.utils.gcs.models import Image
 from merino.jobs.navigational_suggestions.io.async_favicon_downloader import AsyncFaviconDownloader
 
 logger = logging.getLogger(__name__)
+
+CACHE_CONTROL = settings.jobs.navigational_suggestions.cache_control
 
 
 class DomainMetadataUploader:
@@ -104,7 +107,10 @@ class DomainMetadataUploader:
             try:
                 dst_favicon_name = self.destination_favicon_name(favicon_image)
                 dst_favicon_public_url = self.uploader.upload_image(
-                    favicon_image, dst_favicon_name, forced_upload=self.force_upload
+                    favicon_image,
+                    dst_favicon_name,
+                    forced_upload=self.force_upload,
+                    cache_control=CACHE_CONTROL,
                 )
                 return dst_favicon_public_url
             except Exception as e:
@@ -113,7 +119,11 @@ class DomainMetadataUploader:
         return ""
 
     def upload_image(
-        self, favicon_image: Image, dst_favicon_name: str, forced_upload: bool
+        self,
+        favicon_image: Image,
+        dst_favicon_name: str,
+        forced_upload: bool,
+        cache_control: str | None = None,
     ) -> str:
         """Upload an already downloaded favicon image to GCS and return its public URL.
 
@@ -126,7 +136,10 @@ class DomainMetadataUploader:
             Public URL of the uploaded favicon
         """
         return self.uploader.upload_image(
-            favicon_image, dst_favicon_name, forced_upload=forced_upload
+            favicon_image,
+            dst_favicon_name,
+            forced_upload=forced_upload,
+            cache_control=cache_control,
         )
 
     def upload_favicons(self, src_favicons: list[str]) -> list[str]:

--- a/merino/jobs/navigational_suggestions/processing/domain_processor.py
+++ b/merino/jobs/navigational_suggestions/processing/domain_processor.py
@@ -7,6 +7,7 @@ from typing import Any, Optional, TYPE_CHECKING
 
 import tldextract
 
+from merino.configs import settings
 from merino.jobs.navigational_suggestions.enrichments.custom_favicons import get_custom_favicon_url
 from merino.jobs.navigational_suggestions.favicon.favicon_extractor import FaviconExtractor
 from merino.jobs.navigational_suggestions.favicon.favicon_processor import FaviconProcessor
@@ -33,6 +34,7 @@ logger = logging.getLogger(__name__)
 current_web_scraper: contextvars.ContextVar[WebScraper] = contextvars.ContextVar(
     "current_web_scraper"
 )
+CACHE_CONTROL = settings.jobs.navigational_suggestions.cache_control
 
 
 class DomainProcessor:
@@ -208,7 +210,10 @@ class DomainProcessor:
                 if favicon_image:
                     dst_favicon_name = uploader.destination_favicon_name(favicon_image)
                     favicon = uploader.upload_image(
-                        favicon_image, dst_favicon_name, forced_upload=uploader.force_upload
+                        favicon_image,
+                        dst_favicon_name,
+                        forced_upload=uploader.force_upload,
+                        cache_control=CACHE_CONTROL,
                     )
                 else:
                     favicon = ""

--- a/merino/jobs/utils/domain_tester.py
+++ b/merino/jobs/utils/domain_tester.py
@@ -60,12 +60,19 @@ async def async_test_domain(domain: str, min_width: int) -> DomainTestResult:
         # Create a mock uploader that doesn't actually upload to GCS
         class MockUploader(BaseContentUploader):
             def upload_content(
-                self, content, destination_name, content_type="text/plain", forced_upload=False
+                self,
+                content,
+                destination_name,
+                content_type="text/plain",
+                forced_upload=False,
+                cache_control=None,
             ):
                 mock_blob = Blob(name=destination_name, bucket=None)
                 return mock_blob
 
-            def upload_image(self, image, destination_name, forced_upload=False):
+            def upload_image(
+                self, image, destination_name, forced_upload=False, cache_control=None
+            ):
                 return f"https://dummy-cdn.example.com/{destination_name}"
 
             def get_most_recent_file(self, match, sort_key):

--- a/merino/providers/rss/wikimedia_potd/backends/wikimedia_potd.py
+++ b/merino/providers/rss/wikimedia_potd/backends/wikimedia_potd.py
@@ -8,6 +8,7 @@ from pydantic import HttpUrl
 from feedparser import FeedParserDict
 from httpx import AsyncClient, Response
 
+from merino.configs import settings
 from merino.providers.rss.wikimedia_potd.backends.protocol import (
     PictureOfTheDay,
     WikimediaPotdError,
@@ -45,6 +46,7 @@ class WikimediaPictureOfTheDayBackend:
         self.metrics_client = metrics_client
         self.http_client = http_client
         self.gcs_uploader = gcs_uploader
+        self.cache_control = settings.rss_providers.wikimedia_potd.cache_control
 
     async def upload_picture_of_the_day(self) -> bool:
         """Orchestrates fetching the RSS feed, extracting the Picture of the Day (POTD),
@@ -149,7 +151,9 @@ class WikimediaPictureOfTheDayBackend:
         potd_image_path = build_potd_image_path(image=image, is_thumbnail=is_thumbnail)
 
         # return a public cdn url for the image after a successful upload
-        public_url = self.gcs_uploader.upload_image(image=image, destination_name=potd_image_path)
+        public_url = self.gcs_uploader.upload_image(
+            image=image, destination_name=potd_image_path, cache_control=self.cache_control
+        )
 
         # GcsUploader.upload_content swallows storage errors and returns a public url regardless,
         # so confirm the object actually landed in the bucket and fail loudly otherwise.

--- a/merino/providers/suggest/finance/backends/polygon/backend.py
+++ b/merino/providers/suggest/finance/backends/polygon/backend.py
@@ -135,6 +135,7 @@ class PolygonBackend:
         self.cache.register_script(
             SCRIPT_ID_BULK_WRITE_TICKERS, LUA_SCRIPT_CACHE_BULK_WRITE_TICKERS
         )
+        self.cache_control = settings.providers.polygon.image_cache_control
 
     async def get_snapshots(self, tickers: list[str]) -> list[TickerSnapshot]:
         """Get snapshots for the list of tickers."""
@@ -311,12 +312,14 @@ class PolygonBackend:
                         image=logo,
                         destination_name=destination_name,
                         forced_upload=False,
+                        cache_control=self.cache_control,
                     )
 
                     public_url_v2 = self.gcs_uploader_v2.upload_image(
                         image=logo,
                         destination_name=destination_name,
                         forced_upload=False,
+                        cache_control=self.cache_control,
                     )
 
                     uploaded_urls["v1"][ticker] = public_url

--- a/merino/utils/gcs/gcs_uploader.py
+++ b/merino/utils/gcs/gcs_uploader.py
@@ -32,12 +32,17 @@ class GcsUploader(BaseContentUploader):
         self.cdn_hostname = destination_cdn_hostname
 
     def upload_image(
-        self, image: Image, destination_name: str, forced_upload: bool = False
+        self,
+        image: Image,
+        destination_name: str,
+        forced_upload: bool = False,
+        cache_control: str | None = None,
     ) -> str:
         """Upload an Image to our GCS Bucket and return the public URL where it is hosted."""
         image_blob: Blob = self.upload_content(
-            image.content, destination_name, image.content_type, forced_upload
+            image.content, destination_name, image.content_type, forced_upload, cache_control
         )
+
         image_public_url = self._get_public_url(image_blob, destination_name)
 
         logger.info(f"Content public url: {image_public_url}")
@@ -50,6 +55,7 @@ class GcsUploader(BaseContentUploader):
         destination_name: str,
         content_type: str = "text/plain",
         forced_upload: bool = False,
+        cache_control: str | None = None,
     ) -> Blob:
         """Upload the content then return the blob."""
         bucket: Bucket = self.storage_client.bucket(self.bucket_name)
@@ -58,7 +64,7 @@ class GcsUploader(BaseContentUploader):
         try:
             if forced_upload or not destination_blob.exists():
                 logger.info(f"Uploading blob: {destination_blob.name}")
-
+                destination_blob.cache_control = cache_control
                 destination_blob.upload_from_string(
                     content,
                     content_type=content_type,
@@ -76,6 +82,7 @@ class GcsUploader(BaseContentUploader):
         destination_name: str,
         content_type: str,
         forced_upload: bool = False,
+        cache_control: str | None = None,
     ) -> Blob:
         """Upload a local file and return the blob."""
         bucket: Bucket = self.storage_client.bucket(self.bucket_name)
@@ -84,6 +91,7 @@ class GcsUploader(BaseContentUploader):
         try:
             if forced_upload or not destination_blob.exists():
                 logger.info(f"Uploading file: {destination_blob.name}")
+                destination_blob.cache_control = cache_control
                 destination_blob.upload_from_filename(
                     file_path,
                     content_type=content_type,

--- a/merino/utils/gcs/models.py
+++ b/merino/utils/gcs/models.py
@@ -38,6 +38,7 @@ class BaseContentUploader(ABC):
         destination_name: str,
         content_type: str = "text/plain",
         forced_upload: bool = False,
+        cache_control: str | None = None,
     ) -> Blob:
         """Abstract method for uploading content to our GCS Bucket."""
         ...
@@ -47,7 +48,8 @@ class BaseContentUploader(ABC):
         self,
         image: Image,
         destination_name: str,
-        forced_upload=None,
+        forced_upload: bool = False,
+        cache_control: str | None = None,
     ) -> str:
         """Abstract method for uploading an image to our GCS Bucket."""
         ...

--- a/merino/utils/icon_processor.py
+++ b/merino/utils/icon_processor.py
@@ -34,6 +34,7 @@ class IconProcessor:
 
         # Metrics
         self.metrics_client = metrics.get_metrics_client()
+        self.cache_control = settings.icon.cache_control
 
     async def process_icon_url(self, url: str) -> str:
         """Process an external icon URL and return a GCS-hosted URL."""
@@ -75,7 +76,10 @@ class IconProcessor:
                 # GcsUploader already checks if the file exists before uploading
                 with self.metrics_client.timeit("icon_processor.upload_time"):
                     gcs_url = self.uploader.upload_image(
-                        favicon_image, destination, forced_upload=False
+                        favicon_image,
+                        destination,
+                        forced_upload=False,
+                        cache_control=self.cache_control,
                     )
 
                 # Cache the result

--- a/tests/integration/jobs/navigational_suggestions/test_favicon_pipeline_integration.py
+++ b/tests/integration/jobs/navigational_suggestions/test_favicon_pipeline_integration.py
@@ -426,7 +426,7 @@ class TestFaviconProcessorIntegration:
         # Only one download call should be made (for SVG), since SVG succeeds
         assert mock_downloader.download_multiple_favicons.call_count == 1
         mock_uploader.upload_image.assert_called_once_with(
-            svg_image, "favicon.svg", forced_upload=True
+            svg_image, "favicon.svg", forced_upload=True, cache_control=None
         )
 
     @pytest.mark.asyncio

--- a/tests/integration/utils/test_gcs_uploader.py
+++ b/tests/integration/utils/test_gcs_uploader.py
@@ -5,6 +5,7 @@ import pytest
 from google.cloud.storage import Bucket
 
 from merino.utils.gcs.gcs_uploader import GcsUploader
+from merino.utils.gcs.models import Image
 
 
 @pytest.fixture(scope="function")
@@ -66,9 +67,11 @@ class TestUploadFromFilename:
             file_path="tests/data/games/particle/image.jpg",
             destination_name="image.jpg",
             content_type="image/jpeg",
+            cache_control="public, max-age=86400",
         )
 
         assert blob.name == "image.jpg"
+        assert blob.cache_control == "public, max-age=86400"
 
     def test_bucket_failure(self, gcs_storage_client):
         """Verify bucket failure raises."""
@@ -262,3 +265,48 @@ class TestUploadContent:
         )
 
         assert blob2.id
+
+    def test_cache_control_set(self, gcs_client):
+        """Verify cache_control is applied to the uploaded blob."""
+        gcs_client.upload_content(
+            content="{}",
+            destination_name="test.json",
+            content_type="application/json",
+            cache_control="public, max-age=99",
+        )
+
+        blob = gcs_client.get_file_by_name("test.json")
+
+        assert blob
+        assert blob.cache_control == "public, max-age=99"
+
+    def test_cache_control_default_none(self, gcs_client):
+        """Verify cache_control is unset when not provided."""
+        gcs_client.upload_content(
+            content="{}", destination_name="test.json", content_type="application/json"
+        )
+
+        blob = gcs_client.get_file_by_name("test.json")
+
+        assert blob
+        assert blob.cache_control is None
+
+
+class TestUploadImage:
+    """Tests against the upload_image function."""
+
+    def test_cache_control_threaded_through(self, gcs_client):
+        """Verify upload_image forwards cache_control down to the stored blob."""
+        image = Image(content=b"fake_image_bytes", content_type="image/png")
+
+        gcs_client.upload_image(
+            image,
+            destination_name="image.png",
+            forced_upload=True,
+            cache_control="public, max-age=99",
+        )
+
+        blob = gcs_client.get_file_by_name("image.png")
+
+        assert blob
+        assert blob.cache_control == "public, max-age=99"

--- a/tests/unit/jobs/navigational_suggestions/test_domain_metadata_uploader.py
+++ b/tests/unit/jobs/navigational_suggestions/test_domain_metadata_uploader.py
@@ -13,6 +13,7 @@ from google.cloud.storage import Blob, Bucket, Client
 from pytest import LogCaptureFixture
 from pytest_mock import MockerFixture
 
+from merino.configs import settings
 from merino.utils.gcs.gcs_uploader import GcsUploader
 from merino.utils.gcs.models import Image
 from merino.jobs.navigational_suggestions.io.domain_metadata_uploader import (
@@ -299,7 +300,10 @@ def test_upload_favicons_upload_if_not_present(mock_favicon_downloader, mock_gcs
 
     assert uploaded_favicons == [UPLOADED_FAVICON_PUBLIC_URL]
     mock_gcs_uploader.upload_image.assert_called_once_with(
-        expected_image, expected_destination, forced_upload=FORCE_UPLOAD
+        expected_image,
+        expected_destination,
+        forced_upload=FORCE_UPLOAD,
+        cache_control=settings.jobs.navigational_suggestions.cache_control,
     )
 
 
@@ -326,7 +330,59 @@ def test_upload_favicons_upload_if_force_upload_set(
 
     assert uploaded_favicons == [UPLOADED_FAVICON_PUBLIC_URL]
     mock_gcs_uploader.upload_image.assert_called_once_with(
-        expected_image, expected_destination, forced_upload=FORCE_UPLOAD
+        expected_image,
+        expected_destination,
+        forced_upload=FORCE_UPLOAD,
+        cache_control=settings.jobs.navigational_suggestions.cache_control,
+    )
+
+
+def test_upload_favicon_passes_cache_control_to_uploader(
+    mock_favicon_downloader, mock_gcs_uploader
+) -> None:
+    """Test that upload_favicon forwards the configured cache_control to the uploader."""
+    mock_gcs_uploader.upload_image.return_value = "DUMMY_PUBLIC_URL"
+
+    domain_metadata_uploader = DomainMetadataUploader(
+        uploader=mock_gcs_uploader,
+        force_upload=False,
+        async_favicon_downloader=mock_favicon_downloader,
+    )
+
+    domain_metadata_uploader.upload_favicon("favicon1.png")
+
+    _, call_kwargs = mock_gcs_uploader.upload_image.call_args
+    assert call_kwargs["cache_control"] == settings.jobs.navigational_suggestions.cache_control
+
+
+def test_upload_image_forwards_cache_control_to_uploader(
+    mock_favicon_downloader, mock_gcs_uploader
+) -> None:
+    """Test that upload_image forwards the given cache_control value to the uploader."""
+    mock_gcs_uploader.upload_image.return_value = "DUMMY_PUBLIC_URL"
+
+    domain_metadata_uploader = DomainMetadataUploader(
+        uploader=mock_gcs_uploader,
+        force_upload=False,
+        async_favicon_downloader=mock_favicon_downloader,
+    )
+
+    favicon_image = Image(content=b"\xff", content_type="image/png")
+    dst_favicon_name = domain_metadata_uploader.destination_favicon_name(favicon_image)
+
+    result = domain_metadata_uploader.upload_image(
+        favicon_image,
+        dst_favicon_name,
+        forced_upload=False,
+        cache_control="public, max-age=99",
+    )
+
+    assert result == "DUMMY_PUBLIC_URL"
+    mock_gcs_uploader.upload_image.assert_called_once_with(
+        favicon_image,
+        dst_favicon_name,
+        forced_upload=False,
+        cache_control="public, max-age=99",
     )
 
 

--- a/tests/unit/jobs/navigational_suggestions/test_domain_processor.py
+++ b/tests/unit/jobs/navigational_suggestions/test_domain_processor.py
@@ -4,6 +4,9 @@
 
 """Unit tests for domain_processor module."""
 
+import pytest
+
+from merino.configs import settings
 from merino.jobs.navigational_suggestions.processing.domain_processor import DomainProcessor
 
 
@@ -137,3 +140,41 @@ class TestDomainProcessorExtractTitle:
         result = processor._extract_title(mock_scraper, "secure")
 
         assert result == "Secure"
+
+
+class TestDomainProcessorTryCustomFavicon:
+    """Tests for DomainProcessor._try_custom_favicon method."""
+
+    @pytest.mark.asyncio
+    async def test_passes_cache_control_to_upload_image(self, mocker):
+        """Test that the configured cache_control setting is passed to upload_image."""
+        mocker.patch(
+            "merino.jobs.navigational_suggestions.processing.domain_processor."
+            "get_custom_favicon_url",
+            return_value="https://example.com/favicon.ico",
+        )
+
+        downloader_mock = mocker.AsyncMock()
+        downloader_mock.download_favicon.return_value = b"favicon-bytes"
+        processor = DomainProcessor(blocked_domains=set(), favicon_downloader=downloader_mock)
+
+        uploader_mock = mocker.MagicMock()
+        uploader_mock.uploader.cdn_hostname = "cdn.example.net"
+        uploader_mock.force_upload = False
+        uploader_mock.destination_favicon_name.return_value = "favicons/favicon.ico"
+        uploader_mock.upload_image.return_value = "https://cdn.example.net/favicons/favicon.ico"
+
+        result = await processor._try_custom_favicon(
+            domain_key="example",
+            full_domain="www.example.com",
+            second_level_domain="example",
+            uploader=uploader_mock,
+        )
+
+        assert result is not None
+        uploader_mock.upload_image.assert_called_once_with(
+            b"favicon-bytes",
+            "favicons/favicon.ico",
+            forced_upload=uploader_mock.force_upload,
+            cache_control=settings.jobs.navigational_suggestions.cache_control,
+        )

--- a/tests/unit/jobs/navigational_suggestions/test_favicon_processor.py
+++ b/tests/unit/jobs/navigational_suggestions/test_favicon_processor.py
@@ -72,9 +72,7 @@ class TestFaviconProcessorInit:
 
     def test_init_with_cache_control(self, mock_favicon_downloader):
         """Test that cache_control is stored on the instance."""
-        processor = FaviconProcessor(
-            mock_favicon_downloader, cache_control="public, max-age=99"
-        )
+        processor = FaviconProcessor(mock_favicon_downloader, cache_control="public, max-age=99")
         assert processor.cache_control == "public, max-age=99"
 
 
@@ -290,10 +288,7 @@ class TestProcessSvgFavicons:
 
         assert result == "https://cdn.example.com/test_favicon.png"
         mock_uploader.upload_image.assert_called_once()
-        assert (
-            mock_uploader.upload_image.call_args.kwargs["cache_control"]
-            == "public, max-age=99"
-        )
+        assert mock_uploader.upload_image.call_args.kwargs["cache_control"] == "public, max-age=99"
 
     @pytest.mark.asyncio
     async def test_process_svg_favicons_skip_masked(

--- a/tests/unit/jobs/navigational_suggestions/test_favicon_processor.py
+++ b/tests/unit/jobs/navigational_suggestions/test_favicon_processor.py
@@ -65,6 +65,18 @@ class TestFaviconProcessorInit:
         processor = FaviconProcessor(mock_favicon_downloader)
         assert processor.base_url == ""
 
+    def test_init_default_cache_control_is_none(self, mock_favicon_downloader):
+        """Test that cache_control defaults to None."""
+        processor = FaviconProcessor(mock_favicon_downloader)
+        assert processor.cache_control is None
+
+    def test_init_with_cache_control(self, mock_favicon_downloader):
+        """Test that cache_control is stored on the instance."""
+        processor = FaviconProcessor(
+            mock_favicon_downloader, cache_control="public, max-age=99"
+        )
+        assert processor.cache_control == "public, max-age=99"
+
 
 class TestProcessAndUploadBestFavicon:
     """Test the main process_and_upload_best_favicon method."""
@@ -253,6 +265,35 @@ class TestProcessSvgFavicons:
 
         assert result == "https://cdn.example.com/test_favicon.png"
         mock_uploader.upload_image.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_process_svg_favicons_passes_cache_control(
+        self, mock_favicon_downloader, mock_uploader, mock_svg_image
+    ):
+        """Test that cache_control is threaded through to uploader.upload_image."""
+        processor = FaviconProcessor(
+            mock_favicon_downloader,
+            "https://example.com",
+            cache_control="public, max-age=99",
+        )
+        svg_urls = ["https://example.com/favicon.svg"]
+        svg_indices = [0]
+        masked_svg_indices: list[int] = []
+
+        mock_favicon_downloader.download_multiple_favicons = AsyncMock(
+            return_value=[mock_svg_image]
+        )
+
+        result = await processor._process_svg_favicons(
+            svg_urls, svg_indices, masked_svg_indices, mock_uploader
+        )
+
+        assert result == "https://cdn.example.com/test_favicon.png"
+        mock_uploader.upload_image.assert_called_once()
+        assert (
+            mock_uploader.upload_image.call_args.kwargs["cache_control"]
+            == "public, max-age=99"
+        )
 
     @pytest.mark.asyncio
     async def test_process_svg_favicons_skip_masked(

--- a/tests/unit/providers/rss/wikimedia_potd/backends/test_wikimedia_potd_backend.py
+++ b/tests/unit/providers/rss/wikimedia_potd/backends/test_wikimedia_potd_backend.py
@@ -14,6 +14,7 @@ from pydantic import HttpUrl
 from httpx import AsyncClient, HTTPError, Request, Response
 from pytest_mock import MockerFixture
 
+from merino.configs import settings
 from merino.providers.rss.wikimedia_potd.backends.protocol import (
     PictureOfTheDay,
     WikimediaPotdError,
@@ -346,6 +347,23 @@ class TestGcsUploadVerification:
             backend.upload_potd_image(
                 image=Image(content=b"255", content_type="image/png"), is_thumbnail=True
             )
+
+    def test_upload_potd_image_forwards_cache_control_to_uploader(
+        self, backend: WikimediaPictureOfTheDayBackend
+    ) -> None:
+        """Forwards the configured cache_control setting to gcs_uploader.upload_image."""
+        backend.gcs_uploader.upload_image.return_value = (  # type: ignore[attr-defined]
+            "https://cdn/rss/wikimedia_potd/image.png"
+        )
+        # the object is present in the bucket so the upload does not raise.
+        backend.gcs_uploader.get_file_by_name.return_value = MagicMock()  # type: ignore[attr-defined]
+
+        backend.upload_potd_image(
+            image=Image(content=b"255", content_type="image/png"), is_thumbnail=True
+        )
+
+        _, kwargs = backend.gcs_uploader.upload_image.call_args  # type: ignore[attr-defined]
+        assert kwargs["cache_control"] == settings.rss_providers.wikimedia_potd.cache_control
 
     def test_upload_potd_manifest_raises_when_object_not_in_bucket(
         self, backend: WikimediaPictureOfTheDayBackend, potd: PictureOfTheDay

--- a/tests/unit/providers/suggest/finance/backends/test_polygon.py
+++ b/tests/unit/providers/suggest/finance/backends/test_polygon.py
@@ -811,6 +811,31 @@ async def test_upload_ticker_images_upload_fails(
     assert upload_image_mock.called
 
 
+@pytest.mark.asyncio
+async def test_upload_ticker_images_passes_cache_control_to_both_uploaders(
+    polygon: PolygonBackend,
+    sample_image: Image,
+    mock_gcs_uploader: GcsUploader,
+    mocker,
+):
+    """Test that both v1 and v2 uploaders receive the configured cache_control string."""
+    expected_cache_control = settings.providers.polygon.image_cache_control
+    # Lock the config shape: image_cache_control must resolve to a plain string.
+    assert isinstance(expected_cache_control, str)
+
+    mocker.patch.object(polygon, "download_ticker_image", return_value=sample_image)
+    upload_image_mock = mocker.patch.object(
+        mock_gcs_uploader, "upload_image", return_value="https://cdn.example.com/fake.svg"
+    )
+
+    await polygon.bulk_download_and_upload_ticker_images(["AAPL"])
+
+    # gcs_uploader (v1) and gcs_uploader_v2 both call upload_image once per ticker.
+    assert upload_image_mock.call_count == 2
+    for upload_call in upload_image_mock.call_args_list:
+        assert upload_call.kwargs["cache_control"] == expected_cache_control
+
+
 def test_build_finance_manifest_valid():
     """Test that build_finance_manifest creates a valid FinanceManifest with uppercased tickers
     and valid URLs

--- a/tests/unit/utils/test_gcs_models.py
+++ b/tests/unit/utils/test_gcs_models.py
@@ -56,13 +56,24 @@ class DummyUploader(BaseContentUploader):
     """Dummy uploader."""
 
     def upload_content(
-        self, content, destination_name, content_type="text/plain", forced_upload=False
+        self,
+        content,
+        destination_name,
+        content_type="text/plain",
+        forced_upload=False,
+        cache_control: str | None = None,
     ) -> DummyBlob:
         """Upload dummy content."""
         # Return a dummy blob with a predictable URL
         return DummyBlob(destination_name)
 
-    def upload_image(self, image: Image, destination_name: str, forced_upload=None) -> str:
+    def upload_image(
+        self,
+        image: Image,
+        destination_name: str,
+        forced_upload=None,
+        cache_control: str | None = None,
+    ) -> str:
         """Upload dummy image."""
         # Use upload_content to simulate uploading and get the URL
         blob = self.upload_content(

--- a/tests/unit/utils/test_icon_processor.py
+++ b/tests/unit/utils/test_icon_processor.py
@@ -259,6 +259,31 @@ async def test_process_icon_url_integration(icon_processor, mock_image, mocker: 
 
 
 @pytest.mark.asyncio
+async def test_process_icon_url_forwards_cache_control(
+    icon_processor, mock_image, mocker: MockerFixture
+):
+    """Test that cache_control from settings is forwarded to upload_image."""
+    url = "https://example.com/favicon.ico"
+
+    # Mock the internal methods
+    mocker.patch.object(icon_processor, "_download_favicon", return_value=mock_image)
+    mocker.patch.object(icon_processor, "_is_valid_image", return_value=True)
+    upload_mock = mocker.patch.object(
+        icon_processor.uploader,
+        "upload_image",
+        return_value="https://cdn.test.mozilla.net/favicons/test_hash_17.png",
+    )
+
+    # Process the URL
+    await icon_processor.process_icon_url(url)
+
+    # Verify upload_image received the cache_control value from settings
+    upload_mock.assert_called_once()
+    assert upload_mock.call_args.kwargs["cache_control"] == settings.icon.cache_control
+    assert icon_processor.cache_control == settings.icon.cache_control
+
+
+@pytest.mark.asyncio
 async def test_process_icon_url_content_hash_cache(
     icon_processor, mock_image, mocker: MockerFixture
 ):


### PR DESCRIPTION


## References

JIRA: [DISCO-4326]

## Description
Add cache control headers for favicons, uploaded logos, picture of the day, etc.

Between 1-12 hours depending on how frequently the images are updated.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2459)


[DISCO-4326]: https://mozilla-hub.atlassian.net/browse/DISCO-4326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ