### PR TITLE
AIMOD-1424 Shift time zone interpretation for inferred presonalization

### DIFF
--- a/merino/curated_recommendations/ml_backends/static_local_model.py
+++ b/merino/curated_recommendations/ml_backends/static_local_model.py
@@ -303,7 +303,11 @@ class SuperInferredModel(LocalModelBackend):
     @staticmethod
     def _get_time_zone(small_population=False) -> InterestVectorConfig:
         """Time zone key has special functionality in Firefox, but we must specifiy threshols here
-        based on UTC offset +24 (positive values). These thresholds support the 4 continental US zones
+        based on UTC offset +24 (positive values). These thresholds originally supported 4 time zones, but
+        what we are finding is that a lot of users have 0 offset, due to either a privacy blocker or some
+        OS issue. Therefore we segment users with offset below pacific (hawaii, and all users with no privacy set)
+        into the 0 bucket. The following bucket is pacific and mountain combined, then we continue with central
+        and eastern time.
         """
         now: datetime = datetime.now(ZoneInfo("America/Los_Angeles"))
         offset: timedelta = now.utcoffset() or timedelta(0)
@@ -311,14 +315,14 @@ class SuperInferredModel(LocalModelBackend):
         if small_population:
             return InterestVectorConfig(
                 features={},
-                thresholds=[pacific_bucket + 1.1],  # split west from east
+                thresholds=[pacific_bucket + 2.1],  # split west from east
                 diff_p=MODEL_P_VALUE_SMALL_POPULATION,
                 diff_q=MODEL_Q_VALUE_SMALL_POPULATION,
             )
         else:
             return InterestVectorConfig(
                 features={},
-                thresholds=[pacific_bucket + 0.1, pacific_bucket + 1.1, pacific_bucket + 2.1],
+                thresholds=[pacific_bucket - 2, pacific_bucket + 1.1, pacific_bucket + 2.1],
                 diff_p=MODEL_P_VALUE,
                 diff_q=MODEL_Q_VALUE,
             )

--- a/tests/unit/curated_recommendations/ml_backends/test_lints_interest_model.py
+++ b/tests/unit/curated_recommendations/ml_backends/test_lints_interest_model.py
@@ -169,7 +169,7 @@ def _build_synthetic_bundle(
         tensors["tz_preds"] = tz_pred_values
         metadata["tz_pred_idx"] = str(tz_pred_idx)
         metadata["tz_baseline_idx"] = str(tz_baseline_idx)
-        metadata["tz_labels"] = json.dumps(["PT", "MT", "CT", "ET"][:n_tz_labels])
+        metadata["tz_labels"] = json.dumps(["UNK", "PT_MT", "CT", "ET"][:n_tz_labels])
         metadata["tz_pred_item_to_idx"] = json.dumps(tz_pred_item_to_idx)
 
     blob = save(tensors, metadata=metadata)


### PR DESCRIPTION
## References

JIRA: https://mozilla-hub.atlassian.net/browse/AIMOD-1424

## Description
There is a high volume of users with null time zone indicating that the time zone is not set or blocked by the user. These have been getting lumped with pacific time, causing PT personalization to not work well.

A fix is to segment these null users in their own timezone, and combine pacific and mountain time.

Companion PR https://github.com/mozilla/content-ml-services/pull/1269

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2498)
