### PR TITLE
[DISCO-4377] suggest/adm: set is_top_pick only if top_pick_prefix is not null

### DIFF
--- a/merino/providers/suggest/adm/provider.py
+++ b/merino/providers/suggest/adm/provider.py
@@ -374,9 +374,9 @@ class Provider(BaseProvider):
             # opted into `top_pick_promotion` and the record's `top_pick_prefix`
             # appears in the query.
             is_top_pick = None
-            if TOP_PICK_PROMOTION in client_variants:
-                is_top_pick = res.top_pick_prefix is not None and q.startswith(res.top_pick_prefix)
-                if is_top_pick and res.top_pick_prefix:
+            if TOP_PICK_PROMOTION in client_variants and res.top_pick_prefix is not None:
+                is_top_pick = q.startswith(res.top_pick_prefix)
+                if is_top_pick:
                     self.metrics_client.increment(
                         "providers.adm.top_pick_promotion",
                         tags={

--- a/tests/unit/providers/suggest/adm/test_provider.py
+++ b/tests/unit/providers/suggest/adm/test_provider.py
@@ -464,6 +464,25 @@ async def test_top_pick_promotion_metric_not_emitted(
     adm_top_pick.metrics_client.increment.assert_not_called()  # type: ignore[attr-defined]
 
 
+@pytest.mark.asyncio
+async def test_query_is_top_pick_none_when_record_has_no_prefix(
+    srequest: SuggestionRequestFixture,
+    adm: Provider,
+) -> None:
+    """`is_top_pick` is None when the client opts into
+    `top_pick_promotion` but the matched record has no `top_pick_prefix`.
+    """
+    await adm.initialize()
+    user_agent = UserAgent(form_factor="desktop", browser="firefox", os_family="macos")
+    geolocation = Location(country="US")
+
+    res = await adm.query(srequest("firefox", geolocation, user_agent, ["top_pick_promotion"]))
+
+    assert len(res) == 1
+    assert res[0].is_top_pick is None
+    adm.metrics_client.increment.assert_not_called()  # type: ignore[attr-defined]
+
+
 SAMPLE_ENGAGEMENT_DATA = EngagementData(
     amp={
         "mozilla/firefox": KeywordEntry(


### PR DESCRIPTION
…not null

## References

JIRA: [DISCO-4377](https://mozilla-hub.atlassian.net/browse/DISCO-4377)

## Description
MARs would like to have `top_pick_prefix` field for all suggestions. we need to account for this, so that `is_top_pick` isn't set to false



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2494)


[DISCO-4377]: https://mozilla-hub.atlassian.net/browse/DISCO-4377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ