### PR TITLE
[AIMOD-1408] Stratify engagement by experiment branch

### DIFF
--- a/merino/curated_recommendations/article_balancer_configs.py
+++ b/merino/curated_recommendations/article_balancer_configs.py
@@ -4,7 +4,13 @@ from collections.abc import Callable, Collection
 from dataclasses import dataclass, replace
 
 from merino.curated_recommendations.corpus_backends.protocol import SurfaceId, Topic
-from merino.curated_recommendations.protocol import ITEM_SUBTOPIC_FLAG, CuratedRecommendation
+from merino.curated_recommendations.protocol import (
+    ITEM_SUBTOPIC_FLAG,
+    CuratedRecommendation,
+    CuratedRecommendationsRequest,
+    ExperimentName,
+)
+from merino.curated_recommendations.utils import is_enrolled_in_experiment
 
 
 @dataclass(frozen=True)
@@ -72,10 +78,26 @@ TOP_STORIES_BALANCER_CONFIG_BY_SURFACE: dict[SurfaceId, ArticleBalancerConfig] =
 }
 
 
-def get_top_stories_article_balancer_config(surface_id: SurfaceId) -> ArticleBalancerConfig:
+def get_top_stories_article_balancer_config(
+    surface_id: SurfaceId,
+    request: CuratedRecommendationsRequest | None = None,
+) -> ArticleBalancerConfig:
     """Return the Top Stories/Popular Today balancer config for a surface."""
-    # Future experiment-specific overrides should be selected here once the experiment id
-    # is threaded into this function.
-    return TOP_STORIES_BALANCER_CONFIG_BY_SURFACE.get(
+    config = TOP_STORIES_BALANCER_CONFIG_BY_SURFACE.get(
         surface_id, DEFAULT_TOP_STORIES_ARTICLE_BALANCER_CONFIG
     )
+    if (
+        surface_id == SurfaceId.NEW_TAB_DE_DE
+        and request is not None
+        and is_enrolled_in_experiment(
+            request,
+            ExperimentName.PUBLISHER_CONSTRAINT_IN_GERMANY_EXPERIMENT.value,
+            "treatment",
+        )
+    ):
+        return replace(
+            config,
+            max_per_publisher=DEFAULT_TOP_STORIES_ARTICLE_BALANCER_CONFIG.max_per_publisher,
+            publisher_enforcement_likelyhood=0.0,
+        )
+    return config

--- a/merino/curated_recommendations/legacy/sections_adapter.py
+++ b/merino/curated_recommendations/legacy/sections_adapter.py
@@ -59,7 +59,6 @@ async def get_legacy_recommendations_from_sections(
     surface_id: SurfaceId,
     count: int,
     region: str | None = None,
-    engagement_region: str | None = None,
     rescaler: EngagementRescaler | None = None,
 ) -> list[CuratedRecommendation]:
     """Fetch section items and return as a flat list for non-sections clients.
@@ -71,15 +70,12 @@ async def get_legacy_recommendations_from_sections(
         surface_id: Surface identifier (e.g. NEW_TAB_EN_US, NEW_TAB_EN_GB)
         count: Maximum number of recommendations to return
         region: Optional region for engagement filtering (e.g., 'US', 'CA')
-        engagement_region: Optional engagement lookup region. Defaults to region.
         rescaler: Optional rescaler for Thompson sampling (applies pessimistic priors
             and scales engagement metrics for gaming/hobbies content)
 
     Returns:
         Ranked list of CuratedRecommendation objects
     """
-    engagement_region = region if engagement_region is None else engagement_region
-
     # 1. Fetch corpus sections (headlines section discarded; only used in sections feed)
     _, corpus_sections = await get_corpus_sections(
         sections_backend=sections_backend,
@@ -118,7 +114,6 @@ async def get_legacy_recommendations_from_sections(
     recommendations = ranker.rank_items(
         recommendations,
         region=region,
-        engagement_region=engagement_region,
         rescaler=rescaler,
     )
 

--- a/merino/curated_recommendations/legacy/sections_adapter.py
+++ b/merino/curated_recommendations/legacy/sections_adapter.py
@@ -59,6 +59,7 @@ async def get_legacy_recommendations_from_sections(
     surface_id: SurfaceId,
     count: int,
     region: str | None = None,
+    engagement_region: str | None = None,
     rescaler: EngagementRescaler | None = None,
 ) -> list[CuratedRecommendation]:
     """Fetch section items and return as a flat list for non-sections clients.
@@ -70,12 +71,15 @@ async def get_legacy_recommendations_from_sections(
         surface_id: Surface identifier (e.g. NEW_TAB_EN_US, NEW_TAB_EN_GB)
         count: Maximum number of recommendations to return
         region: Optional region for engagement filtering (e.g., 'US', 'CA')
+        engagement_region: Optional engagement lookup region. Defaults to region.
         rescaler: Optional rescaler for Thompson sampling (applies pessimistic priors
             and scales engagement metrics for gaming/hobbies content)
 
     Returns:
         Ranked list of CuratedRecommendation objects
     """
+    engagement_region = region if engagement_region is None else engagement_region
+
     # 1. Fetch corpus sections (headlines section discarded; only used in sections feed)
     _, corpus_sections = await get_corpus_sections(
         sections_backend=sections_backend,
@@ -111,7 +115,12 @@ async def get_legacy_recommendations_from_sections(
         engagement_backend=engagement_backend,
         prior_backend=prior_backend,
     )
-    recommendations = ranker.rank_items(recommendations, region=region, rescaler=rescaler)
+    recommendations = ranker.rank_items(
+        recommendations,
+        region=region,
+        engagement_region=engagement_region,
+        rescaler=rescaler,
+    )
 
     # 7. Apply publisher spread
     recommendations = spread_publishers(recommendations, spread_distance=3)

--- a/merino/curated_recommendations/protocol.py
+++ b/merino/curated_recommendations/protocol.py
@@ -116,6 +116,8 @@ class ExperimentName(str, Enum):
     SECTIONS_IN_EN_EUROPE_EXPERIMENT = "sections-in-en-europe"
     # Experiment to serve the global Spanish sections surface (NEW_TAB_ES_XA)
     SECTIONS_IN_GLOBAL_SPANISH_EXPERIMENT = "sections-in-global-spanish"
+    # Experiment to apply Germany publisher constraint engagement by branch
+    PUBLISHER_CONSTRAINT_IN_GERMANY_EXPERIMENT = "publisher-constraint-in-germany"
 
     # Experiment for doing local reranking of popular today via inferred interests
     INFERRED_LOCAL_EXPERIMENT = "new-tab-automated-personalization-local-ranking"

--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -45,6 +45,7 @@ from merino.curated_recommendations.prior_backends.engagment_rescaler import (
 from merino.curated_recommendations.sections import get_sections
 from merino.curated_recommendations.utils import (
     ROLLED_OUT_SECTION_SURFACES,
+    derive_engagement_region,
     get_recommendation_surface_id,
     get_millisecond_epoch_time,
     derive_region,
@@ -116,13 +117,16 @@ class CuratedRecommendationsProvider:
         @param request: The full API request with all the data
         @return: A re-ranked list of curated recommendations
         """
+        region = derive_region(request.locale, request.region)
+        engagement_region = derive_engagement_region(request)
         ranker = ThompsonSamplingRanker(
             engagement_backend=self.engagement_backend,
             prior_backend=self.prior_backend,
         )
         recommendations = ranker.rank_items(
             recommendations,
-            region=derive_region(request.locale, request.region),
+            region=region,
+            engagement_region=engagement_region,
         )
 
         # 2. Perform publisher spread on the recommendation set
@@ -147,6 +151,8 @@ class CuratedRecommendationsProvider:
         surface_id = get_recommendation_surface_id(
             locale=request.locale, region=request.region, request=request
         )
+        region = derive_region(request.locale, request.region)
+        engagement_region = derive_engagement_region(request)
 
         sections_feeds = None
         general_feed: list[CuratedRecommendation] = []
@@ -172,7 +178,8 @@ class CuratedRecommendationsProvider:
                 sections_backend=self.sections_backend,
                 ml_backend=self.ml_recommendations_backend,
                 lints_interest_backend=self.lints_interest_backend,
-                region=derive_region(request.locale, request.region),
+                region=region,
+                engagement_region=engagement_region,
                 spindle_backend=self.spindle_backend,
             )
         elif surface_id in ROLLED_OUT_SECTION_SURFACES:
@@ -184,7 +191,8 @@ class CuratedRecommendationsProvider:
                 prior_backend=self.prior_backend,
                 surface_id=surface_id,
                 count=request.count,
-                region=derive_region(request.locale, request.region),
+                region=region,
+                engagement_region=engagement_region,
                 rescaler=rescaler,
             )
         else:

--- a/merino/curated_recommendations/provider.py
+++ b/merino/curated_recommendations/provider.py
@@ -192,7 +192,6 @@ class CuratedRecommendationsProvider:
                 surface_id=surface_id,
                 count=request.count,
                 region=region,
-                engagement_region=engagement_region,
                 rescaler=rescaler,
             )
         else:

--- a/merino/curated_recommendations/rankers/contextual_ranker.py
+++ b/merino/curated_recommendations/rankers/contextual_ranker.py
@@ -78,6 +78,8 @@ class ContextualRanker(Ranker):
         """Pull out scores that were previously computed from the contextual ranker
         data artifact. We need to look up the items in the ml backend using region.
         """
+        regional_prior = self.get_regional_prior(region, engagement_region)
+        engagement_region = self.resolve_engagement_region(recs, region, engagement_region)
 
         def boost_interest(rec: CuratedRecommendation) -> float:
             if personal_interests is None or rec.topic is None:
@@ -117,6 +119,7 @@ class ContextualRanker(Ranker):
                 rescaler,
                 region,
                 engagement_region=engagement_region,
+                regional_prior=regional_prior,
                 blend_region_with_global=False,
             )
             is_fresh = False

--- a/merino/curated_recommendations/rankers/contextual_ranker.py
+++ b/merino/curated_recommendations/rankers/contextual_ranker.py
@@ -73,6 +73,7 @@ class ContextualRanker(Ranker):
         rescaler: EngagementRescaler | None = None,
         personal_interests: ProcessedInterests | None = None,
         region: str | None = None,
+        engagement_region: str | None = None,
     ) -> list[CuratedRecommendation]:
         """Pull out scores that were previously computed from the contextual ranker
         data artifact. We need to look up the items in the ml backend using region.
@@ -112,7 +113,11 @@ class ContextualRanker(Ranker):
         rng = np.random.default_rng()
         for rec in recs:
             opens, no_opens, a_prior, b_prior, non_rescaled_b_prior = self.compute_interactions(
-                rec, rescaler, region, blend_region_with_global=False
+                rec,
+                rescaler,
+                region,
+                engagement_region=engagement_region,
+                blend_region_with_global=False,
             )
             is_fresh = False
             # add random value between 0 and 1 to break ties randomly
@@ -166,6 +171,8 @@ class ContextualRanker(Ranker):
         sections: dict[str, Section],
         top_n: int = 4,
         rescaler: EngagementRescaler | None = None,
+        region: str | None = None,
+        engagement_region: str | None = None,
     ) -> dict[str, Section]:
         """Re-rank sections using average score of top items."""
 

--- a/merino/curated_recommendations/rankers/contextual_ranker.py
+++ b/merino/curated_recommendations/rankers/contextual_ranker.py
@@ -78,8 +78,6 @@ class ContextualRanker(Ranker):
         """Pull out scores that were previously computed from the contextual ranker
         data artifact. We need to look up the items in the ml backend using region.
         """
-        regional_prior = self.get_regional_prior(region, engagement_region)
-        engagement_region = self.resolve_engagement_region(recs, region, engagement_region)
 
         def boost_interest(rec: CuratedRecommendation) -> float:
             if personal_interests is None or rec.topic is None:
@@ -119,7 +117,6 @@ class ContextualRanker(Ranker):
                 rescaler,
                 region,
                 engagement_region=engagement_region,
-                regional_prior=regional_prior,
                 blend_region_with_global=False,
             )
             is_fresh = False

--- a/merino/curated_recommendations/rankers/interest_ranker.py
+++ b/merino/curated_recommendations/rankers/interest_ranker.py
@@ -78,8 +78,8 @@ class InterestRanker(Ranker):
         Falls back to vanilla Thompson sampling for items the model doesn't
         know, and for the whole list if ``personal_interests`` is missing.
         """
-        regional_prior = self.get_regional_prior(region, engagement_region)
-        engagement_region = self.resolve_engagement_region(recs, region, engagement_region)
+        # LinTS artifacts are not branch-engagement-aware yet, so keep engagement_region
+        # as a no-op for this ranker until the model path explicitly supports it.
         rng = np.random.default_rng()
         fresh_items_limit_prior_threshold_multiplier: float = (
             rescaler.fresh_items_limit_prior_threshold_multiplier if rescaler else 0
@@ -112,8 +112,6 @@ class InterestRanker(Ranker):
                 rec,
                 rescaler,
                 region,
-                engagement_region=engagement_region,
-                regional_prior=regional_prior,
                 blend_region_with_global=False,
             )
 

--- a/merino/curated_recommendations/rankers/interest_ranker.py
+++ b/merino/curated_recommendations/rankers/interest_ranker.py
@@ -78,8 +78,6 @@ class InterestRanker(Ranker):
         Falls back to vanilla Thompson sampling for items the model doesn't
         know, and for the whole list if ``personal_interests`` is missing.
         """
-        regional_prior = self.get_regional_prior(region, engagement_region)
-        engagement_region = self.resolve_engagement_region(recs, region, engagement_region)
         rng = np.random.default_rng()
         fresh_items_limit_prior_threshold_multiplier: float = (
             rescaler.fresh_items_limit_prior_threshold_multiplier if rescaler else 0
@@ -113,7 +111,6 @@ class InterestRanker(Ranker):
                 rescaler,
                 region,
                 engagement_region=engagement_region,
-                regional_prior=regional_prior,
                 blend_region_with_global=False,
             )
 

--- a/merino/curated_recommendations/rankers/interest_ranker.py
+++ b/merino/curated_recommendations/rankers/interest_ranker.py
@@ -71,6 +71,7 @@ class InterestRanker(Ranker):
         rescaler: EngagementRescaler | None = None,
         personal_interests: ProcessedInterests | None = None,
         region: str | None = None,
+        engagement_region: str | None = None,
     ) -> list[CuratedRecommendation]:
         """Score and sort recommendations using the LinTS-interest model.
 
@@ -106,7 +107,11 @@ class InterestRanker(Ranker):
 
         for r, rec in enumerate(recs):
             opens, no_opens, a_prior, b_prior, non_rescaled_b_prior = self.compute_interactions(
-                rec, rescaler, region, blend_region_with_global=False
+                rec,
+                rescaler,
+                region,
+                engagement_region=engagement_region,
+                blend_region_with_global=False,
             )
 
             # Two conditions must hold to use the LinTS score:
@@ -154,6 +159,8 @@ class InterestRanker(Ranker):
         sections: dict[str, Section],
         top_n: int = 4,
         rescaler: EngagementRescaler | None = None,
+        region: str | None = None,
+        engagement_region: str | None = None,
     ) -> dict[str, Section]:
         """Rank sections by mean score of their top items."""
 

--- a/merino/curated_recommendations/rankers/interest_ranker.py
+++ b/merino/curated_recommendations/rankers/interest_ranker.py
@@ -78,6 +78,8 @@ class InterestRanker(Ranker):
         Falls back to vanilla Thompson sampling for items the model doesn't
         know, and for the whole list if ``personal_interests`` is missing.
         """
+        regional_prior = self.get_regional_prior(region, engagement_region)
+        engagement_region = self.resolve_engagement_region(recs, region, engagement_region)
         rng = np.random.default_rng()
         fresh_items_limit_prior_threshold_multiplier: float = (
             rescaler.fresh_items_limit_prior_threshold_multiplier if rescaler else 0
@@ -111,6 +113,7 @@ class InterestRanker(Ranker):
                 rescaler,
                 region,
                 engagement_region=engagement_region,
+                regional_prior=regional_prior,
                 blend_region_with_global=False,
             )
 

--- a/merino/curated_recommendations/rankers/ranker.py
+++ b/merino/curated_recommendations/rankers/ranker.py
@@ -37,7 +37,7 @@ class Ranker:
     def get_opens_no_opens(
         self, rec: CuratedRecommendation, region_query: str | None = None
     ) -> tuple[float, float, bool]:
-        """Get opens and no-opens counts for a recommendation, optionally in a region."""
+        """Get opens, no-opens, and whether engagement exists for a recommendation."""
         engagement = self.engagement_backend.get(rec.corpusItemId, region_query)
         if engagement:
             return (

--- a/merino/curated_recommendations/rankers/ranker.py
+++ b/merino/curated_recommendations/rankers/ranker.py
@@ -49,11 +49,14 @@ class Ranker:
         rec: CuratedRecommendation,
         rescaler: EngagementRescaler | None = None,
         region: str | None = None,
+        engagement_region: str | None = None,
         blend_region_with_global=True,
     ) -> tuple[float, float, float, float, float]:
         """Compute opens, no_opens, a_prior, b_prior, non_rescaled_b_prior for a recommendation."""
         opens, no_opens = self.get_opens_no_opens(rec)
-        region_opens, region_no_opens = self.get_opens_no_opens(rec, region_query=region)
+        region_opens, region_no_opens = self.get_opens_no_opens(
+            rec, region_query=engagement_region if engagement_region is not None else region
+        )
 
         prior: Prior = self.prior_backend.get() or ConstantPrior().get()
         a_prior = float(prior.alpha)
@@ -101,6 +104,7 @@ class Ranker:
         rescaler: EngagementRescaler | None = None,
         personal_interests: ProcessedInterests | None = None,
         region: str | None = None,
+        engagement_region: str | None = None,
     ) -> list[CuratedRecommendation]:
         """Rank items according to some criteria."""
         # Placeholder implementation: sort by title alphabetically
@@ -111,6 +115,8 @@ class Ranker:
         sections: dict[str, Section],
         top_n: int = 4,
         rescaler: EngagementRescaler | None = None,
+        region: str | None = None,
+        engagement_region: str | None = None,
     ) -> dict[str, Section]:
         """Rank sections."""
         return sections

--- a/merino/curated_recommendations/rankers/ranker.py
+++ b/merino/curated_recommendations/rankers/ranker.py
@@ -48,31 +48,64 @@ class Ranker:
         else:
             return 0, 0, False
 
+    def resolve_engagement_region(
+        self,
+        recs: list[CuratedRecommendation],
+        region: str | None = None,
+        engagement_region: str | None = None,
+    ) -> str | None:
+        """Return the engagement region to use for the full candidate list.
+
+        Branch-specific engagement regions should be all-or-nothing for a ranking pass:
+        use the branch region if any candidate has branch engagement, otherwise fall back
+        to the base country region.
+        """
+        if engagement_region is None or engagement_region == region:
+            return engagement_region
+
+        for rec in recs:
+            if self.engagement_backend.get(rec.corpusItemId, engagement_region) is not None:
+                return engagement_region
+
+        return region
+
+    def get_regional_prior(
+        self,
+        region: str | None = None,
+        prior_region: str | None = None,
+    ) -> Prior | None:
+        """Return the prior for a branch region, falling back to the base region.
+
+        Branch-specific priors are request-level artifacts. If a branch prior exists,
+        use it for the full ranking pass; otherwise fall back to the base country prior.
+        """
+        if prior_region is not None and prior_region != region:
+            prior = self.prior_backend.get(prior_region)
+            if prior is not None:
+                return prior
+
+        return self.prior_backend.get(region)
+
     def compute_interactions(
         self,
         rec: CuratedRecommendation,
         rescaler: EngagementRescaler | None = None,
         region: str | None = None,
         engagement_region: str | None = None,
+        regional_prior: Prior | None = None,
         blend_region_with_global=True,
     ) -> tuple[float, float, float, float, float]:
         """Compute opens, no_opens, a_prior, b_prior, non_rescaled_b_prior for a recommendation."""
         opens, no_opens, _ = self.get_opens_no_opens(rec)
         region_query = engagement_region if engagement_region is not None else region
-        region_opens, region_no_opens, found_region_engagement = self.get_opens_no_opens(
-            rec, region_query=region_query
-        )
-        if (
-            not found_region_engagement
-            and engagement_region is not None
-            and engagement_region != region
-        ):
-            region_opens, region_no_opens, _ = self.get_opens_no_opens(rec, region_query=region)
+        region_opens, region_no_opens, _ = self.get_opens_no_opens(rec, region_query=region_query)
 
         prior: Prior = self.prior_backend.get() or ConstantPrior().get()
         a_prior = float(prior.alpha)
         b_prior = float(prior.beta)
-        region_prior = self.prior_backend.get(region)
+        region_prior = (
+            regional_prior if regional_prior is not None else self.prior_backend.get(region)
+        )
 
         if region_no_opens and region_prior:
             # Weighted average of regional and global engagement

--- a/merino/curated_recommendations/rankers/ranker.py
+++ b/merino/curated_recommendations/rankers/ranker.py
@@ -36,13 +36,17 @@ class Ranker:
 
     def get_opens_no_opens(
         self, rec: CuratedRecommendation, region_query: str | None = None
-    ) -> tuple[float, float]:
+    ) -> tuple[float, float, bool]:
         """Get opens and no-opens counts for a recommendation, optionally in a region."""
         engagement = self.engagement_backend.get(rec.corpusItemId, region_query)
         if engagement:
-            return engagement.click_count, engagement.impression_count - engagement.click_count
+            return (
+                engagement.click_count,
+                engagement.impression_count - engagement.click_count,
+                True,
+            )
         else:
-            return 0, 0
+            return 0, 0, False
 
     def compute_interactions(
         self,
@@ -53,10 +57,17 @@ class Ranker:
         blend_region_with_global=True,
     ) -> tuple[float, float, float, float, float]:
         """Compute opens, no_opens, a_prior, b_prior, non_rescaled_b_prior for a recommendation."""
-        opens, no_opens = self.get_opens_no_opens(rec)
-        region_opens, region_no_opens = self.get_opens_no_opens(
-            rec, region_query=engagement_region if engagement_region is not None else region
+        opens, no_opens, _ = self.get_opens_no_opens(rec)
+        region_query = engagement_region if engagement_region is not None else region
+        region_opens, region_no_opens, found_region_engagement = self.get_opens_no_opens(
+            rec, region_query=region_query
         )
+        if (
+            not found_region_engagement
+            and engagement_region is not None
+            and engagement_region != region
+        ):
+            region_opens, region_no_opens, _ = self.get_opens_no_opens(rec, region_query=region)
 
         prior: Prior = self.prior_backend.get() or ConstantPrior().get()
         a_prior = float(prior.alpha)

--- a/merino/curated_recommendations/rankers/t_sampling.py
+++ b/merino/curated_recommendations/rankers/t_sampling.py
@@ -59,6 +59,8 @@ class ThompsonSamplingRanker(Ranker):
 
         [thompson-sampling]: https://en.wikipedia.org/wiki/Thompson_sampling
         """
+        regional_prior = self.get_regional_prior(region, engagement_region)
+        engagement_region = self.resolve_engagement_region(recs, region, engagement_region)
         fresh_items_max: int = rescaler.fresh_items_max if rescaler else 0
         fresh_items_limit_prior_threshold_multiplier: float = (
             rescaler.fresh_items_limit_prior_threshold_multiplier if rescaler else 0
@@ -81,7 +83,11 @@ class ThompsonSamplingRanker(Ranker):
         def compute_ranking_scores(rec: CuratedRecommendation):
             """Sample beta distributed from weighted regional/global engagement for a recommendation."""
             opens, no_opens, a_prior, b_prior, non_rescaled_b_prior = self.compute_interactions(
-                rec, rescaler, region, engagement_region=engagement_region
+                rec,
+                rescaler,
+                region,
+                engagement_region=engagement_region,
+                regional_prior=regional_prior,
             )
             # Add priors and ensure opens and no_opens are > 0, which is required by beta.rvs.
             alpha_val = opens + max(a_prior, 1e-18)
@@ -129,6 +135,12 @@ class ThompsonSamplingRanker(Ranker):
 
         [thompson-sampling]: https://en.wikipedia.org/wiki/Thompson_sampling
         """
+        regional_prior = self.get_regional_prior(region, engagement_region)
+        engagement_region = self.resolve_engagement_region(
+            [rec for sec in sections.values() for rec in sec.recommendations],
+            region,
+            engagement_region,
+        )
 
         def sample_score(section_id: str, sec: Section) -> float:
             """Sample beta distribution for the combined engagement of the top _n_ items."""
@@ -159,6 +171,7 @@ class ThompsonSamplingRanker(Ranker):
                         rescaler,
                         region,
                         engagement_region=engagement_region,
+                        regional_prior=regional_prior,
                     )
                 )
                 total_clicks += opens

--- a/merino/curated_recommendations/rankers/t_sampling.py
+++ b/merino/curated_recommendations/rankers/t_sampling.py
@@ -42,6 +42,7 @@ class ThompsonSamplingRanker(Ranker):
         rescaler: EngagementRescaler | None = None,
         personal_interests: ProcessedInterests | None = None,
         region: str | None = None,
+        engagement_region: str | None = None,
     ) -> list[CuratedRecommendation]:
         """Re-rank items using [Thompson sampling][thompson-sampling], combining exploitation of known item
         CTR with exploration of new items using a prior.
@@ -80,7 +81,7 @@ class ThompsonSamplingRanker(Ranker):
         def compute_ranking_scores(rec: CuratedRecommendation):
             """Sample beta distributed from weighted regional/global engagement for a recommendation."""
             opens, no_opens, a_prior, b_prior, non_rescaled_b_prior = self.compute_interactions(
-                rec, rescaler, region
+                rec, rescaler, region, engagement_region=engagement_region
             )
             # Add priors and ensure opens and no_opens are > 0, which is required by beta.rvs.
             alpha_val = opens + max(a_prior, 1e-18)
@@ -114,6 +115,8 @@ class ThompsonSamplingRanker(Ranker):
         sections: dict[str, Section],
         top_n: int = 4,
         rescaler: EngagementRescaler | None = None,
+        region: str | None = None,
+        engagement_region: str | None = None,
     ) -> dict[str, Section]:
         """Re-rank sections using [Thompson sampling][thompson-sampling], based on the combined engagement of top items.
 
@@ -151,7 +154,12 @@ class ThompsonSamplingRanker(Ranker):
 
             for rec in recs:
                 opens, no_opens, a_prior, b_prior, non_rescaled_b_prior = (
-                    self.compute_interactions(rec, rescaler, "??")
+                    self.compute_interactions(
+                        rec,
+                        rescaler,
+                        region,
+                        engagement_region=engagement_region,
+                    )
                 )
                 total_clicks += opens
                 total_imps += no_opens

--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -595,6 +595,8 @@ def rank_sections(
     engagement_rescaler: EngagementRescaler | None,
     do_section_personalization_reranking: bool = True,
     include_daily_briefing_section: bool = False,
+    region: str | None = None,
+    engagement_region: str | None = None,
 ) -> dict[str, Section]:
     """Apply a series of stable ranking passes to the sections feed, in order of priority.
 
@@ -621,7 +623,11 @@ def rank_sections(
     """
     # 4th priority: reorder for exploration via Thompson sampling on engagement
     sections = ranker.rank_sections(
-        sections, rescaler=engagement_rescaler, top_n=SECTION_ITEM_RANKING_TOP_N
+        sections,
+        rescaler=engagement_rescaler,
+        top_n=SECTION_ITEM_RANKING_TOP_N,
+        region=region,
+        engagement_region=engagement_region,
     )
 
     # 3rd priority: reorder based on inferred interest vector
@@ -823,6 +829,7 @@ async def get_sections(
     lints_interest_backend: LinTSInterestBackend | EmptyLinTSInterestBackend,
     personal_interests: ProcessedInterests | None = None,
     region: str | None = None,
+    engagement_region: str | None = None,
     spindle_backend: SpindleBackendProtocol | None = None,
 ) -> dict[str, Section]:
     """Build, rank, and layout recommendation sections for a "sections" experiment.
@@ -838,6 +845,8 @@ async def get_sections(
     Returns:
         A dict mapping section IDs to fully-configured Section models.
     """
+    engagement_region = region if engagement_region is None else engagement_region
+
     # Determine if we should include subtopics based on experiments
     include_subtopics = is_subtopics_experiment(request)
 
@@ -945,6 +954,7 @@ async def get_sections(
     all_ranked_corpus_recommendations = ranker.rank_items(
         all_remaining_corpus_recommendations,
         region=region,
+        engagement_region=engagement_region,
         rescaler=rescaler,
         personal_interests=personal_interests,
     )
@@ -1040,6 +1050,8 @@ async def get_sections(
             use_contexual_ranker or use_interest_ranker
         ),  # Contextual + Interest rankers already re-rank sections implicitly
         include_daily_briefing_section=include_daily_briefing_section,
+        region=region if engagement_region != region else None,
+        engagement_region=engagement_region if engagement_region != region else None,
     )
 
     # 16. Apply cross-section deduplication, preserving higher-priority sections

--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -976,7 +976,7 @@ async def get_sections(
         prior=prior,
         spindle_backend=spindle_backend,
         surface_id=surface_id,
-        article_balancer_config=get_top_stories_article_balancer_config(surface_id),
+        article_balancer_config=get_top_stories_article_balancer_config(surface_id, request),
     )
 
     # 9. Create a global rank lookup from the already-ranked recommendations

--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -621,18 +621,13 @@ def rank_sections(
     Returns:
         The same `sections` dict, with each Section’s `receivedFeedRank` updated to the new order.
     """
-    ranker_region = region if isinstance(ranker, ThompsonSamplingRanker) else None
-    ranker_engagement_region = (
-        engagement_region if isinstance(ranker, ThompsonSamplingRanker) else None
-    )
-
     # 4th priority: reorder for exploration via Thompson sampling on engagement
     sections = ranker.rank_sections(
         sections,
         rescaler=engagement_rescaler,
         top_n=SECTION_ITEM_RANKING_TOP_N,
-        region=ranker_region,
-        engagement_region=ranker_engagement_region,
+        region=region,
+        engagement_region=engagement_region,
     )
 
     # 3rd priority: reorder based on inferred interest vector
@@ -954,15 +949,12 @@ async def get_sections(
         ranker = ThompsonSamplingRanker(
             engagement_backend=engagement_backend, prior_backend=prior_backend
         )
-    ranker_engagement_region = (
-        engagement_region if isinstance(ranker, ThompsonSamplingRanker) else None
-    )
 
     # 7. Rank all corpus recommendations globally by engagement
     all_ranked_corpus_recommendations = ranker.rank_items(
         all_remaining_corpus_recommendations,
         region=region,
-        engagement_region=ranker_engagement_region,
+        engagement_region=engagement_region,
         rescaler=rescaler,
         personal_interests=personal_interests,
     )
@@ -974,7 +966,7 @@ async def get_sections(
     if is_contextual_ads_experiment(request):
         popular_today_layout = layout_4_large
 
-    prior = ranker.get_regional_prior(region, ranker_engagement_region)
+    prior = ranker.get_regional_prior(region, engagement_region)
     top_stories = get_top_story_list(
         all_ranked_corpus_recommendations,
         top_stories_count,
@@ -1048,16 +1040,6 @@ async def get_sections(
     sections = get_sections_with_enough_items(sections)
 
     # 16. Rank the sections according to follows and engagement. 'Top Stories' goes at the top.
-    section_rank_region = (
-        region
-        if ranker_engagement_region is not None and ranker_engagement_region != region
-        else None
-    )
-    section_rank_engagement_region = (
-        ranker_engagement_region
-        if ranker_engagement_region is not None and ranker_engagement_region != region
-        else None
-    )
     sections = rank_sections(
         sections,
         request.sections,
@@ -1068,8 +1050,8 @@ async def get_sections(
             use_contexual_ranker or use_interest_ranker
         ),  # Contextual + Interest rankers already re-rank sections implicitly
         include_daily_briefing_section=include_daily_briefing_section,
-        region=section_rank_region,
-        engagement_region=section_rank_engagement_region,
+        region=region if engagement_region != region else None,
+        engagement_region=engagement_region if engagement_region != region else None,
     )
 
     # 16. Apply cross-section deduplication, preserving higher-priority sections

--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -621,13 +621,18 @@ def rank_sections(
     Returns:
         The same `sections` dict, with each Section’s `receivedFeedRank` updated to the new order.
     """
+    ranker_region = region if isinstance(ranker, ThompsonSamplingRanker) else None
+    ranker_engagement_region = (
+        engagement_region if isinstance(ranker, ThompsonSamplingRanker) else None
+    )
+
     # 4th priority: reorder for exploration via Thompson sampling on engagement
     sections = ranker.rank_sections(
         sections,
         rescaler=engagement_rescaler,
         top_n=SECTION_ITEM_RANKING_TOP_N,
-        region=region,
-        engagement_region=engagement_region,
+        region=ranker_region,
+        engagement_region=ranker_engagement_region,
     )
 
     # 3rd priority: reorder based on inferred interest vector
@@ -949,12 +954,15 @@ async def get_sections(
         ranker = ThompsonSamplingRanker(
             engagement_backend=engagement_backend, prior_backend=prior_backend
         )
+    ranker_engagement_region = (
+        engagement_region if isinstance(ranker, ThompsonSamplingRanker) else None
+    )
 
     # 7. Rank all corpus recommendations globally by engagement
     all_ranked_corpus_recommendations = ranker.rank_items(
         all_remaining_corpus_recommendations,
         region=region,
-        engagement_region=engagement_region,
+        engagement_region=ranker_engagement_region,
         rescaler=rescaler,
         personal_interests=personal_interests,
     )
@@ -966,7 +974,7 @@ async def get_sections(
     if is_contextual_ads_experiment(request):
         popular_today_layout = layout_4_large
 
-    prior = ranker.get_regional_prior(region, engagement_region)
+    prior = ranker.get_regional_prior(region, ranker_engagement_region)
     top_stories = get_top_story_list(
         all_ranked_corpus_recommendations,
         top_stories_count,
@@ -1040,6 +1048,16 @@ async def get_sections(
     sections = get_sections_with_enough_items(sections)
 
     # 16. Rank the sections according to follows and engagement. 'Top Stories' goes at the top.
+    section_rank_region = (
+        region
+        if ranker_engagement_region is not None and ranker_engagement_region != region
+        else None
+    )
+    section_rank_engagement_region = (
+        ranker_engagement_region
+        if ranker_engagement_region is not None and ranker_engagement_region != region
+        else None
+    )
     sections = rank_sections(
         sections,
         request.sections,
@@ -1050,8 +1068,8 @@ async def get_sections(
             use_contexual_ranker or use_interest_ranker
         ),  # Contextual + Interest rankers already re-rank sections implicitly
         include_daily_briefing_section=include_daily_briefing_section,
-        region=region if engagement_region != region else None,
-        engagement_region=engagement_region if engagement_region != region else None,
+        region=section_rank_region,
+        engagement_region=section_rank_engagement_region,
     )
 
     # 16. Apply cross-section deduplication, preserving higher-priority sections

--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -966,7 +966,7 @@ async def get_sections(
     if is_contextual_ads_experiment(request):
         popular_today_layout = layout_4_large
 
-    prior = prior_backend.get(region)
+    prior = ranker.get_regional_prior(region, engagement_region)
     top_stories = get_top_story_list(
         all_ranked_corpus_recommendations,
         top_stories_count,

--- a/merino/curated_recommendations/utils.py
+++ b/merino/curated_recommendations/utils.py
@@ -35,6 +35,10 @@ ROLLED_OUT_SECTION_SURFACES: frozenset[SurfaceId] = frozenset(
 # IN) take priority, so this only applies to regions not handled above.
 EN_XE_REGIONS: frozenset[str] = frozenset({"DE", "FR", "AT", "CH", "BE", "IT", "ES", "PL"})
 
+PUBLISHER_CONSTRAINT_IN_GERMANY_REGION = "DE"
+PUBLISHER_CONSTRAINT_IN_GERMANY_BRANCHES: frozenset[str] = frozenset({"control", "treatment"})
+PUBLISHER_CONSTRAINT_IN_GERMANY_ENGAGEMENT_REGION_PREFIX = "DE-publisher-constraint-in-germany"
+
 
 def get_recommendation_surface_id(
     locale: Locale,
@@ -147,6 +151,31 @@ def derive_region(locale: Locale, region: str | None = None) -> str | None:
         return m2.group(1).upper()
     else:
         return None
+
+
+def derive_engagement_region(request: CuratedRecommendationsRequest) -> str | None:
+    """Derive the engagement lookup region for a curated recommendations request.
+
+    Most requests use the country-level region. The publisher constraint experiment in Germany
+    writes branch-specific engagement rows while preserving the existing artifact schema by
+    encoding the branch in the region field.
+    """
+    region = derive_region(request.locale, request.region)
+    branch = request.experimentBranch
+
+    if (
+        region == PUBLISHER_CONSTRAINT_IN_GERMANY_REGION
+        and branch is not None
+        and branch in PUBLISHER_CONSTRAINT_IN_GERMANY_BRANCHES
+        and is_enrolled_in_experiment(
+            request,
+            ExperimentName.PUBLISHER_CONSTRAINT_IN_GERMANY_EXPERIMENT.value,
+            branch,
+        )
+    ):
+        return f"{PUBLISHER_CONSTRAINT_IN_GERMANY_ENGAGEMENT_REGION_PREFIX}-{branch}"
+
+    return region
 
 
 def is_enrolled_in_experiment(

--- a/tests/integration/api/v1/curated_recommendations/engagement_backends/test_gcs_engagement.py
+++ b/tests/integration/api/v1/curated_recommendations/engagement_backends/test_gcs_engagement.py
@@ -205,6 +205,33 @@ async def test_gcs_engagement_fetches_region_data(
 
 
 @pytest.mark.asyncio
+async def test_gcs_engagement_fetches_branch_region_data(
+    gcs_storage_client, gcs_bucket, metrics_client
+):
+    """Test that branch-specific synthetic region strings load without schema changes."""
+    create_blob(
+        gcs_bucket,
+        [
+            {
+                "corpus_item_id": "DE1",
+                "region": "DE-publisher-constraint-in-germany-treatment",
+                "click_count": 7,
+                "impression_count": 70,
+            }
+        ],
+    )
+    gcs_engagement = create_gcs_engagement(gcs_storage_client, gcs_bucket, metrics_client)
+    await wait_until_engagement_is_updated(gcs_engagement)
+
+    assert gcs_engagement.get("DE1", "DE-publisher-constraint-in-germany-treatment") == Engagement(
+        corpus_item_id="DE1",
+        region="DE-publisher-constraint-in-germany-treatment",
+        click_count=7,
+        impression_count=70,
+    )
+
+
+@pytest.mark.asyncio
 async def test_gcs_engagement_logs_error_for_large_blob(
     gcs_storage_client, gcs_bucket, metrics_client, large_blob, caplog
 ):

--- a/tests/unit/curated_recommendations/rankers/test_interest_ranker.py
+++ b/tests/unit/curated_recommendations/rankers/test_interest_ranker.py
@@ -64,9 +64,11 @@ class StubEngagementBackend(EngagementBackend):
     def __init__(self, metrics: dict[str, tuple[int, int]]) -> None:
         # corpusItemId → (clicks, impressions)
         self._metrics = metrics
+        self.calls: list[tuple[str, str | None]] = []
 
     def get(self, corpus_item_id: str, region: str | None = None) -> Engagement | None:
         """Return the engagement, or None if no record."""
+        self.calls.append((corpus_item_id, region))
         if corpus_item_id not in self._metrics:
             return None
         clicks, impressions = self._metrics[corpus_item_id]
@@ -260,6 +262,27 @@ def test_personal_interests_none() -> None:
     assert [r.corpusItemId for r in ranked] == ["B", "A"]
     # Backend was still called — with an empty strength dict.
     assert backend.last_strengths == {}
+
+
+def test_engagement_region_is_ignored_for_lints_ranker() -> None:
+    """LinTS does not support branch engagement regions yet, so use the base region."""
+    recs = generate_recommendations(item_ids=["A"], time_sensitive_count=0)
+    backend = FakeLinTSBackend(known_items={"A"}, item_scores={"A": 0.2})
+    engagement_backend = StubEngagementBackend({"A": (10, 100)})
+    ranker = InterestRanker(
+        engagement_backend=engagement_backend,
+        prior_backend=StubPriorBackend(),
+        surface_id=SurfaceId.NEW_TAB_EN_US,
+        lints_backend=backend,  # type: ignore[arg-type]
+    )
+
+    ranker.rank_items(
+        recs,
+        region="DE",
+        engagement_region="DE-publisher-constraint-in-germany-treatment",
+    )
+
+    assert engagement_backend.calls == [("A", None), ("A", "DE")]
 
 
 def test_strict_score_descending_order() -> None:

--- a/tests/unit/curated_recommendations/test_article_balancer_configs.py
+++ b/tests/unit/curated_recommendations/test_article_balancer_configs.py
@@ -9,7 +9,22 @@ from merino.curated_recommendations.article_balancer_configs import (
     get_top_stories_article_balancer_config,
 )
 from merino.curated_recommendations.corpus_backends.protocol import SurfaceId, Topic
+from merino.curated_recommendations.protocol import (
+    CuratedRecommendationsRequest,
+    ExperimentName,
+    Locale,
+)
 from tests.unit.curated_recommendations.fixtures import generate_recommendations
+
+
+def _publisher_constraint_request(branch: str) -> CuratedRecommendationsRequest:
+    """Build a request enrolled in the Germany publisher constraint experiment."""
+    return CuratedRecommendationsRequest(
+        locale=Locale.DE_DE,
+        region="DE",
+        experimentName=ExperimentName.PUBLISHER_CONSTRAINT_IN_GERMANY_EXPERIMENT.value,
+        experimentBranch=branch,
+    )
 
 
 def test_get_top_stories_article_balancer_config_returns_surface_config():
@@ -34,6 +49,32 @@ def test_get_top_stories_article_balancer_config_falls_back_to_default():
 
     assert config is DEFAULT_TOP_STORIES_ARTICLE_BALANCER_CONFIG
     assert config.max_per_publisher == 100
+    assert config.publisher_enforcement_likelyhood == 0.0
+
+
+def test_germany_publisher_constraint_control_uses_surface_config():
+    """Control branch keeps the existing Germany publisher constraint."""
+    config = get_top_stories_article_balancer_config(
+        SurfaceId.NEW_TAB_DE_DE, request=_publisher_constraint_request("control")
+    )
+
+    assert config is TOP_STORIES_BALANCER_CONFIG_BY_SURFACE[SurfaceId.NEW_TAB_DE_DE]
+    assert config.max_per_publisher == 1
+    assert config.publisher_enforcement_likelyhood == 0.85
+
+
+def test_germany_publisher_constraint_treatment_disables_publisher_limit():
+    """Treatment branch disables only the Germany publisher constraint."""
+    config = get_top_stories_article_balancer_config(
+        SurfaceId.NEW_TAB_DE_DE, request=_publisher_constraint_request("treatment")
+    )
+
+    assert config is not TOP_STORIES_BALANCER_CONFIG_BY_SURFACE[SurfaceId.NEW_TAB_DE_DE]
+    assert config.min_per_topic_limit == 2
+    assert config.government_max_override == 3
+    assert (
+        config.max_per_publisher == DEFAULT_TOP_STORIES_ARTICLE_BALANCER_CONFIG.max_per_publisher
+    )
     assert config.publisher_enforcement_likelyhood == 0.0
 
 

--- a/tests/unit/curated_recommendations/test_provider.py
+++ b/tests/unit/curated_recommendations/test_provider.py
@@ -9,11 +9,13 @@ from merino.curated_recommendations.corpus_backends.protocol import (
 )
 from merino.curated_recommendations.provider import CuratedRecommendationsProvider
 from merino.curated_recommendations.protocol import (
+    ExperimentName,
     MAX_TILE_ID,
     MIN_TILE_ID,
     CuratedRecommendation,
     CuratedRecommendationsRequest,
 )
+from merino.curated_recommendations.rankers import ThompsonSamplingRanker
 
 
 class TestCuratedRecommendationTileId:
@@ -124,3 +126,45 @@ class TestIsSectionsExperiment:
             experimentBranch="treatment",
         )
         assert CuratedRecommendationsProvider.is_sections_experiment(request, surface_id) is False
+
+
+class TestRankRecommendationsEngagementRegion:
+    """Unit tests for provider engagement-region routing."""
+
+    def test_germany_publisher_constraint_request_passes_branch_region_to_ranker(
+        self, monkeypatch
+    ):
+        """The provider should pass country region for priors and branch region for engagement."""
+        captured_regions = {}
+
+        def fake_rank_items(
+            self,
+            recommendations,
+            rescaler=None,
+            personal_interests=None,
+            region=None,
+            engagement_region=None,
+        ):
+            captured_regions["region"] = region
+            captured_regions["engagement_region"] = engagement_region
+            return recommendations
+
+        monkeypatch.setattr(ThompsonSamplingRanker, "rank_items", fake_rank_items)
+        provider = CuratedRecommendationsProvider.__new__(CuratedRecommendationsProvider)
+        provider.engagement_backend = object()
+        provider.prior_backend = object()
+
+        request = CuratedRecommendationsRequest(
+            locale="de-DE",
+            region="DE",
+            experimentName=ExperimentName.PUBLISHER_CONSTRAINT_IN_GERMANY_EXPERIMENT.value,
+            experimentBranch="control",
+        )
+        recommendations = [CuratedRecommendation(**TestCuratedRecommendationTileId.common_params)]
+
+        provider.rank_recommendations(recommendations, request)
+
+        assert captured_regions == {
+            "region": "DE",
+            "engagement_region": "DE-publisher-constraint-in-germany-control",
+        }

--- a/tests/unit/curated_recommendations/test_rankers.py
+++ b/tests/unit/curated_recommendations/test_rankers.py
@@ -196,6 +196,24 @@ class StubPriorBackend(PriorBackend):
         return 0
 
 
+class RegionAwareStubPriorBackend(PriorBackend):
+    """Prior backend returning priors keyed by exact region."""
+
+    def __init__(self, priors: dict[str | None, Prior]):
+        self._priors = priors
+        self.calls: list[str | None] = []
+
+    def get(self, region: str | None = None) -> Prior | None:
+        """Return prior for the exact region key."""
+        self.calls.append(region)
+        return self._priors.get(region)
+
+    @property
+    def update_count(self) -> int:
+        """Update count stub"""
+        return 0
+
+
 class StubEngagementBackend(EngagementBackend):
     """Engagement backend returning pre-set click and impression tuples."""
 
@@ -368,8 +386,8 @@ class TestFilterFreshItemsWithProbability:
 class TestThompsonSampling:
     """Tests for the thompson_sampling ranker."""
 
-    def test_rank_items_can_use_branch_engagement_with_country_prior(self, monkeypatch):
-        """Branch-specific engagement should be blended with the country-level prior."""
+    def test_rank_items_can_use_branch_engagement_with_fixed_prior(self, monkeypatch):
+        """Branch-specific engagement should be blended with the configured prior."""
         recs = generate_recommendations(
             item_ids=["item"],
             topics=[Topic.BUSINESS.value],
@@ -404,8 +422,88 @@ class TestThompsonSampling:
         assert ranked[0].ranking_data.alpha == pytest.approx(48.05)
         assert ranked[0].ranking_data.beta == pytest.approx(162.0)
 
+    def test_rank_items_can_use_branch_prior(self, monkeypatch):
+        """Branch-specific priors should be blended with the global prior when present."""
+        recs = generate_recommendations(
+            item_ids=["item"],
+            topics=[Topic.BUSINESS.value],
+            time_sensitive_count=0,
+        )
+        prior_backend = RegionAwareStubPriorBackend(
+            {
+                None: Prior(alpha=10, beta=100, total_impressions_per_day=1_000_000),
+                "DE": Prior(alpha=20, beta=200, total_impressions_per_day=1_000_000),
+                "DE-publisher-constraint-in-germany-treatment": Prior(
+                    alpha=30,
+                    beta=300,
+                    total_impressions_per_day=1_000_000,
+                ),
+            }
+        )
+        engagement_backend = RegionAwareStubEngagementBackend(
+            {
+                ("item", None): (1, 101),
+                ("item", "DE-publisher-constraint-in-germany-treatment"): (40, 100),
+            }
+        )
+
+        monkeypatch.setattr(
+            "merino.curated_recommendations.rankers.t_sampling.beta.rvs", lambda a, b: 0.42
+        )
+
+        ranker = ThompsonSamplingRanker(engagement_backend, prior_backend)
+        ranked = ranker.rank_items(
+            recs,
+            region="DE",
+            engagement_region="DE-publisher-constraint-in-germany-treatment",
+        )
+
+        assert "DE-publisher-constraint-in-germany-treatment" in prior_backend.calls
+        assert ranked[0].ranking_data is not None
+        assert ranked[0].ranking_data.alpha == pytest.approx(67.05)
+        assert ranked[0].ranking_data.beta == pytest.approx(352.0)
+
+    def test_rank_items_falls_back_to_country_prior_when_branch_prior_missing(self, monkeypatch):
+        """Missing branch-specific priors should fall back to the base country prior."""
+        recs = generate_recommendations(
+            item_ids=["item"],
+            topics=[Topic.BUSINESS.value],
+            time_sensitive_count=0,
+        )
+        prior_backend = RegionAwareStubPriorBackend(
+            {
+                None: Prior(alpha=10, beta=100, total_impressions_per_day=1_000_000),
+                "DE": Prior(alpha=20, beta=200, total_impressions_per_day=1_000_000),
+            }
+        )
+        engagement_backend = RegionAwareStubEngagementBackend(
+            {
+                ("item", None): (1, 101),
+                ("item", "DE-publisher-constraint-in-germany-treatment"): (40, 100),
+            }
+        )
+
+        monkeypatch.setattr(
+            "merino.curated_recommendations.rankers.t_sampling.beta.rvs", lambda a, b: 0.42
+        )
+
+        ranker = ThompsonSamplingRanker(engagement_backend, prior_backend)
+        ranked = ranker.rank_items(
+            recs,
+            region="DE",
+            engagement_region="DE-publisher-constraint-in-germany-treatment",
+        )
+
+        assert prior_backend.calls[:2] == [
+            "DE-publisher-constraint-in-germany-treatment",
+            "DE",
+        ]
+        assert ranked[0].ranking_data is not None
+        assert ranked[0].ranking_data.alpha == pytest.approx(57.55)
+        assert ranked[0].ranking_data.beta == pytest.approx(257.0)
+
     def test_rank_items_falls_back_to_country_engagement_when_branch_missing(self, monkeypatch):
-        """Missing branch-specific engagement should fall back to country engagement."""
+        """Missing branch-specific engagement for the whole list should fall back to country engagement."""
         recs = generate_recommendations(
             item_ids=["item"],
             topics=[Topic.BUSINESS.value],
@@ -433,13 +531,55 @@ class TestThompsonSampling:
         )
 
         assert engagement_backend.calls == [
-            ("item", None),
             ("item", "DE-publisher-constraint-in-germany-treatment"),
+            ("item", None),
             ("item", "DE"),
         ]
         assert ranked[0].ranking_data is not None
         assert ranked[0].ranking_data.alpha == pytest.approx(29.05)
         assert ranked[0].ranking_data.beta == pytest.approx(181.0)
+
+    def test_rank_items_uses_branch_engagement_for_whole_list_when_any_branch_exists(
+        self, monkeypatch
+    ):
+        """One branch engagement row should make the full ranking list use branch engagement."""
+        recs = generate_recommendations(
+            item_ids=["branch-item", "base-only-item"],
+            topics=[Topic.BUSINESS.value, Topic.SCIENCE.value],
+            time_sensitive_count=0,
+        )
+        prior_backend = StubPriorBackend(
+            Prior(alpha=10, beta=100, total_impressions_per_day=1_000_000)
+        )
+        engagement_backend = RegionAwareStubEngagementBackend(
+            {
+                ("branch-item", None): (1, 101),
+                ("base-only-item", None): (2, 102),
+                ("branch-item", "DE-publisher-constraint-in-germany-treatment"): (40, 100),
+                ("base-only-item", "DE"): (20, 100),
+            }
+        )
+
+        monkeypatch.setattr(
+            "merino.curated_recommendations.rankers.t_sampling.beta.rvs", lambda a, b: 0.42
+        )
+
+        ranker = ThompsonSamplingRanker(engagement_backend, prior_backend)
+        ranked = ranker.rank_items(
+            recs,
+            region="DE",
+            engagement_region="DE-publisher-constraint-in-germany-treatment",
+        )
+
+        assert (
+            "base-only-item",
+            "DE-publisher-constraint-in-germany-treatment",
+        ) in engagement_backend.calls
+        assert ("base-only-item", "DE") not in engagement_backend.calls
+        by_id = {rec.corpusItemId: rec for rec in ranked}
+        assert by_id["base-only-item"].ranking_data is not None
+        assert by_id["base-only-item"].ranking_data.alpha == pytest.approx(12)
+        assert by_id["base-only-item"].ranking_data.beta == pytest.approx(200)
 
     def test_ranking_data_and_fresh_flag_set_with_default_rescaler(self, monkeypatch):
         """Ranking data should be populated and fresh items flagged when using DefaultRescaler."""

--- a/tests/unit/curated_recommendations/test_rankers.py
+++ b/tests/unit/curated_recommendations/test_rankers.py
@@ -404,6 +404,43 @@ class TestThompsonSampling:
         assert ranked[0].ranking_data.alpha == pytest.approx(48.05)
         assert ranked[0].ranking_data.beta == pytest.approx(162.0)
 
+    def test_rank_items_falls_back_to_country_engagement_when_branch_missing(self, monkeypatch):
+        """Missing branch-specific engagement should fall back to country engagement."""
+        recs = generate_recommendations(
+            item_ids=["item"],
+            topics=[Topic.BUSINESS.value],
+            time_sensitive_count=0,
+        )
+        prior_backend = StubPriorBackend(
+            Prior(alpha=10, beta=100, total_impressions_per_day=1_000_000)
+        )
+        engagement_backend = RegionAwareStubEngagementBackend(
+            {
+                ("item", None): (1, 101),
+                ("item", "DE"): (20, 100),
+            }
+        )
+
+        monkeypatch.setattr(
+            "merino.curated_recommendations.rankers.t_sampling.beta.rvs", lambda a, b: 0.42
+        )
+
+        ranker = ThompsonSamplingRanker(engagement_backend, prior_backend)
+        ranked = ranker.rank_items(
+            recs,
+            region="DE",
+            engagement_region="DE-publisher-constraint-in-germany-treatment",
+        )
+
+        assert engagement_backend.calls == [
+            ("item", None),
+            ("item", "DE-publisher-constraint-in-germany-treatment"),
+            ("item", "DE"),
+        ]
+        assert ranked[0].ranking_data is not None
+        assert ranked[0].ranking_data.alpha == pytest.approx(29.05)
+        assert ranked[0].ranking_data.beta == pytest.approx(181.0)
+
     def test_ranking_data_and_fresh_flag_set_with_default_rescaler(self, monkeypatch):
         """Ranking data should be populated and fresh items flagged when using DefaultRescaler."""
         recs = generate_recommendations(

--- a/tests/unit/curated_recommendations/test_rankers.py
+++ b/tests/unit/curated_recommendations/test_rankers.py
@@ -222,6 +222,34 @@ class StubEngagementBackend(EngagementBackend):
         return 0
 
 
+class RegionAwareStubEngagementBackend(EngagementBackend):
+    """Engagement backend returning click/impression tuples keyed by item and region."""
+
+    def __init__(self, metrics: dict[tuple[str, str | None], tuple[int, int]]):
+        """Create engagement with per-region metrics."""
+        self._metrics = metrics
+        self.calls: list[tuple[str, str | None]] = []
+
+    def get(self, corpus_item_id: str, region: str | None = None) -> Engagement | None:
+        """Return engagement for a corpus item and exact region key."""
+        self.calls.append((corpus_item_id, region))
+        if (corpus_item_id, region) not in self._metrics:
+            return None
+        clicks, impressions = self._metrics[(corpus_item_id, region)]
+        return Engagement(
+            corpus_item_id=corpus_item_id,
+            region=region,
+            click_count=clicks,
+            impression_count=impressions,
+            report_count=0,
+        )
+
+    @property
+    def update_count(self) -> int:
+        """Update count stub"""
+        return 0
+
+
 class TestRenumberRecommendations:
     """Tests for the renumber_recommendations function."""
 
@@ -339,6 +367,42 @@ class TestFilterFreshItemsWithProbability:
 
 class TestThompsonSampling:
     """Tests for the thompson_sampling ranker."""
+
+    def test_rank_items_can_use_branch_engagement_with_country_prior(self, monkeypatch):
+        """Branch-specific engagement should be blended with the country-level prior."""
+        recs = generate_recommendations(
+            item_ids=["item"],
+            topics=[Topic.BUSINESS.value],
+            time_sensitive_count=0,
+        )
+        prior_backend = StubPriorBackend(
+            Prior(alpha=10, beta=100, total_impressions_per_day=1_000_000)
+        )
+        engagement_backend = RegionAwareStubEngagementBackend(
+            {
+                ("item", None): (1, 101),
+                ("item", "DE-publisher-constraint-in-germany-treatment"): (40, 100),
+            }
+        )
+
+        monkeypatch.setattr(
+            "merino.curated_recommendations.rankers.t_sampling.beta.rvs", lambda a, b: 0.42
+        )
+
+        ranker = ThompsonSamplingRanker(engagement_backend, prior_backend)
+        ranked = ranker.rank_items(
+            recs,
+            region="DE",
+            engagement_region="DE-publisher-constraint-in-germany-treatment",
+        )
+
+        assert ("item", "DE-publisher-constraint-in-germany-treatment") in (
+            engagement_backend.calls
+        )
+        assert ("item", "DE") not in engagement_backend.calls
+        assert ranked[0].ranking_data is not None
+        assert ranked[0].ranking_data.alpha == pytest.approx(48.05)
+        assert ranked[0].ranking_data.beta == pytest.approx(162.0)
 
     def test_ranking_data_and_fresh_flag_set_with_default_rescaler(self, monkeypatch):
         """Ranking data should be populated and fresh items flagged when using DefaultRescaler."""

--- a/tests/unit/curated_recommendations/test_sections.py
+++ b/tests/unit/curated_recommendations/test_sections.py
@@ -2033,3 +2033,41 @@ class TestGetSectionsForcedInterests:
                 assert personal_interests.scores[topic] == value
         else:
             assert not any(topic in personal_interests.scores for topic in DEFAULT_TOPIC_INTERESTS)
+
+    @pytest.mark.asyncio
+    async def test_get_sections_passes_request_to_top_stories_balancer_config(
+        self, sections_backend, monkeypatch
+    ):
+        """Top Stories config selection should be able to inspect experiment enrollment."""
+        captured = {}
+
+        def capture_config(surface_id, request=None):
+            captured["surface_id"] = surface_id
+            captured["request"] = request
+            return DEFAULT_TOP_STORIES_ARTICLE_BALANCER_CONFIG
+
+        monkeypatch.setattr(
+            "merino.curated_recommendations.sections.get_top_stories_article_balancer_config",
+            capture_config,
+        )
+        ml_backend = MagicMock(spec=MLRecsBackend)
+        ml_backend.is_valid.return_value = False
+        request = CuratedRecommendationsRequest(
+            locale=Locale.DE_DE,
+            region="DE",
+            experimentName=ExperimentName.PUBLISHER_CONSTRAINT_IN_GERMANY_EXPERIMENT.value,
+            experimentBranch="treatment",
+        )
+
+        await get_sections(
+            request=request,
+            surface_id=SurfaceId.NEW_TAB_DE_DE,
+            sections_backend=sections_backend,
+            ml_backend=ml_backend,
+            engagement_backend=_StubEngagementBackend(),
+            prior_backend=ConstantPrior(),
+            lints_interest_backend=_FakeLinTSBackend(),
+            region="DE",
+        )
+
+        assert captured == {"surface_id": SurfaceId.NEW_TAB_DE_DE, "request": request}

--- a/tests/unit/curated_recommendations/test_sections.py
+++ b/tests/unit/curated_recommendations/test_sections.py
@@ -1976,14 +1976,30 @@ class _FakeLinTSBackend:
 class _StubEngagementBackend:
     """Engagement backend that reports no engagement for any item."""
 
+    def __init__(self):
+        self.calls = []
+
     def get(self, corpus_item_id, region=None):
         """Return None — no engagement data."""
+        self.calls.append((corpus_item_id, region))
         return None
 
     @property
     def update_count(self) -> int:
         """Stub — never updates."""
         return 0
+
+
+class _TrackingPriorBackend(ConstantPrior):
+    """Constant prior backend that records region lookups."""
+
+    def __init__(self):
+        self.calls = []
+
+    def get(self, region: str | None = None) -> Prior:
+        """Record the requested region and return the constant prior."""
+        self.calls.append(region)
+        return super().get(region)
 
 
 class TestGetSectionsForcedInterests:
@@ -2033,3 +2049,29 @@ class TestGetSectionsForcedInterests:
                 assert personal_interests.scores[topic] == value
         else:
             assert not any(topic in personal_interests.scores for topic in DEFAULT_TOPIC_INTERESTS)
+
+    @pytest.mark.asyncio
+    async def test_interest_ranker_ignores_branch_engagement_region(self, sections_backend):
+        """Branch-specific engagement and priors should stay scoped to Thompson sampling."""
+        branch_region = "DE-publisher-constraint-in-germany-treatment"
+        engagement_backend = _StubEngagementBackend()
+        prior_backend = _TrackingPriorBackend()
+        personal_interests = ProcessedInterests(scores={"sports": 0.9})
+
+        await get_sections(
+            request=CuratedRecommendationsRequest(locale=Locale.EN_US),
+            surface_id=SurfaceId.NEW_TAB_EN_US,
+            sections_backend=sections_backend,
+            ml_backend=MagicMock(spec=MLRecsBackend),
+            engagement_backend=engagement_backend,
+            prior_backend=prior_backend,
+            lints_interest_backend=_FakeLinTSBackend(),
+            personal_interests=personal_interests,
+            region="DE",
+            engagement_region=branch_region,
+        )
+
+        assert branch_region not in {region for _, region in engagement_backend.calls}
+        assert branch_region not in prior_backend.calls
+        assert "DE" in {region for _, region in engagement_backend.calls}
+        assert "DE" in prior_backend.calls

--- a/tests/unit/curated_recommendations/test_sections.py
+++ b/tests/unit/curated_recommendations/test_sections.py
@@ -1976,30 +1976,14 @@ class _FakeLinTSBackend:
 class _StubEngagementBackend:
     """Engagement backend that reports no engagement for any item."""
 
-    def __init__(self):
-        self.calls = []
-
     def get(self, corpus_item_id, region=None):
         """Return None — no engagement data."""
-        self.calls.append((corpus_item_id, region))
         return None
 
     @property
     def update_count(self) -> int:
         """Stub — never updates."""
         return 0
-
-
-class _TrackingPriorBackend(ConstantPrior):
-    """Constant prior backend that records region lookups."""
-
-    def __init__(self):
-        self.calls = []
-
-    def get(self, region: str | None = None) -> Prior:
-        """Record the requested region and return the constant prior."""
-        self.calls.append(region)
-        return super().get(region)
 
 
 class TestGetSectionsForcedInterests:
@@ -2049,29 +2033,3 @@ class TestGetSectionsForcedInterests:
                 assert personal_interests.scores[topic] == value
         else:
             assert not any(topic in personal_interests.scores for topic in DEFAULT_TOPIC_INTERESTS)
-
-    @pytest.mark.asyncio
-    async def test_interest_ranker_ignores_branch_engagement_region(self, sections_backend):
-        """Branch-specific engagement and priors should stay scoped to Thompson sampling."""
-        branch_region = "DE-publisher-constraint-in-germany-treatment"
-        engagement_backend = _StubEngagementBackend()
-        prior_backend = _TrackingPriorBackend()
-        personal_interests = ProcessedInterests(scores={"sports": 0.9})
-
-        await get_sections(
-            request=CuratedRecommendationsRequest(locale=Locale.EN_US),
-            surface_id=SurfaceId.NEW_TAB_EN_US,
-            sections_backend=sections_backend,
-            ml_backend=MagicMock(spec=MLRecsBackend),
-            engagement_backend=engagement_backend,
-            prior_backend=prior_backend,
-            lints_interest_backend=_FakeLinTSBackend(),
-            personal_interests=personal_interests,
-            region="DE",
-            engagement_region=branch_region,
-        )
-
-        assert branch_region not in {region for _, region in engagement_backend.calls}
-        assert branch_region not in prior_backend.calls
-        assert "DE" in {region for _, region in engagement_backend.calls}
-        assert "DE" in prior_backend.calls

--- a/tests/unit/curated_recommendations/test_utils.py
+++ b/tests/unit/curated_recommendations/test_utils.py
@@ -13,6 +13,7 @@ from merino.curated_recommendations.protocol import (
     Locale,
 )
 from merino.curated_recommendations.utils import (
+    derive_engagement_region,
     derive_region,
     extract_language_from_locale,
     get_recommendation_surface_id,
@@ -22,6 +23,7 @@ from merino.curated_recommendations.utils import (
 
 _EN_EUROPE = ExperimentName.SECTIONS_IN_EN_EUROPE_EXPERIMENT.value
 _GLOBAL_SPANISH = ExperimentName.SECTIONS_IN_GLOBAL_SPANISH_EXPERIMENT.value
+_GERMANY_PUBLISHER_CONSTRAINT = ExperimentName.PUBLISHER_CONSTRAINT_IN_GERMANY_EXPERIMENT.value
 
 
 class TestCuratedRecommendationsProviderExtractLanguageFromLocale:
@@ -108,6 +110,75 @@ class TestCuratedRecommendationsProviderDeriveRegion:
         assert derive_region("123") is None
         # if only locale is passed
         assert derive_region("en") is None
+
+
+class TestCuratedRecommendationsProviderDeriveEngagementRegion:
+    """Unit tests for derive_engagement_region."""
+
+    @pytest.mark.parametrize(
+        "branch, expected",
+        [
+            ("control", "DE-publisher-constraint-in-germany-control"),
+            ("treatment", "DE-publisher-constraint-in-germany-treatment"),
+        ],
+    )
+    def test_germany_publisher_constraint_branches_use_branch_region(
+        self, branch: str, expected: str
+    ):
+        """Germany publisher constraint branches use branch-specific engagement keys."""
+        request = CuratedRecommendationsRequest(
+            locale=Locale.DE_DE,
+            region="DE",
+            experimentName=_GERMANY_PUBLISHER_CONSTRAINT,
+            experimentBranch=branch,
+        )
+
+        assert derive_engagement_region(request) == expected
+
+    def test_optin_germany_publisher_constraint_uses_branch_region(self):
+        """Opt-in experiment enrollment follows the same branch-specific routing."""
+        request = CuratedRecommendationsRequest(
+            locale=Locale.DE_DE,
+            region="DE",
+            experimentName=f"optin-{_GERMANY_PUBLISHER_CONSTRAINT}",
+            experimentBranch="treatment",
+        )
+
+        assert derive_engagement_region(request) == "DE-publisher-constraint-in-germany-treatment"
+
+    @pytest.mark.parametrize(
+        "experiment_name, branch",
+        [
+            ("some-other-experiment", "treatment"),
+            (_GERMANY_PUBLISHER_CONSTRAINT, "other"),
+            (_GERMANY_PUBLISHER_CONSTRAINT, None),
+            (None, "treatment"),
+        ],
+    )
+    def test_germany_non_matching_enrollment_uses_country_region(
+        self, experiment_name: str | None, branch: str | None
+    ):
+        """Germany requests outside the exact experiment branches keep country-level engagement."""
+        request = CuratedRecommendationsRequest(
+            locale=Locale.DE_DE,
+            region="DE",
+            experimentName=experiment_name,
+            experimentBranch=branch,
+        )
+
+        assert derive_engagement_region(request) == "DE"
+
+    @pytest.mark.parametrize("region", ["US", "FR", "CA"])
+    def test_non_germany_regions_are_unchanged(self, region: str):
+        """The Germany experiment does not affect non-Germany engagement keys."""
+        request = CuratedRecommendationsRequest(
+            locale=Locale.EN_US,
+            region=region,
+            experimentName=_GERMANY_PUBLISHER_CONSTRAINT,
+            experimentBranch="treatment",
+        )
+
+        assert derive_engagement_region(request) == region
 
 
 class TestCuratedRecommendationsProviderGetRecommendationSurfaceId:


### PR DESCRIPTION
## References

JIRA: [AIMOD-1408](https://mozilla-hub.atlassian.net/browse/AIMOD-1408)

## Description
There is a GCS artifact storing engagement ~(region, article, clicks, impressions). We now stratify that table by experiment name and branch ~(region,experiment-name-branch, article, clicks, impressions). This corresponds with a ETL PR https://github.com/mozilla/bigquery-etl/pull/9714.

We check the engagement table for any row with (region,experiment-name-branch) and if true, we use that path for all articles. If that path fails, then we use (region) for all articles).

The general change is we now pass around region and engagement_region where engagement_region is the key for looking up in the engagement table.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2501)


[AIMOD-1408]: https://mozilla-hub.atlassian.net/browse/AIMOD-1408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ