### PR TITLE
[DISCO-4307] Enable query pattern matching in prod for flight + stock

### DIFF
--- a/merino/configs/production.toml
+++ b/merino/configs/production.toml
@@ -147,17 +147,21 @@ providers = ["adm"]
 [production.query_pattern_matching]
 # MERINO_QUERY_PATTERN_MATCHING__ENABLED
 # Master switch. When false the matcher is never built and the hot path is a no-op.
-enabled = false
+enabled = true
 
 # MERINO_QUERY_PATTERN_MATCHING__SAMPLE_RATE
 # Fraction of suggest requests to evaluate, 0.0–1.0. 0.0 disables evaluation.
-sample_rate = 0.0
+sample_rate = 0.1
 
 # MERINO_QUERY_PATTERN_MATCHING__PATTERNS
 # List of { id = "...", regex = "..." }. `id` is a low-cardinality metric label
 # (^[a-z][a-z0-9_]{0,63}$); `regex` is matched case-insensitively. Invalid
 # entries are skipped at build time rather than failing startup.
-patterns = []
+# NOTE: temporary measurement patterns for flight numbers and stock tickers.
+patterns = [
+    { id = "flight_numbers_v1", regex = '(?:\b[A-Za-z]{1,3}\s*\d{1,5}\b)|(?:\b\d\s*[A-Za-z]\s*\d{1,4}\b)' },
+    { id = "stocks_v1", regex = '\b(aapl|msft|amzn|nvda|googl|goog|meta|tsla|nflx|amd)\b' },
+]
 
 [production.ml_recommendations.gcs]
 # MERINO__ML_RECOMMENDATIONS__GCS__GCP_PROJECT


### PR DESCRIPTION
## References

JIRA: [DISCO-4307](https://mozilla-hub.atlassian.net/browse/DISCO-4307)

## Description
 This PR enables query pattern matching in prod using flight + stock ticker patterns.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2479)


[DISCO-4307]: https://mozilla-hub.atlassian.net/browse/DISCO-4307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ