### PR TITLE
[AIMOD-1355] Set up query normalization for AMP experiment

### DIFF
--- a/merino/configs/stage.toml
+++ b/merino/configs/stage.toml
@@ -144,6 +144,8 @@ dummy_attempted_count = 1000
 enabled = true
 data_source = "remote"
 gcs_bucket = "merino-ml-data-stage"
+# appended to default (sports, polygon); enables AMP normalization on stage only
+providers = ["adm"]
 
 [stage.mars]
 # MERINO_MARS__BASE_URL

--- a/merino/providers/suggest/adm/provider.py
+++ b/merino/providers/suggest/adm/provider.py
@@ -22,6 +22,7 @@ from merino.utils.gcs.engagement.filemanager import (
     EngagementFilemanager,
 )
 from merino.utils import cron
+from merino.utils.query_processing.normalization import get_pipeline
 from merino.providers.suggest.adm.backends.protocol import AdmBackend, SuggestionContent
 from merino.providers.suggest.adm.fuzzy import rejection_reason
 from merino.providers.suggest.base import (
@@ -63,6 +64,8 @@ TOP_PICK_PROMOTION: str = "top_pick_promotion"
 AMP_FUZZY_VARIANT: str = "amp-fuzzy-matching-treatment"
 # toggle fuzzy matching for AMP suggestions
 AMP_FUZZY_ENABLED: bool = settings.providers.adm.fuzzy.enabled
+# providers that receive normalized queries (AMP gated per-environment)
+NORMALIZATION_PROVIDERS = frozenset(settings.query_normalization.providers)
 
 
 class SponsoredSuggestion(BaseSuggestion):
@@ -213,6 +216,18 @@ class Provider(BaseProvider):
         """Fetch suggestions, keywords, and icons from Remote Settings."""
         self.suggestion_content = await self.backend.fetch()
         self.last_fetch_at = time.time()
+        self._refresh_normalization_terms()
+
+    def _refresh_normalization_terms(self) -> None:
+        """Feed MARS full keywords to the normalization canonical (AMP arm only)."""
+        pipeline = get_pipeline()
+        if pipeline is None or self.name not in NORMALIZATION_PROVIDERS:
+            return
+        index_manager = self.suggestion_content.index_manager
+        full_keywords: set[str] = set()
+        for idx_id in index_manager.list():
+            full_keywords.update(index_manager.full_keywords(idx_id))
+        pipeline.update_mars_terms(full_keywords)
 
     async def _fetch_engagement_data(self) -> None:
         """Fetch engagement data from GCS and store it in memory.

--- a/merino/utils/query_processing/normalization/pipeline.py
+++ b/merino/utils/query_processing/normalization/pipeline.py
@@ -342,6 +342,7 @@ class NormalizePipeline:
     ) -> None:
         """Initialize with pre-built components."""
         self._canonical = canonical
+        self._base_canonical = canonical  # AMP terms layer on top via update_mars_terms()
         self._fin_bm25 = finance_bm25
         self._canonical_prefix_index = canonical_prefix_index or {}
         self._canonical_words: set[str] = {w for phrase in canonical for w in phrase.split()}
@@ -409,3 +410,11 @@ class NormalizePipeline:
                 q = reordered
 
         return q
+
+    def update_mars_terms(self, full_keywords: set[str]) -> None:
+        """Rebuild canonical as base ∪ MARS full keywords (called on each ADM resync)."""
+        canonical = self._base_canonical | full_keywords
+        canonical_words = {word for phrase in canonical for word in phrase.split()}
+        # single-assignment swap so a concurrent normalize() sees a consistent pair
+        self._canonical = canonical
+        self._canonical_words = canonical_words

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -44,6 +44,8 @@ from merino.providers.rss.wikimedia_potd.provider import (
 )
 from merino.providers.suggest import get_providers as get_suggest_providers
 from merino.providers.suggest import get_weather_provider
+from merino.providers.suggest.adm.provider import AMP_FUZZY_VARIANT
+from merino.providers.suggest.manager import ProviderType
 from merino.providers.manifest import get_provider as get_manifest_provider
 from merino.providers.suggest.base import (
     BaseProvider,
@@ -98,6 +100,19 @@ router = APIRouter()
 
 # Providers enabled for query normalization
 NORMALIZATION_PROVIDERS: frozenset[str] = frozenset(settings.query_normalization.providers)
+
+
+def _should_normalize_query(provider_name: str, client_variants: list[str]) -> bool:
+    """Whether a provider receives the normalized query for this request.
+
+    sports/polygon are always-on (graduated); AMP is gated on the experiment variant.
+    """
+    if provider_name not in NORMALIZATION_PROVIDERS:
+        return False
+    if provider_name == ProviderType.ADM:
+        return AMP_FUZZY_VARIANT in client_variants
+    return True
+
 
 # Compiled query pattern matcher, or None when the feature is disabled.
 _QUERY_PATTERN_MATCHER: QueryPatternMatcher | None = build_query_pattern_matcher(
@@ -300,7 +315,7 @@ async def suggest(
     geolocation = refine_geolocation_for_suggestion(request, city, region, country)
     client_variants_list = client_variants.split(",") if client_variants else []
 
-    # Query normalization (sports and finance only)
+    # Query normalization (sports/finance always-on; AMP gated on the experiment variant)
     pipeline = get_pipeline()
     use_normalization = pipeline is not None
     if pipeline is not None:
@@ -311,7 +326,9 @@ async def suggest(
 
     for p in search_from:
         q_for_provider = (
-            q_normalized if use_normalization and p.name in NORMALIZATION_PROVIDERS else q
+            q_normalized
+            if use_normalization and _should_normalize_query(p.name, client_variants_list)
+            else q
         )
         srequest = SuggestionRequest(
             query=p.normalize_query(q_for_provider),

--- a/tests/unit/providers/suggest/adm/test_provider.py
+++ b/tests/unit/providers/suggest/adm/test_provider.py
@@ -571,3 +571,51 @@ async def test_should_emit_staleness(
 
     backend_mock.last_new_data_at = 1000.0
     assert adm._should_emit_staleness() is True
+
+
+# _refresh_normalization_terms (d2)
+@pytest.mark.asyncio
+async def test_fetch_refreshes_normalization_terms(mocker: MockerFixture, adm: Provider) -> None:
+    """_fetch feeds MARS full keywords to the pipeline when adm is a normalization provider."""
+    mock_pipeline = mocker.MagicMock()
+    mocker.patch("merino.providers.suggest.adm.provider.get_pipeline", return_value=mock_pipeline)
+    mocker.patch(
+        "merino.providers.suggest.adm.provider.NORMALIZATION_PROVIDERS", frozenset({"adm"})
+    )
+
+    await adm._fetch()
+
+    mock_pipeline.update_mars_terms.assert_called_once()
+    terms = mock_pipeline.update_mars_terms.call_args.args[0]
+    assert {"firefox accounts", "mozilla firefox accounts"} <= terms
+
+
+@pytest.mark.asyncio
+async def test_fetch_skips_normalization_when_adm_not_enabled(
+    mocker: MockerFixture, adm: Provider
+) -> None:
+    """When adm is not a normalization provider (e.g. prod), the pipeline is left untouched."""
+    mock_pipeline = mocker.MagicMock()
+    mocker.patch("merino.providers.suggest.adm.provider.get_pipeline", return_value=mock_pipeline)
+    mocker.patch(
+        "merino.providers.suggest.adm.provider.NORMALIZATION_PROVIDERS", frozenset({"sports"})
+    )
+
+    await adm._fetch()
+
+    mock_pipeline.update_mars_terms.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_fetch_normalization_noop_without_pipeline(
+    mocker: MockerFixture, adm: Provider
+) -> None:
+    """A missing pipeline (e.g. adm's first fetch at startup) is a safe no-op."""
+    mocker.patch("merino.providers.suggest.adm.provider.get_pipeline", return_value=None)
+    mocker.patch(
+        "merino.providers.suggest.adm.provider.NORMALIZATION_PROVIDERS", frozenset({"adm"})
+    )
+
+    await adm._fetch()
+
+    assert adm.last_fetch_at > 0

--- a/tests/unit/query_normalization/test_pipeline.py
+++ b/tests/unit/query_normalization/test_pipeline.py
@@ -358,3 +358,36 @@ def test_pipeline_prefix_then_bm25_reorder() -> None:
 def test_pipeline_long_query_skips_split(pipeline: NormalizePipeline) -> None:
     """Queries with more than 2 tokens should skip split step."""
     assert pipeline.normalize("this is a long query") == "this is a long query"
+
+
+# update_mars_terms
+def test_update_mars_terms_enables_amp_normalization() -> None:
+    """After update_mars_terms, queries normalize to the newly added MARS terms."""
+    pipeline = NormalizePipeline(canonical={"dow jones"})
+    # not recognized before the MARS terms are loaded
+    assert pipeline.normalize("door dash") == "door dash"
+
+    pipeline.update_mars_terms({"doordash"})
+
+    assert pipeline.normalize("doordash") == "doordash"  # exact hit
+    assert pipeline.normalize("door dash") == "doordash"  # join -> MARS term
+
+
+def test_update_mars_terms_replaces_slice_and_keeps_base() -> None:
+    """Each refresh rebuilds base ∪ MARS: the previous slice drops, the base stays."""
+    pipeline = NormalizePipeline(canonical={"dow jones"})
+    pipeline.update_mars_terms({"doordash"})
+    assert pipeline.normalize("door dash") == "doordash"
+
+    pipeline.update_mars_terms({"instacart"})
+    assert pipeline.normalize("door dash") == "door dash"  # old slice dropped -> no join
+    assert pipeline.normalize("insta cart") == "instacart"  # new MARS term joins
+    assert pipeline.normalize("dow jones") == "dow jones"  # base preserved
+
+
+def test_update_mars_terms_recomputes_canonical_words() -> None:
+    """The word index (used by prefix-complete) picks up the new MARS tokens."""
+    pipeline = NormalizePipeline(canonical={"dow jones"})
+    pipeline.update_mars_terms({"home depot"})
+    assert {"home", "depot"} <= pipeline._canonical_words
+    assert "dow" in pipeline._canonical_words  # base words retained


### PR DESCRIPTION
## References

JIRA: [AIMOD-1355](https://mozilla-hub.atlassian.net/browse/AIMOD-1355)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->
- This is part 1 of a 2 PR series setting up for the upcoming fuzzy matching + query normalization AMP experiment
-  Part 2 for setting up fuzzy matching is here: https://github.com/mozilla-services/merino-py/pull/1665
- On MARS re-sync, we update the canonical terms used by the query normalization pipeline so we can do normalization on incoming queries
- Limited the scope of this so it's not too big. There wasn't a big lift with BM25 here so it wasn't included. Also that would have added more latency to the pipeline potentially.
- We're currently only doing word segmentation (e.g. "homedepot" -> "home depot") and word joins (e.g. "ama zon" -> "amazon") and checking against the canonical set for normalizing.
- Best part to start review is probably `_should_normalize_query`[ here](https://github.com/mozilla-services/merino-py/pull/1667/changes#diff-931e455fcb04ce125a820ad46678a9d17158518219686ee9c0d33e5ccb8db51bR330).
- This PR uses the existing normalization pipeline so there's not much algorithmic change here.
- Latency delta figures are in the fuzzy matching PR!

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2468)


[AIMOD-1355]: https://mozilla-hub.atlassian.net/browse/AIMOD-1355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ