### PR TITLE
[HNT-2843] Add retry logic for fetch picture of the day method

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -234,7 +234,7 @@ countries = ["US"]
 # MERINO_MARS__FORM_FACTORS
 # Form factors to fetch suggestions for from the MARS API.
 form_factors = ["desktop"]
- 
+
 [default.fleece]
 # MERINO_FLEECE__URL_BASE
 # Base URL of the merino-fleece service. Empty by default.
@@ -576,7 +576,7 @@ retry_factor_sec=0.5
 [default.providers.sports.sportsdata.WCS]
 # MERINO_PROVIDERS__SPORTS__SPORTSDATA__WCS__GAMES_BY_DATE_TTL_SEC
 # Local-disk cache lifetime (seconds) for live `GamesByDate` score responses
-# before refetching from SportsData.io. 
+# before refetching from SportsData.io.
 games_by_date_ttl_sec = 5
 
 [default.providers.wcs]
@@ -1222,6 +1222,20 @@ connect_timeout_sec = 3.0
 # A float (in seconds) indicating the maximum waiting period when querying for POTD data.
 query_timeout_sec = 1.0
 
+# MERINO_RSS_PROVIDERS__WIKIMEDIA_POTD__RETRY_COUNT
+# Maximum number of attempts for a Wikimedia Featured API fetch before giving up, so a
+# transient failure (e.g. a read timeout) does not lose the whole day's picture.
+retry_count = 3
+
+# MERINO_RSS_PROVIDERS__WIKIMEDIA_POTD__RETRY_WAIT_INITIAL_SECONDS
+# Initial backoff before the first retry of a Wikimedia Featured API fetch. The wait grows
+# exponentially on each subsequent attempt.
+retry_wait_initial_seconds = 0.5
+
+# MERINO_RSS_PROVIDERS__WIKIMEDIA_POTD__RETRY_WAIT_JITTER_SECONDS
+# Random jitter (in seconds) added to each backoff wait between fetch retries.
+retry_wait_jitter_seconds = 0.2
+
 # MERINO_RSS_PROVIDERS__WIKIMEDIA_POTD__FEED_URL
 # Base URL for the Wikimedia Featured API; the backend appends /{yyyy}/{mm}/{dd}.
 feed_url = "https://api.wikimedia.org/feed/v1/wikipedia/en/featured"
@@ -1512,7 +1526,7 @@ force_upload = false
 # Minimum width of the domain favicon required for it to be a part of domain metadata
 min_favicon_width = 48
 
-# MERINO_JOBS__NAVIGATIONAL_SUGGESTIONS__CACHE_CONTROL  
+# MERINO_JOBS__NAVIGATIONAL_SUGGESTIONS__CACHE_CONTROL
 # cache control headers for uploaded favicons (12 hrs)
 cache_control = "public, max-age=43200"
 

--- a/merino/configs/testing.toml
+++ b/merino/configs/testing.toml
@@ -184,3 +184,9 @@ gcp_project = "test-project"
 # Tests sleep for a shorter duration than defautl to make them execute more quickly.
 retry_wait_initial_seconds = 0.05
 retry_wait_jitter_seconds = 0.02
+
+[testing.rss_providers.wikimedia_potd]
+
+# Tests use near-zero backoff so retry paths execute quickly.
+retry_wait_initial_seconds = 0.0
+retry_wait_jitter_seconds = 0.0

--- a/merino/providers/rss/wikimedia_potd/backends/wikimedia_potd.py
+++ b/merino/providers/rss/wikimedia_potd/backends/wikimedia_potd.py
@@ -4,7 +4,14 @@ import logging
 import aiodogstatsd
 from datetime import datetime, timezone
 from pydantic import HttpUrl
-from httpx import AsyncClient, Response
+from httpx import AsyncClient, HTTPError, Response
+from tenacity import (
+    before_sleep_log,
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential_jitter,
+)
 
 from merino.configs import settings
 from merino.providers.rss.wikimedia_potd.backends.protocol import (
@@ -93,8 +100,23 @@ class WikimediaPictureOfTheDayBackend:
 
         return (HttpUrl(thumbnail_cdn_url), HttpUrl(hires_cdn_url))
 
+    @retry(
+        wait=wait_exponential_jitter(
+            initial=settings.rss_providers.wikimedia_potd.retry_wait_initial_seconds,
+            jitter=settings.rss_providers.wikimedia_potd.retry_wait_jitter_seconds,
+        ),
+        stop=stop_after_attempt(settings.rss_providers.wikimedia_potd.retry_count),
+        # retry on read/connect timeouts, connection resets, 5xx,
+        # all HTTPError, empty/invalid-body responses that may recover
+        retry=retry_if_exception_type((HTTPError, WikimediaPotdError)),
+        reraise=True,
+        before_sleep=before_sleep_log(logger, logging.INFO),
+    )
     async def fetch_picture_of_the_day(self) -> dict:
         """Fetch the Wikimedia Featured API picture of the day for today.
+
+        Retries transient failures with exponential backoff before giving up; the final
+        failure is re-raised so the upload job's error boundary reports it once.
 
         Returns:
             The parsed JSON response as a dict. Raises WikimediaPotdError on failure.

--- a/tests/unit/providers/rss/wikimedia_potd/backends/test_wikimedia_potd_backend.py
+++ b/tests/unit/providers/rss/wikimedia_potd/backends/test_wikimedia_potd_backend.py
@@ -11,7 +11,7 @@ import freezegun
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock
 from pydantic import HttpUrl
-from httpx import AsyncClient, HTTPError, Request, Response
+from httpx import AsyncClient, HTTPError, ReadTimeout, Request, Response
 from pytest_mock import MockerFixture
 
 from merino.configs import settings
@@ -305,6 +305,44 @@ class TestFetchPictureOfTheDayMethod:
 
         with pytest.raises(HTTPError):
             await backend.fetch_picture_of_the_day()
+
+    @pytest.mark.asyncio
+    @freezegun.freeze_time("2026-06-24")
+    async def test_fetch_potd_retries_transient_error_then_succeeds(
+        self,
+        backend: WikimediaPictureOfTheDayBackend,
+    ) -> None:
+        """Retries a transient read timeout and returns the response once the fetch succeeds."""
+        client_mock: AsyncMock = cast(AsyncMock, backend.http_client)
+        client_mock.get.side_effect = [
+            ReadTimeout("transient"),
+            ReadTimeout("transient"),
+            Response(
+                status_code=200,
+                content=TEST_FEATURED_JSON.encode(),
+                request=Request(method="GET", url=FEED_URL),
+            ),
+        ]
+
+        result = await backend.fetch_picture_of_the_day()
+
+        assert result["image"]["title"] == "File:Milky Way over Sagittarius.jpg"
+        assert client_mock.get.call_count == 3
+
+    @pytest.mark.asyncio
+    @freezegun.freeze_time("2026-06-24")
+    async def test_fetch_potd_reraises_after_exhausting_retries(
+        self,
+        backend: WikimediaPictureOfTheDayBackend,
+    ) -> None:
+        """Reraises the underlying error after exhausting the configured attempts."""
+        client_mock: AsyncMock = cast(AsyncMock, backend.http_client)
+        client_mock.get.side_effect = ReadTimeout("always down")
+
+        with pytest.raises(ReadTimeout):
+            await backend.fetch_picture_of_the_day()
+
+        assert client_mock.get.call_count == settings.rss_providers.wikimedia_potd.retry_count
 
 
 class TestGcsUploadVerification:


### PR DESCRIPTION
## References

JIRA: [HNT-2843](https://mozilla-hub.atlassian.net/browse/HNT-2843)

## Description
Add retry logic for fetching the picture of the day. This is to address any transient api call failures when the k8s job runs. Adding this due to this [sentry error](https://mozilla.sentry.io/issues/7621109829/?environment=prod&project=6622434&query=is%3Aunresolved&referrer=issue-stream) which happened in _prod_ env only and not in _stage_ with led to clients serving a stale picture.



## PR Review Checklist
- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2489)


[HNT-2843]: https://mozilla-hub.atlassian.net/browse/HNT-2843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ