### PR TITLE
AIMOD-1380 Adjustment for LinTS for inferred content ranking

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -1316,7 +1316,7 @@ cron_interval_seconds = 600
 [default.curated_recommendations.gcs.engagement]
 # MERINO__CURATED_RECOMMENDATIONS__GCS__ENGAGEMENT__MAX_SIZE
 # The maximum size in bytes of the GCS engagement blob. If exceeded, an error will be logged.
-max_size = 4_000_000
+max_size = 5_000_000
 
 # MERINO__CURATED_RECOMMENDATIONS__GCS__ENGAGEMENT__BLOB_PREFIX
 # GCS path of the priors JSON file.

--- a/merino/curated_recommendations/ml_backends/lints_interest_model.py
+++ b/merino/curated_recommendations/ml_backends/lints_interest_model.py
@@ -37,6 +37,15 @@ L_FORMAT_LAPACK_LOWER_PACKED = "lapack_lower_packed"
 VALIDITY_PERIOD_MINUTES = 60
 
 
+def remap_interests_for_real_world_strengths(val: float | None):
+    """Remap ~1.1 and below to 0.87 reflecting analysis.
+    See content-ml-services/jobs/metaflow/prospecting/inferred_tuning for details
+    """
+    if val is not None and val <= 1.1:
+        return val * 0.87 / 1.1
+    return val
+
+
 class LinTSInterestBackend:
     """Per-surface backend that loads the LinTS-interest safetensors bundle and
     samples θ̃ per request via packed-triangular solve.
@@ -275,6 +284,9 @@ class LinTSInterestBackend:
                 f"LinTSInterestBackend.score_request called for {surface_id} "
                 f"without a valid bundle"
             )
+        strengths_adjusted = {
+            key: remap_interests_for_real_world_strengths(val) for key, val in strengths.items()
+        }
         d = self._dim[surface_id]
         bias_idx = self._bias_idx[surface_id]
         v = self._v[surface_id]
@@ -298,7 +310,7 @@ class LinTSInterestBackend:
         # 2) Constant-across-candidates terms: bias + Σ_t strength_t · θ̃[topic_main(t)]
         strength_vec = np.zeros(n_topics, dtype=np.float32)
         for t, name in enumerate(topic_names):
-            sv = strengths.get(name)
+            sv = strengths_adjusted.get(name)
             if isinstance(sv, (int, float)):
                 strength_vec[t] = float(sv)
         topic_main_indices = np.array(

--- a/tests/unit/curated_recommendations/ml_backends/test_lints_interest_model.py
+++ b/tests/unit/curated_recommendations/ml_backends/test_lints_interest_model.py
@@ -361,7 +361,7 @@ def test_score_matches_reference_implementation() -> None:
     backend._fetch_callback(blob, surface_id=SurfaceId.NEW_TAB_EN_US)
 
     items = list(expected["item_to_idx"].keys())
-    strengths = {DEFAULT_SYNTHETIC_TOPIC_NAMES[t]: (0.5 if t < 3 else 0.0) for t in range(7)}
+    strengths = {DEFAULT_SYNTHETIC_TOPIC_NAMES[t]: (1.5 if t < 3 else 0.0) for t in range(7)}
 
     # Reference: reconstruct dense L, run solve_triangular with the SAME ε
     # the backend will draw, then score every item by the score formula in
@@ -402,7 +402,7 @@ def test_unknown_item_gets_bias_plus_topic_main_only() -> None:
     backend._fetch_callback(blob, surface_id=SurfaceId.NEW_TAB_EN_US)
 
     # Use the same rng for both calls so the θ̃ draw is identical.
-    strengths = {DEFAULT_SYNTHETIC_TOPIC_NAMES[t]: (0.5 if t < 3 else 0.0) for t in range(7)}
+    strengths = {DEFAULT_SYNTHETIC_TOPIC_NAMES[t]: (1.5 if t < 3 else 0.0) for t in range(7)}
     rng_known = np.random.default_rng(7)
     rng_unknown = np.random.default_rng(7)
 


### PR DESCRIPTION
## References

JIRA: https://mozilla-hub.atlassian.net/browse/AIMOD-1380

## Description
An analysis shows that the interest thresholds don't map linearly to overall per topic CTR boost. A 25% softening of the lower threshold should give better results.

If this seems to work, the value will be calculated automatically and included in the data artifact.

See companion PR for details https://github.com/mozilla/content-ml-services/pull/1260

Note we're also support larger payload for the GCS merino data blob to make sure international expansion doesn't break our data payloads. That is the toml update in this PR

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2490)
