### PR TITLE
fix(config): Update gcp v2 project config value for stage environment

### DIFF
--- a/merino/configs/stage.toml
+++ b/merino/configs/stage.toml
@@ -34,14 +34,14 @@ gcs_enabled = false
 
 [stage.image_gcs_v2]
 # MERINO_IMAGE_GCS_V2__GCS_PROJECT
-gcs_project = "moz-fx-merino-nonprod-ee93"
+gcs_project = "moz-fx-merino-nonprod-db57"
 
 # MERINO_IMAGE_GCS_V2__GCS_BUCKET
-gcs_bucket = "merino-images-stagepy"
+gcs_bucket = "merino-images-stage"
 
 # MERINO_IMAGE_GCS_V2__CDN_HOSTNAME
 # Stage temporarily points at the prod CDN because the stage image bucket
-# isn't populated with the WCS logo assets yet. Revisit once `merino-images-stagepy`
+# isn't populated with the WCS logo assets yet. Revisit once `merino-images-stage`
 # carries the same content as prod.
 cdn_hostname = "prod-images.merino.prod.webservices.mozgcp.net"
 


### PR DESCRIPTION
## References

N/A

## Description
While testing a cron job execution in the stage environment, a [sentry error](https://mozilla.sentry.io/issues/7600839048/?environment=stage&project=6622434&query=is%3Aunresolved&referrer=issue-stream) was caught. This error was caused due to the job execution trying to write to GCP v1 project storage bucket. Updating configs to fix this.



## PR Review Checklist
- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2460)
