### PR TITLE
[AIMOD-1373] Add default interest for users with no topic interests

### DIFF
--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -86,9 +86,7 @@ TOP_STORIES_SECTION_EXTRA_COUNT = 5  # Extra top stories pulled from later secti
 HEADLINES_SECTION_KEY = "headlines"
 DAILY_BRIEFING_SECTION_KEY = "daily-briefing"
 
-# When a request has personal_interests but no non-zero topic strength, inject a
-# modest default for these topics so InterestRanker has signal to work with.
-# Strength matches the first v3 threshold (mild interest).
+# Users with no topic interests will be assigned this default topic interest.
 DEFAULT_TOPIC_INTERESTS: dict[str, float] = {"arts": 1.1, "government": 1.1}
 # Require enough recommendations to fill the layout plus a single fallback item
 SECTION_FALLBACK_BUFFER = 1

--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -22,6 +22,7 @@ from merino.curated_recommendations.layouts import (
 )
 from merino.curated_recommendations.localization import get_translation
 from merino.curated_recommendations.ml_backends.protocol import (
+    LOCAL_MODEL_MODEL_ID_KEY,
     TIME_ZONE_OFFSET_INFERRED_KEY,
     MLRecsBackend,
     SpindleBackendProtocol,
@@ -84,6 +85,11 @@ DOUBLE_ROW_TOP_STORIES_COUNT = 9
 TOP_STORIES_SECTION_EXTRA_COUNT = 5  # Extra top stories pulled from later sections
 HEADLINES_SECTION_KEY = "headlines"
 DAILY_BRIEFING_SECTION_KEY = "daily-briefing"
+
+# When a request has personal_interests but no non-zero topic strength, inject a
+# modest default for these topics so InterestRanker has signal to work with.
+# Strength matches the first v3 threshold (mild interest).
+DEFAULT_TOPIC_INTERESTS: dict[str, float] = {"arts": 1.1, "government": 1.1}
 # Require enough recommendations to fill the layout plus a single fallback item
 SECTION_FALLBACK_BUFFER = 1
 MAX_SECTIONS_PER_RESPONSE = 20
@@ -894,6 +900,15 @@ async def get_sections(
         and ml_backend is not None
         and ml_backend.is_valid(surface_id)
     )
+    # If the client sent interests but every topic strength is zero, inject a
+    # small default so InterestRanker has something to personalize against.
+    if personal_interests is not None and not any(
+        isinstance(v, (int, float)) and v > 0.0
+        for k, v in personal_interests.scores.items()
+        if k not in (LOCAL_MODEL_MODEL_ID_KEY, TIME_ZONE_OFFSET_INFERRED_KEY)
+    ):
+        personal_interests.scores.update(DEFAULT_TOPIC_INTERESTS)
+
     # Use InterestRanker when the per-surface LinTS bundle is loaded and the request has interests.
     use_interest_ranker = (
         lints_interest_backend.is_valid(surface_id)


### PR DESCRIPTION
## References

JIRA: [AIMOD-1373](https://mozilla-hub.atlassian.net/browse/AIMOD-1373)

## Description
Adds small arts and politics interests for users with no topic interests so new users get some personalization. Rolf suggested this might improve first time user recommendations on NT.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2464)


[AIMOD-1373]: https://mozilla-hub.atlassian.net/browse/AIMOD-1373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ