### PR TITLE
[HNT-2158] Add localization logic for potd

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -1218,6 +1218,10 @@ enabled_by_default = false
 # Timeout in seconds for establishing a connection to the Wikimedia Featured API endpoint.
 connect_timeout_sec = 3.0
 
+# MERINO_RSS_PROVIDERS__WIKIMEDIA_POTD__REQUEST_TIMEOUT_SEC
+# Timeout in seconds for reading/writing a single request to the Wikimedia APIs.
+request_timeout_sec = 5.0
+
 # MERINO_RSS_PROVIDERS__WIKIMEDIA_POTD__QUERY_TIMEOUT_SEC
 # A float (in seconds) indicating the maximum waiting period when querying for POTD data.
 query_timeout_sec = 1.0
@@ -1239,6 +1243,15 @@ retry_wait_jitter_seconds = 0.2
 # MERINO_RSS_PROVIDERS__WIKIMEDIA_POTD__FEED_URL
 # Base URL for the Wikimedia Featured API; the backend appends /{yyyy}/{mm}/{dd}.
 feed_url = "https://api.wikimedia.org/feed/v1/wikipedia/en/featured"
+# MERINO_RSS_PROVIDERS__WIKIMEDIA_POTD__FEATURED_API_BASE
+# Base URL for the Wikimedia Featured API; the backend appends
+# /{lang}/featured/{yyyy}/{mm}/{dd} to fetch a language's picture of the day.
+featured_api_base = "https://api.wikimedia.org/feed/v1/wikipedia"
+
+# MERINO_RSS_PROVIDERS__WIKIMEDIA_POTD__COMMONS_API_URL
+# Wikimedia Commons Action API, used to discover which languages have an authored
+# picture of the day description for a given day (Template:Potd/{date} (xx) subpages).
+commons_api_url = "https://commons.wikimedia.org/w/api.php"
 
 # MERINO_RSS_PROVIDERS__WIKIMEDIA_POTD__CACHE_CONTROL
 # Cache control headers for stored images in the bucket (1hr)

--- a/merino/providers/rss/manager.py
+++ b/merino/providers/rss/manager.py
@@ -31,13 +31,15 @@ def _create_provider(provider_id: str, setting: Settings) -> BaseRssProvider:
     match setting.type:
         case RssProviderType.WIKIMEDIA_POTD:
             http_client = create_http_client(
-                base_url=settings.rss_providers.wikimedia_potd.feed_url,
+                base_url=settings.rss_providers.wikimedia_potd.featured_api_base,
                 connect_timeout=settings.rss_providers.wikimedia_potd.connect_timeout_sec,
+                request_timeout=settings.rss_providers.wikimedia_potd.request_timeout_sec,
             )
 
             return WikimediaPictureOfTheDayProvider(
                 backend=WikimediaPictureOfTheDayBackend(
-                    feed_url=setting.feed_url,
+                    featured_api_base=setting.featured_api_base,
+                    commons_api_url=setting.commons_api_url,
                     http_client=http_client,
                     metrics_client=get_metrics_client(),
                     gcs_uploader=GcsUploader(

--- a/merino/providers/rss/wikimedia_potd/backends/protocol.py
+++ b/merino/providers/rss/wikimedia_potd/backends/protocol.py
@@ -68,11 +68,12 @@ class WikimediaPictureOfTheDayBackend(Protocol):
         """
         ...
 
-    async def discover_languages(self, date_str: str) -> list[str]:  # pragma: no cover
+    async def discover_languages(self, date_str: str) -> set[str]:  # pragma: no cover
         """Discover the languages that have an authored POTD description for `date_str`.
 
         Returns:
-            A list of language codes, always including the default language.
+            A set of language codes with an authored description, excluding the default
+            language (en).
         """
         ...
 

--- a/merino/providers/rss/wikimedia_potd/backends/protocol.py
+++ b/merino/providers/rss/wikimedia_potd/backends/protocol.py
@@ -21,10 +21,16 @@ class PictureOfTheDay(BaseModel):
         description="High resolution URL of the picture of the day image."
     )
     published_date: str = Field(description="Date when the image was published.")
-    description: str = Field(description="Description of the image in the default language.")
+    description: str = Field(
+        description="Description of the image in the default (en) or the requested language."
+    )
     localized_descriptions: dict[str, str] = Field(
         default_factory=dict,
-        description="Localized descriptions keyed by language code (e.g. 'de', 'es').",
+        description=(
+            "Localized descriptions keyed by language code (e.g. 'de', 'es'). Server-side "
+            "NOTE: only used to localize `description` for the client's Accept-Language and is "
+            "omitted from the API response."
+        ),
     )
     author: str = Field(default="", description="Name of the image's artist.")
     file_page: HttpUrl | None = Field(default=None, description="Commons file page URL.")

--- a/merino/providers/rss/wikimedia_potd/backends/protocol.py
+++ b/merino/providers/rss/wikimedia_potd/backends/protocol.py
@@ -21,7 +21,11 @@ class PictureOfTheDay(BaseModel):
         description="High resolution URL of the picture of the day image."
     )
     published_date: str = Field(description="Date when the image was published.")
-    description: str = Field(description="Description of the image.")
+    description: str = Field(description="Description of the image in the default language.")
+    localized_descriptions: dict[str, str] = Field(
+        default_factory=dict,
+        description="Localized descriptions keyed by language code (e.g. 'de', 'es').",
+    )
     author: str = Field(default="", description="Name of the image's artist.")
     file_page: HttpUrl | None = Field(default=None, description="Commons file page URL.")
     license_label: str = Field(default="", description="License type, e.g. 'CC BY-SA 4.0'.")
@@ -50,13 +54,19 @@ class WikimediaPictureOfTheDayBackend(Protocol):
         """
         ...
 
-    async def fetch_picture_of_the_day(
-        self,
-    ) -> dict:  # pragma: no cover
-        """Fetch the Wikimedia Featured API picture of the day for today.
+    async def fetch_picture_of_the_day(self, lang: str) -> dict:  # pragma: no cover
+        """Fetch the Wikimedia Featured API picture of the day for today in `lang`.
 
         Returns:
             The parsed JSON response as a dict. Raises WikimediaPotdError on failure.
+        """
+        ...
+
+    async def discover_languages(self, date_str: str) -> list[str]:  # pragma: no cover
+        """Discover the languages that have an authored POTD description for `date_str`.
+
+        Returns:
+            A list of language codes, always including the default language.
         """
         ...
 

--- a/merino/providers/rss/wikimedia_potd/backends/utils.py
+++ b/merino/providers/rss/wikimedia_potd/backends/utils.py
@@ -1,5 +1,6 @@
 """Utility functions for parsing Wikimedia Featured API picture of the day data."""
 
+import re
 from datetime import datetime, timezone
 from pydantic import HttpUrl
 
@@ -12,6 +13,11 @@ from merino.providers.rss.wikimedia_potd.backends.protocol import (
 WIKIMEDIA_REQUEST_HEADERS = {
     "User-Agent": "Mozilla/5.0 (compatible; Merino/1.0; +https://github.com/mozilla-services/merino-py)"
 }
+
+# Commons stores each language's POTD description on its own template subpage titled
+# "Template:Potd/{date} ({lang})", so the trailing parenthesized code is the language.
+# The bare "Template:Potd/{date}" page (the file selector) has no suffix and is ignored.
+POTD_DESCRIPTION_LANG_RE = re.compile(r"\(([\w-]+)\)$")
 
 
 def parse_potd(data: dict) -> PictureOfTheDay:
@@ -49,6 +55,33 @@ def parse_potd(data: dict) -> PictureOfTheDay:
         license_label=lic.get("type", ""),
         license_link=HttpUrl(lic["url"]) if lic.get("url") else None,
     )
+
+
+def extract_image_description_with_lang_code(data: dict) -> tuple[str, str]:
+    """Extract the image description language and text from a Wikimedia Featured API response.
+
+    Returns:
+        A (lang, text) tuple. Both are empty strings when the description is absent.
+    """
+    description = data.get("image", {}).get("description", {})
+    return description.get("lang", ""), description.get("text", "")
+
+
+def parse_discovered_languages(commons_data: dict) -> list[str]:
+    """Extract POTD description language codes from a Commons allpages response.
+
+    Returns:
+        The list of discovered language codes, in the order returned by the API.
+    """
+    pages = commons_data.get("query", {}).get("allpages", [])
+
+    discovered_languages = []
+    for page in pages:
+        match = POTD_DESCRIPTION_LANG_RE.search(page.get("title", ""))
+        if match:
+            discovered_languages.append(match.group(1))
+
+    return discovered_languages
 
 
 def build_potd_bucket_directory_path() -> str:

--- a/merino/providers/rss/wikimedia_potd/backends/utils.py
+++ b/merino/providers/rss/wikimedia_potd/backends/utils.py
@@ -67,19 +67,20 @@ def extract_image_description_with_lang_code(data: dict) -> tuple[str, str]:
     return description.get("lang", ""), description.get("text", "")
 
 
-def parse_discovered_languages(commons_data: dict) -> list[str]:
+def parse_discovered_languages(commons_data: dict) -> set[str]:
     """Extract POTD description language codes from a Commons allpages response.
 
     Returns:
-        The list of discovered language codes, in the order returned by the API.
+        A set of discovered language codes, in the order returned by the API.
     """
     pages = commons_data.get("query", {}).get("allpages", [])
 
-    discovered_languages = []
+    discovered_languages: set[str] = set()
+
     for page in pages:
         match = POTD_DESCRIPTION_LANG_RE.search(page.get("title", ""))
         if match:
-            discovered_languages.append(match.group(1))
+            discovered_languages.add(match.group(1))
 
     return discovered_languages
 

--- a/merino/providers/rss/wikimedia_potd/backends/wikimedia_potd.py
+++ b/merino/providers/rss/wikimedia_potd/backends/wikimedia_potd.py
@@ -77,9 +77,9 @@ class WikimediaPictureOfTheDayBackend:
             # parse the response to extract a PictureOfTheDay instance
             potd = parse_potd(potd_en)
 
-            # collect localized image descriptions keyed by language; "en" is already excluded
-            # during discovery (it is the default description), so this maps only non-English
-            # languages and is empty when no localized descriptions exist
+            # collect localized image descriptions keyed by language, "en" is already excluded
+            # during discovery (it is the default description). This maps only non-English
+            # languages and is empty when no localized descriptions exist.
             localized_descriptions = await self.fetch_localized_descriptions(languages)
 
             # download thumbnail and high resolution images and get the respective cdn urls

--- a/merino/providers/rss/wikimedia_potd/backends/wikimedia_potd.py
+++ b/merino/providers/rss/wikimedia_potd/backends/wikimedia_potd.py
@@ -77,8 +77,9 @@ class WikimediaPictureOfTheDayBackend:
             # parse the response to extract a PictureOfTheDay instance
             potd = parse_potd(potd_en)
 
-            # collect localized image descriptions keyed by language ("en" is skipped since it
-            # is already the default description, so an en-only discovery yields an empty map)
+            # collect localized image descriptions keyed by language; "en" is already excluded
+            # during discovery (it is the default description), so this maps only non-English
+            # languages and is empty when no localized descriptions exist
             localized_descriptions = await self.fetch_localized_descriptions(languages)
 
             # download thumbnail and high resolution images and get the respective cdn urls
@@ -99,15 +100,16 @@ class WikimediaPictureOfTheDayBackend:
             sentry_sdk.capture_exception(ex)
             return False
 
-    async def discover_languages(self, date_str: str) -> list[str]:
+    async def discover_languages(self, date_str: str) -> set[str]:
         """Discover the languages with an authored POTD description for `date_str`.
 
         Queries the Wikimedia Commons allpages API for the "Template:Potd/{date} ({lang})"
-        subpages that exist for the day. Discovery failures fallback to just the default
-        language (en) rather than failing the upload, and the default language is always included.
+        subpages that exist for the day. The default language (en) is excluded because it is
+        already the default description on the potd. A discovery failure degrades to an empty
+        set (logged, not raised) rather than failing the upload.
 
         Returns:
-            A list of language codes, always containing the default language.
+            A set of language codes with an authored description, excluding en.
         """
         params = {
             "action": "query",
@@ -118,22 +120,17 @@ class WikimediaPictureOfTheDayBackend:
             "aplimit": "500",
         }
 
-        # make sure "en" is in the list as a default
-        languages = ["en"]
+        discovered_languages: set[str] = set()
 
         try:
             response: Response = await self.http_client.get(
                 self.commons_api_url, params=params, headers=WIKIMEDIA_REQUEST_HEADERS
             )
             response.raise_for_status()
-            discovered_languages = parse_discovered_languages(response.json())
+            discovered_languages.update(parse_discovered_languages(response.json()))
 
-            # make sure we don't include a duplicate "en"
-            if "en" in discovered_languages:
-                discovered_languages.remove("en")
-
-            # append the list with discovered languages
-            languages.extend(discovered_languages)
+            # "en" is the default description already on the potd, so never fetch it again
+            discovered_languages.discard("en")
 
         except Exception as ex:
             logger.warning(
@@ -141,15 +138,15 @@ class WikimediaPictureOfTheDayBackend:
                 extra={"error": str(ex), "date": date_str},
             )
 
-        return languages
+        return discovered_languages
 
-    async def fetch_localized_descriptions(self, languages: list[str]) -> dict[str, str]:
+    async def fetch_localized_descriptions(self, languages: set[str]) -> dict[str, str]:
         """Fetch a description for each language, keeping only genuinely localized text.
 
-        "en" is skipped because its description is already the default on the potd object.
-        For every other language the Featured API silently returns the English description
-        when no localization exists, so a response whose description comes back as "en" is
-        dropped rather than stored as a duplicate.
+        "en" is excluded upstream by `discover_languages` because its description is already
+        the default on the potd object. For every other language the Featured API silently
+        returns the English description when no localization exists, so a response whose
+        description comes back as "en" is dropped rather than stored as a duplicate.
 
         Returns:
             A mapping of language code to localized description text.
@@ -157,9 +154,6 @@ class WikimediaPictureOfTheDayBackend:
         localized_descriptions: dict[str, str] = {}
 
         for lang in languages:
-            # we already have the default (en) description on the potd object
-            if lang == "en":
-                continue
             try:
                 potd_in_lang = await self.fetch_picture_of_the_day(lang)
                 lang_code, description = extract_image_description_with_lang_code(potd_in_lang)

--- a/merino/providers/rss/wikimedia_potd/backends/wikimedia_potd.py
+++ b/merino/providers/rss/wikimedia_potd/backends/wikimedia_potd.py
@@ -23,6 +23,8 @@ from merino.utils.gcs.models import Image
 from merino.providers.rss.wikimedia_potd.backends.utils import (
     WIKIMEDIA_REQUEST_HEADERS,
     parse_potd,
+    extract_image_description_with_lang_code,
+    parse_discovered_languages,
     build_potd_bucket_directory_path,
     is_valid_potd_image_url,
 )
@@ -42,11 +44,13 @@ class WikimediaPictureOfTheDayBackend:
         self,
         metrics_client: aiodogstatsd.Client,
         http_client: AsyncClient,
-        feed_url: str,
+        featured_api_base: str,
+        commons_api_url: str,
         gcs_uploader: GcsUploader,
     ) -> None:
-        """Initialize the backend with the Featured API base url."""
-        self.feed_url = feed_url
+        """Initialize the backend with the Featured API base url and Commons discovery url."""
+        self.featured_api_base = featured_api_base
+        self.commons_api_url = commons_api_url
         self.metrics_client = metrics_client
         self.http_client = http_client
         self.gcs_uploader = gcs_uploader
@@ -62,17 +66,30 @@ class WikimediaPictureOfTheDayBackend:
         # This is the single error boundary for the upload job: every helper below either
         # returns a value or raises, and any failure is reported to Sentry once here.
         try:
-            # fetch today's Wikimedia Featured API response
-            data = await self.fetch_picture_of_the_day()
+            today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+            # discover which languages have an authored description for today's picture
+            languages = await self.discover_languages(today)
+
+            # fetch the default (en) response for the image urls and base metadata
+            potd_en = await self.fetch_picture_of_the_day("en")
 
             # parse the response to extract a PictureOfTheDay instance
-            potd = parse_potd(data)
+            potd = parse_potd(potd_en)
+
+            # collect localized image descriptions keyed by language ("en" is skipped since it
+            # is already the default description, so an en-only discovery yields an empty map)
+            localized_descriptions = await self.fetch_localized_descriptions(languages)
 
             # download thumbnail and high resolution images and get the respective cdn urls
             thumbnail_url, hi_res_url = await self.download_and_upload_potd_images(potd)
 
             potd_to_upload = potd.model_copy(
-                update={"thumbnail_image_url": thumbnail_url, "high_res_image_url": hi_res_url}
+                update={
+                    "thumbnail_image_url": thumbnail_url,
+                    "high_res_image_url": hi_res_url,
+                    "localized_descriptions": localized_descriptions,
+                }
             )
 
             self.upload_potd_manifest(potd_to_upload)
@@ -81,6 +98,87 @@ class WikimediaPictureOfTheDayBackend:
         except Exception as ex:
             sentry_sdk.capture_exception(ex)
             return False
+
+    async def discover_languages(self, date_str: str) -> list[str]:
+        """Discover the languages with an authored POTD description for `date_str`.
+
+        Queries the Wikimedia Commons allpages API for the "Template:Potd/{date} ({lang})"
+        subpages that exist for the day. Discovery failures fallback to just the default
+        language (en) rather than failing the upload, and the default language is always included.
+
+        Returns:
+            A list of language codes, always containing the default language.
+        """
+        params = {
+            "action": "query",
+            "format": "json",
+            "list": "allpages",
+            "apprefix": f"Potd/{date_str}",
+            "apnamespace": "10",
+            "aplimit": "500",
+        }
+
+        # make sure "en" is in the list as a default
+        languages = ["en"]
+
+        try:
+            response: Response = await self.http_client.get(
+                self.commons_api_url, params=params, headers=WIKIMEDIA_REQUEST_HEADERS
+            )
+            response.raise_for_status()
+            discovered_languages = parse_discovered_languages(response.json())
+
+            # make sure we don't include a duplicate "en"
+            if "en" in discovered_languages:
+                discovered_languages.remove("en")
+
+            # append the list with discovered languages
+            languages.extend(discovered_languages)
+
+        except Exception as ex:
+            logger.warning(
+                "Failed to discover POTD description languages",
+                extra={"error": str(ex), "date": date_str},
+            )
+
+        return languages
+
+    async def fetch_localized_descriptions(self, languages: list[str]) -> dict[str, str]:
+        """Fetch a description for each language, keeping only genuinely localized text.
+
+        "en" is skipped because its description is already the default on the potd object.
+        For every other language the Featured API silently returns the English description
+        when no localization exists, so a response whose description comes back as "en" is
+        dropped rather than stored as a duplicate.
+
+        Returns:
+            A mapping of language code to localized description text.
+        """
+        localized_descriptions: dict[str, str] = {}
+
+        for lang in languages:
+            # we already have the default (en) description on the potd object
+            if lang == "en":
+                continue
+            try:
+                potd_in_lang = await self.fetch_picture_of_the_day(lang)
+                lang_code, description = extract_image_description_with_lang_code(potd_in_lang)
+            except Exception as ex:
+                logger.warning(
+                    "Failed to fetch localized POTD description",
+                    extra={"error": str(ex), "lang": lang},
+                )
+                continue
+
+            # wikimedia featured api call returns English description as a fallback,
+            # making sure not to add duplicate English descriptions as we have it on the default potd already.
+            # so a call for potd to the Featured API, in Italian ("it"),
+            # could return the fall back "en" version even if the language discovery call returned with "it"
+            # as one of the supported languages for this potd.
+            if description and lang_code != "en":
+                localized_descriptions[lang_code] = description
+
+        return localized_descriptions
 
     async def download_and_upload_potd_images(
         self, potd: PictureOfTheDay
@@ -112,8 +210,8 @@ class WikimediaPictureOfTheDayBackend:
         reraise=True,
         before_sleep=before_sleep_log(logger, logging.INFO),
     )
-    async def fetch_picture_of_the_day(self) -> dict:
-        """Fetch the Wikimedia Featured API picture of the day for today.
+    async def fetch_picture_of_the_day(self, lang: str) -> dict:
+        """Fetch the Wikimedia Featured API picture of the day for today in `lang`.
 
         Retries transient failures with exponential backoff before giving up; the final
         failure is re-raised so the upload job's error boundary reports it once.
@@ -124,8 +222,8 @@ class WikimediaPictureOfTheDayBackend:
         # setting the format to YYYY/MM/DD which is accepted as the url param
         today = datetime.now(timezone.utc).strftime("%Y/%m/%d")
 
-        # the Featured API expects the date in the url path: .../en/featured/{yyyy}/{mm}/{dd}
-        url = f"{self.feed_url}/{today}"
+        # the Featured API expects lang and date in the url path: .../{lang}/featured/{yyyy}/{mm}/{dd}
+        url = f"{self.featured_api_base}/{lang}/featured/{today}"
 
         response: Response = await self.http_client.get(url, headers=WIKIMEDIA_REQUEST_HEADERS)
 

--- a/merino/providers/rss/wikimedia_potd/provider.py
+++ b/merino/providers/rss/wikimedia_potd/provider.py
@@ -67,12 +67,39 @@ class WikimediaPictureOfTheDayProvider(BaseRssProvider):
 
         await self._refresh_potd()
 
-    async def get_picture_of_the_day(self) -> PictureOfTheDay | None:
+    @staticmethod
+    def _select_description(
+        potd: PictureOfTheDay, accepted_languages: list[str] | None
+    ) -> str | None:
+        """Return the best localized description for `accepted_languages`, or None.
+
+        Each accepted language is matched against the potd's localized descriptions, trying
+        the full code first (e.g. "pt-br") then the base subtag (e.g. "pt"), in the client's
+        order of preference. Returns None when no localized description matches, so callers
+        keep the default-language description already on the model.
+        """
+        if not accepted_languages or len(potd.localized_descriptions) == 0:
+            return None
+
+        for language in accepted_languages:
+            code = language.lower()
+            if code in potd.localized_descriptions:
+                return potd.localized_descriptions[code]
+            base = code.split("-")[0]
+            if base in potd.localized_descriptions:
+                return potd.localized_descriptions[base]
+
+        return None
+
+    async def get_picture_of_the_day(
+        self, accepted_languages: list[str] | None = None
+    ) -> PictureOfTheDay | None:
         """Return the Wikimedia Picture of the Day, or None if none has ever been cached.
 
         Re-fetches when the cached potd is missing or from a previous day. When today's
         potd isn't available yet we serve the previous day's cached potd rather than
-        nothing.
+        nothing. When `accepted_languages` matches a localized description, the returned
+        potd's `description` is swapped for it; otherwise the default description is kept.
         """
         if not self._is_todays_potd(self.potd):
             await self._refresh_potd()
@@ -80,6 +107,14 @@ class WikimediaPictureOfTheDayProvider(BaseRssProvider):
         # TODO @herraj jira: [HNT-2162]
         # add a metric to track when we serve a stale (previous-day) potd here
         # because today's picture isn't yet available in the gcs bucket.
+        if self.potd is None:
+            return None
+
+        localized = self._select_description(self.potd, accepted_languages)
+
+        if localized is not None:
+            return self.potd.model_copy(update={"description": localized})
+
         return self.potd
 
     async def upload_picture_of_the_day(self) -> bool:

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -674,10 +674,11 @@ async def get_picture_of_the_day(
     accept_language: Annotated[str | None, Header(max_length=HEADER_CHARACTER_MAX)] = None,
     provider: WikimediaPictureOfTheDayProvider = Depends(get_wikimedia_potd_provider),
 ) -> Response:  # pragma: no cover
-    """Get the picture of the day."""
+    """Get the picture of the day, localized to the client's Accept-Language when available."""
     potd = None
     try:
-        potd = await provider.get_picture_of_the_day()
+        languages = get_accepted_languages(accept_language)
+        potd = await provider.get_picture_of_the_day(languages)
     except Exception as ex:
         logger.info(f"Something went wrong when fetching potd: {ex.__class__.__name__}")
 

--- a/merino/web/api_v1.py
+++ b/merino/web/api_v1.py
@@ -673,7 +673,7 @@ async def get_picture_of_the_day(
     request: Request,
     accept_language: Annotated[str | None, Header(max_length=HEADER_CHARACTER_MAX)] = None,
     provider: WikimediaPictureOfTheDayProvider = Depends(get_wikimedia_potd_provider),
-) -> Response:  # pragma: no cover
+) -> Response:
     """Get the picture of the day, localized to the client's Accept-Language when available."""
     potd = None
     try:
@@ -682,8 +682,11 @@ async def get_picture_of_the_day(
     except Exception as ex:
         logger.info(f"Something went wrong when fetching potd: {ex.__class__.__name__}")
 
+    # localized_descriptions is a server-side selection map used to swap `description` into
+    # the client's language; it is not part of the client-facing contract, so exclude it here
+    # (but keep it on the model and in the GCS manifest, which localization reads back from).
     return JSONResponse(
-        content=jsonable_encoder(potd),
+        content=jsonable_encoder(potd, exclude={"localized_descriptions"}),
     )
 
 

--- a/tests/integration/providers/rss/potd/test_wikimedia_potd.py
+++ b/tests/integration/providers/rss/potd/test_wikimedia_potd.py
@@ -118,8 +118,6 @@ class TestUploadPictureOfTheDayMethod:
     async def test_upload_picture_of_the_day_stores_localized_descriptions(
         self,
         backend: WikimediaPictureOfTheDayBackend,
-        gcs_storage_client,
-        gcs_storage_bucket,
         mocker: MockerFixture,
     ) -> None:
         """Discovers languages, keeps localized descriptions, and drops English fallbacks."""
@@ -137,12 +135,13 @@ class TestUploadPictureOfTheDayMethod:
             },
             request=Request(method="GET", url=FEED_URL),
         )
-        # de has an authored description; fr does not, so the API returns the English fallback.
+
         de_response = Response(
             status_code=200,
             json={"image": {"description": {"lang": "de", "text": "Deutscher Text"}}},
             request=Request(method="GET", url=FEED_URL),
         )
+        # fr does not have a description so the API returns the English fallback.
         fr_fallback_response = Response(
             status_code=200,
             json={"image": {"description": {"lang": "en", "text": "English fallback"}}},
@@ -155,16 +154,17 @@ class TestUploadPictureOfTheDayMethod:
         )
 
         client_mock: AsyncMock = cast(AsyncMock, backend.http_client)
-        # order: discover (commons), fetch en (base), then localized de + fr fetches
+
+        # side effect values set in order of requests
         client_mock.get.side_effect = [
             commons_response,
             en_response,
             de_response,
             fr_fallback_response,
         ]
-        mocker.patch.object(backend, "download_potd_image").return_value = Image(
-            content=b"255", content_type="Image/png"
-        )
+
+        backend_download_method_mock = mocker.patch.object(backend, "download_potd_image")
+        backend_download_method_mock.return_value = Image(content=b"255", content_type="Image/png")
 
         result = await backend.upload_picture_of_the_day()
         assert result is True
@@ -175,8 +175,8 @@ class TestUploadPictureOfTheDayMethod:
         # "en" stays on potd.description and is never duplicated into localized_descriptions
         assert potd_manifest.description == "The Milky Way over the Sagittarius region."
         assert potd_manifest.localized_descriptions == {"de": "Deutscher Text"}
-        # the image is downloaded once and shared across languages
-        assert backend.download_potd_image.call_count == 2  # thumbnail + hi-res, once each
+        # assert that image download is only called twice (thumbnail and hi-res)
+        assert backend_download_method_mock.call_count == 2
 
     @freezegun.freeze_time("2026-06-24")
     @pytest.mark.asyncio

--- a/tests/integration/providers/rss/potd/test_wikimedia_potd.py
+++ b/tests/integration/providers/rss/potd/test_wikimedia_potd.py
@@ -44,7 +44,8 @@ def fixture_backend(
     return WikimediaPictureOfTheDayBackend(
         metrics_client=statsd_mock,
         http_client=mocker.AsyncMock(spec=AsyncClient),
-        feed_url="https://example.com/feed",
+        featured_api_base="https://example.com/feed",
+        commons_api_url="https://commons.example.com/w/api.php",
         gcs_uploader=GcsUploader(
             destination_gcp_project=gcs_storage_client.project,
             destination_bucket_name=gcs_storage_bucket.name,
@@ -111,6 +112,71 @@ class TestUploadPictureOfTheDayMethod:
         assert potd_blobs[0].name == "wikimedia_potd/2026-06-24/hi_res.png"
         assert potd_blobs[1].name == "wikimedia_potd/2026-06-24/potd.json"
         assert potd_blobs[2].name == "wikimedia_potd/2026-06-24/thumbnail.png"
+
+    @freezegun.freeze_time("2026-06-24")
+    @pytest.mark.asyncio
+    async def test_upload_picture_of_the_day_stores_localized_descriptions(
+        self,
+        backend: WikimediaPictureOfTheDayBackend,
+        gcs_storage_client,
+        gcs_storage_bucket,
+        mocker: MockerFixture,
+    ) -> None:
+        """Discovers languages, keeps localized descriptions, and drops English fallbacks."""
+        commons_response = Response(
+            status_code=200,
+            json={
+                "query": {
+                    "allpages": [
+                        {"title": "Template:Potd/2026-06-24"},
+                        {"title": "Template:Potd/2026-06-24 (en)"},
+                        {"title": "Template:Potd/2026-06-24 (de)"},
+                        {"title": "Template:Potd/2026-06-24 (fr)"},
+                    ]
+                }
+            },
+            request=Request(method="GET", url=FEED_URL),
+        )
+        # de has an authored description; fr does not, so the API returns the English fallback.
+        de_response = Response(
+            status_code=200,
+            json={"image": {"description": {"lang": "de", "text": "Deutscher Text"}}},
+            request=Request(method="GET", url=FEED_URL),
+        )
+        fr_fallback_response = Response(
+            status_code=200,
+            json={"image": {"description": {"lang": "en", "text": "English fallback"}}},
+            request=Request(method="GET", url=FEED_URL),
+        )
+        en_response = Response(
+            status_code=200,
+            content=TEST_FEATURED_JSON,
+            request=Request(method="GET", url=FEED_URL),
+        )
+
+        client_mock: AsyncMock = cast(AsyncMock, backend.http_client)
+        # order: discover (commons), fetch en (base), then localized de + fr fetches
+        client_mock.get.side_effect = [
+            commons_response,
+            en_response,
+            de_response,
+            fr_fallback_response,
+        ]
+        mocker.patch.object(backend, "download_potd_image").return_value = Image(
+            content=b"255", content_type="Image/png"
+        )
+
+        result = await backend.upload_picture_of_the_day()
+        assert result is True
+
+        potd_manifest = backend.fetch_potd_from_gcs_bucket()
+
+        assert potd_manifest is not None
+        # "en" stays on potd.description and is never duplicated into localized_descriptions
+        assert potd_manifest.description == "The Milky Way over the Sagittarius region."
+        assert potd_manifest.localized_descriptions == {"de": "Deutscher Text"}
+        # the image is downloaded once and shared across languages
+        assert backend.download_potd_image.call_count == 2  # thumbnail + hi-res, once each
 
     @freezegun.freeze_time("2026-06-24")
     @pytest.mark.asyncio
@@ -257,7 +323,7 @@ class TestFetchPictureOfTheDayMethod:
         )
 
         with pytest.raises(WikimediaPotdError):
-            await backend.fetch_picture_of_the_day()
+            await backend.fetch_picture_of_the_day("en")
 
 
 class TestUploadImageMethod:

--- a/tests/unit/providers/rss/wikimedia_potd/backends/test_utils.py
+++ b/tests/unit/providers/rss/wikimedia_potd/backends/test_utils.py
@@ -15,6 +15,8 @@ from merino.providers.rss.wikimedia_potd.backends.protocol import (
 from merino.providers.rss.wikimedia_potd.backends.utils import (
     is_valid_potd_image_url,
     parse_potd,
+    extract_image_description_with_lang_code,
+    parse_discovered_languages,
     build_potd_bucket_directory_path,
 )
 
@@ -146,3 +148,45 @@ def test_is_valid_potd_image_url(url: HttpUrl, expected: bool) -> None:
 def test_build_potd_bucket_directory_path() -> None:
     """Test build_potd_bucket_directory_path returns the dated gcs bucket directory path."""
     assert build_potd_bucket_directory_path() == "wikimedia_potd/2026-06-07/"
+
+
+def test_extract_image_description_with_lang_code_returns_lang_and_text(featured: dict) -> None:
+    """Returns the description language and text from a Featured API response."""
+    featured["image"]["description"] = {"lang": "de", "text": "Deutscher Text"}
+
+    assert extract_image_description_with_lang_code(featured) == ("de", "Deutscher Text")
+
+
+@pytest.mark.parametrize(
+    ["data"],
+    [
+        ({"image": {"description": {}}},),
+        ({"image": {}},),
+        ({},),
+    ],
+    ids=["empty-description", "no-description", "no-image"],
+)
+def test_extract_image_description_with_lang_code_defaults_to_empty(data: dict) -> None:
+    """Returns empty strings when the description or image is absent."""
+    assert extract_image_description_with_lang_code(data) == ("", "")
+
+
+def test_parse_discovered_languages_extracts_codes() -> None:
+    """Extracts language codes and skips the bare file-selector subpage."""
+    commons_data = {
+        "query": {
+            "allpages": [
+                {"title": "Template:Potd/2026-07-14"},
+                {"title": "Template:Potd/2026-07-14 (de)"},
+                {"title": "Template:Potd/2026-07-14 (es)"},
+                {"title": "Template:Potd/2026-07-14 (zh-hans)"},
+            ]
+        }
+    }
+
+    assert parse_discovered_languages(commons_data) == ["de", "es", "zh-hans"]
+
+
+def test_parse_discovered_languages_returns_empty_when_no_pages() -> None:
+    """Returns an empty list when the Commons response has no allpages."""
+    assert parse_discovered_languages({}) == []

--- a/tests/unit/providers/rss/wikimedia_potd/backends/test_utils.py
+++ b/tests/unit/providers/rss/wikimedia_potd/backends/test_utils.py
@@ -184,9 +184,9 @@ def test_parse_discovered_languages_extracts_codes() -> None:
         }
     }
 
-    assert parse_discovered_languages(commons_data) == ["de", "es", "zh-hans"]
+    assert parse_discovered_languages(commons_data) == {"de", "es", "zh-hans"}
 
 
 def test_parse_discovered_languages_returns_empty_when_no_pages() -> None:
-    """Returns an empty list when the Commons response has no allpages."""
-    assert parse_discovered_languages({}) == []
+    """Returns an empty set when the Commons response has no allpages."""
+    assert parse_discovered_languages({}) == set()

--- a/tests/unit/providers/rss/wikimedia_potd/backends/test_wikimedia_potd_backend.py
+++ b/tests/unit/providers/rss/wikimedia_potd/backends/test_wikimedia_potd_backend.py
@@ -309,37 +309,14 @@ class TestFetchPictureOfTheDayMethod:
             await backend.fetch_picture_of_the_day("en")
 
 
-class TestFetchPictureOfTheDayLanguage:
-    """Tests that fetch_picture_of_the_day requests the given language."""
-
-    @pytest.mark.asyncio
-    @freezegun.freeze_time("2026-06-24")
-    async def test_fetch_potd_uses_requested_language_in_url(
-        self, backend: WikimediaPictureOfTheDayBackend
-    ) -> None:
-        """Builds the Featured API url with the requested language segment."""
-        client_mock: AsyncMock = cast(AsyncMock, backend.http_client)
-        client_mock.get.return_value = Response(
-            status_code=200,
-            content=TEST_FEATURED_JSON.encode(),
-            request=Request(method="GET", url=FEED_URL),
-        )
-
-        await backend.fetch_picture_of_the_day("de")
-
-        client_mock.get.assert_called_once_with(
-            f"{FEED_URL}/de/featured/2026/06/24", headers=WIKIMEDIA_REQUEST_HEADERS
-        )
-
-
 class TestDiscoverLanguages:
     """Tests for the discover_languages method."""
 
     @pytest.mark.asyncio
-    async def test_discover_languages_parses_commons_subpages(
+    async def test_discover_languages_parses_commons_subpages_for_a_given_date(
         self, backend: WikimediaPictureOfTheDayBackend
     ) -> None:
-        """Parses language codes from Commons subpages and prepends the default language."""
+        """Parses language codes from Commons subpages and prepends the default language for a given date."""
         commons_json = {
             "query": {
                 "allpages": [
@@ -359,15 +336,12 @@ class TestDiscoverLanguages:
         result = await backend.discover_languages("2026-06-24")
 
         assert result == ["en", "de", "es"]
-        _, kwargs = client_mock.get.call_args
-        assert kwargs["params"]["apprefix"] == "Potd/2026-06-24"
-        assert kwargs["params"]["apnamespace"] == "10"
 
     @pytest.mark.asyncio
-    async def test_discover_languages_does_not_duplicate_default(
+    async def test_discover_languages_does_not_duplicate_fallback_language(
         self, backend: WikimediaPictureOfTheDayBackend
     ) -> None:
-        """Does not append the default language again when Commons already lists it."""
+        """Does not append the fallback language (en) again when Commons already lists it."""
         commons_json = {
             "query": {
                 "allpages": [
@@ -388,10 +362,10 @@ class TestDiscoverLanguages:
         assert result == ["en", "de"]
 
     @pytest.mark.asyncio
-    async def test_discover_languages_falls_back_to_default_on_error(
+    async def test_discover_languages_falls_back_to_en_on_error(
         self, backend: WikimediaPictureOfTheDayBackend
     ) -> None:
-        """Returns just the default language when the Commons request fails."""
+        """Returns just the fallback (en) when the Commons request fails."""
         client_mock: AsyncMock = cast(AsyncMock, backend.http_client)
         client_mock.get.side_effect = HTTPError("commons down")
 
@@ -404,10 +378,10 @@ class TestFetchLocalizedDescriptions:
     """Tests for the fetch_localized_descriptions method."""
 
     @pytest.mark.asyncio
-    async def test_skips_en_keeps_localized_drops_fallbacks(
+    async def test_only_returns_de_localized_description(
         self, backend: WikimediaPictureOfTheDayBackend
     ) -> None:
-        """Skips "en", keeps genuinely localized text, and drops English fallbacks."""
+        """Skip en and fr_fallback and return just de as the only valid localized description"""
         de_data = {"image": {"description": {"lang": "de", "text": "Deutscher Text"}}}
         # fr has no authored description, so the API returns the English fallback.
         fr_fallback = {"image": {"description": {"lang": "en", "text": "English text"}}}
@@ -422,16 +396,16 @@ class TestFetchLocalizedDescriptions:
 
         result = await backend.fetch_localized_descriptions(["en", "de", "fr"])
 
-        # "en" is never fetched or stored; only "de" is fetched and both requests are localized
+        # "en" is never fetched or stored, only "de" is fetched and both requests are localized
         assert result == {"de": "Deutscher Text"}
 
     @pytest.mark.asyncio
     async def test_skips_language_when_fetch_raises(
         self, backend: WikimediaPictureOfTheDayBackend
     ) -> None:
-        """Skips a language whose fetch raises, keeping the rest of the map intact."""
+        """Skips a language whose fetch raises, keeping the rest of the dict intact."""
         client_mock: AsyncMock = cast(AsyncMock, backend.http_client)
-        client_mock.get.side_effect = HTTPError("boom")
+        client_mock.get.side_effect = HTTPError("Unexpected error")
 
         result = await backend.fetch_localized_descriptions(["en", "de"])
 

--- a/tests/unit/providers/rss/wikimedia_potd/backends/test_wikimedia_potd_backend.py
+++ b/tests/unit/providers/rss/wikimedia_potd/backends/test_wikimedia_potd_backend.py
@@ -316,7 +316,7 @@ class TestDiscoverLanguages:
     async def test_discover_languages_parses_commons_subpages_for_a_given_date(
         self, backend: WikimediaPictureOfTheDayBackend
     ) -> None:
-        """Parses language codes from Commons subpages and prepends the default language for a given date."""
+        """Parses language codes from Commons subpages for a given date."""
         commons_json = {
             "query": {
                 "allpages": [
@@ -335,13 +335,13 @@ class TestDiscoverLanguages:
 
         result = await backend.discover_languages("2026-06-24")
 
-        assert result == ["en", "de", "es"]
+        assert result == {"de", "es"}
 
     @pytest.mark.asyncio
-    async def test_discover_languages_does_not_duplicate_fallback_language(
+    async def test_discover_languages_excludes_en(
         self, backend: WikimediaPictureOfTheDayBackend
     ) -> None:
-        """Does not append the fallback language (en) again when Commons already lists it."""
+        """Excludes "en" from the discovered set since it is already the default description."""
         commons_json = {
             "query": {
                 "allpages": [
@@ -359,19 +359,19 @@ class TestDiscoverLanguages:
 
         result = await backend.discover_languages("2026-06-24")
 
-        assert result == ["en", "de"]
+        assert result == {"de"}
 
     @pytest.mark.asyncio
-    async def test_discover_languages_falls_back_to_en_on_error(
+    async def test_discover_languages_returns_empty_set_on_error(
         self, backend: WikimediaPictureOfTheDayBackend
     ) -> None:
-        """Returns just the fallback (en) when the Commons request fails."""
+        """Returns an empty set when the Commons request fails."""
         client_mock: AsyncMock = cast(AsyncMock, backend.http_client)
         client_mock.get.side_effect = HTTPError("commons down")
 
         result = await backend.discover_languages("2026-06-24")
 
-        assert result == ["en"]
+        assert result == set()
 
 
 class TestFetchLocalizedDescriptions:
@@ -381,7 +381,7 @@ class TestFetchLocalizedDescriptions:
     async def test_only_returns_de_localized_description(
         self, backend: WikimediaPictureOfTheDayBackend
     ) -> None:
-        """Skip en and fr_fallback and return just de as the only valid localized description"""
+        """Keeps a genuinely localized description (de) and drops the English fallback (fr)."""
         de_data = {"image": {"description": {"lang": "de", "text": "Deutscher Text"}}}
         # fr has no authored description, so the API returns the English fallback.
         fr_fallback = {"image": {"description": {"lang": "en", "text": "English text"}}}
@@ -394,9 +394,9 @@ class TestFetchLocalizedDescriptions:
             ),
         ]
 
-        result = await backend.fetch_localized_descriptions(["en", "de", "fr"])
+        result = await backend.fetch_localized_descriptions({"de", "fr"})
 
-        # "en" is never fetched or stored, only "de" is fetched and both requests are localized
+        # de is kept; the fr response came back as an "en" fallback, so it is dropped
         assert result == {"de": "Deutscher Text"}
 
     @pytest.mark.asyncio
@@ -407,7 +407,7 @@ class TestFetchLocalizedDescriptions:
         client_mock: AsyncMock = cast(AsyncMock, backend.http_client)
         client_mock.get.side_effect = HTTPError("Unexpected error")
 
-        result = await backend.fetch_localized_descriptions(["en", "de"])
+        result = await backend.fetch_localized_descriptions({"de"})
 
         assert result == {}
 
@@ -423,7 +423,7 @@ class TestFetchLocalizedDescriptions:
             status_code=200, json=de_empty, request=Request(method="GET", url=FEED_URL)
         )
 
-        result = await backend.fetch_localized_descriptions(["en", "de"])
+        result = await backend.fetch_localized_descriptions({"de"})
 
         assert result == {}
 
@@ -445,7 +445,7 @@ class TestFetchLocalizedDescriptions:
             ),
         ]
 
-        result = await backend.fetch_picture_of_the_day()
+        result = await backend.fetch_picture_of_the_day("en")
 
         assert result["image"]["title"] == "File:Milky Way over Sagittarius.jpg"
         assert client_mock.get.call_count == 3
@@ -461,7 +461,7 @@ class TestFetchLocalizedDescriptions:
         client_mock.get.side_effect = ReadTimeout("always down")
 
         with pytest.raises(ReadTimeout):
-            await backend.fetch_picture_of_the_day()
+            await backend.fetch_picture_of_the_day("en")
 
         assert client_mock.get.call_count == settings.rss_providers.wikimedia_potd.retry_count
 

--- a/tests/unit/providers/rss/wikimedia_potd/backends/test_wikimedia_potd_backend.py
+++ b/tests/unit/providers/rss/wikimedia_potd/backends/test_wikimedia_potd_backend.py
@@ -27,6 +27,7 @@ from merino.providers.rss.wikimedia_potd.backends.wikimedia_potd import (
 from merino.utils.gcs.models import Image
 
 FEED_URL = "https://example.com/feed"
+COMMONS_API_URL = "https://commons.example.com/w/api.php"
 
 # The sample response is stored verbatim as JSON so the fixture matches the Featured API payload.
 TEST_FEATURED_JSON = Path("tests/data/rss/wikimedia_potd/potd_featured.json").read_text(
@@ -51,7 +52,8 @@ def fixture_backend(
     return WikimediaPictureOfTheDayBackend(
         metrics_client=statsd_mock,
         http_client=mocker.AsyncMock(spec=AsyncClient),
-        feed_url=FEED_URL,
+        featured_api_base=FEED_URL,
+        commons_api_url=COMMONS_API_URL,
         gcs_uploader=gcs_uploader_mock,
     )
 
@@ -267,12 +269,12 @@ class TestFetchPictureOfTheDayMethod:
             request=Request(method="GET", url=FEED_URL),
         )
 
-        result = await backend.fetch_picture_of_the_day()
+        result = await backend.fetch_picture_of_the_day("en")
 
         assert result is not None
         assert result["image"]["title"] == "File:Milky Way over Sagittarius.jpg"
         client_mock.get.assert_called_once_with(
-            f"{FEED_URL}/2026/06/24", headers=WIKIMEDIA_REQUEST_HEADERS
+            f"{FEED_URL}/en/featured/2026/06/24", headers=WIKIMEDIA_REQUEST_HEADERS
         )
 
     @pytest.mark.asyncio
@@ -289,7 +291,7 @@ class TestFetchPictureOfTheDayMethod:
         )
 
         with pytest.raises(WikimediaPotdError):
-            await backend.fetch_picture_of_the_day()
+            await backend.fetch_picture_of_the_day("en")
 
     @pytest.mark.asyncio
     async def test_fetch_potd_propagates_http_error(
@@ -304,7 +306,152 @@ class TestFetchPictureOfTheDayMethod:
         )
 
         with pytest.raises(HTTPError):
-            await backend.fetch_picture_of_the_day()
+            await backend.fetch_picture_of_the_day("en")
+
+
+class TestFetchPictureOfTheDayLanguage:
+    """Tests that fetch_picture_of_the_day requests the given language."""
+
+    @pytest.mark.asyncio
+    @freezegun.freeze_time("2026-06-24")
+    async def test_fetch_potd_uses_requested_language_in_url(
+        self, backend: WikimediaPictureOfTheDayBackend
+    ) -> None:
+        """Builds the Featured API url with the requested language segment."""
+        client_mock: AsyncMock = cast(AsyncMock, backend.http_client)
+        client_mock.get.return_value = Response(
+            status_code=200,
+            content=TEST_FEATURED_JSON.encode(),
+            request=Request(method="GET", url=FEED_URL),
+        )
+
+        await backend.fetch_picture_of_the_day("de")
+
+        client_mock.get.assert_called_once_with(
+            f"{FEED_URL}/de/featured/2026/06/24", headers=WIKIMEDIA_REQUEST_HEADERS
+        )
+
+
+class TestDiscoverLanguages:
+    """Tests for the discover_languages method."""
+
+    @pytest.mark.asyncio
+    async def test_discover_languages_parses_commons_subpages(
+        self, backend: WikimediaPictureOfTheDayBackend
+    ) -> None:
+        """Parses language codes from Commons subpages and prepends the default language."""
+        commons_json = {
+            "query": {
+                "allpages": [
+                    {"title": "Template:Potd/2026-06-24"},
+                    {"title": "Template:Potd/2026-06-24 (de)"},
+                    {"title": "Template:Potd/2026-06-24 (es)"},
+                ]
+            }
+        }
+        client_mock: AsyncMock = cast(AsyncMock, backend.http_client)
+        client_mock.get.return_value = Response(
+            status_code=200,
+            json=commons_json,
+            request=Request(method="GET", url=COMMONS_API_URL),
+        )
+
+        result = await backend.discover_languages("2026-06-24")
+
+        assert result == ["en", "de", "es"]
+        _, kwargs = client_mock.get.call_args
+        assert kwargs["params"]["apprefix"] == "Potd/2026-06-24"
+        assert kwargs["params"]["apnamespace"] == "10"
+
+    @pytest.mark.asyncio
+    async def test_discover_languages_does_not_duplicate_default(
+        self, backend: WikimediaPictureOfTheDayBackend
+    ) -> None:
+        """Does not append the default language again when Commons already lists it."""
+        commons_json = {
+            "query": {
+                "allpages": [
+                    {"title": "Template:Potd/2026-06-24 (en)"},
+                    {"title": "Template:Potd/2026-06-24 (de)"},
+                ]
+            }
+        }
+        client_mock: AsyncMock = cast(AsyncMock, backend.http_client)
+        client_mock.get.return_value = Response(
+            status_code=200,
+            json=commons_json,
+            request=Request(method="GET", url=COMMONS_API_URL),
+        )
+
+        result = await backend.discover_languages("2026-06-24")
+
+        assert result == ["en", "de"]
+
+    @pytest.mark.asyncio
+    async def test_discover_languages_falls_back_to_default_on_error(
+        self, backend: WikimediaPictureOfTheDayBackend
+    ) -> None:
+        """Returns just the default language when the Commons request fails."""
+        client_mock: AsyncMock = cast(AsyncMock, backend.http_client)
+        client_mock.get.side_effect = HTTPError("commons down")
+
+        result = await backend.discover_languages("2026-06-24")
+
+        assert result == ["en"]
+
+
+class TestFetchLocalizedDescriptions:
+    """Tests for the fetch_localized_descriptions method."""
+
+    @pytest.mark.asyncio
+    async def test_skips_en_keeps_localized_drops_fallbacks(
+        self, backend: WikimediaPictureOfTheDayBackend
+    ) -> None:
+        """Skips "en", keeps genuinely localized text, and drops English fallbacks."""
+        de_data = {"image": {"description": {"lang": "de", "text": "Deutscher Text"}}}
+        # fr has no authored description, so the API returns the English fallback.
+        fr_fallback = {"image": {"description": {"lang": "en", "text": "English text"}}}
+
+        client_mock: AsyncMock = cast(AsyncMock, backend.http_client)
+        client_mock.get.side_effect = [
+            Response(status_code=200, json=de_data, request=Request(method="GET", url=FEED_URL)),
+            Response(
+                status_code=200, json=fr_fallback, request=Request(method="GET", url=FEED_URL)
+            ),
+        ]
+
+        result = await backend.fetch_localized_descriptions(["en", "de", "fr"])
+
+        # "en" is never fetched or stored; only "de" is fetched and both requests are localized
+        assert result == {"de": "Deutscher Text"}
+
+    @pytest.mark.asyncio
+    async def test_skips_language_when_fetch_raises(
+        self, backend: WikimediaPictureOfTheDayBackend
+    ) -> None:
+        """Skips a language whose fetch raises, keeping the rest of the map intact."""
+        client_mock: AsyncMock = cast(AsyncMock, backend.http_client)
+        client_mock.get.side_effect = HTTPError("boom")
+
+        result = await backend.fetch_localized_descriptions(["en", "de"])
+
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_drops_language_with_empty_description_text(
+        self, backend: WikimediaPictureOfTheDayBackend
+    ) -> None:
+        """Does not store a language whose description text is empty."""
+        de_empty = {"image": {"description": {"lang": "de", "text": ""}}}
+
+        client_mock: AsyncMock = cast(AsyncMock, backend.http_client)
+        client_mock.get.return_value = Response(
+            status_code=200, json=de_empty, request=Request(method="GET", url=FEED_URL)
+        )
+
+        result = await backend.fetch_localized_descriptions(["en", "de"])
+
+        assert result == {}
 
     @pytest.mark.asyncio
     @freezegun.freeze_time("2026-06-24")

--- a/tests/unit/providers/rss/wikimedia_potd/test_provider.py
+++ b/tests/unit/providers/rss/wikimedia_potd/test_provider.py
@@ -211,8 +211,6 @@ async def test_get_picture_of_the_day_returns_localized_description_for_accepted
 
     assert potd is not None
     assert potd.description == "Deutscher Text"
-    # the cached model is left untouched; only the returned copy is localized
-    assert provider.potd.description == "test description"
 
 
 @freezegun.freeze_time("2026-06-07")
@@ -251,11 +249,14 @@ async def test_get_picture_of_the_day_keeps_default_when_no_language_matches(
     provider: WikimediaPictureOfTheDayProvider, test_potd
 ) -> None:
     """Serves the default description (and the cached instance) when no language matches."""
-    provider.potd = test_potd.model_copy(update={"localized_descriptions": {"de": "Deutscher Text"}})
+    provider.potd = test_potd.model_copy(
+        update={"localized_descriptions": {"de": "Deutscher Text"}}
+    )
 
     potd = await provider.get_picture_of_the_day(["fr-FR"])
 
-    assert potd is provider.potd
+    assert potd is not None
+    # same as the default (en) description of the test_potd fixture
     assert potd.description == "test description"
 
 
@@ -265,11 +266,14 @@ async def test_get_picture_of_the_day_keeps_default_when_no_accepted_languages(
     provider: WikimediaPictureOfTheDayProvider, test_potd
 ) -> None:
     """Returns the cached instance unchanged when no Accept-Language is provided."""
-    provider.potd = test_potd.model_copy(update={"localized_descriptions": {"de": "Deutscher Text"}})
+    provider.potd = test_potd.model_copy(
+        update={"localized_descriptions": {"de": "Deutscher Text"}}
+    )
 
     potd = await provider.get_picture_of_the_day()
 
-    assert potd is provider.potd
+    assert potd is not None
+    # same as the default (en) description of the test_potd fixture
     assert potd.description == "test description"
 
 

--- a/tests/unit/providers/rss/wikimedia_potd/test_provider.py
+++ b/tests/unit/providers/rss/wikimedia_potd/test_provider.py
@@ -197,6 +197,82 @@ async def test_get_picture_of_the_day_serves_stale_potd_when_refetch_misses(
     assert potd is test_potd
 
 
+@freezegun.freeze_time("2026-06-07")
+@pytest.mark.asyncio
+async def test_get_picture_of_the_day_returns_localized_description_for_accepted_language(
+    provider: WikimediaPictureOfTheDayProvider, test_potd
+) -> None:
+    """Swaps in the localized description matching the client's Accept-Language."""
+    provider.potd = test_potd.model_copy(
+        update={"localized_descriptions": {"de": "Deutscher Text"}}
+    )
+
+    potd = await provider.get_picture_of_the_day(["de-DE", "en-US"])
+
+    assert potd is not None
+    assert potd.description == "Deutscher Text"
+    # the cached model is left untouched; only the returned copy is localized
+    assert provider.potd.description == "test description"
+
+
+@freezegun.freeze_time("2026-06-07")
+@pytest.mark.asyncio
+async def test_get_picture_of_the_day_matches_base_subtag(
+    provider: WikimediaPictureOfTheDayProvider, test_potd
+) -> None:
+    """Falls back to the base language subtag when the full code has no description."""
+    provider.potd = test_potd.model_copy(update={"localized_descriptions": {"pt": "Português"}})
+
+    potd = await provider.get_picture_of_the_day(["pt-BR"])
+
+    assert potd is not None
+    assert potd.description == "Português"
+
+
+@freezegun.freeze_time("2026-06-07")
+@pytest.mark.asyncio
+async def test_get_picture_of_the_day_prefers_exact_code_over_base_subtag(
+    provider: WikimediaPictureOfTheDayProvider, test_potd
+) -> None:
+    """Prefers an exact language-code match over the base subtag match."""
+    provider.potd = test_potd.model_copy(
+        update={"localized_descriptions": {"pt": "Português", "pt-br": "Português brasileiro"}}
+    )
+
+    potd = await provider.get_picture_of_the_day(["pt-BR"])
+
+    assert potd is not None
+    assert potd.description == "Português brasileiro"
+
+
+@freezegun.freeze_time("2026-06-07")
+@pytest.mark.asyncio
+async def test_get_picture_of_the_day_keeps_default_when_no_language_matches(
+    provider: WikimediaPictureOfTheDayProvider, test_potd
+) -> None:
+    """Serves the default description (and the cached instance) when no language matches."""
+    provider.potd = test_potd.model_copy(update={"localized_descriptions": {"de": "Deutscher Text"}})
+
+    potd = await provider.get_picture_of_the_day(["fr-FR"])
+
+    assert potd is provider.potd
+    assert potd.description == "test description"
+
+
+@freezegun.freeze_time("2026-06-07")
+@pytest.mark.asyncio
+async def test_get_picture_of_the_day_keeps_default_when_no_accepted_languages(
+    provider: WikimediaPictureOfTheDayProvider, test_potd
+) -> None:
+    """Returns the cached instance unchanged when no Accept-Language is provided."""
+    provider.potd = test_potd.model_copy(update={"localized_descriptions": {"de": "Deutscher Text"}})
+
+    potd = await provider.get_picture_of_the_day()
+
+    assert potd is provider.potd
+    assert potd.description == "test description"
+
+
 @freezegun.freeze_time("2026-06-08")
 @pytest.mark.asyncio
 async def test_get_picture_of_the_day_refetches_on_every_miss(


### PR DESCRIPTION
## References

JIRA: [DISCO-2158](https://mozilla-hub.atlassian.net/browse/DISCO-2158)

## Description
- Adding an additional api call to the Wikimedia Commons Action API to discover which languages have an authored picture of the day description for a given day.
- Adding a loop to make N number of requests for the picture of the day Featured API depending on the number of localized languages available.
- Downloads and upload logic remains the same for thumbnail and hi-res images.
- Parses `accept-languages` request header and determines the `description` field on the `potd` based on that and what's available.



## PR Review Checklist
- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2485)


[DISCO-2158]: https://mozilla-hub.atlassian.net/browse/DISCO-2158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ