### PR TITLE
AIMOD-1364 Fallback for non interests for Lin inferred

### DIFF
--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -895,11 +895,15 @@ async def get_sections(
         and ml_backend.is_valid(surface_id)
     )
     # Use InterestRanker when the per-surface LinTS bundle is loaded and the request has interests.
+    has_interest_non_zero_scores = False
+    if personal_interests is not None and personal_interests.scores:
+        for key, score in personal_interests.scores.items():
+            if score > 0 and key != "timeZoneOffset":
+                has_interest_non_zero_scores = True
     use_interest_ranker = (
-        lints_interest_backend.is_valid(surface_id)
-        and personal_interests is not None
-        and bool(personal_interests.scores)
+        lints_interest_backend.is_valid(surface_id) and has_interest_non_zero_scores
     )
+
     # Interest ranker is experimental so gets priority over contexual ranker
     if use_interest_ranker:
         ranker = InterestRanker(

--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -898,7 +898,7 @@ async def get_sections(
     has_interest_non_zero_scores = False
     if personal_interests is not None and personal_interests.scores:
         for key, score in personal_interests.scores.items():
-            if score > 0 and key != "timeZoneOffset":
+            if score > 0 and key != TIME_ZONE_OFFSET_INFERRED_KEY:
                 has_interest_non_zero_scores = True
     use_interest_ranker = (
         lints_interest_backend.is_valid(surface_id) and has_interest_non_zero_scores


### PR DESCRIPTION
## References

JIRA: https://mozilla-hub.atlassian.net/browse/AIMOD-1364

## Description
During all experiments we've seen a ranking anomaly for users with no inferred interests expressed yet. In this case it is better to fall back to the default contextual ranking or thompson sampling ranking.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2467)
