### PR TITLE
[AIMOD-1357] Enable AMP Fuzzy Matching Experiment

### DIFF
--- a/merino/configs/production.toml
+++ b/merino/configs/production.toml
@@ -141,7 +141,7 @@ cache = "redis"
 enabled = true
 data_source = "remote"
 gcs_bucket = "merino-ml-data-prod"
-# appended to default (sports, polygon); enables AMP normalization for the experiment
+# appended to default (sports, polygon); only enabled for experiment
 providers = ["adm"]
 
 [production.query_pattern_matching]

--- a/merino/configs/production.toml
+++ b/merino/configs/production.toml
@@ -108,7 +108,7 @@ dry_run = false
 
 [production.providers.adm.fuzzy]
 # MERINO_PROVIDERS__ADM__FUZZY__ENABLED
-enabled = false
+enabled = true
 
 [production.providers.top_picks]
 # MERINO_PROVIDERS__TOP_PICKS__DOMAIN_DATA_SOURCE
@@ -141,6 +141,8 @@ cache = "redis"
 enabled = true
 data_source = "remote"
 gcs_bucket = "merino-ml-data-prod"
+# appended to default (sports, polygon); enables AMP normalization for the experiment
+providers = ["adm"]
 
 [production.query_pattern_matching]
 # MERINO_QUERY_PATTERN_MATCHING__ENABLED

--- a/merino/configs/stage.toml
+++ b/merino/configs/stage.toml
@@ -144,7 +144,7 @@ dummy_attempted_count = 1000
 enabled = true
 data_source = "remote"
 gcs_bucket = "merino-ml-data-stage"
-# appended to default (sports, polygon); enables AMP normalization on stage only
+# appended to default (sports, polygon)
 providers = ["adm"]
 
 [stage.query_pattern_matching]


### PR DESCRIPTION
## References

JIRA: [AIMOD-1357](https://mozilla-hub.atlassian.net/browse/AIMOD-1357)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->
Tested on staging with:
```
curl "https://merino.services.allizom.org/api/v1/suggest?q=amazn&client_variants=amp-fuzzy-matching-treatment"
```
- The experiment hasn't started yet so it won't serve anyone atm.
- Here's the experimenter ticket: https://experimenter.services.mozilla.com/nimbus/amp-fuzzy-matching-experiment/summary/



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2477)


[AIMOD-1357]: https://mozilla-hub.atlassian.net/browse/AIMOD-1357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ