### PR TITLE
[AIMOD-1388] Skip spindle calls if content hasn't changed

### DIFF
--- a/merino/curated_recommendations/ml_backends/spindle_backend.py
+++ b/merino/curated_recommendations/ml_backends/spindle_backend.py
@@ -6,7 +6,6 @@ ranking pipeline via the `SimilarStoriesProtocol`.
 """
 
 import logging
-from hashlib import sha256
 
 import aiodogstatsd
 from httpx import AsyncClient, HTTPError
@@ -33,13 +32,12 @@ LOCALE_FOR_SURFACE: dict[SurfaceId, str] = {
 METRIC_NAMESPACE = "recommendation.spindle"
 
 
-def _content_id_hash(items: list[CorpusItem]) -> str:
-    """Return a stable hash for the unique corpus ids in `items`."""
-    digest = sha256()
-    for corpus_item_id in sorted({item.corpusItemId for item in items}):
-        digest.update(corpus_item_id.encode("utf-8"))
-        digest.update(b"\0")
-    return digest.hexdigest()
+def _content_ids(items: list[CorpusItem]) -> tuple[str, ...]:
+    """Return corpus ids in received order."""
+    # The Sections API is expected to return unchanged content in a stable
+    # order, so avoid sorting here. A pure reorder may cause an extra Spindle
+    # refresh, but it will not reuse stale similarity info.
+    return tuple(item.corpusItemId for item in items)
 
 
 class SimilarStoriesTextItem(BaseModel):
@@ -137,7 +135,7 @@ class SpindleBackend(SpindleBackendProtocol):
         )
         self._text_info: dict[SurfaceId, SimilarStoriesInfo] = {}
         self._image_info: dict[SurfaceId, SimilarStoriesInfo] = {}
-        self._text_content_id_hashes: dict[SurfaceId, str] = {}
+        self._text_content_ids: dict[SurfaceId, tuple[str, ...]] = {}
         self._api_key = api_key
 
     def _language_for_surface(self, surface: SurfaceId) -> str | None:
@@ -175,8 +173,8 @@ class SpindleBackend(SpindleBackendProtocol):
         if language is None:
             return
 
-        content_id_hash = _content_id_hash(items)
-        if self._text_content_id_hashes.get(surface) == content_id_hash:
+        content_ids = _content_ids(items)
+        if self._text_content_ids.get(surface) == content_ids:
             return
 
         request = FindSimilarStoriesRequest(
@@ -198,7 +196,7 @@ class SpindleBackend(SpindleBackendProtocol):
         )
         if response is not None:
             self._text_info[surface] = SimilarStoriesInfo(response.similar)
-            self._text_content_id_hashes[surface] = content_id_hash
+            self._text_content_ids[surface] = content_ids
 
     async def _refresh_image(
         self, items: list[CorpusItem], surface: SurfaceId, threshold: float

--- a/merino/curated_recommendations/ml_backends/spindle_backend.py
+++ b/merino/curated_recommendations/ml_backends/spindle_backend.py
@@ -6,6 +6,7 @@ ranking pipeline via the `SimilarStoriesProtocol`.
 """
 
 import logging
+from hashlib import sha256
 
 import aiodogstatsd
 from httpx import AsyncClient, HTTPError
@@ -30,6 +31,15 @@ LOCALE_FOR_SURFACE: dict[SurfaceId, str] = {
 }
 
 METRIC_NAMESPACE = "recommendation.spindle"
+
+
+def _content_id_hash(items: list[CorpusItem]) -> str:
+    """Return a stable hash for the unique corpus ids in `items`."""
+    digest = sha256()
+    for corpus_item_id in sorted({item.corpusItemId for item in items}):
+        digest.update(corpus_item_id.encode("utf-8"))
+        digest.update(b"\0")
+    return digest.hexdigest()
 
 
 class SimilarStoriesTextItem(BaseModel):
@@ -127,6 +137,7 @@ class SpindleBackend(SpindleBackendProtocol):
         )
         self._text_info: dict[SurfaceId, SimilarStoriesInfo] = {}
         self._image_info: dict[SurfaceId, SimilarStoriesInfo] = {}
+        self._text_content_id_hashes: dict[SurfaceId, str] = {}
         self._api_key = api_key
 
     def _language_for_surface(self, surface: SurfaceId) -> str | None:
@@ -163,6 +174,11 @@ class SpindleBackend(SpindleBackendProtocol):
         language = self._language_for_surface(surface)
         if language is None:
             return
+
+        content_id_hash = _content_id_hash(items)
+        if self._text_content_id_hashes.get(surface) == content_id_hash:
+            return
+
         request = FindSimilarStoriesRequest(
             items=[
                 SimilarStoriesTextItem(
@@ -182,6 +198,7 @@ class SpindleBackend(SpindleBackendProtocol):
         )
         if response is not None:
             self._text_info[surface] = SimilarStoriesInfo(response.similar)
+            self._text_content_id_hashes[surface] = content_id_hash
 
     async def _refresh_image(
         self, items: list[CorpusItem], surface: SurfaceId, threshold: float

--- a/tests/unit/curated_recommendations/ml_backends/test_spindle_backend.py
+++ b/tests/unit/curated_recommendations/ml_backends/test_spindle_backend.py
@@ -220,7 +220,7 @@ class TestSpindleBackendRefresh:
             [_item("a"), _item("b")], SurfaceId.NEW_TAB_EN_US
         )
         await backend.refresh_duplicate_item_info(
-            [_item("b"), _item("a")], SurfaceId.NEW_TAB_EN_US
+            [_item("a"), _item("b")], SurfaceId.NEW_TAB_EN_US
         )
 
         http_client.post.assert_awaited_once()

--- a/tests/unit/curated_recommendations/ml_backends/test_spindle_backend.py
+++ b/tests/unit/curated_recommendations/ml_backends/test_spindle_backend.py
@@ -202,6 +202,97 @@ class TestSpindleBackendRefresh:
         # assert "recommendation.spindle.image.timing" in timing_calls
 
     @pytest.mark.asyncio
+    async def test_unchanged_content_ids_skip_refresh(self):
+        """The same content ids for a surface reuse cached similarity info."""
+        http_client = MagicMock(spec=AsyncClient)
+        response_body = {
+            "similar": {"a": ["b"]},
+            "model_version": "text-v1",
+            "threshold": 0.7,
+            "language": "en",
+            "num_items": 2,
+            "num_pairs": 1,
+        }
+        http_client.post = AsyncMock(return_value=_ok_response(response_body))
+        backend = _make_backend(http_client)
+
+        await backend.refresh_duplicate_item_info(
+            [_item("a"), _item("b")], SurfaceId.NEW_TAB_EN_US
+        )
+        await backend.refresh_duplicate_item_info(
+            [_item("b"), _item("a")], SurfaceId.NEW_TAB_EN_US
+        )
+
+        http_client.post.assert_awaited_once()
+        text_info = backend.get_similar_stories_text(SurfaceId.NEW_TAB_EN_US)
+        assert text_info is not None
+        assert text_info.neighbors("a") == ["b"]
+
+    @pytest.mark.asyncio
+    async def test_changed_content_ids_refresh_again(self):
+        """A changed content id set triggers a new Spindle request."""
+        http_client = MagicMock(spec=AsyncClient)
+        first_response = {
+            "similar": {"a": ["b"]},
+            "model_version": "text-v1",
+            "threshold": 0.7,
+            "language": "en",
+            "num_items": 2,
+            "num_pairs": 1,
+        }
+        second_response = {
+            "similar": {"a": ["c"]},
+            "model_version": "text-v1",
+            "threshold": 0.7,
+            "language": "en",
+            "num_items": 2,
+            "num_pairs": 1,
+        }
+        http_client.post = AsyncMock(
+            side_effect=[_ok_response(first_response), _ok_response(second_response)]
+        )
+        backend = _make_backend(http_client)
+
+        await backend.refresh_duplicate_item_info(
+            [_item("a"), _item("b")], SurfaceId.NEW_TAB_EN_US
+        )
+        await backend.refresh_duplicate_item_info(
+            [_item("a"), _item("c")], SurfaceId.NEW_TAB_EN_US
+        )
+
+        assert http_client.post.await_count == 2
+        text_info = backend.get_similar_stories_text(SurfaceId.NEW_TAB_EN_US)
+        assert text_info is not None
+        assert text_info.neighbors("a") == ["c"]
+
+    @pytest.mark.asyncio
+    async def test_failed_refresh_does_not_cache_content_ids(self):
+        """A failed refresh should retry the same content ids next time."""
+        http_client = MagicMock(spec=AsyncClient)
+        response_body = {
+            "similar": {"a": ["b"]},
+            "model_version": "text-v1",
+            "threshold": 0.7,
+            "language": "en",
+            "num_items": 2,
+            "num_pairs": 1,
+        }
+        http_client.post = AsyncMock(side_effect=[HTTPError("boom"), _ok_response(response_body)])
+        backend = _make_backend(http_client)
+
+        await backend.refresh_duplicate_item_info(
+            [_item("a"), _item("b")], SurfaceId.NEW_TAB_EN_US
+        )
+        await backend.refresh_duplicate_item_info(
+            [_item("a"), _item("b")], SurfaceId.NEW_TAB_EN_US
+        )
+
+        assert http_client.post.await_count == 2
+        text_info = backend.get_similar_stories_text(SurfaceId.NEW_TAB_EN_US)
+        assert text_info is not None
+        assert text_info.neighbors("a") == ["b"]
+
+    @pytest.mark.asyncio
     async def test_http_error_does_not_raise_and_leaves_cache_alone(self):
         """A 5xx from Spindle should be swallowed and the previous cache preserved."""
         http_client = MagicMock(spec=AsyncClient)


### PR DESCRIPTION
## References

JIRA: [AIMOD-1388](https://mozilla-hub.atlassian.net/browse/AIMOD-1388)

## Description
We hash the list of content ids, store for each surface, and only call spindle if the hash has changed. This saves redundant spindle calls.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2475)


[AIMOD-1388]: https://mozilla-hub.atlassian.net/browse/AIMOD-1388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ