### PR TITLE
[AIMOD-1386] Dedupe adjacent sections

### DIFF
--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -564,16 +564,6 @@ def _renumber_recommendations(section: Section) -> None:
         rec.receivedRank = idx
 
 
-def _index_by_identity(
-    recommendations: list[CuratedRecommendation], target: CuratedRecommendation
-) -> int | None:
-    """Return the list index for `target`, using object identity."""
-    for idx, rec in enumerate(recommendations):
-        if rec is target:
-            return idx
-    return None
-
-
 def _get_spindle_similarity_info(
     spindle_backend: SpindleBackendProtocol | None,
     surface_id: SurfaceId | None,
@@ -598,8 +588,9 @@ def reorder_top_sections_for_similarity(
     This is best-effort and reorder-only. For the configured top ranked sections,
     visible recommendations that conflict with already-accepted visible stories
     are moved to the end only when an acceptable fallback exists in the section's
-    small hidden buffer. Fallbacks must be clean against all other visible stories
-    that would remain beside them.
+    small hidden buffer. Later recommendations shift left to fill the vacated
+    slot, and the shifted-in fallback must be clean against all other visible
+    stories that would remain beside it.
 
     Protected sections, like Popular Today, are never reordered. Their visible
     stories are treated as accepted up front so other top sections yield to them
@@ -625,8 +616,11 @@ def reorder_top_sections_for_similarity(
         if section_id in protected_section_ids:
             continue
 
-        candidate_end = min(len(section.recommendations), visible_count + extra_candidates)
-        fallback_candidates = section.recommendations[visible_count:candidate_end]
+        available_extra_candidates = min(
+            extra_candidates,
+            len(section.recommendations) - visible_count,
+        )
+        consumed_extra_candidates = 0
 
         idx = 0
         while idx < visible_count:
@@ -642,28 +636,25 @@ def reorder_top_sections_for_similarity(
                 for visible_idx, rec in enumerate(section.recommendations[:visible_count])
                 if visible_idx != idx
             ]
-            replacement_idx = None
-            fallback_idx_to_remove = None
-            for fallback_idx, candidate in enumerate(fallback_candidates):
+            shift_count = None
+            remaining_extra_candidates = available_extra_candidates - consumed_extra_candidates
+            for candidate_offset in range(remaining_extra_candidates):
+                candidate = section.recommendations[visible_count + candidate_offset]
                 if _has_similar_story_conflict(
                     candidate, visible_without_current, similar_stories_info
                 ):
                     continue
-                replacement_idx = _index_by_identity(section.recommendations, candidate)
-                fallback_idx_to_remove = fallback_idx
+                shift_count = candidate_offset + 1
                 break
 
-            if replacement_idx is None:
+            if shift_count is None:
                 idx += 1
                 continue
 
-            assert fallback_idx_to_remove is not None
-            fallback_candidates.pop(fallback_idx_to_remove)
-            replacement = section.recommendations.pop(replacement_idx)
-            conflict = section.recommendations.pop(idx)
-            section.recommendations.insert(idx, replacement)
-            section.recommendations.append(conflict)
-            idx += 1
+            section.recommendations.append(section.recommendations.pop(idx))
+            for _ in range(shift_count - 1):
+                section.recommendations.append(section.recommendations.pop(visible_count - 1))
+            consumed_extra_candidates += shift_count
 
         _renumber_recommendations(section)
         accepted_visible.extend(section.recommendations[:visible_count])

--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -1,6 +1,7 @@
 """Module for building and ranking curated recommendation sections."""
 
 import logging
+from collections.abc import Collection
 from copy import deepcopy
 
 import random
@@ -98,6 +99,7 @@ MAX_SECTIONS_PER_RESPONSE = 20
 SECTION_ITEM_RANKING_TOP_N = 4
 TOP_SECTION_SIMILAR_DEDUP_SECTION_LIMIT = 3
 TOP_SECTION_SIMILAR_DEDUP_EXTRA_CANDIDATES = 2
+TOP_SECTION_SIMILAR_DEDUP_PROTECTED_SECTION_IDS = frozenset({TOP_STORIES_SECTION_KEY})
 
 
 def map_section_item_to_recommendation(
@@ -589,6 +591,7 @@ def reorder_top_sections_for_similarity(
     similar_stories_info: SimilarStoriesProtocol | None,
     section_limit: int = TOP_SECTION_SIMILAR_DEDUP_SECTION_LIMIT,
     extra_candidates: int = TOP_SECTION_SIMILAR_DEDUP_EXTRA_CANDIDATES,
+    protected_section_ids: Collection[str] = TOP_SECTION_SIMILAR_DEDUP_PROTECTED_SECTION_IDS,
 ) -> None:
     """Move visible near-duplicates in top ranked sections behind fallbacks.
 
@@ -597,18 +600,29 @@ def reorder_top_sections_for_similarity(
     are moved to the end only when an acceptable fallback exists in the section's
     small hidden buffer. Fallbacks must be clean against all other visible stories
     that would remain beside them.
+
+    Protected sections, like Popular Today, are never reordered. Their visible
+    stories are treated as accepted up front so other top sections yield to them
+    even when the protected section is not first by feed rank.
     """
     if similar_stories_info is None or section_limit < 1 or extra_candidates < 1:
         return
 
-    ranked_sections = sorted(sections.values(), key=lambda section: section.receivedFeedRank)[
+    ranked_sections = sorted(sections.items(), key=lambda item: item[1].receivedFeedRank)[
         :section_limit
     ]
-    accepted_visible: list[CuratedRecommendation] = []
+    accepted_visible = [
+        rec
+        for section_id, section in ranked_sections
+        if section_id in protected_section_ids
+        for rec in section.recommendations[: section.layout.max_tile_count]
+    ]
 
-    for section in ranked_sections:
+    for section_id, section in ranked_sections:
         visible_count = min(section.layout.max_tile_count, len(section.recommendations))
         if visible_count == 0:
+            continue
+        if section_id in protected_section_ids:
             continue
 
         candidate_end = min(len(section.recommendations), visible_count + extra_candidates)

--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -589,11 +589,12 @@ def reorder_top_sections_for_similarity(
 
     This is best-effort and reorder-only. For each adjacent pair in the
     configured top ranked sections, visible recommendations in the lower-ranked
-    section that conflict with the immediately previous section are moved to the
-    end only when an acceptable fallback exists in the section's small hidden
-    buffer. Later recommendations shift left to fill the vacated slot, and the
-    shifted-in fallback must be clean against the previous section plus all
-    other visible stories that would remain beside it.
+    section that conflict with the immediately previous section or an earlier
+    visible story in the same section are moved to the end only when an
+    acceptable fallback exists in the section's small hidden buffer. Later
+    recommendations shift left to fill the vacated slot, and the shifted-in
+    fallback must be clean against the previous section plus all other visible
+    stories that would remain beside it.
 
     Protected sections, like Daily Briefing and Popular Today, are never
     reordered. They can still be the previous section that the next ranked
@@ -602,22 +603,27 @@ def reorder_top_sections_for_similarity(
     if similar_stories_info is None or section_limit < 1 or extra_candidates < 1:
         return
 
+    # Only the top feed-ranked sections participate. Sections outside this slice
+    # are left exactly as they came in.
     ranked_sections = sorted(sections.items(), key=lambda item: item[1].receivedFeedRank)[
         :section_limit
     ]
+
+    # This is intentionally only the visible window from the immediately
+    # previous ranked section. We do not compare against every earlier section.
     previous_visible: list[CuratedRecommendation] = []
 
     for section_id, section in ranked_sections:
         visible_count = min(section.layout.max_tile_count, len(section.recommendations))
         if visible_count == 0:
+            # An empty section has no visible stories for the next section to
+            # compare against, so it breaks the adjacent-section chain.
             previous_visible = []
             continue
 
         if section_id in protected_section_ids:
-            previous_visible = section.recommendations[:visible_count]
-            continue
-
-        if not previous_visible:
+            # Protected sections can anchor the next section, but their own
+            # recommendation order is never changed.
             previous_visible = section.recommendations[:visible_count]
             continue
 
@@ -629,12 +635,18 @@ def reorder_top_sections_for_similarity(
 
         idx = 0
         while idx < visible_count:
+            # A visible story moves only if it conflicts with the immediately
+            # previous section or with an earlier visible story in this section.
+            comparison_recs = previous_visible + section.recommendations[:idx]
             if not _has_similar_story_conflict(
-                section.recommendations[idx], previous_visible, similar_stories_info
+                section.recommendations[idx], comparison_recs, similar_stories_info
             ):
                 idx += 1
                 continue
 
+            # A replacement candidate must be clean against the previous
+            # section and against the other visible stories it would sit beside
+            # after the conflict is moved out.
             visible_without_current = previous_visible + [
                 rec
                 for visible_idx, rec in enumerate(section.recommendations[:visible_count])
@@ -655,6 +667,9 @@ def reorder_top_sections_for_similarity(
                 idx += 1
                 continue
 
+            # Move the conflicting visible story to the end. Later items shift
+            # left, and if the clean fallback was not the first hidden item, any
+            # skipped hidden candidates are moved behind the conflict too.
             section.recommendations.append(section.recommendations.pop(idx))
             for _ in range(shift_count - 1):
                 section.recommendations.append(section.recommendations.pop(visible_count - 1))

--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -25,6 +25,7 @@ from merino.curated_recommendations.ml_backends.protocol import (
     TIME_ZONE_OFFSET_INFERRED_KEY,
     MLRecsBackend,
     SpindleBackendProtocol,
+    SimilarStoriesProtocol,
 )
 from merino.curated_recommendations.ml_backends.static_local_model import (
     CONTEXTUAL_RANKING_TREATMENT_TZ,
@@ -95,6 +96,8 @@ MAX_SECTIONS_PER_RESPONSE = 20
 # This Gist runs an eval script on localhost https://gist.github.com/rolf-moz/cfd1062016f1898869248b27af009830
 
 SECTION_ITEM_RANKING_TOP_N = 4
+TOP_SECTION_SIMILAR_DEDUP_SECTION_LIMIT = 3
+TOP_SECTION_SIMILAR_DEDUP_EXTRA_CANDIDATES = 2
 
 
 def map_section_item_to_recommendation(
@@ -538,6 +541,120 @@ def dedupe_recommendations_across_sections(sections: dict[str, Section]) -> dict
     return deduped_sections
 
 
+def _has_similar_story_conflict(
+    rec: CuratedRecommendation,
+    comparison_recs: list[CuratedRecommendation],
+    similar_stories_info: SimilarStoriesProtocol,
+) -> bool:
+    """Return whether `rec` is near-duplicate of any comparison recommendation."""
+    rec_neighbors = set(similar_stories_info.neighbors(rec.corpusItemId))
+    for comparison_rec in comparison_recs:
+        if comparison_rec.corpusItemId in rec_neighbors:
+            return True
+        if rec.corpusItemId in similar_stories_info.neighbors(comparison_rec.corpusItemId):
+            return True
+    return False
+
+
+def _renumber_recommendations(section: Section) -> None:
+    """Set recommendation ranks to match their current order in a section."""
+    for idx, rec in enumerate(section.recommendations):
+        rec.receivedRank = idx
+
+
+def _index_by_identity(
+    recommendations: list[CuratedRecommendation], target: CuratedRecommendation
+) -> int | None:
+    """Return the list index for `target`, using object identity."""
+    for idx, rec in enumerate(recommendations):
+        if rec is target:
+            return idx
+    return None
+
+
+def _get_spindle_similarity_info(
+    spindle_backend: SpindleBackendProtocol | None,
+    surface_id: SurfaceId | None,
+) -> SimilarStoriesProtocol | None:
+    """Return cached Spindle near-duplicate info, preferring text similarity."""
+    if spindle_backend is None or surface_id is None:
+        return None
+    return spindle_backend.get_similar_stories_text(
+        surface_id
+    ) or spindle_backend.get_similar_stories_image(surface_id)
+
+
+def reorder_top_sections_for_similarity(
+    sections: dict[str, Section],
+    similar_stories_info: SimilarStoriesProtocol | None,
+    section_limit: int = TOP_SECTION_SIMILAR_DEDUP_SECTION_LIMIT,
+    extra_candidates: int = TOP_SECTION_SIMILAR_DEDUP_EXTRA_CANDIDATES,
+) -> None:
+    """Move visible near-duplicates in top ranked sections behind fallbacks.
+
+    This is best-effort and reorder-only. For the configured top ranked sections,
+    visible recommendations that conflict with already-accepted visible stories
+    are moved to the end only when an acceptable fallback exists in the section's
+    small hidden buffer. Fallbacks must be clean against all other visible stories
+    that would remain beside them.
+    """
+    if similar_stories_info is None or section_limit < 1 or extra_candidates < 1:
+        return
+
+    ranked_sections = sorted(sections.values(), key=lambda section: section.receivedFeedRank)[
+        :section_limit
+    ]
+    accepted_visible: list[CuratedRecommendation] = []
+
+    for section in ranked_sections:
+        visible_count = min(section.layout.max_tile_count, len(section.recommendations))
+        if visible_count == 0:
+            continue
+
+        candidate_end = min(len(section.recommendations), visible_count + extra_candidates)
+        fallback_candidates = section.recommendations[visible_count:candidate_end]
+
+        idx = 0
+        while idx < visible_count:
+            already_accepted = accepted_visible + section.recommendations[:idx]
+            if not _has_similar_story_conflict(
+                section.recommendations[idx], already_accepted, similar_stories_info
+            ):
+                idx += 1
+                continue
+
+            visible_without_current = accepted_visible + [
+                rec
+                for visible_idx, rec in enumerate(section.recommendations[:visible_count])
+                if visible_idx != idx
+            ]
+            replacement_idx = None
+            fallback_idx_to_remove = None
+            for fallback_idx, candidate in enumerate(fallback_candidates):
+                if _has_similar_story_conflict(
+                    candidate, visible_without_current, similar_stories_info
+                ):
+                    continue
+                replacement_idx = _index_by_identity(section.recommendations, candidate)
+                fallback_idx_to_remove = fallback_idx
+                break
+
+            if replacement_idx is None:
+                idx += 1
+                continue
+
+            assert fallback_idx_to_remove is not None
+            fallback_candidates.pop(fallback_idx_to_remove)
+            replacement = section.recommendations.pop(replacement_idx)
+            conflict = section.recommendations.pop(idx)
+            section.recommendations.insert(idx, replacement)
+            section.recommendations.append(conflict)
+            idx += 1
+
+        _renumber_recommendations(section)
+        accepted_visible.extend(section.recommendations[:visible_count])
+
+
 def cycle_layouts_for_ranked_sections(sections: dict[str, Section], layout_cycle: list[Layout]):
     """Cycle through layouts & assign final layouts to all ranked sections except 'top_stories_section' & 'daily-briefing'."""
     # Exclude top_stories_section & daily-briefing (if present) from layout cycling
@@ -746,12 +863,7 @@ def get_top_story_list(
     )
     non_throttled = items[len(items_throttled_fresh) + len(unused_fresh) :]
 
-    similar_stories_info = None
-    if spindle_backend is not None and surface_id is not None:
-        # Prefer text similarity (more reliable today); fall back to image.
-        similar_stories_info = spindle_backend.get_similar_stories_text(
-            surface_id
-        ) or spindle_backend.get_similar_stories_image(surface_id)
+    similar_stories_info = _get_spindle_similarity_info(spindle_backend, surface_id)
     balancer = TopStoriesArticleBalancer(
         round(top_count * constraint_scale),
         config=article_balancer_config,
@@ -1041,7 +1153,13 @@ async def get_sections(
     # 17. Apply final layout cycling to ranked sections except top_stories
     cycle_layouts_for_ranked_sections(sections, LAYOUT_CYCLE)
 
-    # 18. Apply ad adjustments
+    # 18. Use cached near-duplicate info to reduce similar stories across top visible sections.
+    reorder_top_sections_for_similarity(
+        sections,
+        _get_spindle_similarity_info(spindle_backend, surface_id),
+    )
+
+    # 19. Apply ad adjustments
     adjust_ads_in_sections(sections)
 
     return sections

--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -99,7 +99,9 @@ MAX_SECTIONS_PER_RESPONSE = 20
 SECTION_ITEM_RANKING_TOP_N = 4
 TOP_SECTION_SIMILAR_DEDUP_SECTION_LIMIT = 3
 TOP_SECTION_SIMILAR_DEDUP_EXTRA_CANDIDATES = 2
-TOP_SECTION_SIMILAR_DEDUP_PROTECTED_SECTION_IDS = frozenset({TOP_STORIES_SECTION_KEY})
+TOP_SECTION_SIMILAR_DEDUP_PROTECTED_SECTION_IDS = frozenset(
+    {DAILY_BRIEFING_SECTION_KEY, TOP_STORIES_SECTION_KEY}
+)
 
 
 def map_section_item_to_recommendation(
@@ -585,16 +587,17 @@ def reorder_top_sections_for_similarity(
 ) -> None:
     """Move visible near-duplicates in top ranked sections behind fallbacks.
 
-    This is best-effort and reorder-only. For the configured top ranked sections,
-    visible recommendations that conflict with already-accepted visible stories
-    are moved to the end only when an acceptable fallback exists in the section's
-    small hidden buffer. Later recommendations shift left to fill the vacated
-    slot, and the shifted-in fallback must be clean against all other visible
-    stories that would remain beside it.
+    This is best-effort and reorder-only. For each adjacent pair in the
+    configured top ranked sections, visible recommendations in the lower-ranked
+    section that conflict with the immediately previous section are moved to the
+    end only when an acceptable fallback exists in the section's small hidden
+    buffer. Later recommendations shift left to fill the vacated slot, and the
+    shifted-in fallback must be clean against the previous section plus all
+    other visible stories that would remain beside it.
 
-    Protected sections, like Popular Today, are never reordered. Their visible
-    stories are treated as accepted up front so other top sections yield to them
-    even when the protected section is not first by feed rank.
+    Protected sections, like Daily Briefing and Popular Today, are never
+    reordered. They can still be the previous section that the next ranked
+    section yields to.
     """
     if similar_stories_info is None or section_limit < 1 or extra_candidates < 1:
         return
@@ -602,18 +605,20 @@ def reorder_top_sections_for_similarity(
     ranked_sections = sorted(sections.items(), key=lambda item: item[1].receivedFeedRank)[
         :section_limit
     ]
-    accepted_visible = [
-        rec
-        for section_id, section in ranked_sections
-        if section_id in protected_section_ids
-        for rec in section.recommendations[: section.layout.max_tile_count]
-    ]
+    previous_visible: list[CuratedRecommendation] = []
 
     for section_id, section in ranked_sections:
         visible_count = min(section.layout.max_tile_count, len(section.recommendations))
         if visible_count == 0:
+            previous_visible = []
             continue
+
         if section_id in protected_section_ids:
+            previous_visible = section.recommendations[:visible_count]
+            continue
+
+        if not previous_visible:
+            previous_visible = section.recommendations[:visible_count]
             continue
 
         available_extra_candidates = min(
@@ -624,14 +629,13 @@ def reorder_top_sections_for_similarity(
 
         idx = 0
         while idx < visible_count:
-            already_accepted = accepted_visible + section.recommendations[:idx]
             if not _has_similar_story_conflict(
-                section.recommendations[idx], already_accepted, similar_stories_info
+                section.recommendations[idx], previous_visible, similar_stories_info
             ):
                 idx += 1
                 continue
 
-            visible_without_current = accepted_visible + [
+            visible_without_current = previous_visible + [
                 rec
                 for visible_idx, rec in enumerate(section.recommendations[:visible_count])
                 if visible_idx != idx
@@ -657,7 +661,7 @@ def reorder_top_sections_for_similarity(
             consumed_extra_candidates += shift_count
 
         _renumber_recommendations(section)
-        accepted_visible.extend(section.recommendations[:visible_count])
+        previous_visible = section.recommendations[:visible_count]
 
 
 def cycle_layouts_for_ranked_sections(sections: dict[str, Section], layout_cycle: list[Layout]):

--- a/tests/unit/curated_recommendations/test_sections.py
+++ b/tests/unit/curated_recommendations/test_sections.py
@@ -45,7 +45,7 @@ from merino.curated_recommendations.protocol import (
     CuratedRecommendation,
     RankingData,
 )
-from merino.curated_recommendations.rankers import ThompsonSamplingRanker
+from merino.curated_recommendations.rankers import TOP_STORIES_SECTION_KEY, ThompsonSamplingRanker
 from merino.curated_recommendations.sections import (
     adjust_ads_in_sections,
     dedupe_experiment_sections,
@@ -983,6 +983,44 @@ class TestReorderTopSectionsForSimilarity:
             "bad",
         ]
         assert [rec.receivedRank for rec in sections["lower"].recommendations] == list(range(6))
+
+    def test_popular_today_section_is_not_reordered(self):
+        """Popular Today is protected even when it has visible duplicate stories."""
+        popular_today_ids = ["a", "bad", "p1", "p2", "ok", "spare"]
+        sections = {
+            TOP_STORIES_SECTION_KEY: self.build_section(popular_today_ids, 0, "Popular Today"),
+        }
+        similarity_info = self.SimilarityInfo({"bad": ["a"]})
+
+        reorder_top_sections_for_similarity(sections, similarity_info)
+
+        assert [
+            rec.corpusItemId for rec in sections[TOP_STORIES_SECTION_KEY].recommendations
+        ] == popular_today_ids
+
+    def test_non_first_popular_today_is_protected_and_used_for_comparisons(self):
+        """Higher-ranked mutable sections yield to protected Popular Today stories."""
+        mutable_ids = ["bad", "d1", "d2", "d3", "ok", "spare"]
+        popular_today_ids = ["pt", "p1", "p2", "p3", "p4"]
+        sections = {
+            "daily-briefing": self.build_section(mutable_ids, 0, "Daily Briefing"),
+            TOP_STORIES_SECTION_KEY: self.build_section(popular_today_ids, 1, "Popular Today"),
+        }
+        similarity_info = self.SimilarityInfo({"bad": ["pt"]})
+
+        reorder_top_sections_for_similarity(sections, similarity_info)
+
+        assert [rec.corpusItemId for rec in sections["daily-briefing"].recommendations] == [
+            "ok",
+            "d1",
+            "d2",
+            "d3",
+            "spare",
+            "bad",
+        ]
+        assert [
+            rec.corpusItemId for rec in sections[TOP_STORIES_SECTION_KEY].recommendations
+        ] == popular_today_ids
 
     def test_promotes_later_same_section_conflict_behind_fallback(self):
         """A later visible item conflicting within its section is moved behind a fallback."""

--- a/tests/unit/curated_recommendations/test_sections.py
+++ b/tests/unit/curated_recommendations/test_sections.py
@@ -1017,67 +1017,90 @@ class TestReorderTopSectionsForSimilarity:
             rec.corpusItemId for rec in sections[TOP_STORIES_SECTION_KEY].recommendations
         ] == popular_today_ids
 
-    def test_non_first_popular_today_is_protected_and_used_for_comparisons(self):
-        """Higher-ranked mutable sections yield to protected Popular Today stories."""
-        mutable_ids = ["bad", "d1", "d2", "d3", "ok", "spare"]
+    def test_non_first_popular_today_is_protected_and_used_for_next_section_comparison(self):
+        """Popular Today is protected and only the next ranked section yields to it."""
+        higher_ranked_ids = ["bad", "d1", "d2", "d3", "d4"]
         popular_today_ids = ["pt", "p1", "p2", "p3", "p4"]
+        lower_ids = ["bad-lower", "l1", "l2", "l3", "ok", "spare"]
         sections = {
-            "daily-briefing": self.build_section(mutable_ids, 0, "Daily Briefing"),
+            "higher-ranked-section": self.build_section(higher_ranked_ids, 0, "Higher Ranked"),
             TOP_STORIES_SECTION_KEY: self.build_section(popular_today_ids, 1, "Popular Today"),
+            "lower": self.build_section(lower_ids, 2, "Lower"),
         }
-        similarity_info = self.SimilarityInfo({"bad": ["pt"]})
+        similarity_info = self.SimilarityInfo({"bad": ["pt"], "bad-lower": ["pt"]})
 
         reorder_top_sections_for_similarity(sections, similarity_info)
 
-        assert [rec.corpusItemId for rec in sections["daily-briefing"].recommendations] == [
+        assert [rec.corpusItemId for rec in sections["higher-ranked-section"].recommendations] == [
+            "bad",
             "d1",
             "d2",
             "d3",
-            "ok",
-            "spare",
-            "bad",
+            "d4",
         ]
         assert [
             rec.corpusItemId for rec in sections[TOP_STORIES_SECTION_KEY].recommendations
         ] == popular_today_ids
+        assert [rec.corpusItemId for rec in sections["lower"].recommendations] == [
+            "l1",
+            "l2",
+            "l3",
+            "ok",
+            "spare",
+            "bad-lower",
+        ]
 
-    def test_promotes_later_same_section_conflict_behind_fallback(self):
-        """A later visible item conflicting within its section is moved behind a fallback."""
+    def test_daily_briefing_is_protected_and_used_for_comparisons(self):
+        """Mutable sections yield to Daily Briefing, but Daily Briefing is unchanged."""
+        daily_briefing_ids = ["db", "db-bad", "db1", "db2", "db-ok", "db-spare"]
+        lower_ids = ["bad", "l1", "l2", "l3", "ok", "spare"]
         sections = {
-            "first": self.build_section(["a", "bad", "f1", "f2", "ok", "spare"], 0, "First"),
+            DAILY_BRIEFING_SECTION_KEY: self.build_section(
+                daily_briefing_ids, 0, "Daily Briefing"
+            ),
+            "lower": self.build_section(lower_ids, 1, "Lower"),
         }
-        similarity_info = self.SimilarityInfo({"bad": ["a"]})
+        similarity_info = self.SimilarityInfo({"db-bad": ["db"], "bad": ["db"]})
 
         reorder_top_sections_for_similarity(sections, similarity_info)
 
-        assert [rec.corpusItemId for rec in sections["first"].recommendations] == [
-            "a",
-            "f1",
-            "f2",
+        assert [
+            rec.corpusItemId for rec in sections[DAILY_BRIEFING_SECTION_KEY].recommendations
+        ] == daily_briefing_ids
+        assert [rec.corpusItemId for rec in sections["lower"].recommendations] == [
+            "l1",
+            "l2",
+            "l3",
             "ok",
             "spare",
             "bad",
         ]
 
-    def test_compares_against_all_prior_visible_top_sections(self):
-        """A third section is checked against every prior top-section visible item."""
+    def test_first_section_same_section_conflict_is_not_reordered(self):
+        """The first ranked section is not checked against itself."""
+        first_ids = ["a", "bad", "f1", "f2", "ok", "spare"]
+        sections = {
+            "first": self.build_section(first_ids, 0, "First"),
+        }
+        similarity_info = self.SimilarityInfo({"bad": ["a"]})
+
+        reorder_top_sections_for_similarity(sections, similarity_info)
+
+        assert [rec.corpusItemId for rec in sections["first"].recommendations] == first_ids
+
+    def test_compares_only_against_immediately_prior_visible_top_section(self):
+        """A third section is not checked against the first section."""
+        third_ids = ["bad", "t1", "t2", "t3", "ok", "spare"]
         sections = {
             "first": self.build_section(["a", "f1", "f2", "f3", "f4"], 0, "First"),
             "second": self.build_section(["s0", "s1", "s2", "s3", "s4"], 1, "Second"),
-            "third": self.build_section(["bad", "t1", "t2", "t3", "ok", "spare"], 2, "Third"),
+            "third": self.build_section(third_ids, 2, "Third"),
         }
         similarity_info = self.SimilarityInfo({"bad": ["a"]})
 
         reorder_top_sections_for_similarity(sections, similarity_info)
 
-        assert [rec.corpusItemId for rec in sections["third"].recommendations] == [
-            "t1",
-            "t2",
-            "t3",
-            "ok",
-            "spare",
-            "bad",
-        ]
+        assert [rec.corpusItemId for rec in sections["third"].recommendations] == third_ids
 
     def test_skips_fallback_that_conflicts_with_same_section_visible_item(self):
         """A fallback must be clean against visible items it would remain beside."""

--- a/tests/unit/curated_recommendations/test_sections.py
+++ b/tests/unit/curated_recommendations/test_sections.py
@@ -1076,17 +1076,23 @@ class TestReorderTopSectionsForSimilarity:
             "bad",
         ]
 
-    def test_first_section_same_section_conflict_is_not_reordered(self):
-        """The first ranked section is not checked against itself."""
-        first_ids = ["a", "bad", "f1", "f2", "ok", "spare"]
+    def test_first_section_same_section_conflict_moves_behind_fallback(self):
+        """The first ranked section can still dedupe within its visible range."""
         sections = {
-            "first": self.build_section(first_ids, 0, "First"),
+            "first": self.build_section(["a", "bad", "f1", "f2", "ok", "spare"], 0, "First"),
         }
         similarity_info = self.SimilarityInfo({"bad": ["a"]})
 
         reorder_top_sections_for_similarity(sections, similarity_info)
 
-        assert [rec.corpusItemId for rec in sections["first"].recommendations] == first_ids
+        assert [rec.corpusItemId for rec in sections["first"].recommendations] == [
+            "a",
+            "f1",
+            "f2",
+            "ok",
+            "spare",
+            "bad",
+        ]
 
     def test_compares_only_against_immediately_prior_visible_top_section(self):
         """A third section is not checked against the first section."""

--- a/tests/unit/curated_recommendations/test_sections.py
+++ b/tests/unit/curated_recommendations/test_sections.py
@@ -72,6 +72,8 @@ from merino.curated_recommendations.sections import (
     resolve_section_experiment,
     split_daily_briefing_section,
     dedupe_recommendations_across_sections,
+    _get_spindle_similarity_info,
+    reorder_top_sections_for_similarity,
 )
 from tests.unit.curated_recommendations.fixtures import (
     generate_recommendations,
@@ -885,6 +887,237 @@ class TestDedupeRecommendationsAcrossSections:
         assert [rec.receivedRank for rec in sections["mid"].recommendations] == list(
             range(len(sections["mid"].recommendations))
         )
+
+
+class TestReorderTopSectionsForSimilarity:
+    """Tests for Spindle-backed top-section visible near-duplicate reordering."""
+
+    @staticmethod
+    def build_section(item_ids: list[str], rank: int, title: str) -> Section:
+        """Lightweight helper to create a section with the given ids and rank."""
+        return Section(
+            receivedFeedRank=rank,
+            recommendations=generate_recommendations(item_ids=item_ids, time_sensitive_count=0),
+            title=title,
+            layout=copy.deepcopy(layout_4_medium),
+        )
+
+    class SimilarityInfo:
+        """Small SimilarStoriesProtocol implementation for tests."""
+
+        def __init__(self, neighbors: dict[str, list[str]]) -> None:
+            self._neighbors = neighbors
+
+        def neighbors(self, corpus_item_id: str) -> list[str]:
+            """Return test neighbors for a corpus item id."""
+            return self._neighbors.get(corpus_item_id, [])
+
+    class SpindleBackend:
+        """Small SpindleBackendProtocol implementation for tests."""
+
+        def __init__(
+            self,
+            text_info: "TestReorderTopSectionsForSimilarity.SimilarityInfo | None" = None,
+            image_info: "TestReorderTopSectionsForSimilarity.SimilarityInfo | None" = None,
+        ) -> None:
+            self._text_info = text_info
+            self._image_info = image_info
+
+        async def refresh_duplicate_item_info(self, items, surface, threshold=0.7) -> None:
+            """No-op refresh for protocol compatibility."""
+            return None
+
+        def get_similar_stories_text(self, surface):
+            """Return configured text similarity info."""
+            return self._text_info
+
+        def get_similar_stories_image(self, surface):
+            """Return configured image similarity info."""
+            return self._image_info
+
+    def test_get_spindle_similarity_info_prefers_text_similarity(self):
+        """Cached text similarity is preferred over cached image similarity."""
+        text_info = self.SimilarityInfo({"a": ["b"]})
+        image_info = self.SimilarityInfo({"a": ["c"]})
+
+        assert (
+            _get_spindle_similarity_info(
+                self.SpindleBackend(text_info=text_info, image_info=image_info),
+                SurfaceId.NEW_TAB_EN_US,
+            )
+            is text_info
+        )
+
+    def test_get_spindle_similarity_info_falls_back_to_image_similarity(self):
+        """Cached image similarity is used when text similarity is unavailable."""
+        image_info = self.SimilarityInfo({"a": ["c"]})
+
+        assert (
+            _get_spindle_similarity_info(
+                self.SpindleBackend(image_info=image_info),
+                SurfaceId.NEW_TAB_EN_US,
+            )
+            is image_info
+        )
+
+    def test_get_spindle_similarity_info_without_backend_is_none(self):
+        """Missing Spindle backend means no cached similarity info is available."""
+        assert _get_spindle_similarity_info(None, SurfaceId.NEW_TAB_EN_US) is None
+
+    def test_promotes_buffered_fallback_when_visible_item_conflicts(self):
+        """A visible item conflicting with an earlier section is moved behind a fallback."""
+        sections = {
+            "prior": self.build_section(["a", "p1", "p2", "p3", "p4"], 0, "Prior"),
+            "lower": self.build_section(["bad", "l1", "l2", "l3", "ok", "spare"], 1, "Lower"),
+        }
+        similarity_info = self.SimilarityInfo({"bad": ["a"]})
+
+        reorder_top_sections_for_similarity(sections, similarity_info)
+
+        assert [rec.corpusItemId for rec in sections["lower"].recommendations] == [
+            "ok",
+            "l1",
+            "l2",
+            "l3",
+            "spare",
+            "bad",
+        ]
+        assert [rec.receivedRank for rec in sections["lower"].recommendations] == list(range(6))
+
+    def test_promotes_later_same_section_conflict_behind_fallback(self):
+        """A later visible item conflicting within its section is moved behind a fallback."""
+        sections = {
+            "first": self.build_section(["a", "bad", "f1", "f2", "ok", "spare"], 0, "First"),
+        }
+        similarity_info = self.SimilarityInfo({"bad": ["a"]})
+
+        reorder_top_sections_for_similarity(sections, similarity_info)
+
+        assert [rec.corpusItemId for rec in sections["first"].recommendations] == [
+            "a",
+            "ok",
+            "f1",
+            "f2",
+            "spare",
+            "bad",
+        ]
+
+    def test_compares_against_all_prior_visible_top_sections(self):
+        """A third section is checked against every prior top-section visible item."""
+        sections = {
+            "first": self.build_section(["a", "f1", "f2", "f3", "f4"], 0, "First"),
+            "second": self.build_section(["s0", "s1", "s2", "s3", "s4"], 1, "Second"),
+            "third": self.build_section(["bad", "t1", "t2", "t3", "ok", "spare"], 2, "Third"),
+        }
+        similarity_info = self.SimilarityInfo({"bad": ["a"]})
+
+        reorder_top_sections_for_similarity(sections, similarity_info)
+
+        assert [rec.corpusItemId for rec in sections["third"].recommendations] == [
+            "ok",
+            "t1",
+            "t2",
+            "t3",
+            "spare",
+            "bad",
+        ]
+
+    def test_skips_fallback_that_conflicts_with_same_section_visible_item(self):
+        """A fallback must be clean against visible items it would remain beside."""
+        sections = {
+            "prior": self.build_section(["a", "p1", "p2", "p3", "p4"], 0, "Prior"),
+            "lower": self.build_section(["bad", "l1", "l2", "l3", "also-bad", "ok"], 1, "Lower"),
+        }
+        similarity_info = self.SimilarityInfo({"bad": ["a"], "also-bad": ["l1"]})
+
+        reorder_top_sections_for_similarity(sections, similarity_info)
+
+        assert [rec.corpusItemId for rec in sections["lower"].recommendations] == [
+            "ok",
+            "l1",
+            "l2",
+            "l3",
+            "also-bad",
+            "bad",
+        ]
+
+    def test_prior_section_without_visible_items_is_noop(self):
+        """A higher-ranked section with no visible items contributes no comparisons."""
+        lower_ids = ["bad", "l1", "l2", "l3", "ok", "spare"]
+        sections = {
+            "prior": self.build_section([], 0, "Prior"),
+            "lower": self.build_section(lower_ids, 1, "Lower"),
+        }
+        similarity_info = self.SimilarityInfo({"bad": ["a"]})
+
+        reorder_top_sections_for_similarity(sections, similarity_info)
+
+        assert [rec.corpusItemId for rec in sections["lower"].recommendations] == lower_ids
+
+    def test_lower_section_without_visible_items_is_noop(self):
+        """A lower section with no recommendations is left unchanged."""
+        sections = {
+            "prior": self.build_section(["a", "p1", "p2", "p3", "p4"], 0, "Prior"),
+            "lower": self.build_section([], 1, "Lower"),
+        }
+        similarity_info = self.SimilarityInfo({"a": ["bad"]})
+
+        reorder_top_sections_for_similarity(sections, similarity_info)
+
+        assert sections["lower"].recommendations == []
+
+    def test_lower_section_without_buffer_candidates_is_noop(self):
+        """A lower section without hidden fallbacks is left unchanged."""
+        lower_ids = ["bad", "l1", "l2", "l3"]
+        sections = {
+            "prior": self.build_section(["a", "p1", "p2", "p3", "p4"], 0, "Prior"),
+            "lower": self.build_section(lower_ids, 1, "Lower"),
+        }
+        similarity_info = self.SimilarityInfo({"a": ["bad"]})
+
+        reorder_top_sections_for_similarity(sections, similarity_info)
+
+        assert [rec.corpusItemId for rec in sections["lower"].recommendations] == lower_ids
+
+    def test_leaves_conflict_when_buffer_candidates_also_conflict(self):
+        """If both buffered fallbacks conflict, leave the visible order unchanged."""
+        lower_ids = ["bad", "l1", "l2", "l3", "also-bad-1", "also-bad-2", "ok-too-deep"]
+        sections = {
+            "prior": self.build_section(["a", "p1", "p2", "p3", "p4"], 0, "Prior"),
+            "lower": self.build_section(lower_ids, 1, "Lower"),
+        }
+        similarity_info = self.SimilarityInfo({"a": ["bad", "also-bad-1", "also-bad-2"]})
+
+        reorder_top_sections_for_similarity(sections, similarity_info)
+
+        assert [rec.corpusItemId for rec in sections["lower"].recommendations] == lower_ids
+
+    def test_no_similarity_info_is_noop(self):
+        """Without cached Spindle info, section order is unchanged."""
+        lower_ids = ["bad", "l1", "l2", "l3", "ok", "spare"]
+        sections = {
+            "prior": self.build_section(["a", "p1", "p2", "p3", "p4"], 0, "Prior"),
+            "lower": self.build_section(lower_ids, 1, "Lower"),
+        }
+
+        reorder_top_sections_for_similarity(sections, similar_stories_info=None)
+
+        assert [rec.corpusItemId for rec in sections["lower"].recommendations] == lower_ids
+
+    def test_only_first_three_sections_are_considered_by_default(self):
+        """The default section limit does not compare the third and fourth sections."""
+        fourth_ids = ["bad", "l1", "l2", "l3", "ok", "spare"]
+        sections = {
+            "first": self.build_section(["a0", "p1", "p2", "p3", "p4"], 0, "First"),
+            "second": self.build_section(["a1", "s1", "s2", "s3", "s4"], 1, "Second"),
+            "third": self.build_section(["a2", "t1", "t2", "t3", "t4"], 2, "Third"),
+            "fourth": self.build_section(fourth_ids, 3, "Fourth"),
+        }
+        similarity_info = self.SimilarityInfo({"a2": ["bad"]})
+
+        reorder_top_sections_for_similarity(sections, similarity_info)
+
+        assert [rec.corpusItemId for rec in sections["fourth"].recommendations] == fourth_ids
 
 
 class TestGetTopStoryList:

--- a/tests/unit/curated_recommendations/test_sections.py
+++ b/tests/unit/curated_recommendations/test_sections.py
@@ -965,7 +965,7 @@ class TestReorderTopSectionsForSimilarity:
         assert _get_spindle_similarity_info(None, SurfaceId.NEW_TAB_EN_US) is None
 
     def test_promotes_buffered_fallback_when_visible_item_conflicts(self):
-        """A visible item conflicting with an earlier section is moved behind a fallback."""
+        """A visible conflict is moved to the end when the buffer has a clean story."""
         sections = {
             "prior": self.build_section(["a", "p1", "p2", "p3", "p4"], 0, "Prior"),
             "lower": self.build_section(["bad", "l1", "l2", "l3", "ok", "spare"], 1, "Lower"),
@@ -975,14 +975,33 @@ class TestReorderTopSectionsForSimilarity:
         reorder_top_sections_for_similarity(sections, similarity_info)
 
         assert [rec.corpusItemId for rec in sections["lower"].recommendations] == [
-            "ok",
             "l1",
             "l2",
             "l3",
+            "ok",
             "spare",
             "bad",
         ]
         assert [rec.receivedRank for rec in sections["lower"].recommendations] == list(range(6))
+
+    def test_conflict_removal_shifts_later_items_left(self):
+        """Removing a conflict from the visible range shifts later stories left."""
+        sections = {
+            "prior": self.build_section(["a", "p1", "p2", "p3", "p4"], 0, "Prior"),
+            "lower": self.build_section(["l0", "l1", "l2", "bad", "ok", "spare"], 1, "Lower"),
+        }
+        similarity_info = self.SimilarityInfo({"bad": ["a"]})
+
+        reorder_top_sections_for_similarity(sections, similarity_info)
+
+        assert [rec.corpusItemId for rec in sections["lower"].recommendations] == [
+            "l0",
+            "l1",
+            "l2",
+            "ok",
+            "spare",
+            "bad",
+        ]
 
     def test_popular_today_section_is_not_reordered(self):
         """Popular Today is protected even when it has visible duplicate stories."""
@@ -1011,10 +1030,10 @@ class TestReorderTopSectionsForSimilarity:
         reorder_top_sections_for_similarity(sections, similarity_info)
 
         assert [rec.corpusItemId for rec in sections["daily-briefing"].recommendations] == [
-            "ok",
             "d1",
             "d2",
             "d3",
+            "ok",
             "spare",
             "bad",
         ]
@@ -1033,9 +1052,9 @@ class TestReorderTopSectionsForSimilarity:
 
         assert [rec.corpusItemId for rec in sections["first"].recommendations] == [
             "a",
-            "ok",
             "f1",
             "f2",
+            "ok",
             "spare",
             "bad",
         ]
@@ -1052,10 +1071,10 @@ class TestReorderTopSectionsForSimilarity:
         reorder_top_sections_for_similarity(sections, similarity_info)
 
         assert [rec.corpusItemId for rec in sections["third"].recommendations] == [
-            "ok",
             "t1",
             "t2",
             "t3",
+            "ok",
             "spare",
             "bad",
         ]
@@ -1071,12 +1090,12 @@ class TestReorderTopSectionsForSimilarity:
         reorder_top_sections_for_similarity(sections, similarity_info)
 
         assert [rec.corpusItemId for rec in sections["lower"].recommendations] == [
-            "ok",
             "l1",
             "l2",
             "l3",
-            "also-bad",
+            "ok",
             "bad",
+            "also-bad",
         ]
 
     def test_prior_section_without_visible_items_is_noop(self):


### PR DESCRIPTION
## References

JIRA: [AIMOD-1386](https://mozilla-hub.atlassian.net/browse/AIMOD-1386)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->

  Adds Spindle-backed visible-range deduping across the top ranked sections.

  The reorder is best-effort and reorder-only:

  - considers the top 3 ranked sections
  - skips mutating Popular Today and Daily Briefing
  - dedupes a section against the immediately previous ranked section
  - also dedupes against earlier visible stories in the same section
  - moves conflicting visible stories to the end only when a clean fallback exists in the hidden buffer

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2474)


[AIMOD-1386]: https://mozilla-hub.atlassian.net/browse/AIMOD-1386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ