### PR TITLE
[DISCO-4333] feat(fleece): add an endpoint for search terms submission

### DIFF
--- a/merino-common/CLAUDE.md
+++ b/merino-common/CLAUDE.md
@@ -7,6 +7,7 @@ A package for common reusable modules of **merino-py**.
 - **app_configs**, located in @merino-common/merino_common/app_configs/, provide various common application configurations.
 - **routers**, located in @merino-common/merino_common/routers/, common FastAPI routers such as DockerFlow for **merino** and **merino-fleece**.
 - **utils**, located in @merino-common/merino_common/utils/, common utilities for **merino-py**.
+- **testing**, located in @merino-common/merino_common/testings/, common utilities for testing.
 
 ## Package Dependencies
 

--- a/merino-common/merino_common/models/__init__.py
+++ b/merino-common/merino_common/models/__init__.py
@@ -1,0 +1,1 @@
+"""Shared data models for Merino services."""

--- a/merino-common/merino_common/models/suggest_logging.py
+++ b/merino-common/merino_common/models/suggest_logging.py
@@ -1,0 +1,39 @@
+"""Shared log data models for Suggest logging."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, field_serializer
+
+
+class LogDataModel(BaseModel):
+    """Shared generic log data model."""
+
+    errno: int
+    time: datetime
+    path: str
+    method: str
+
+    @field_serializer("time")
+    def serialize_time(self, v: datetime, **kwargs):
+        """Return a datetime value as an iso formatted str."""
+        return v.isoformat()
+
+
+class SuggestLogDataModel(LogDataModel):
+    """Log metadata specific to Suggest logs."""
+
+    sensitive: bool
+    query: str | None = None
+    code: int
+    rid: str  # Provided by the asgi-correlation-id middleware.
+    session_id: str | None = None
+    sequence_no: int | None = None
+    client_variants: str
+    requested_providers: str
+    country: str | None = None
+    region: str | None = None
+    city: str | None = None
+    dma: int | None = None
+    browser: str
+    os_family: str
+    form_factor: str

--- a/merino-common/merino_common/models/suggest_logging.py
+++ b/merino-common/merino_common/models/suggest_logging.py
@@ -1,12 +1,13 @@
 """Shared log data models for Suggest logging."""
 
 from datetime import datetime
+from typing import Any
 
-from pydantic import BaseModel, field_serializer
+from pydantic import BaseModel, field_serializer, model_serializer
 
 
-class LogDataModel(BaseModel):
-    """Shared generic log data model."""
+class MozlogDataModel(BaseModel):
+    """Generic fields for Mozlog."""
 
     errno: int
     time: datetime
@@ -19,10 +20,9 @@ class LogDataModel(BaseModel):
         return v.isoformat()
 
 
-class SuggestLogDataModel(LogDataModel):
-    """Log metadata specific to Suggest logs."""
+class SuggestRequestParams(BaseModel):
+    """Suggest request parameters specific to Suggest logs."""
 
-    sensitive: bool
     query: str | None = None
     code: int
     rid: str  # Provided by the asgi-correlation-id middleware.
@@ -39,7 +39,27 @@ class SuggestLogDataModel(LogDataModel):
     form_factor: str
 
 
+class SuggestLogDataModel(BaseModel):
+    """Log metadata specific to Suggest logs."""
+
+    # The Suggest search term data log is always flagged as sensitive for
+    # Merino's search terms data log routing. Note that this field should
+    # _not_ be used to flag the search term sanitization result.
+    sensitive: bool
+    mozlog: MozlogDataModel
+    request_params: SuggestRequestParams
+
+    @model_serializer
+    def serialize_flat(self) -> dict[str, Any]:
+        """Dump to a flat dict for backward-compatible logging output."""
+        return {
+            "sensitive": self.sensitive,
+            **self.mozlog.model_dump(),
+            **self.request_params.model_dump(),
+        }
+
+
 class SearchTermsSubmission(BaseModel):
     """Request body for submitting search terms for sanitization."""
 
-    search_terms: list[SuggestLogDataModel]
+    search_terms: list[SuggestRequestParams]

--- a/merino-common/merino_common/models/suggest_logging.py
+++ b/merino-common/merino_common/models/suggest_logging.py
@@ -37,3 +37,9 @@ class SuggestLogDataModel(LogDataModel):
     browser: str
     os_family: str
     form_factor: str
+
+
+class SearchTermsSubmission(BaseModel):
+    """Request body for submitting search terms for sanitization."""
+
+    search_terms: list[SuggestLogDataModel]

--- a/merino-common/merino_common/testing/__init__.py
+++ b/merino-common/merino_common/testing/__init__.py
@@ -1,0 +1,1 @@
+"""Shared test utilities for Merino services."""

--- a/merino-common/merino_common/testing/metrics.py
+++ b/merino-common/merino_common/testing/metrics.py
@@ -1,0 +1,62 @@
+"""Helpers for asserting on OpenTelemetry metrics via an ``InMemoryMetricReader``.
+
+These utilities read back the metrics collected by an
+``opentelemetry.sdk.metrics.export.InMemoryMetricReader`` so tests can assert on
+counter/gauge values and data-point attributes without mocking the instruments.
+"""
+
+from collections.abc import Iterator
+
+from opentelemetry.sdk.metrics.export import (
+    Gauge,
+    InMemoryMetricReader,
+    Metric,
+    NumberDataPoint,
+    Sum,
+)
+
+
+def _iter_metrics(reader: InMemoryMetricReader) -> Iterator[Metric]:
+    """Yield every collected ``Metric`` across all resources and scopes."""
+    data = reader.get_metrics_data()
+    if data is None:
+        return
+    for resource_metric in data.resource_metrics:
+        for scope_metric in resource_metric.scope_metrics:
+            yield from scope_metric.metrics
+
+
+def collect_metrics(reader: InMemoryMetricReader) -> dict[str, float]:
+    """Collect Sum/Gauge metrics into a ``{name: summed-value}`` dict."""
+    values: dict[str, float] = {}
+    for metric in _iter_metrics(reader):
+        if isinstance(metric.data, (Sum, Gauge)):
+            values[metric.name] = sum((p.value for p in metric.data.data_points), 0.0)
+    return values
+
+
+def number_points(reader: InMemoryMetricReader, name: str) -> list[NumberDataPoint]:
+    """Return the ``NumberDataPoint``s for the named Sum/Gauge metric."""
+    points: list[NumberDataPoint] = []
+    for metric in _iter_metrics(reader):
+        if metric.name == name and isinstance(metric.data, (Sum, Gauge)):
+            points.extend(metric.data.data_points)
+    return points
+
+
+def find_point(reader: InMemoryMetricReader, name: str, **match: object) -> NumberDataPoint | None:
+    """Return the single data point for ``name`` whose attributes match all of ``match``.
+
+    Data point order is not guaranteed, so tests select by attributes rather than
+    index.
+    """
+    for point in number_points(reader, name):
+        attributes = point.attributes or {}
+        if all(attributes.get(key) == value for key, value in match.items()):
+            return point
+    return None
+
+
+def counter_value(reader: InMemoryMetricReader, name: str) -> float:
+    """Sum the data points of the named counter metric collected by the reader."""
+    return sum((point.value for point in number_points(reader, name)), 0.0)

--- a/merino-common/pyproject.toml
+++ b/merino-common/pyproject.toml
@@ -14,6 +14,13 @@ dependencies = [
     "opentelemetry-api>=1.42.1,<2",
 ]
 
+[project.optional-dependencies]
+# Required by the merino_common.testing.metrics helpers (InMemoryMetricReader).
+# Test-only; not needed at runtime.
+testing = [
+    "opentelemetry-sdk>=1.42.1,<2",
+]
+
 [tool.uv.build-backend]
 module-name = "merino_common"
 # Opt for the flat structure "merino_commont" over "src/merino_common"

--- a/merino-common/tests/unit/models/__init__.py
+++ b/merino-common/tests/unit/models/__init__.py
@@ -1,0 +1,5 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Modules dedicated to unit testing the models in the merino-common package."""

--- a/merino-common/tests/unit/models/test_suggest_logging.py
+++ b/merino-common/tests/unit/models/test_suggest_logging.py
@@ -10,7 +10,11 @@ from typing import Any
 import pytest
 from pydantic import ValidationError
 
-from merino_common.models.suggest_logging import LogDataModel
+from merino_common.models.suggest_logging import (
+    MozlogDataModel,
+    SuggestLogDataModel,
+    SuggestRequestParams,
+)
 
 
 @pytest.mark.parametrize(
@@ -21,7 +25,7 @@ from merino_common.models.suggest_logging import LogDataModel
 def test_create_log_object_fails_on_invalid_time(time_input: Any):
     """Test that `time` fails validation on invalid time input."""
     with pytest.raises(ValidationError):
-        LogDataModel(
+        MozlogDataModel(
             errno=0,
             time=time_input,
             path="/",
@@ -43,10 +47,63 @@ def test_create_log_object_can_convert_time_to_isoformat(
     """Ensure that `time` field correctly validates datetime inputs
     and outputs ISO format string.
     """
-    log_data = LogDataModel(
+    log_data = MozlogDataModel(
         errno=0,
         time=datetime_rep,
         path="/",
         method="GET",
     )
     assert log_data.model_dump().get("time") == expected_time
+
+
+def test_suggest_log_data_model_dumps_flat():
+    """Ensure `SuggestLogDataModel` serializes to a flat dict despite being composed
+    of `mozlog` and `request_params` submodels, with `time` as an ISO string.
+    """
+    log_data = SuggestLogDataModel(
+        sensitive=True,
+        mozlog=MozlogDataModel(
+            errno=0,
+            time=datetime(2022, 12, 18, hour=15, minute=58, second=41, tzinfo=timezone.utc),
+            path="/api/v1/suggest",
+            method="GET",
+        ),
+        request_params=SuggestRequestParams(
+            query="nope",
+            code=200,
+            rid="1b11844c52b34c33a6ad54b7bc2eb7c7",
+            session_id="deadbeef-0000-1111-2222-333344445555",
+            sequence_no=0,
+            client_variants="foo,bar",
+            requested_providers="pro,vider",
+            country="US",
+            region="WA",
+            city="Milton",
+            dma=819,
+            browser="Firefox(103.0)",
+            os_family="macos",
+            form_factor="desktop",
+        ),
+    )
+
+    assert log_data.model_dump() == {
+        "sensitive": True,
+        "errno": 0,
+        "time": "2022-12-18T15:58:41+00:00",
+        "path": "/api/v1/suggest",
+        "method": "GET",
+        "query": "nope",
+        "code": 200,
+        "rid": "1b11844c52b34c33a6ad54b7bc2eb7c7",
+        "session_id": "deadbeef-0000-1111-2222-333344445555",
+        "sequence_no": 0,
+        "client_variants": "foo,bar",
+        "requested_providers": "pro,vider",
+        "country": "US",
+        "region": "WA",
+        "city": "Milton",
+        "dma": 819,
+        "browser": "Firefox(103.0)",
+        "os_family": "macos",
+        "form_factor": "desktop",
+    }

--- a/merino-common/tests/unit/models/test_suggest_logging.py
+++ b/merino-common/tests/unit/models/test_suggest_logging.py
@@ -1,0 +1,52 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Unit tests for the suggest_logging.py models module."""
+
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from merino_common.models.suggest_logging import LogDataModel
+
+
+@pytest.mark.parametrize(
+    "time_input",
+    ["not a datetime string", {"not", "a", "datetime", "object"}],
+    ids=["invalid_string", "invalid_object_type"],
+)
+def test_create_log_object_fails_on_invalid_time(time_input: Any):
+    """Test that `time` fails validation on invalid time input."""
+    with pytest.raises(ValidationError):
+        LogDataModel(
+            errno=0,
+            time=time_input,
+            path="/",
+            method="GET",
+        )
+
+
+@pytest.mark.parametrize("expected_time", ["2022-12-18T15:58:41+00:00"])
+@pytest.mark.parametrize(
+    "datetime_rep",
+    [
+        datetime(2022, 12, 18, hour=15, minute=58, second=41, tzinfo=timezone.utc),
+    ],
+    ids=["datetime_obj"],
+)
+def test_create_log_object_can_convert_time_to_isoformat(
+    datetime_rep: datetime, expected_time: str
+):
+    """Ensure that `time` field correctly validates datetime inputs
+    and outputs ISO format string.
+    """
+    log_data = LogDataModel(
+        errno=0,
+        time=datetime_rep,
+        path="/",
+        method="GET",
+    )
+    assert log_data.model_dump().get("time") == expected_time

--- a/merino-common/tests/unit/utils/test_async_batch_queue.py
+++ b/merino-common/tests/unit/utils/test_async_batch_queue.py
@@ -10,8 +10,9 @@ import signal
 
 import pytest
 from opentelemetry.sdk.metrics import MeterProvider
-from opentelemetry.sdk.metrics.export import Gauge, InMemoryMetricReader, NumberDataPoint, Sum
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
 
+from merino_common.testing.metrics import collect_metrics, find_point, number_points
 from merino_common.utils.async_batch_queue import (
     AsyncBatchQueue,
     QueueFullException,
@@ -186,7 +187,7 @@ async def test_shutdown_deadline_drops_and_logs_and_metrics_unflushable_items(
     assert any("Shutdown deadline exceeded" in r.message for r in caplog.records), (
         "expected a warning logging the dropped items"
     )
-    dropped = _number_points(reader, "async_batch_queue.dropped.count")
+    dropped = number_points(reader, "async_batch_queue.dropped.count")
     assert sum(point.value for point in dropped) == 5
 
 
@@ -502,51 +503,6 @@ async def test_put_raises_queue_full_when_at_capacity() -> None:
     await batcher.stop(force=True)
 
 
-def _collect_metrics(reader: InMemoryMetricReader) -> dict[str, float]:
-    """Collect metrics into a {name: summed-value} dict."""
-    values: dict[str, float] = {}
-    data = reader.get_metrics_data()
-    if data is None:
-        return values
-    for resource_metric in data.resource_metrics:
-        for scope_metric in resource_metric.scope_metrics:
-            for metric in scope_metric.metrics:
-                metric_data = metric.data
-                # Only Sum/Gauge carry NumberDataPoints with a `.value`.
-                if isinstance(metric_data, (Sum, Gauge)):
-                    values[metric.name] = sum((p.value for p in metric_data.data_points), 0.0)
-    return values
-
-
-def _number_points(reader: InMemoryMetricReader, name: str) -> list[NumberDataPoint]:
-    """Return the NumberDataPoints for the named Sum/Gauge metric."""
-    points: list[NumberDataPoint] = []
-    data = reader.get_metrics_data()
-    if data is None:
-        return points
-    for resource_metric in data.resource_metrics:
-        for scope_metric in resource_metric.scope_metrics:
-            for metric in scope_metric.metrics:
-                if metric.name == name and isinstance(metric.data, (Sum, Gauge)):
-                    points.extend(metric.data.data_points)
-    return points
-
-
-def _find_point(
-    reader: InMemoryMetricReader, name: str, **match: object
-) -> NumberDataPoint | None:
-    """Return the single data point for `name` whose attributes match all of `match`.
-
-    Data point order is not guaranteed, so tests select by attributes rather than
-    index.
-    """
-    for point in _number_points(reader, name):
-        attributes = point.attributes or {}
-        if all(attributes.get(key) == value for key, value in match.items()):
-            return point
-    return None
-
-
 @pytest.mark.asyncio
 async def test_metrics_report_queue_size_capacity_and_processed() -> None:
     """A meter_provider gets queue.size, queue.capacity, and processed.count."""
@@ -569,7 +525,7 @@ async def test_metrics_report_queue_size_capacity_and_processed() -> None:
     # Enqueue without yielding: run() hasn't executed, so all 6 are still queued.
     for i in range(6):
         batcher.put(i)
-    before = _collect_metrics(reader)
+    before = collect_metrics(reader)
     assert before["async_batch_queue.queue.capacity"] == 100
     assert before["async_batch_queue.queue.size"] == 6
     assert before.get("async_batch_queue.processed.count", 0) == 0
@@ -582,7 +538,7 @@ async def test_metrics_report_queue_size_capacity_and_processed() -> None:
     await asyncio.wait_for(all_processed(), timeout=5.0)
     await batcher.stop(force=True)
 
-    after = _collect_metrics(reader)
+    after = collect_metrics(reader)
     assert after["async_batch_queue.queue.size"] == 0
     assert after["async_batch_queue.processed.count"] == 6
 
@@ -606,14 +562,14 @@ async def test_processed_metric_labels_failures() -> None:
     batcher.put(1)
 
     async def one_processed() -> None:
-        while _collect_metrics(reader).get("async_batch_queue.processed.count", 0) < 1:
+        while collect_metrics(reader).get("async_batch_queue.processed.count", 0) < 1:
             await asyncio.sleep(0.005)
 
     await asyncio.wait_for(one_processed(), timeout=5.0)
     await batcher.stop(force=True)
 
     # Find the processed-count data point and check its error attributes.
-    points = _number_points(reader, "async_batch_queue.processed.count")
+    points = number_points(reader, "async_batch_queue.processed.count")
     assert len(points) == 1
     assert points[0].value == 1
     attributes = points[0].attributes
@@ -645,7 +601,7 @@ async def test_rejected_metric_counts_queue_full_rejections() -> None:
 
     await batcher.stop(force=True)
 
-    points = _number_points(reader, "async_batch_queue.rejected.count")
+    points = number_points(reader, "async_batch_queue.rejected.count")
     assert len(points) == 1
     assert points[0].value == 2  # both overflowing puts counted
     attributes = points[0].attributes
@@ -681,20 +637,20 @@ async def test_error_callback_metric_records_successful_error_callback() -> None
     # error_callback.count is recorded after processed.count, so waiting on it
     # guarantees both are present.
     async def error_callback_recorded() -> None:
-        while _find_point(reader, "async_batch_queue.error_callback.count") is None:
+        while find_point(reader, "async_batch_queue.error_callback.count") is None:
             await asyncio.sleep(0.005)
 
     await asyncio.wait_for(error_callback_recorded(), timeout=5.0)
     await batcher.stop(force=True)
 
-    processed_point = _find_point(reader, "async_batch_queue.processed.count", outcome="error")
+    processed_point = find_point(reader, "async_batch_queue.processed.count", outcome="error")
     assert processed_point is not None
     assert processed_point.value == 1
     attributes = processed_point.attributes
     assert attributes is not None
     assert attributes["error.type"] == "ValueError"
 
-    error_point = _find_point(reader, "async_batch_queue.error_callback.count", outcome="success")
+    error_point = find_point(reader, "async_batch_queue.error_callback.count", outcome="success")
     assert error_point is not None
     assert error_point.value == 1
     attributes = error_point.attributes
@@ -728,13 +684,13 @@ async def test_error_callback_metric_records_failed_error_callback() -> None:
     batcher.put(1)
 
     async def error_callback_recorded() -> None:
-        while _find_point(reader, "async_batch_queue.error_callback.count") is None:
+        while find_point(reader, "async_batch_queue.error_callback.count") is None:
             await asyncio.sleep(0.005)
 
     await asyncio.wait_for(error_callback_recorded(), timeout=5.0)
     await batcher.stop(force=True)
 
-    error_point = _find_point(reader, "async_batch_queue.error_callback.count", outcome="error")
+    error_point = find_point(reader, "async_batch_queue.error_callback.count", outcome="error")
     assert error_point is not None
     assert error_point.value == 1
     attributes = error_point.attributes

--- a/merino-fleece/CLAUDE.md
+++ b/merino-fleece/CLAUDE.md
@@ -7,6 +7,7 @@ A web service providing supporting functionalities that can be integrated by **M
 The main domain components are as follows:
 
 - **PII Detection API**, located in @merino-fleece/merino_fleece/pii/, the backend of the `api/v1/pii` endpoint defined in @merino-fleece/merino_fleece/api/v1/pii.py.
+- **Search Terms API**, the backend of the `api/v1/search-terms` endpoint defined in @merino-fleece/merino_fleece/api/v1/search_terms.py, which accepts search term submissions from **merino** for sanitization.
 
 ## Testing
 

--- a/merino-fleece/merino_fleece/api/v1/__init__.py
+++ b/merino-fleece/merino_fleece/api/v1/__init__.py
@@ -2,7 +2,8 @@
 
 from fastapi import APIRouter
 
-from merino_fleece.api.v1 import pii
+from merino_fleece.api.v1 import pii, search_terms
 
 router = APIRouter()
 router.include_router(pii.router)
+router.include_router(search_terms.router)

--- a/merino-fleece/merino_fleece/api/v1/search_terms.py
+++ b/merino-fleece/merino_fleece/api/v1/search_terms.py
@@ -1,0 +1,40 @@
+"""Search terms submission endpoint."""
+
+from fastapi import APIRouter
+from opentelemetry import metrics
+from pydantic import BaseModel
+
+from merino_common.models.suggest_logging import SearchTermsSubmission
+
+_meter = metrics.get_meter("fleece")
+_search_terms_received_counter = _meter.create_counter(
+    name="api.search_terms.receive.count",
+    description="Number of search terms received by the submission endpoint.",
+)
+
+router = APIRouter(tags=["search-terms"])
+
+
+class SearchTermsResponse(BaseModel):
+    """Response for the search-terms submission endpoint."""
+
+    submitted: int
+
+
+@router.post(
+    "/search-terms",
+    tags=["search-terms"],
+    summary="Merino-fleece search terms submission endpoint",
+    status_code=201,
+    response_model=SearchTermsResponse,
+)
+async def submit_search_terms(body: SearchTermsSubmission) -> SearchTermsResponse:
+    """Accept a batch of search terms for sanitization.
+
+    The request body is validated by FastAPI and then discarded for now;
+    sanitization and logging will be added as a follow-up.
+    """
+    count = len(body.search_terms)
+    _search_terms_received_counter.add(count)
+
+    return SearchTermsResponse(submitted=count)

--- a/merino-fleece/metrics.yaml
+++ b/merino-fleece/metrics.yaml
@@ -1,0 +1,26 @@
+version: 1.0
+
+service: Merino-fleece
+
+search-terms:
+  api.search_terms.receive.count:
+    description: |
+      A counter recording the number of search terms received in each submission
+      to the search-terms endpoint. Incremented once per request by the size of
+      the submitted batch.
+    type: counter
+    labels: []
+    scope: |
+      The "api/v1/search-terms" API endpoint of "merino-fleece".
+    alert_policy: []
+
+pii:
+  pii.detect_duration:
+    description: |
+      A timer instrumenting the duration of each PII detection call, emitted
+      via the aiodogstatsd metrics client (namespace "merino.fleece").
+    type: timing
+    labels: []
+    scope: |
+      The "api/v1/pii" API endpoint of "merino-fleece".
+    alert_policy: []

--- a/merino-fleece/tests/unit/api/v1/test_search_terms.py
+++ b/merino-fleece/tests/unit/api/v1/test_search_terms.py
@@ -1,0 +1,87 @@
+"""Tests for the FastAPI /api/v1/search-terms endpoint."""
+
+from typing import Any
+
+import pytest
+from opentelemetry import metrics
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+
+from fastapi.testclient import TestClient
+
+from merino_common.testing.metrics import counter_value
+from merino_fleece.app import create_app
+
+
+@pytest.fixture
+def client() -> TestClient:
+    """Yield a TestClient for the app.
+
+    The search-terms route has no dependencies or app state, so no lifespan
+    context is needed.
+    """
+    return TestClient(create_app())
+
+
+def _search_term(**overrides: Any) -> dict[str, Any]:
+    """Build a valid SuggestLogDataModel payload, applying any field overrides."""
+    payload: dict[str, Any] = {
+        "sensitive": True,
+        "errno": 0,
+        "time": "1998-03-31T00:00:00",
+        "path": "/api/v1/suggest",
+        "method": "GET",
+        "code": 200,
+        "rid": "1b11844c52b34c33a6ad54b7bc2eb7c7",
+        "client_variants": "",
+        "requested_providers": "",
+        "browser": "Firefox(103.0)",
+        "os_family": "macos",
+        "form_factor": "desktop",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_submit_search_terms(client: TestClient) -> None:
+    """A valid batch of search terms returns 201 and the submitted count."""
+    body = {"search_terms": [_search_term(query="foo"), _search_term(query="bar")]}
+    resp = client.post("/api/v1/search-terms", json=body)
+    assert resp.status_code == 201
+    assert resp.json() == {"submitted": 2}
+
+
+def test_submit_empty_search_terms(client: TestClient) -> None:
+    """An empty batch is valid and returns a submitted count of 0."""
+    resp = client.post("/api/v1/search-terms", json={"search_terms": []})
+    assert resp.status_code == 201
+    assert resp.json() == {"submitted": 0}
+
+
+def test_missing_search_terms(client: TestClient) -> None:
+    """A body missing the `search_terms` field is rejected with 422."""
+    resp = client.post("/api/v1/search-terms", json={})
+    assert resp.status_code == 422
+
+
+def test_malformed_search_term(client: TestClient) -> None:
+    """A search term missing required fields is rejected with 422."""
+    resp = client.post("/api/v1/search-terms", json={"search_terms": [{"query": "foo"}]})
+    assert resp.status_code == 422
+
+
+def test_search_terms_metrics(client: TestClient) -> None:
+    """The receive counter records the batch size via a real OpenTelemetry reader.
+
+    The endpoint's counter is created against the global (proxy) meter at import
+    time; installing a MeterProvider with an InMemoryMetricReader makes that
+    proxy forward to a real instrument we can read back.
+    """
+    reader = InMemoryMetricReader()
+    metrics.set_meter_provider(MeterProvider(metric_readers=[reader]))
+
+    body = {"search_terms": [_search_term(), _search_term(), _search_term()]}
+    resp = client.post("/api/v1/search-terms", json=body)
+
+    assert resp.status_code == 201
+    assert counter_value(reader, "api.search_terms.receive.count") == 3

--- a/merino-fleece/tests/unit/api/v1/test_search_terms.py
+++ b/merino-fleece/tests/unit/api/v1/test_search_terms.py
@@ -24,13 +24,8 @@ def client() -> TestClient:
 
 
 def _search_term(**overrides: Any) -> dict[str, Any]:
-    """Build a valid SuggestLogDataModel payload, applying any field overrides."""
+    """Build a valid SuggestRequestParams payload, applying any field overrides."""
     payload: dict[str, Any] = {
-        "sensitive": True,
-        "errno": 0,
-        "time": "1998-03-31T00:00:00",
-        "path": "/api/v1/suggest",
-        "method": "GET",
         "code": 200,
         "rid": "1b11844c52b34c33a6ad54b7bc2eb7c7",
         "client_variants": "",

--- a/merino/middleware/logging.py
+++ b/merino/middleware/logging.py
@@ -10,10 +10,8 @@ from starlette.requests import Request
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from merino.middleware import ScopeKey
-from merino.utils.log_data_creators import (
-    SuggestLogDataModel,
-    create_suggest_log_data,
-)
+from merino.utils.log_data_creators import create_suggest_log_data
+from merino_common.models.suggest_logging import SuggestLogDataModel
 from merino.configs import settings
 from merino.utils.query_processing.pii_detect import PIIType
 

--- a/merino/utils/log_data_creators.py
+++ b/merino/utils/log_data_creators.py
@@ -2,7 +2,6 @@
 
 from datetime import datetime
 
-from pydantic import BaseModel, field_serializer
 from starlette.datastructures import Headers
 from starlette.requests import Request
 from starlette.types import Message
@@ -10,40 +9,7 @@ from starlette.types import Message
 from merino.middleware import ScopeKey
 from merino.middleware.geolocation import Location
 from merino.middleware.user_agent import UserAgent
-
-
-class LogDataModel(BaseModel):
-    """Shared generic log data model."""
-
-    errno: int
-    time: datetime
-    path: str
-    method: str
-
-    @field_serializer("time")
-    def serialize_time(self, v: datetime, **kwargs):
-        """Return a datetime value as an iso formatted str."""
-        return v.isoformat()
-
-
-class SuggestLogDataModel(LogDataModel):
-    """Log metadata specific to Suggest logs."""
-
-    sensitive: bool
-    query: str | None = None
-    code: int
-    rid: str  # Provided by the asgi-correlation-id middleware.
-    session_id: str | None = None
-    sequence_no: int | None = None
-    client_variants: str
-    requested_providers: str
-    country: str | None = None
-    region: str | None = None
-    city: str | None = None
-    dma: int | None = None
-    browser: str
-    os_family: str
-    form_factor: str
+from merino_common.models.suggest_logging import SuggestLogDataModel
 
 
 def create_suggest_log_data(

--- a/merino/utils/log_data_creators.py
+++ b/merino/utils/log_data_creators.py
@@ -9,7 +9,11 @@ from starlette.types import Message
 from merino.middleware import ScopeKey
 from merino.middleware.geolocation import Location
 from merino.middleware.user_agent import UserAgent
-from merino_common.models.suggest_logging import SuggestLogDataModel
+from merino_common.models.suggest_logging import (
+    MozlogDataModel,
+    SuggestLogDataModel,
+    SuggestRequestParams,
+)
 
 
 def create_suggest_log_data(
@@ -20,29 +24,35 @@ def create_suggest_log_data(
     user_agent: UserAgent = request.scope[ScopeKey.USER_AGENT]
 
     return SuggestLogDataModel(
-        # General Data
         sensitive=True,
-        errno=0,
-        time=dt,
-        # Request Data
-        path=request.url.path,
-        method=request.method,
-        query=request.query_params.get("q"),
-        code=message["status"],
-        rid=Headers(scope=message)["X-Request-ID"],
-        session_id=request.query_params.get("sid"),
-        sequence_no=(
-            int(seq) if (seq := request.query_params.get("seq", "")) and seq.isdecimal() else None
+        mozlog=MozlogDataModel(
+            # General Data
+            errno=0,
+            time=dt,
+            # Request Data
+            path=request.url.path,
+            method=request.method,
         ),
-        client_variants=request.query_params.get("client_variants", ""),
-        requested_providers=request.query_params.get("providers", ""),
-        # Location Data
-        country=location.country,
-        region=location.regions[0] if location.regions else None,
-        city=location.city,
-        dma=location.dma,
-        # User Agent Data
-        browser=user_agent.browser,
-        os_family=user_agent.os_family,
-        form_factor=user_agent.form_factor,
+        request_params=SuggestRequestParams(
+            query=request.query_params.get("q"),
+            code=message["status"],
+            rid=Headers(scope=message)["X-Request-ID"],
+            session_id=request.query_params.get("sid"),
+            sequence_no=(
+                int(seq)
+                if (seq := request.query_params.get("seq", "")) and seq.isdecimal()
+                else None
+            ),
+            client_variants=request.query_params.get("client_variants", ""),
+            requested_providers=request.query_params.get("providers", ""),
+            # Location Data
+            country=location.country,
+            region=location.regions[0] if location.regions else None,
+            city=location.city,
+            dma=location.dma,
+            # User Agent Data
+            browser=user_agent.browser,
+            os_family=user_agent.os_family,
+            form_factor=user_agent.form_factor,
+        ),
     )

--- a/tests/integration/api/v1/suggest/test_suggest.py
+++ b/tests/integration/api/v1/suggest/test_suggest.py
@@ -16,7 +16,7 @@ from pytest import LogCaptureFixture
 from pytest_mock import MockerFixture
 
 from merino.configs import settings
-from merino.utils.log_data_creators import SuggestLogDataModel
+from merino_common.models.suggest_logging import SuggestLogDataModel
 from merino.utils.query_processing.query_patterns import build_query_pattern_matcher
 from tests.integration.api.v1.fake_providers import FakeProviderFactory
 from tests.integration.api.v1.types import Providers

--- a/tests/integration/api/v1/suggest/test_suggest.py
+++ b/tests/integration/api/v1/suggest/test_suggest.py
@@ -16,7 +16,11 @@ from pytest import LogCaptureFixture
 from pytest_mock import MockerFixture
 
 from merino.configs import settings
-from merino_common.models.suggest_logging import SuggestLogDataModel
+from merino_common.models.suggest_logging import (
+    MozlogDataModel,
+    SuggestLogDataModel,
+    SuggestRequestParams,
+)
 from merino.utils.query_processing.query_patterns import build_query_pattern_matcher
 from tests.integration.api.v1.fake_providers import FakeProviderFactory
 from tests.integration.api.v1.types import Providers
@@ -261,34 +265,38 @@ def test_suggest_request_log_data(
 
     expected_log_data: SuggestLogDataModel = SuggestLogDataModel(
         sensitive=True,
-        errno=0,
-        time=datetime(1998, 3, 31),
-        path="/api/v1/suggest",
-        method="GET",
-        query="nope",
-        code=200,
-        rid="1b11844c52b34c33a6ad54b7bc2eb7c7",
-        session_id="deadbeef-0000-1111-2222-333344445555",
-        sequence_no=0,
-        client_variants="foo,bar",
-        requested_providers="pro,vider",
-        country="US",
-        region="WA",
-        city="Milton",
-        dma=819,
-        browser="Firefox(103.0)",
-        os_family="macos",
-        form_factor="desktop",
+        mozlog=MozlogDataModel(
+            errno=0,
+            time=datetime(1998, 3, 31),
+            path="/api/v1/suggest",
+            method="GET",
+        ),
+        request_params=SuggestRequestParams(
+            query="nope",
+            code=200,
+            rid="1b11844c52b34c33a6ad54b7bc2eb7c7",
+            session_id="deadbeef-0000-1111-2222-333344445555",
+            sequence_no=0,
+            client_variants="foo,bar",
+            requested_providers="pro,vider",
+            country="US",
+            region="WA",
+            city="Milton",
+            dma=819,
+            browser="Firefox(103.0)",
+            os_family="macos",
+            form_factor="desktop",
+        ),
     )
 
     client.get(
-        url=expected_log_data.path,
+        url=expected_log_data.mozlog.path,
         params={
-            "q": expected_log_data.query,
-            "sid": expected_log_data.session_id,
-            "seq": expected_log_data.sequence_no,
-            "client_variants": expected_log_data.client_variants,
-            "providers": expected_log_data.requested_providers,
+            "q": expected_log_data.request_params.query,
+            "sid": expected_log_data.request_params.session_id,
+            "seq": expected_log_data.request_params.sequence_no,
+            "client_variants": expected_log_data.request_params.client_variants,
+            "providers": expected_log_data.request_params.requested_providers,
         },
         headers={
             "User-Agent": (
@@ -305,24 +313,28 @@ def test_suggest_request_log_data(
     record = records[0]
     log_data: SuggestLogDataModel = SuggestLogDataModel(
         sensitive=record.__dict__["sensitive"],
-        errno=record.__dict__["errno"],
-        time=record.__dict__["time"],
-        path=record.__dict__["path"],
-        method=record.__dict__["method"],
-        query=record.__dict__["query"],
-        code=record.__dict__["code"],
-        rid=record.__dict__["rid"],
-        session_id=record.__dict__["session_id"],
-        sequence_no=record.__dict__["sequence_no"],
-        client_variants=record.__dict__["client_variants"],
-        requested_providers=record.__dict__["requested_providers"],
-        country=record.__dict__["country"],
-        region=record.__dict__["region"],
-        city=record.__dict__["city"],
-        dma=record.__dict__["dma"],
-        browser=record.__dict__["browser"],
-        os_family=record.__dict__["os_family"],
-        form_factor=record.__dict__["form_factor"],
+        mozlog=MozlogDataModel(
+            errno=record.__dict__["errno"],
+            time=record.__dict__["time"],
+            path=record.__dict__["path"],
+            method=record.__dict__["method"],
+        ),
+        request_params=SuggestRequestParams(
+            query=record.__dict__["query"],
+            code=record.__dict__["code"],
+            rid=record.__dict__["rid"],
+            session_id=record.__dict__["session_id"],
+            sequence_no=record.__dict__["sequence_no"],
+            client_variants=record.__dict__["client_variants"],
+            requested_providers=record.__dict__["requested_providers"],
+            country=record.__dict__["country"],
+            region=record.__dict__["region"],
+            city=record.__dict__["city"],
+            dma=record.__dict__["dma"],
+            browser=record.__dict__["browser"],
+            os_family=record.__dict__["os_family"],
+            form_factor=record.__dict__["form_factor"],
+        ),
     )
 
     assert log_data == expected_log_data

--- a/tests/unit/middleware/test_logging.py
+++ b/tests/unit/middleware/test_logging.py
@@ -11,8 +11,8 @@ from pytest import LogCaptureFixture
 from pytest_mock import MockerFixture
 from starlette.types import Receive, Scope, Send
 
-from merino.utils.log_data_creators import SuggestLogDataModel
 from merino.middleware.logging import LoggingMiddleware
+from merino_common.models.suggest_logging import SuggestLogDataModel
 from merino.configs import settings
 
 

--- a/tests/unit/utils/test_log_data_creator.py
+++ b/tests/unit/utils/test_log_data_creator.py
@@ -14,7 +14,11 @@ from merino.middleware import ScopeKey
 from merino.middleware.geolocation import Location
 from merino.middleware.user_agent import UserAgent
 from merino.utils.log_data_creators import create_suggest_log_data
-from merino_common.models.suggest_logging import SuggestLogDataModel
+from merino_common.models.suggest_logging import (
+    MozlogDataModel,
+    SuggestLogDataModel,
+    SuggestRequestParams,
+)
 
 
 @pytest.mark.parametrize(
@@ -73,24 +77,28 @@ def test_create_suggest_log_data(
     )
     expected_log_data: SuggestLogDataModel = SuggestLogDataModel(
         sensitive=True,
-        errno=0,
-        time=datetime(1998, 3, 31),
-        path="/api/v1/suggest",
-        method="GET",
-        query=expected_query,
-        code=200,
-        rid="1b11844c52b34c33a6ad54b7bc2eb7c7",
-        session_id=expected_sid,
-        sequence_no=expected_seq,
-        client_variants=expected_client_variants,
-        requested_providers=expected_providers,
-        country=location.country,
-        region=location.regions[0] if location.regions else None,
-        city=location.city,
-        dma=location.dma,
-        browser=user_agent.browser,
-        os_family=user_agent.os_family,
-        form_factor=user_agent.form_factor,
+        mozlog=MozlogDataModel(
+            errno=0,
+            time=datetime(1998, 3, 31),
+            path="/api/v1/suggest",
+            method="GET",
+        ),
+        request_params=SuggestRequestParams(
+            query=expected_query,
+            code=200,
+            rid="1b11844c52b34c33a6ad54b7bc2eb7c7",
+            session_id=expected_sid,
+            sequence_no=expected_seq,
+            client_variants=expected_client_variants,
+            requested_providers=expected_providers,
+            country=location.country,
+            region=location.regions[0] if location.regions else None,
+            city=location.city,
+            dma=location.dma,
+            browser=user_agent.browser,
+            os_family=user_agent.os_family,
+            form_factor=user_agent.form_factor,
+        ),
     )
 
     request: Request = Request(

--- a/tests/unit/utils/test_log_data_creator.py
+++ b/tests/unit/utils/test_log_data_creator.py
@@ -4,22 +4,17 @@
 
 """Unit tests for the log_data_creator.py utility module."""
 
-from datetime import datetime, timezone
-from typing import Any
+from datetime import datetime
 
 import pytest
-from pydantic import ValidationError
 from starlette.requests import Request
 from starlette.types import Message
 
 from merino.middleware import ScopeKey
 from merino.middleware.geolocation import Location
 from merino.middleware.user_agent import UserAgent
-from merino.utils.log_data_creators import (
-    LogDataModel,
-    SuggestLogDataModel,
-    create_suggest_log_data,
-)
+from merino.utils.log_data_creators import create_suggest_log_data
+from merino_common.models.suggest_logging import SuggestLogDataModel
 
 
 @pytest.mark.parametrize(
@@ -124,42 +119,3 @@ def test_create_suggest_log_data(
     log_data: SuggestLogDataModel = create_suggest_log_data(request, message, dt)
 
     assert log_data == expected_log_data
-
-
-@pytest.mark.parametrize(
-    "time_input",
-    ["not a datetime string", {"not", "a", "datetime", "object"}],
-    ids=["invalid_string", "invalid_object_type"],
-)
-def test_create_log_object_fails_on_invalid_time(time_input: Any):
-    """Test that `time` fails validation on invalid time input."""
-    with pytest.raises(ValidationError):
-        LogDataModel(
-            errno=0,
-            time=time_input,
-            path="/",
-            method="GET",
-        )
-
-
-@pytest.mark.parametrize("expected_time", ["2022-12-18T15:58:41+00:00"])
-@pytest.mark.parametrize(
-    "datetime_rep",
-    [
-        datetime(2022, 12, 18, hour=15, minute=58, second=41, tzinfo=timezone.utc),
-    ],
-    ids=["datetime_obj"],
-)
-def test_create_log_object_can_convert_time_to_isoformat(
-    datetime_rep: datetime, expected_time: str
-):
-    """Ensure that `time` field correctly validates datetime inputs
-    and outputs ISO format string.
-    """
-    log_data = LogDataModel(
-        errno=0,
-        time=datetime_rep,
-        path="/",
-        method="GET",
-    )
-    assert log_data.model_dump().get("time") == expected_time

--- a/uv.lock
+++ b/uv.lock
@@ -1784,14 +1784,21 @@ dependencies = [
     { name = "sentry-sdk", extra = ["fastapi"] },
 ]
 
+[package.optional-dependencies]
+testing = [
+    { name = "opentelemetry-sdk" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "dockerflow", specifier = ">=2026.3.4,<2027" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.0,<1" },
     { name = "opentelemetry-api", specifier = ">=1.42.1,<2" },
+    { name = "opentelemetry-sdk", marker = "extra == 'testing'", specifier = ">=1.42.1,<2" },
     { name = "pydantic", specifier = ">=2.13.0,<3" },
     { name = "sentry-sdk", extras = ["fastapi"], specifier = ">=2.13.0,<3" },
 ]
+provides-extras = ["testing"]
 
 [[package]]
 name = "merino-fleece"
@@ -3391,13 +3398,13 @@ resolution-markers = [
     "sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "filelock", marker = "sys_platform == 'darwin'" },
-    { name = "fsspec", marker = "sys_platform == 'darwin'" },
-    { name = "jinja2", marker = "sys_platform == 'darwin'" },
-    { name = "networkx", marker = "sys_platform == 'darwin'" },
-    { name = "setuptools", marker = "sys_platform == 'darwin'" },
-    { name = "sympy", marker = "sys_platform == 'darwin'" },
-    { name = "typing-extensions", marker = "sys_platform == 'darwin'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:e9b6f7d2dd66ea87a3ae620069d31335d594c06effb1a383bdd21cfe61e44ece", upload-time = "2026-06-17T15:44:16Z" },
@@ -3412,13 +3419,13 @@ resolution-markers = [
     "sys_platform != 'darwin'",
 ]
 dependencies = [
-    { name = "filelock", marker = "sys_platform != 'darwin'" },
-    { name = "fsspec", marker = "sys_platform != 'darwin'" },
-    { name = "jinja2", marker = "sys_platform != 'darwin'" },
-    { name = "networkx", marker = "sys_platform != 'darwin'" },
-    { name = "setuptools", marker = "sys_platform != 'darwin'" },
-    { name = "sympy", marker = "sys_platform != 'darwin'" },
-    { name = "typing-extensions", marker = "sys_platform != 'darwin'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp314-cp314-linux_s390x.whl", hash = "sha256:ef228ec70f5e73762c213f145c0fdb672e5770a6de760801c58b933b0d5b6957", upload-time = "2026-06-18T01:58:09Z" },


### PR DESCRIPTION
## References

JIRA: [DISCO-4333](https://mozilla-hub.atlassian.net/browse/DISCO-4333)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->

This adds a new endpoint `api/v1/search_terms` to Fleece to receive search terms from Merino for sanitization and logging.

- The new endpoint only validates the request and replies a response code. Sanitization and logging will be added as a followup.
- It records a metric to count the number of search terms received using OTEL metics. Various metric test utility functions are moved to `merino-common.testing` for reusing.
- Also move various Suggest logging models to `merino-common` for the same reason.
- Add `metrics.yaml` to `merino-fleece` to document Fleece's metrics.

Changes are split into two parts to facilitate review.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-4333]: https://mozilla-hub.atlassian.net/browse/DISCO-4333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ