### PR TITLE
[HNT-2787] Wikimedia POTD provider logic to serve non-stubbed data

### DIFF
--- a/merino/providers/rss/wikimedia_potd/backends/utils.py
+++ b/merino/providers/rss/wikimedia_potd/backends/utils.py
@@ -1,7 +1,7 @@
 """Utility functions for parsing Wikimedia POTD RSS feed data."""
 
 from bs4 import BeautifulSoup, Tag
-from datetime import datetime
+from datetime import datetime, timezone
 from feedparser import FeedParserDict
 from pydantic import HttpUrl
 
@@ -23,7 +23,7 @@ def parse_potd(potd: FeedParserDict) -> PictureOfTheDay:
     Returns:
         A PictureOfTheDay instance. Raises WikimediaPotdError if required data is missing.
     """
-    today = datetime.today().strftime("%Y-%m-%d")
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
 
     # convert date to "2026-06-11" format from this format "Thu, 11 Jun 2026 00:00:00 GMT"
     published_date = datetime.strptime(str(potd.published), "%a, %d %b %Y %H:%M:%S %Z").strftime(
@@ -98,7 +98,7 @@ def extract_potd(parsed_feed: FeedParserDict) -> FeedParserDict:
 def build_potd_image_path(image: Image, is_thumbnail: bool) -> str:
     """Build the name string for a potd and prepend the bucket directory path to it."""
     # YYYY-MM-DD format
-    date_time = datetime.today().strftime("%Y-%m-%d")
+    date_time = datetime.now(timezone.utc).strftime("%Y-%m-%d")
 
     # Under the bucket merino-images-prod, potd images are stored in the following directory.
     dir_path_in_bucket = "rss/wikimedia_potd"

--- a/merino/providers/rss/wikimedia_potd/backends/wikimedia_potd.py
+++ b/merino/providers/rss/wikimedia_potd/backends/wikimedia_potd.py
@@ -3,7 +3,7 @@
 import logging
 import aiodogstatsd
 import feedparser
-from datetime import datetime
+from datetime import datetime, timezone
 from pydantic import HttpUrl
 from feedparser import FeedParserDict
 from httpx import AsyncClient, Response
@@ -163,7 +163,7 @@ class WikimediaPictureOfTheDayBackend:
 
         Raises WikimediaPotdError if the manifest fails to upload.
         """
-        today = datetime.today().strftime("%Y-%m-%d")
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
 
         # manifest json is just the PictureOfTheDay model in json format
         manifest_json = potd.model_dump_json()
@@ -188,7 +188,7 @@ class WikimediaPictureOfTheDayBackend:
             A PictureOfTheDay object if available, otherwise None.
         """
         try:
-            today = datetime.today().strftime("%Y-%m-%d")
+            today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
             blob = self.gcs_uploader.get_file_by_name(f"rss/wikimedia_potd/POTD_{today}.json")
 
             if blob:

--- a/merino/providers/rss/wikimedia_potd/provider.py
+++ b/merino/providers/rss/wikimedia_potd/provider.py
@@ -5,7 +5,6 @@ import aiodogstatsd
 import asyncio
 from datetime import datetime, timezone
 
-import sentry_sdk
 from pydantic import HttpUrl
 
 from merino.providers.rss.base import BaseRssProvider
@@ -24,7 +23,6 @@ class WikimediaPictureOfTheDayProvider(BaseRssProvider):
     metrics_client: aiodogstatsd.Client
     url: HttpUrl
     potd: PictureOfTheDay | None
-    _reported_missing_potd: bool
 
     def __init__(
         self,
@@ -41,8 +39,6 @@ class WikimediaPictureOfTheDayProvider(BaseRssProvider):
         self.metrics_client = metrics_client
         self.url = HttpUrl("https://merino.services.mozilla.com/")
         self.potd = None
-        # track whether the current fetch from the gcs bucket has been reported for sentry capture
-        self._reported_missing_potd = False
 
     @staticmethod
     def _today() -> str:
@@ -56,26 +52,13 @@ class WikimediaPictureOfTheDayProvider(BaseRssProvider):
     async def _refresh_potd(self) -> None:
         """Fetch the potd from GCS and cache whatever the bucket returns.
 
-        When the fetch returns nothing the cached potd is left untouched and
-        a single Sentry warning is emitted per missing window, which resets once a potd is fetched again.
+        When the fetch returns nothing (e.g. today's manifest hasn't been uploaded yet) the
+        cached potd is left untouched, so a previously cached picture keeps being served.
         """
         fetched_potd = await asyncio.to_thread(self.backend.fetch_potd_from_gcs_bucket)
 
-        # cache the fetched potd and close the missing window
         if fetched_potd is not None:
             self.potd = fetched_potd
-            self._reported_missing_potd = False
-            return
-
-        # fetch returned nothing, warn once per missing window and keep any cached potd
-        if self._reported_missing_potd:
-            return
-
-        sentry_sdk.capture_message(
-            f"Provider could not fetch a potd from the gcs bucket for {self._today()}.",
-            "warning",
-        )
-        self._reported_missing_potd = True
 
     async def initialize(self) -> None:
         """Initialize the provider by warming the potd cache."""

--- a/merino/providers/rss/wikimedia_potd/provider.py
+++ b/merino/providers/rss/wikimedia_potd/provider.py
@@ -3,7 +3,9 @@
 import logging
 import aiodogstatsd
 import asyncio
-from merino.configs import settings
+from datetime import datetime, timezone
+
+import sentry_sdk
 from pydantic import HttpUrl
 
 from merino.providers.rss.base import BaseRssProvider
@@ -22,6 +24,7 @@ class WikimediaPictureOfTheDayProvider(BaseRssProvider):
     metrics_client: aiodogstatsd.Client
     url: HttpUrl
     potd: PictureOfTheDay | None
+    _reported_stale_potd: bool
 
     def __init__(
         self,
@@ -38,27 +41,65 @@ class WikimediaPictureOfTheDayProvider(BaseRssProvider):
         self.metrics_client = metrics_client
         self.url = HttpUrl("https://merino.services.mozilla.com/")
         self.potd = None
+        # Track whether the current stale/missing window has already been reported, so we
+        # emit at most one Sentry warning per window instead of one per request.
+        self._reported_stale_potd = False
+
+    @staticmethod
+    def _today() -> str:
+        """Return today's date (UTC) as a YYYY-MM-DD string."""
+        return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+    def _is_todays_potd(self, potd: PictureOfTheDay | None) -> bool:
+        """Return True when `potd` exists and was published today (UTC)."""
+        return potd is not None and potd.published_date == self._today()
+
+    async def _refresh_potd(self) -> None:
+        """Fetch the potd from GCS and cache it when today's is available.
+
+        On a miss (nothing fetched, or the fetched potd is from another day) the cached
+        potd is left untouched and a single Sentry warning is emitted per stale window,
+        which resets once today's potd is cached again.
+        """
+        fetched_potd = await asyncio.to_thread(self.backend.fetch_potd_from_gcs_bucket)
+
+        # if today's potd is available, cache it and close the stale window
+        if self._is_todays_potd(fetched_potd):
+            self.potd = fetched_potd
+            self._reported_stale_potd = False
+            return
+
+        # return if the stale window is open. Means that stale potd has been reported.
+        if self._reported_stale_potd:
+            return
+
+        # open the stale window and report it once
+        fetched_date = fetched_potd.published_date if fetched_potd is not None else "none"
+        sentry_sdk.capture_message(
+            f"Provider could not fetch a fresh potd for today from the gcs bucket. "
+            f"Fetched published_date: {fetched_date}, today: {self._today()}",
+            "warning",
+        )
+        self._reported_stale_potd = True
 
     async def initialize(self) -> None:
-        """Initialize the provider."""
-        if settings.current_env.lower() == "production":
-            self.potd = PictureOfTheDay(
-                title="Wikimedia Commons picture of the day",
-                description="Sample Picture of the day description.",
-                published_date="2026-04-13",
-                thumbnail_image_url=HttpUrl(
-                    "https://prod-images.merino.prod.webservices.mozgcp.net/rss/wikimedia_potd/POTD_2026_04_13.jpg"
-                ),
-                high_res_image_url=HttpUrl(
-                    "https://prod-images.merino.prod.webservices.mozgcp.net/rss/wikimedia_potd/POTD_hi_res_2026_4_13.jpg"
-                ),
-            )
-        elif self.potd is None:
-            self.potd = await asyncio.to_thread(self.backend.fetch_potd_from_gcs_bucket)
+        """Initialize the provider by warming the potd cache."""
+        if self.potd is not None:
+            return
 
-    def get_picture_of_the_day(self) -> PictureOfTheDay | None:
-        """Return the current Wikimedia Picture of the Day or None."""
-        return self.potd
+        await self._refresh_potd()
+
+    async def get_picture_of_the_day(self) -> PictureOfTheDay | None:
+        """Return today's Wikimedia Picture of the Day or None.
+
+        Re-fetches when the cached potd is missing or from a previous day. We intentionally
+        do not throttle the re-fetch. A single Sentry warning per stale window surfaces the
+        gap.
+        """
+        if not self._is_todays_potd(self.potd):
+            await self._refresh_potd()
+
+        return self.potd if self._is_todays_potd(self.potd) else None
 
     async def upload_picture_of_the_day(self) -> bool:
         """Execute the upload flow. This method is called by the job cli command only."""

--- a/merino/providers/rss/wikimedia_potd/provider.py
+++ b/merino/providers/rss/wikimedia_potd/provider.py
@@ -24,7 +24,7 @@ class WikimediaPictureOfTheDayProvider(BaseRssProvider):
     metrics_client: aiodogstatsd.Client
     url: HttpUrl
     potd: PictureOfTheDay | None
-    _reported_stale_potd: bool
+    _reported_missing_potd: bool
 
     def __init__(
         self,
@@ -41,9 +41,8 @@ class WikimediaPictureOfTheDayProvider(BaseRssProvider):
         self.metrics_client = metrics_client
         self.url = HttpUrl("https://merino.services.mozilla.com/")
         self.potd = None
-        # Track whether the current stale/missing window has already been reported, so we
-        # emit at most one Sentry warning per window instead of one per request.
-        self._reported_stale_potd = False
+        # track whether the current fetch from the gcs bucket has been reported for sentry capture
+        self._reported_missing_potd = False
 
     @staticmethod
     def _today() -> str:
@@ -55,32 +54,28 @@ class WikimediaPictureOfTheDayProvider(BaseRssProvider):
         return potd is not None and potd.published_date == self._today()
 
     async def _refresh_potd(self) -> None:
-        """Fetch the potd from GCS and cache it when today's is available.
+        """Fetch the potd from GCS and cache whatever the bucket returns.
 
-        On a miss (nothing fetched, or the fetched potd is from another day) the cached
-        potd is left untouched and a single Sentry warning is emitted per stale window,
-        which resets once today's potd is cached again.
+        When the fetch returns nothing the cached potd is left untouched and
+        a single Sentry warning is emitted per missing window, which resets once a potd is fetched again.
         """
         fetched_potd = await asyncio.to_thread(self.backend.fetch_potd_from_gcs_bucket)
 
-        # if today's potd is available, cache it and close the stale window
-        if self._is_todays_potd(fetched_potd):
+        # cache the fetched potd and close the missing window
+        if fetched_potd is not None:
             self.potd = fetched_potd
-            self._reported_stale_potd = False
+            self._reported_missing_potd = False
             return
 
-        # return if the stale window is open. Means that stale potd has been reported.
-        if self._reported_stale_potd:
+        # fetch returned nothing, warn once per missing window and keep any cached potd
+        if self._reported_missing_potd:
             return
 
-        # open the stale window and report it once
-        fetched_date = fetched_potd.published_date if fetched_potd is not None else "none"
         sentry_sdk.capture_message(
-            f"Provider could not fetch a fresh potd for today from the gcs bucket. "
-            f"Fetched published_date: {fetched_date}, today: {self._today()}",
+            f"Provider could not fetch a potd from the gcs bucket for {self._today()}.",
             "warning",
         )
-        self._reported_stale_potd = True
+        self._reported_missing_potd = True
 
     async def initialize(self) -> None:
         """Initialize the provider by warming the potd cache."""
@@ -90,16 +85,19 @@ class WikimediaPictureOfTheDayProvider(BaseRssProvider):
         await self._refresh_potd()
 
     async def get_picture_of_the_day(self) -> PictureOfTheDay | None:
-        """Return today's Wikimedia Picture of the Day or None.
+        """Return the Wikimedia Picture of the Day, or None if none has ever been cached.
 
-        Re-fetches when the cached potd is missing or from a previous day. We intentionally
-        do not throttle the re-fetch. A single Sentry warning per stale window surfaces the
-        gap.
+        Re-fetches when the cached potd is missing or from a previous day. When today's
+        potd isn't available yet we serve the previous day's cached potd rather than
+        nothing.
         """
         if not self._is_todays_potd(self.potd):
             await self._refresh_potd()
 
-        return self.potd if self._is_todays_potd(self.potd) else None
+        # TODO @herraj jira: [HNT-2162]
+        # add a metric to track when we serve a stale (previous-day) potd here
+        # because today's picture isn't yet available in the gcs bucket.
+        return self.potd
 
     async def upload_picture_of_the_day(self) -> bool:
         """Execute the upload flow. This method is called by the job cli command only."""

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -670,7 +670,7 @@ async def get_picture_of_the_day(
     """Get the picture of the day."""
     potd = None
     try:
-        potd = provider.get_picture_of_the_day()
+        potd = await provider.get_picture_of_the_day()
     except Exception as ex:
         logger.info(f"Something went wrong when fetching potd: {ex.__class__.__name__}")
 

--- a/tests/unit/providers/rss/wikimedia_potd/test_provider.py
+++ b/tests/unit/providers/rss/wikimedia_potd/test_provider.py
@@ -4,8 +4,9 @@
 
 """Unit tests for the Wikimedia Picture of the Day provider."""
 
-from pydantic.networks import HttpUrl
 import pytest
+import freezegun
+from pydantic.networks import HttpUrl
 from pytest_mock import MockerFixture
 
 from merino.providers.rss.wikimedia_potd.backends.protocol import (
@@ -62,10 +63,44 @@ def test_provider_query_timeout_sec(provider: WikimediaPictureOfTheDayProvider) 
     assert provider.query_timeout_sec == 1.0
 
 
+@freezegun.freeze_time("2026-06-07")
 @pytest.mark.asyncio
-async def test_initialize(provider: WikimediaPictureOfTheDayProvider) -> None:
-    """Test that initialize completes without error."""
+async def test_initialize_caches_fresh_potd(
+    provider: WikimediaPictureOfTheDayProvider, backend_mock, test_potd
+) -> None:
+    """Test that initialize caches the potd when the backend returns a fresh one."""
+    backend_mock.fetch_potd_from_gcs_bucket.return_value = test_potd
+
     await provider.initialize()
+
+    assert provider.potd is test_potd
+
+
+@freezegun.freeze_time("2026-06-08")
+@pytest.mark.asyncio
+async def test_initialize_leaves_potd_none_when_fetch_is_stale_or_missing(
+    provider: WikimediaPictureOfTheDayProvider, backend_mock, test_potd
+) -> None:
+    """Test that initialize leaves potd unset when the backend has no fresh potd."""
+    # test_potd is published 2026-06-07, stale relative to the freeze time
+    backend_mock.fetch_potd_from_gcs_bucket.return_value = test_potd
+
+    await provider.initialize()
+
+    assert provider.potd is None
+
+
+@pytest.mark.asyncio
+async def test_initialize_is_noop_when_potd_already_cached(
+    provider: WikimediaPictureOfTheDayProvider, backend_mock, test_potd
+) -> None:
+    """Test that initialize does not re-fetch when a potd is already cached."""
+    provider.potd = test_potd
+
+    await provider.initialize()
+
+    assert provider.potd is test_potd
+    backend_mock.fetch_potd_from_gcs_bucket.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -75,24 +110,164 @@ async def test_shutdown(provider: WikimediaPictureOfTheDayProvider) -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_picture_of_the_day_returns_none(
-    provider: WikimediaPictureOfTheDayProvider,
+async def test_upload_picture_of_the_day_delegates_to_backend(
+    provider: WikimediaPictureOfTheDayProvider, backend_mock
 ) -> None:
-    """Test that get_picture_of_the_day returns an empty Potd when backend returns None."""
-    assert provider.get_picture_of_the_day() is None
+    """Test that upload_picture_of_the_day delegates to the backend and returns its result."""
+    backend_mock.upload_picture_of_the_day.return_value = True
+
+    result = await provider.upload_picture_of_the_day()
+
+    assert result is True
+    backend_mock.upload_picture_of_the_day.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_get_picture_of_the_day_returns_correct_potd(
-    provider: WikimediaPictureOfTheDayProvider, test_potd
+async def test_get_picture_of_the_day_returns_none_when_backend_fetch_returns_none(
+    provider: WikimediaPictureOfTheDayProvider, backend_mock
 ) -> None:
-    """Test that get_picture_of_the_day returns a correct potd instance."""
+    """Test that get_picture_of_the_day returns an empty Potd when backend returns None."""
+    backend_mock.fetch_potd_from_gcs_bucket.return_value = None
+    assert await provider.get_picture_of_the_day() is None
+
+
+@freezegun.freeze_time("2026-06-07")
+@pytest.mark.asyncio
+async def test_get_picture_of_the_day_returns_correct_potd_when_backend_fetch_returns_correct_potd(
+    provider: WikimediaPictureOfTheDayProvider, backend_mock, test_potd
+) -> None:
+    """Test that get_picture_of_the_day returns a non-stale Potd when backend returns one."""
+    backend_mock.fetch_potd_from_gcs_bucket.return_value = test_potd
+
+    assert await provider.get_picture_of_the_day() is not None
+
+
+@freezegun.freeze_time("2026-06-08")
+@pytest.mark.asyncio
+async def test_get_picture_of_the_day_returns_None_when_backend_fetch_returns_stale_potd(
+    provider: WikimediaPictureOfTheDayProvider, backend_mock, test_potd
+) -> None:
+    """Test that get_picture_of_the_day returns None when backend returns a stale potd."""
+    # test_potd has the published date as 2026-06-07, a day old compared to test freeze time
+    backend_mock.fetch_potd_from_gcs_bucket.return_value = test_potd
+    assert await provider.get_picture_of_the_day() is None
+
+
+@freezegun.freeze_time("2026-06-07")
+@pytest.mark.asyncio
+async def test_get_picture_of_the_day_returns_cached_potd_when_not_stale(
+    provider: WikimediaPictureOfTheDayProvider, backend_mock, test_potd
+) -> None:
+    """Test that a non-stale cached potd is returned directly without re-fetching."""
     provider.potd = test_potd
 
-    potd = provider.get_picture_of_the_day()
+    potd = await provider.get_picture_of_the_day()
 
     assert potd is not None
     assert potd.title == "Wikimedia Commons picture of the day"
     assert potd.thumbnail_image_url == HttpUrl("https://test-thumbnail.jpg")
     assert potd.high_res_image_url == HttpUrl("https://test-high-res.jpg")
     assert potd.published_date == "2026-06-07"
+    backend_mock.fetch_potd_from_gcs_bucket.assert_not_called()
+
+
+@freezegun.freeze_time("2026-06-08")
+@pytest.mark.asyncio
+async def test_get_picture_of_the_day_refetches_when_cached_potd_is_stale(
+    provider: WikimediaPictureOfTheDayProvider, backend_mock, test_potd
+) -> None:
+    """Test that a stale cached potd triggers a re-fetch and the fresh potd is returned."""
+    # cached test_potd is published 2026-06-07, a day old compared to the freeze time
+    provider.potd = test_potd
+    fresh_potd = test_potd.model_copy(update={"published_date": "2026-06-08"})
+    backend_mock.fetch_potd_from_gcs_bucket.return_value = fresh_potd
+
+    potd = await provider.get_picture_of_the_day()
+
+    backend_mock.fetch_potd_from_gcs_bucket.assert_called_once()
+    assert potd is fresh_potd
+    assert provider.potd is fresh_potd
+
+
+@freezegun.freeze_time("2026-06-08")
+@pytest.mark.asyncio
+async def test_get_picture_of_the_day_returns_none_when_cached_stale_and_refetch_misses(
+    provider: WikimediaPictureOfTheDayProvider, backend_mock, test_potd
+) -> None:
+    """Test that a stale cache with no fresh potd available returns None."""
+    provider.potd = test_potd
+    backend_mock.fetch_potd_from_gcs_bucket.return_value = None
+
+    potd = await provider.get_picture_of_the_day()
+
+    backend_mock.fetch_potd_from_gcs_bucket.assert_called_once()
+    assert potd is None
+
+
+@freezegun.freeze_time("2026-06-08")
+@pytest.mark.asyncio
+async def test_get_picture_of_the_day_reports_missing_potd_to_sentry_once(
+    provider: WikimediaPictureOfTheDayProvider, backend_mock, mocker: MockerFixture
+) -> None:
+    """Test that repeated misses emit a single Sentry warning per stale window."""
+    backend_mock.fetch_potd_from_gcs_bucket.return_value = None
+    capture = mocker.patch(
+        "merino.providers.rss.wikimedia_potd.provider.sentry_sdk.capture_message"
+    )
+
+    assert await provider.get_picture_of_the_day() is None
+    assert await provider.get_picture_of_the_day() is None
+
+    # Re-fetch happens on every request, but the warning is emitted only once.
+    assert backend_mock.fetch_potd_from_gcs_bucket.call_count == 2
+    capture.assert_called_once()
+    message = capture.call_args.args[0]
+    assert "Fetched published_date: none" in message
+    assert "today: 2026-06-08" in message
+
+
+@freezegun.freeze_time("2026-06-08")
+@pytest.mark.asyncio
+async def test_get_picture_of_the_day_sentry_message_includes_stale_published_date(
+    provider: WikimediaPictureOfTheDayProvider, backend_mock, test_potd, mocker: MockerFixture
+) -> None:
+    """Test that the Sentry warning reports the fetched (stale) published date and today."""
+    # test_potd is published 2026-06-07, stale relative to the freeze time
+    backend_mock.fetch_potd_from_gcs_bucket.return_value = test_potd
+    capture = mocker.patch(
+        "merino.providers.rss.wikimedia_potd.provider.sentry_sdk.capture_message"
+    )
+
+    assert await provider.get_picture_of_the_day() is None
+
+    message = capture.call_args.args[0]
+    assert "Fetched published_date: 2026-06-07" in message
+    assert "today: 2026-06-08" in message
+
+
+@pytest.mark.asyncio
+async def test_get_picture_of_the_day_reports_again_after_recovery(
+    provider: WikimediaPictureOfTheDayProvider, backend_mock, test_potd, mocker: MockerFixture
+) -> None:
+    """Test that a fresh fetch resets the stale window so a later miss reports again."""
+    capture = mocker.patch(
+        "merino.providers.rss.wikimedia_potd.provider.sentry_sdk.capture_message"
+    )
+
+    # Day 1: miss -> one warning.
+    with freezegun.freeze_time("2026-06-08"):
+        backend_mock.fetch_potd_from_gcs_bucket.return_value = None
+        assert await provider.get_picture_of_the_day() is None
+
+    # Day 2: fresh potd available -> cached, stale window reset.
+    with freezegun.freeze_time("2026-06-09"):
+        fresh_potd = test_potd.model_copy(update={"published_date": "2026-06-09"})
+        backend_mock.fetch_potd_from_gcs_bucket.return_value = fresh_potd
+        assert await provider.get_picture_of_the_day() is fresh_potd
+
+    # Day 3: miss again -> a second warning is emitted.
+    with freezegun.freeze_time("2026-06-10"):
+        backend_mock.fetch_potd_from_gcs_bucket.return_value = None
+        assert await provider.get_picture_of_the_day() is None
+
+    assert capture.call_count == 2

--- a/tests/unit/providers/rss/wikimedia_potd/test_provider.py
+++ b/tests/unit/providers/rss/wikimedia_potd/test_provider.py
@@ -77,14 +77,14 @@ async def test_initialize_caches_fresh_potd(
 
 
 @pytest.mark.asyncio
-async def test_initialize_leaves_potd_none_when_fetch_returns_none(
+async def test_initialize_leaves_cached_potd_unchanged_when_fetch_returns_none(
     provider: WikimediaPictureOfTheDayProvider, backend_mock
 ) -> None:
-    """Test that initialize leaves potd unset when the backend fetch returns nothing."""
+    """Test that initialize leaves cached potd unchanged when the backend fetch returns nothing."""
     backend_mock.fetch_potd_from_gcs_bucket.return_value = None
 
     await provider.initialize()
-
+    # self.potd in provider was never set so it remains None
     assert provider.potd is None
 
 
@@ -120,18 +120,9 @@ async def test_upload_picture_of_the_day_delegates_to_backend(
     backend_mock.upload_picture_of_the_day.assert_awaited_once()
 
 
-@pytest.mark.asyncio
-async def test_get_picture_of_the_day_returns_none_when_backend_fetch_returns_none(
-    provider: WikimediaPictureOfTheDayProvider, backend_mock
-) -> None:
-    """Test that get_picture_of_the_day returns an empty Potd when backend returns None."""
-    backend_mock.fetch_potd_from_gcs_bucket.return_value = None
-    assert await provider.get_picture_of_the_day() is None
-
-
 @freezegun.freeze_time("2026-06-07")
 @pytest.mark.asyncio
-async def test_get_picture_of_the_day_returns_correct_potd_when_backend_fetch_returns_correct_potd(
+async def test_get_picture_of_the_day_returns_fetched_potd_when_backend_fetch_is_not_stale(
     provider: WikimediaPictureOfTheDayProvider, backend_mock, test_potd
 ) -> None:
     """Test that get_picture_of_the_day returns a non-stale Potd when backend returns one."""
@@ -219,25 +210,3 @@ async def test_get_picture_of_the_day_refetches_on_every_miss(
 
     # No throttling: the re-fetch is attempted on every request.
     assert backend_mock.fetch_potd_from_gcs_bucket.call_count == 2
-
-
-@pytest.mark.asyncio
-async def test_get_picture_of_the_day_serves_last_cached_potd_when_later_fetch_misses(
-    provider: WikimediaPictureOfTheDayProvider, backend_mock, test_potd
-) -> None:
-    """Test that the last cached potd keeps being served once a later fetch stops returning one."""
-    # Day 1: fetch miss, nothing cached yet.
-    with freezegun.freeze_time("2026-06-08"):
-        backend_mock.fetch_potd_from_gcs_bucket.return_value = None
-        assert await provider.get_picture_of_the_day() is None
-
-    # Day 2: fetch succeeds -> cached.
-    with freezegun.freeze_time("2026-06-09"):
-        fresh_potd = test_potd.model_copy(update={"published_date": "2026-06-09"})
-        backend_mock.fetch_potd_from_gcs_bucket.return_value = fresh_potd
-        assert await provider.get_picture_of_the_day() is fresh_potd
-
-    # Day 3: fetch miss again -> the stale day-2 potd keeps being served.
-    with freezegun.freeze_time("2026-06-10"):
-        backend_mock.fetch_potd_from_gcs_bucket.return_value = None
-        assert await provider.get_picture_of_the_day() is fresh_potd

--- a/tests/unit/providers/rss/wikimedia_potd/test_provider.py
+++ b/tests/unit/providers/rss/wikimedia_potd/test_provider.py
@@ -143,19 +143,15 @@ async def test_get_picture_of_the_day_returns_correct_potd_when_backend_fetch_re
 @freezegun.freeze_time("2026-06-08")
 @pytest.mark.asyncio
 async def test_get_picture_of_the_day_caches_and_returns_fetched_potd(
-    provider: WikimediaPictureOfTheDayProvider, backend_mock, test_potd, mocker: MockerFixture
+    provider: WikimediaPictureOfTheDayProvider, backend_mock, test_potd
 ) -> None:
-    """Test that a potd returned by the fetch is cached and served without a Sentry warning."""
+    """Test that a potd returned by the fetch is cached and served."""
     backend_mock.fetch_potd_from_gcs_bucket.return_value = test_potd
-    capture = mocker.patch(
-        "merino.providers.rss.wikimedia_potd.provider.sentry_sdk.capture_message"
-    )
 
     potd = await provider.get_picture_of_the_day()
 
     assert potd is test_potd
     assert provider.potd is test_potd
-    capture.assert_not_called()
 
 
 @freezegun.freeze_time("2026-06-07")
@@ -212,48 +208,36 @@ async def test_get_picture_of_the_day_serves_stale_potd_when_refetch_misses(
 
 @freezegun.freeze_time("2026-06-08")
 @pytest.mark.asyncio
-async def test_get_picture_of_the_day_reports_missing_potd_to_sentry_once(
-    provider: WikimediaPictureOfTheDayProvider, backend_mock, mocker: MockerFixture
+async def test_get_picture_of_the_day_refetches_on_every_miss(
+    provider: WikimediaPictureOfTheDayProvider, backend_mock
 ) -> None:
-    """Test that repeated fetch misses emit a single Sentry warning per missing window."""
+    """Test that each request re-fetches while nothing is cached and no potd is available."""
     backend_mock.fetch_potd_from_gcs_bucket.return_value = None
-    capture = mocker.patch(
-        "merino.providers.rss.wikimedia_potd.provider.sentry_sdk.capture_message"
-    )
 
     assert await provider.get_picture_of_the_day() is None
     assert await provider.get_picture_of_the_day() is None
 
-    # Re-fetch happens on every request, but the warning is emitted only once.
+    # No throttling: the re-fetch is attempted on every request.
     assert backend_mock.fetch_potd_from_gcs_bucket.call_count == 2
-    capture.assert_called_once()
-    message = capture.call_args.args[0]
-    assert "could not fetch a potd from the gcs bucket for 2026-06-08" in message
 
 
 @pytest.mark.asyncio
-async def test_get_picture_of_the_day_reports_again_after_recovery(
-    provider: WikimediaPictureOfTheDayProvider, backend_mock, test_potd, mocker: MockerFixture
+async def test_get_picture_of_the_day_serves_last_cached_potd_when_later_fetch_misses(
+    provider: WikimediaPictureOfTheDayProvider, backend_mock, test_potd
 ) -> None:
-    """Test that a successful fetch resets the missing window so a later miss reports again."""
-    capture = mocker.patch(
-        "merino.providers.rss.wikimedia_potd.provider.sentry_sdk.capture_message"
-    )
-
-    # Day 1: fetch miss -> one warning, nothing cached.
+    """Test that the last cached potd keeps being served once a later fetch stops returning one."""
+    # Day 1: fetch miss, nothing cached yet.
     with freezegun.freeze_time("2026-06-08"):
         backend_mock.fetch_potd_from_gcs_bucket.return_value = None
         assert await provider.get_picture_of_the_day() is None
 
-    # Day 2: fetch succeeds -> cached, missing window reset.
+    # Day 2: fetch succeeds -> cached.
     with freezegun.freeze_time("2026-06-09"):
         fresh_potd = test_potd.model_copy(update={"published_date": "2026-06-09"})
         backend_mock.fetch_potd_from_gcs_bucket.return_value = fresh_potd
         assert await provider.get_picture_of_the_day() is fresh_potd
 
-    # Day 3: fetch miss again -> a second warning, and the stale day-2 potd is served.
+    # Day 3: fetch miss again -> the stale day-2 potd keeps being served.
     with freezegun.freeze_time("2026-06-10"):
         backend_mock.fetch_potd_from_gcs_bucket.return_value = None
         assert await provider.get_picture_of_the_day() is fresh_potd
-
-    assert capture.call_count == 2

--- a/tests/unit/providers/rss/wikimedia_potd/test_provider.py
+++ b/tests/unit/providers/rss/wikimedia_potd/test_provider.py
@@ -76,14 +76,12 @@ async def test_initialize_caches_fresh_potd(
     assert provider.potd is test_potd
 
 
-@freezegun.freeze_time("2026-06-08")
 @pytest.mark.asyncio
-async def test_initialize_leaves_potd_none_when_fetch_is_stale_or_missing(
-    provider: WikimediaPictureOfTheDayProvider, backend_mock, test_potd
+async def test_initialize_leaves_potd_none_when_fetch_returns_none(
+    provider: WikimediaPictureOfTheDayProvider, backend_mock
 ) -> None:
-    """Test that initialize leaves potd unset when the backend has no fresh potd."""
-    # test_potd is published 2026-06-07, stale relative to the freeze time
-    backend_mock.fetch_potd_from_gcs_bucket.return_value = test_potd
+    """Test that initialize leaves potd unset when the backend fetch returns nothing."""
+    backend_mock.fetch_potd_from_gcs_bucket.return_value = None
 
     await provider.initialize()
 
@@ -144,13 +142,20 @@ async def test_get_picture_of_the_day_returns_correct_potd_when_backend_fetch_re
 
 @freezegun.freeze_time("2026-06-08")
 @pytest.mark.asyncio
-async def test_get_picture_of_the_day_returns_None_when_backend_fetch_returns_stale_potd(
-    provider: WikimediaPictureOfTheDayProvider, backend_mock, test_potd
+async def test_get_picture_of_the_day_caches_and_returns_fetched_potd(
+    provider: WikimediaPictureOfTheDayProvider, backend_mock, test_potd, mocker: MockerFixture
 ) -> None:
-    """Test that get_picture_of_the_day returns None when backend returns a stale potd."""
-    # test_potd has the published date as 2026-06-07, a day old compared to test freeze time
+    """Test that a potd returned by the fetch is cached and served without a Sentry warning."""
     backend_mock.fetch_potd_from_gcs_bucket.return_value = test_potd
-    assert await provider.get_picture_of_the_day() is None
+    capture = mocker.patch(
+        "merino.providers.rss.wikimedia_potd.provider.sentry_sdk.capture_message"
+    )
+
+    potd = await provider.get_picture_of_the_day()
+
+    assert potd is test_potd
+    assert provider.potd is test_potd
+    capture.assert_not_called()
 
 
 @freezegun.freeze_time("2026-06-07")
@@ -191,17 +196,18 @@ async def test_get_picture_of_the_day_refetches_when_cached_potd_is_stale(
 
 @freezegun.freeze_time("2026-06-08")
 @pytest.mark.asyncio
-async def test_get_picture_of_the_day_returns_none_when_cached_stale_and_refetch_misses(
+async def test_get_picture_of_the_day_serves_stale_potd_when_refetch_misses(
     provider: WikimediaPictureOfTheDayProvider, backend_mock, test_potd
 ) -> None:
-    """Test that a stale cache with no fresh potd available returns None."""
+    """Test that a stale cached potd is served when today's potd cannot be fetched."""
+    # cached test_potd is published 2026-06-07, a day old compared to the freeze time
     provider.potd = test_potd
     backend_mock.fetch_potd_from_gcs_bucket.return_value = None
 
     potd = await provider.get_picture_of_the_day()
 
     backend_mock.fetch_potd_from_gcs_bucket.assert_called_once()
-    assert potd is None
+    assert potd is test_potd
 
 
 @freezegun.freeze_time("2026-06-08")
@@ -209,7 +215,7 @@ async def test_get_picture_of_the_day_returns_none_when_cached_stale_and_refetch
 async def test_get_picture_of_the_day_reports_missing_potd_to_sentry_once(
     provider: WikimediaPictureOfTheDayProvider, backend_mock, mocker: MockerFixture
 ) -> None:
-    """Test that repeated misses emit a single Sentry warning per stale window."""
+    """Test that repeated fetch misses emit a single Sentry warning per missing window."""
     backend_mock.fetch_potd_from_gcs_bucket.return_value = None
     capture = mocker.patch(
         "merino.providers.rss.wikimedia_potd.provider.sentry_sdk.capture_message"
@@ -222,52 +228,32 @@ async def test_get_picture_of_the_day_reports_missing_potd_to_sentry_once(
     assert backend_mock.fetch_potd_from_gcs_bucket.call_count == 2
     capture.assert_called_once()
     message = capture.call_args.args[0]
-    assert "Fetched published_date: none" in message
-    assert "today: 2026-06-08" in message
-
-
-@freezegun.freeze_time("2026-06-08")
-@pytest.mark.asyncio
-async def test_get_picture_of_the_day_sentry_message_includes_stale_published_date(
-    provider: WikimediaPictureOfTheDayProvider, backend_mock, test_potd, mocker: MockerFixture
-) -> None:
-    """Test that the Sentry warning reports the fetched (stale) published date and today."""
-    # test_potd is published 2026-06-07, stale relative to the freeze time
-    backend_mock.fetch_potd_from_gcs_bucket.return_value = test_potd
-    capture = mocker.patch(
-        "merino.providers.rss.wikimedia_potd.provider.sentry_sdk.capture_message"
-    )
-
-    assert await provider.get_picture_of_the_day() is None
-
-    message = capture.call_args.args[0]
-    assert "Fetched published_date: 2026-06-07" in message
-    assert "today: 2026-06-08" in message
+    assert "could not fetch a potd from the gcs bucket for 2026-06-08" in message
 
 
 @pytest.mark.asyncio
 async def test_get_picture_of_the_day_reports_again_after_recovery(
     provider: WikimediaPictureOfTheDayProvider, backend_mock, test_potd, mocker: MockerFixture
 ) -> None:
-    """Test that a fresh fetch resets the stale window so a later miss reports again."""
+    """Test that a successful fetch resets the missing window so a later miss reports again."""
     capture = mocker.patch(
         "merino.providers.rss.wikimedia_potd.provider.sentry_sdk.capture_message"
     )
 
-    # Day 1: miss -> one warning.
+    # Day 1: fetch miss -> one warning, nothing cached.
     with freezegun.freeze_time("2026-06-08"):
         backend_mock.fetch_potd_from_gcs_bucket.return_value = None
         assert await provider.get_picture_of_the_day() is None
 
-    # Day 2: fresh potd available -> cached, stale window reset.
+    # Day 2: fetch succeeds -> cached, missing window reset.
     with freezegun.freeze_time("2026-06-09"):
         fresh_potd = test_potd.model_copy(update={"published_date": "2026-06-09"})
         backend_mock.fetch_potd_from_gcs_bucket.return_value = fresh_potd
         assert await provider.get_picture_of_the_day() is fresh_potd
 
-    # Day 3: miss again -> a second warning is emitted.
+    # Day 3: fetch miss again -> a second warning, and the stale day-2 potd is served.
     with freezegun.freeze_time("2026-06-10"):
         backend_mock.fetch_potd_from_gcs_bucket.return_value = None
-        assert await provider.get_picture_of_the_day() is None
+        assert await provider.get_picture_of_the_day() is fresh_potd
 
     assert capture.call_count == 2


### PR DESCRIPTION
## References

JIRA: [HNT-2787](https://mozilla-hub.atlassian.net/browse/HNT-2787)

## Description
Provider re-fetches from GCS (in UTC, matching the upload job) when the cached picture is missing or a day old, falling back to the last cached one instead of a startup-only snapshot.




## PR Review Checklist
- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2463)


[HNT-2787]: https://mozilla-hub.atlassian.net/browse/HNT-2787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ