### PR TITLE
AIMOD-1374 Update similar stories threshold

### DIFF
--- a/merino/curated_recommendations/ml_backends/spindle_backend.py
+++ b/merino/curated_recommendations/ml_backends/spindle_backend.py
@@ -60,7 +60,7 @@ class FindSimilarStoriesRequest(BaseModel):
     """Request body for /find_similar_stories."""
 
     items: list[SimilarStoriesTextItem]
-    threshold: float = Field(0.85, ge=0.0, le=1.0)
+    threshold: float = Field(0.8, ge=0.0, le=1.0)
     language: str = Field("en", min_length=2, max_length=10)
 
 
@@ -68,7 +68,7 @@ class FindSimilarImagesRequest(BaseModel):
     """Request body for /find_similar_images."""
 
     items: list[SimilarStoriesImageItem]
-    threshold: float = Field(0.85, ge=0.0, le=1.0)
+    threshold: float = Field(0.8, ge=0.0, le=1.0)
     locale: str = Field("en_US", min_length=2, max_length=10)
 
 
@@ -262,7 +262,7 @@ class DummySpindleBackend(SpindleBackendProtocol):
         self,
         items: list[CorpusItem],
         surface: SurfaceId,
-        threshold: float = 0.85,
+        threshold: float = 0.8,
     ) -> None:
         """No-op."""
         return None


### PR DESCRIPTION
## References
https://mozilla-hub.atlassian.net/browse/AIMOD-1374

## Description
With a setting of 0.8, there are 39 articles, 23 relationships.
There are 13 simple pairs.

Previously were seeing < 10 relationships

This has the potential to affect discovery of new similar stories, though we do have 5% randomness to that new similar stories aren't totally blocked out.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2465)
