### PR TITLE
HNT-22236 feat: serve de-AT, de-CH, and fr-BE sections and legacy grid

### DIFF
--- a/merino/curated_recommendations/corpus_backends/protocol.py
+++ b/merino/curated_recommendations/corpus_backends/protocol.py
@@ -40,20 +40,21 @@ class Topic(str, Enum):
 class SurfaceId(str, Enum):
     """Defines the possible recommendation surfaces."""
 
-    NEW_TAB_EN_US = "NEW_TAB_EN_US"
-    NEW_TAB_EN_GB = "NEW_TAB_EN_GB"
-    NEW_TAB_EN_CA = "NEW_TAB_EN_CA"
-    NEW_TAB_EN_IE = "NEW_TAB_EN_IE"
-    NEW_TAB_EN_INTL = "NEW_TAB_EN_INTL"
-    # Cross-Europe English surface for English-speaking users in continental Europe.
-    NEW_TAB_EN_XE = "NEW_TAB_EN_XE"
-    NEW_TAB_DE_DE = "NEW_TAB_DE_DE"
-    NEW_TAB_ES_ES = "NEW_TAB_ES_ES"
-    # Global Spanish surface for Spanish-speaking users regardless of country.
-    NEW_TAB_ES_XA = "NEW_TAB_ES_XA"
-    NEW_TAB_FR_FR = "NEW_TAB_FR_FR"
-    NEW_TAB_IT_IT = "NEW_TAB_IT_IT"
-    NEW_TAB_PL_PL = "NEW_TAB_PL_PL"
+    NEW_TAB_DE_AT = "NEW_TAB_DE_AT"  # austria
+    NEW_TAB_DE_CH = "NEW_TAB_DE_CH"  # switzerland
+    NEW_TAB_DE_DE = "NEW_TAB_DE_DE"  # germany
+    NEW_TAB_EN_CA = "NEW_TAB_EN_CA"  # canada
+    NEW_TAB_EN_GB = "NEW_TAB_EN_GB"  # great britain
+    NEW_TAB_EN_IE = "NEW_TAB_EN_IE"  # irelane
+    NEW_TAB_EN_INTL = "NEW_TAB_EN_INTL"  # india(?)
+    NEW_TAB_EN_US = "NEW_TAB_EN_US"  # united states
+    NEW_TAB_EN_XE = "NEW_TAB_EN_XE"  # cross-europe english
+    NEW_TAB_ES_ES = "NEW_TAB_ES_ES"  # spain
+    NEW_TAB_ES_XA = "NEW_TAB_ES_XA"  # global spanish (non-country specific)
+    NEW_TAB_FR_BE = "NEW_TAB_FR_BE"  # belgium
+    NEW_TAB_FR_FR = "NEW_TAB_FR_FR"  # france
+    NEW_TAB_IT_IT = "NEW_TAB_IT_IT"  # italy
+    NEW_TAB_PL_PL = "NEW_TAB_PL_PL"  # poland
 
 
 class CreateSource(str, Enum):

--- a/merino/curated_recommendations/localization.py
+++ b/merino/curated_recommendations/localization.py
@@ -13,19 +13,25 @@ LocalizedTopicSectionTitles = dict[SurfaceId, dict[str, str]]
 # This dict also acts as a gating mechanism - only surfaces listed here can
 # receive sections.
 LOCALIZED_SECTION_TITLES: LocalizedTopicSectionTitles = {
+    SurfaceId.NEW_TAB_DE_AT: {
+        "top-stories": "Meistgelesen",
+    },
+    SurfaceId.NEW_TAB_DE_CH: {
+        "top-stories": "Meistgelesen",
+    },
     SurfaceId.NEW_TAB_DE_DE: {
         "top-stories": "Meistgelesen",
     },
-    SurfaceId.NEW_TAB_EN_US: {
+    SurfaceId.NEW_TAB_EN_CA: {
         "top-stories": "Popular Today",
     },
     SurfaceId.NEW_TAB_EN_GB: {
         "top-stories": "Popular Today",
     },
-    SurfaceId.NEW_TAB_EN_CA: {
+    SurfaceId.NEW_TAB_EN_IE: {
         "top-stories": "Popular Today",
     },
-    SurfaceId.NEW_TAB_EN_IE: {
+    SurfaceId.NEW_TAB_EN_US: {
         "top-stories": "Popular Today",
     },
     SurfaceId.NEW_TAB_EN_XE: {
@@ -34,6 +40,9 @@ LOCALIZED_SECTION_TITLES: LocalizedTopicSectionTitles = {
     SurfaceId.NEW_TAB_ES_ES: {"top-stories": "Tendencias"},
     SurfaceId.NEW_TAB_ES_XA: {
         "top-stories": "Tendencias",
+    },
+    SurfaceId.NEW_TAB_FR_BE: {
+        "top-stories": "Tendances du jour",
     },
     SurfaceId.NEW_TAB_FR_FR: {
         "top-stories": "Tendances du jour",

--- a/merino/curated_recommendations/protocol.py
+++ b/merino/curated_recommendations/protocol.py
@@ -48,6 +48,7 @@ class Locale(str, Enum):
     """Supported locales for curated recommendations on New Tab"""
 
     FR = ("fr",)
+    FR_BE = ("fr-BE",)
     FR_FR = ("fr-FR",)
     ES = ("es",)
     ES_ES = ("es-ES",)

--- a/merino/curated_recommendations/utils.py
+++ b/merino/curated_recommendations/utils.py
@@ -15,12 +15,15 @@ from merino.curated_recommendations.protocol import (
 # the scheduled-surface backend.
 ROLLED_OUT_SECTION_SURFACES: frozenset[SurfaceId] = frozenset(
     {
+        SurfaceId.NEW_TAB_DE_AT,
+        SurfaceId.NEW_TAB_DE_CH,
         SurfaceId.NEW_TAB_DE_DE,
         SurfaceId.NEW_TAB_EN_CA,
         SurfaceId.NEW_TAB_EN_GB,
         SurfaceId.NEW_TAB_EN_IE,
         SurfaceId.NEW_TAB_EN_US,
         SurfaceId.NEW_TAB_ES_ES,
+        SurfaceId.NEW_TAB_FR_BE,
         SurfaceId.NEW_TAB_FR_FR,
         SurfaceId.NEW_TAB_IT_IT,
     }
@@ -55,7 +58,13 @@ def get_recommendation_surface_id(
     derived_region = derive_region(locale, region)
 
     if language == "de":
-        return SurfaceId.NEW_TAB_DE_DE
+        match derived_region:
+            case "AT":  # austria
+                return SurfaceId.NEW_TAB_DE_AT
+            case "CH":  # switzerland
+                return SurfaceId.NEW_TAB_DE_CH
+            case _:  # fall back to germany
+                return SurfaceId.NEW_TAB_DE_DE
     elif language == "pl":
         return SurfaceId.NEW_TAB_PL_PL
     elif language == "es":
@@ -74,7 +83,11 @@ def get_recommendation_surface_id(
             return SurfaceId.NEW_TAB_ES_XA
         return SurfaceId.NEW_TAB_ES_ES
     elif language == "fr":
-        return SurfaceId.NEW_TAB_FR_FR
+        match derived_region:
+            case "BE":  # belgium
+                return SurfaceId.NEW_TAB_FR_BE
+            case _:  # fall back to france
+                return SurfaceId.NEW_TAB_FR_FR
     elif language == "it":
         return SurfaceId.NEW_TAB_IT_IT
     else:

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -517,12 +517,23 @@ class TestLegacyEndpoints:
     """Test the legacy curated recommendations endpoints (fx114 and fx115-129).
 
     These endpoints have two code paths:
-    - Rolled-out section surfaces (en-US, en-CA, en-GB, de-DE, fr-FR): use sections backend via get_legacy_recommendations_from_sections
-    - Other locales (es-ES, it-IT, etc.): use scheduler backend via CuratedRecommendationsProvider
+    - Rolled-out section surfaces (en-US, en-CA, en-GB, de-DE, fr-FR, es-ES, it-IT, de-AT, de-CH, fr-BE): use sections backend via get_legacy_recommendations_from_sections
+    - Other locales (pl-PL, etc.): use scheduler backend via CuratedRecommendationsProvider
     """
 
     # Locales that use the sections backend (rolled-out section surfaces)
-    SECTIONS_BACKEND_LOCALES = ["en-US", "en-CA", "en-GB", "de-DE", "fr-FR", "es-ES", "it-IT"]
+    SECTIONS_BACKEND_LOCALES = [
+        "de-AT",
+        "de-CH",
+        "de-DE",
+        "en-CA",
+        "en-GB",
+        "en-US",
+        "es-ES",
+        "fr-BE",
+        "fr-FR",
+        "it-IT",
+    ]
     # Locales that use the scheduler backend (non-rolled-out)
     SCHEDULER_BACKEND_LOCALES = ["pl-PL"]
 
@@ -763,9 +774,10 @@ class TestCuratedRecommendationsRequestParameters:
             (Locale.EN_GB, SurfaceId.NEW_TAB_EN_GB),
             (Locale.DE, SurfaceId.NEW_TAB_DE_DE),
             (Locale.DE_DE, SurfaceId.NEW_TAB_DE_DE),
-            (Locale.DE_AT, SurfaceId.NEW_TAB_DE_DE),
-            (Locale.DE_CH, SurfaceId.NEW_TAB_DE_DE),
+            (Locale.DE_AT, SurfaceId.NEW_TAB_DE_AT),
+            (Locale.DE_CH, SurfaceId.NEW_TAB_DE_CH),
             (Locale.FR, SurfaceId.NEW_TAB_FR_FR),
+            (Locale.FR_BE, SurfaceId.NEW_TAB_FR_BE),
             (Locale.FR_FR, SurfaceId.NEW_TAB_FR_FR),
             (Locale.ES, SurfaceId.NEW_TAB_ES_ES),
             (Locale.ES_ES, SurfaceId.NEW_TAB_ES_ES),

--- a/tests/unit/curated_recommendations/test_localization.py
+++ b/tests/unit/curated_recommendations/test_localization.py
@@ -9,23 +9,39 @@ from merino.curated_recommendations.corpus_backends.protocol import SurfaceId
 @pytest.mark.parametrize(
     ("surface_id", "expected_title"),
     [
-        (SurfaceId.NEW_TAB_EN_US, "Popular Today"),
+        (SurfaceId.NEW_TAB_DE_AT, "Meistgelesen"),
+        (SurfaceId.NEW_TAB_DE_CH, "Meistgelesen"),
+        (SurfaceId.NEW_TAB_DE_DE, "Meistgelesen"),
         (SurfaceId.NEW_TAB_EN_CA, "Popular Today"),
         (SurfaceId.NEW_TAB_EN_IE, "Popular Today"),
+        (SurfaceId.NEW_TAB_EN_US, "Popular Today"),
         (SurfaceId.NEW_TAB_EN_XE, "Popular Today"),
-        (SurfaceId.NEW_TAB_DE_DE, "Meistgelesen"),
-        (SurfaceId.NEW_TAB_ES_XA, "Tendencias"),
-        (SurfaceId.NEW_TAB_FR_FR, "Tendances du jour"),
-        (SurfaceId.NEW_TAB_PL_PL, "Przegląd dnia"),
         (SurfaceId.NEW_TAB_ES_ES, "Tendencias"),
+        (SurfaceId.NEW_TAB_ES_XA, "Tendencias"),
+        (SurfaceId.NEW_TAB_FR_BE, "Tendances du jour"),
+        (SurfaceId.NEW_TAB_FR_FR, "Tendances du jour"),
         (SurfaceId.NEW_TAB_IT_IT, "I più letti"),
+        (SurfaceId.NEW_TAB_PL_PL, "Przegląd dnia"),
     ],
-    ids=["en_us", "en_ca", "en_ie", "en_xe", "de_de", "es_xa", "fr_fr", "pl_pl", "es_es", "it_it"],
+    ids=[
+        "de_at",
+        "de_ch",
+        "de_de",
+        "en_ca",
+        "en_ie",
+        "en_us",
+        "en_xe",
+        "es_es",
+        "es_xa",
+        "fr_be",
+        "fr_fr",
+        "it_it",
+        "pl_pl",
+    ],
 )
 def test_get_translation_top_stories(surface_id: SurfaceId, expected_title: str):
     """Test that each supported surface returns its localized top-stories title."""
-    result = get_translation(surface_id, "top-stories", "Default")
-    assert result == expected_title
+    assert expected_title == get_translation(surface_id, "top-stories", "Default")
 
 
 def test_get_translation_non_existing_locale(caplog):

--- a/tests/unit/curated_recommendations/test_utils.py
+++ b/tests/unit/curated_recommendations/test_utils.py
@@ -117,7 +117,7 @@ class TestCuratedRecommendationsProviderGetRecommendationSurfaceId:
         "locale,region,recommendation_surface_id",
         [
             # Test cases below are from the Newtab locales/region documentation maintained by the Firefox integration
-            # team: https://docs.google.com/document/d/1omclr-eETJ7zAWTMI7mvvsc3_-ns2Iiho4jPEfrmZfo/edit Ref:
+            # team: https://mozilla-hub.atlassian.net/wiki/spaces/FPS/pages/80448805/Homepage+New+Tab+i18n+Regional+Differences+HNT Ref:
             # https://github.com/Pocket/recommendation-api/blob/c0fe2d1cab7ec7931c3c8c2e8e3d82908801ab00/tests/unit
             # /data_providers/test_new_tab_dispatch.py#L7 # noqa
             ("en-CA", "US", SurfaceId.NEW_TAB_EN_US),
@@ -129,12 +129,15 @@ class TestCuratedRecommendationsProviderGetRecommendationSurfaceId:
             ("de", "DE", SurfaceId.NEW_TAB_DE_DE),
             ("de-AT", "DE", SurfaceId.NEW_TAB_DE_DE),
             ("de-CH", "DE", SurfaceId.NEW_TAB_DE_DE),
+            ("de-AT", "AT", SurfaceId.NEW_TAB_DE_AT),
+            ("de-CH", "CH", SurfaceId.NEW_TAB_DE_CH),
             ("en-CA", "GB", SurfaceId.NEW_TAB_EN_GB),
             ("en-GB", "GB", SurfaceId.NEW_TAB_EN_GB),
             ("en-US", "GB", SurfaceId.NEW_TAB_EN_GB),
             ("en-CA", "IE", SurfaceId.NEW_TAB_EN_IE),
             ("en-GB", "IE", SurfaceId.NEW_TAB_EN_IE),
             ("en-US", "IE", SurfaceId.NEW_TAB_EN_IE),
+            ("fr", "BE", SurfaceId.NEW_TAB_FR_BE),
             ("fr", "FR", SurfaceId.NEW_TAB_FR_FR),
             ("it", "IT", SurfaceId.NEW_TAB_IT_IT),
             ("es", "ES", SurfaceId.NEW_TAB_ES_ES),
@@ -146,8 +149,8 @@ class TestCuratedRecommendationsProviderGetRecommendationSurfaceId:
             ("en-CA", "IN", SurfaceId.NEW_TAB_EN_INTL),
             ("en-GB", "IN", SurfaceId.NEW_TAB_EN_INTL),
             ("en-US", "IN", SurfaceId.NEW_TAB_EN_INTL),
-            ("de", "CH", SurfaceId.NEW_TAB_DE_DE),
-            ("de", "AT", SurfaceId.NEW_TAB_DE_DE),
+            ("de", "CH", SurfaceId.NEW_TAB_DE_CH),
+            ("de", "AT", SurfaceId.NEW_TAB_DE_AT),
             ("de", "BE", SurfaceId.NEW_TAB_DE_DE),
             # Locale can be a main language only.
             ("en", "CA", SurfaceId.NEW_TAB_EN_CA),


### PR DESCRIPTION
## References

JIRA: [HNT-2236](https://mozilla-hub.atlassian.net/browse/HNT-2236), [HNT-2269](https://mozilla-hub.atlassian.net/browse/HNT-2269), [HNT-2298](https://mozilla-hub.atlassian.net/browse/HNT-2298)

## Description

rolls out de-AT, de-CH, and fr-BE sections when requested by client, falls back to legacy grid when client does not request sections.

similar to https://github.com/mozilla-services/merino-py/pull/1683

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2488)


[HNT-2236]: https://mozilla-hub.atlassian.net/browse/HNT-2236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HNT-2269]: https://mozilla-hub.atlassian.net/browse/HNT-2269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HNT-2298]: https://mozilla-hub.atlassian.net/browse/HNT-2298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ