### PR TITLE
[DISCO-4306] Define stage/prod query pattern config

### DIFF
--- a/merino/configs/production.toml
+++ b/merino/configs/production.toml
@@ -138,6 +138,21 @@ enabled = true
 data_source = "remote"
 gcs_bucket = "merino-ml-data-prod"
 
+[production.query_pattern_matching]
+# MERINO_QUERY_PATTERN_MATCHING__ENABLED
+# Master switch. When false the matcher is never built and the hot path is a no-op.
+enabled = false
+
+# MERINO_QUERY_PATTERN_MATCHING__SAMPLE_RATE
+# Fraction of suggest requests to evaluate, 0.0–1.0. 0.0 disables evaluation.
+sample_rate = 0.0
+
+# MERINO_QUERY_PATTERN_MATCHING__PATTERNS
+# List of { id = "...", regex = "..." }. `id` is a low-cardinality metric label
+# (^[a-z][a-z0-9_]{0,63}$); `regex` is matched case-insensitively. Invalid
+# entries are skipped at build time rather than failing startup.
+patterns = []
+
 [production.ml_recommendations.gcs]
 # MERINO__ML_RECOMMENDATIONS__GCS__GCP_PROJECT
 # GCP project name where the GCS bucket lives.

--- a/merino/configs/stage.toml
+++ b/merino/configs/stage.toml
@@ -145,6 +145,21 @@ enabled = true
 data_source = "remote"
 gcs_bucket = "merino-ml-data-stage"
 
+[stage.query_pattern_matching]
+# MERINO_QUERY_PATTERN_MATCHING__ENABLED
+# Master switch. When false the matcher is never built and the hot path is a no-op.
+enabled = false
+
+# MERINO_QUERY_PATTERN_MATCHING__SAMPLE_RATE
+# Fraction of suggest requests to evaluate, 0.0–1.0. 0.0 disables evaluation.
+sample_rate = 0.0
+
+# MERINO_QUERY_PATTERN_MATCHING__PATTERNS
+# List of { id = "...", regex = "..." }. `id` is a low-cardinality metric label
+# (^[a-z][a-z0-9_]{0,63}$); `regex` is matched case-insensitively. Invalid
+# entries are skipped at build time rather than failing startup.
+patterns = []
+
 [stage.mars]
 # MERINO_MARS__BASE_URL
 base_url = "https://ads.allizom.org/v1/suggest/"

--- a/tests/integration/api/v1/suggest/test_suggest.py
+++ b/tests/integration/api/v1/suggest/test_suggest.py
@@ -462,6 +462,9 @@ def test_query_pattern_metrics_emitted_before_fleece_pii_drop(
     assert response.json()["suggestions"] == []
     add.assert_called_once_with(1, {"pattern_id": "sports_v1", "source": "unknown"})
 
+    # raw query should not appear in any metric call.
+    assert "nba" not in str(add.call_args_list)
+
 
 def test_query_pattern_metrics_not_emitted_when_matcher_none(
     mocker: MockerFixture, client: TestClient
@@ -491,6 +494,21 @@ def test_query_pattern_metrics_not_emitted_outside_sample_rate(
     client.get("/api/v1/suggest?q=nba")
 
     add.assert_not_called()
+
+
+def test_query_pattern_metrics_emitted_for_numeric_pii(
+    mocker: MockerFixture, client: TestClient, sports_pattern_matcher: Any
+) -> None:
+    """Test that pattern metrics fire for a numeric (soft PII) query without leaking text."""
+    mocker.patch("merino.web.api_v1._QUERY_PATTERN_MATCHER", sports_pattern_matcher)
+    add = mocker.patch("merino.utils.query_processing.query_patterns._match_counter.add")
+
+    client.get("/api/v1/suggest?q=nba 2026")
+
+    add.assert_called_once_with(1, {"pattern_id": "sports_v1", "source": "unknown"})
+
+    assert "nba 2026" not in str(add.call_args_list)
+    assert "2026" not in str(add.call_args_list)
 
 
 def test_suggest_with_invalid_geolocation_ip(


### PR DESCRIPTION
## References

JIRA: [DISCO-4306](https://mozilla-hub.atlassian.net/browse/DISCO-4306)

## Description
This PR adds config for stage + prod for query pattern and adds numeric PII test coverage



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2471)


[DISCO-4306]: https://mozilla-hub.atlassian.net/browse/DISCO-4306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ