### PR TITLE
chore(metrics) DISCO-3963 Move from statsd to otel for provider init

### DIFF
--- a/docs/data.md
+++ b/docs/data.md
@@ -92,15 +92,6 @@ log inspection interfaces.
 > appended to their name, to mark the units used (since we shouldn't put the
 > proper unit μs in metric names).
 
-- `merino.providers.initialize` - A timer to measure the overall initialization
-  duration (in ms) for _all_ providers.
-
-- `merino.providers.initialize.<provider>` - A timer to measure the initialization
-  duration (in ms) for the given `<provider>`.
-
-  **Example**:
-  `merino.providers.initialize.adm`
-
 - `merino.<http_method>.<url_path>.status_codes.<status_code>` - A counter to measure
   the status codes of an HTTP method for the `<url_path>`.
 

--- a/merino/providers/suggest/__init__.py
+++ b/merino/providers/suggest/__init__.py
@@ -6,14 +6,35 @@ import asyncio
 import logging
 from timeit import default_timer as timer
 
+from opentelemetry import metrics as otel_metrics
+
 from merino.providers.suggest.base import BaseProvider
 from merino.providers.suggest.manager import load_providers
-from merino.utils import metrics
+from merino.utils import task_runner
 
 providers: dict[str, BaseProvider] = {}
 default_providers: list[BaseProvider] = []
 
 logger = logging.getLogger(__name__)
+
+_meter = otel_metrics.get_meter("merino.providers.suggest")
+_provider_initialize_duration = _meter.create_histogram(
+    "merino_providers_initialize_duration",
+    unit="ms",
+    description="Duration of suggest provider initialization",
+)
+
+
+async def _initialize_provider(provider_name: str, provider: BaseProvider) -> None:
+    """Initialize a provider and record its initialization duration."""
+    start = timer()
+    try:
+        await provider.initialize()
+    finally:
+        _provider_initialize_duration.record(
+            (timer() - start) * 1000,
+            {"provider": provider_name},
+        )
 
 
 async def init_providers() -> None:
@@ -29,18 +50,32 @@ async def init_providers() -> None:
     providers.update(load_providers(disabled_providers_list=settings.runtime.disabled_providers))
 
     # initialize providers and record time
-    init_metric = "providers.initialize"
-    client = metrics.get_metrics_client()
-    with client.timeit(init_metric):
+    initialization_start = timer()
+    try:
         wrapped_tasks = [
-            client.timeit_task(p.initialize(), f"{init_metric}.{provider_name}")
-            for provider_name, p in providers.items()
+            asyncio.create_task(
+                _initialize_provider(provider_name, provider),
+                name=provider_name,
+            )
+            for provider_name, provider in providers.items()
         ]
-        await asyncio.gather(*wrapped_tasks)
+        await task_runner.gather(wrapped_tasks)
+
+        exceptions = [
+            exception for task in wrapped_tasks if (exception := task.exception()) is not None
+        ]
+        if exceptions:
+            raise exceptions[0]
+
         default_providers.extend([p for p in providers.values() if p.enabled_by_default])
         logger.info(
             "Provider initialization completed",
             extra={"providers": [*providers.keys()], "elapsed": timer() - start},
+        )
+    finally:
+        _provider_initialize_duration.record(
+            (timer() - initialization_start) * 1000,
+            {"provider": "__ALL__"},
         )
 
     # init query normalization pipeline

--- a/metrics.yaml
+++ b/metrics.yaml
@@ -741,6 +741,22 @@ merino-fleece/pii:
       The "api/v1/pii" API endpoint of "merino-fleece".
     alert_policy: []
 
+providers/suggest:
+  merino_providers_initialize_duration:
+    description: |
+      An OpenTelemetry histogram recording the wall-clock duration, in
+      milliseconds, of each suggest provider's initialization.
+    type: histogram
+    labels:
+      - name: provider
+        description: |
+          The configured suggest provider name (e.g. "adm" or "accuweather"),
+          or "__ALL__" for the total wall-clock duration of initializing all
+          configured providers concurrently.
+    scope: |
+      Suggest provider initialization during application startup.
+    alert_policy: []
+
 middleware/metrics:
   http_request_duration:
     description: |

--- a/tests/unit/providers/suggest/test_init_providers.py
+++ b/tests/unit/providers/suggest/test_init_providers.py
@@ -15,6 +15,7 @@ from pytest_mock import MockerFixture
 from merino.configs import settings
 from merino.exceptions import InvalidProviderError
 from merino.providers.suggest import (
+    _initialize_provider,
     get_providers,
     init_providers,
     load_providers,
@@ -61,6 +62,51 @@ async def test_init_providers() -> None:
     assert {provider.name for provider in default_providers} == {
         provider.name for provider in providers.values() if provider.enabled_by_default
     }
+
+
+@pytest.mark.asyncio
+async def test_initialize_provider_records_otel_duration(mocker: MockerFixture) -> None:
+    """Test provider initialization duration is recorded with a provider attribute."""
+    provider = mocker.AsyncMock()
+    histogram = mocker.patch("merino.providers.suggest._provider_initialize_duration")
+    mocker.patch("merino.providers.suggest.timer", side_effect=[10.0, 10.125])
+
+    await _initialize_provider("adm", provider)
+
+    provider.initialize.assert_awaited_once_with()
+    histogram.record.assert_called_once_with(125.0, {"provider": "adm"})
+
+
+@pytest.mark.asyncio
+async def test_initialize_provider_records_duration_on_error(mocker: MockerFixture) -> None:
+    """Test failed initialization is timed and its error is propagated."""
+    provider = mocker.AsyncMock()
+    provider.initialize.side_effect = RuntimeError("initialization failed")
+    histogram = mocker.patch("merino.providers.suggest._provider_initialize_duration")
+    mocker.patch("merino.providers.suggest.timer", side_effect=[20.0, 20.25])
+
+    with pytest.raises(RuntimeError, match="initialization failed"):
+        await _initialize_provider("accuweather", provider)
+
+    histogram.record.assert_called_once_with(250.0, {"provider": "accuweather"})
+
+
+@pytest.mark.asyncio
+async def test_init_providers_propagates_initialization_error(mocker: MockerFixture) -> None:
+    """Test initialization errors propagate and both provider durations are recorded."""
+    provider = mocker.AsyncMock()
+    provider.initialize.side_effect = RuntimeError("initialization failed")
+    mocker.patch("merino.providers.suggest.load_providers", return_value={"adm": provider})
+    mocker.patch.dict("merino.providers.suggest.providers", {}, clear=True)
+    histogram = mocker.patch("merino.providers.suggest._provider_initialize_duration")
+
+    with pytest.raises(RuntimeError, match="initialization failed"):
+        await init_providers()
+
+    assert [call.args[1] for call in histogram.record.call_args_list] == [
+        {"provider": "adm"},
+        {"provider": "__ALL__"},
+    ]
 
 
 @pytest.mark.parametrize("provider", ["adm", "amo", "top_picks", "wikipedia"])


### PR DESCRIPTION
## References

JIRA: [DISCO-3963](https://mozilla-hub.atlassian.net/browse/DISCO-3963)

## Description
Convert the provider init timer to a otel histogram.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2472)


[DISCO-3963]: https://mozilla-hub.atlassian.net/browse/DISCO-3963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ