### PR TITLE
[Disco-4339] feat(merino-fleece): sanitize search terms in the background 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,10 +80,17 @@ format: $(INSTALL_STAMP)  ##  Sort imports and reformat code
 dev: $(INSTALL_STAMP)  ##  Run merino locally and reload automatically
 	$(UV) run fastapi dev $(APP_DIR)/main.py --reload
 
-
 .PHONY: dev-otel
 dev-otel: $(INSTALL_STAMP)  ##  Run merino locally with OTEL auto-instrumentation (mimics k8s operator)
 	OTEL_SERVICE_NAME=merino OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf $(UV) run opentelemetry-instrument fastapi run $(APP_DIR)/main.py --host 0.0.0.0 --port 8000
+
+.PHONY: dev-fleece
+dev-fleece: $(INSTALL_STAMP)  ##  Run fleece locally
+	$(UV) run opentelemetry-instrument fastapi run merino-fleece/merino_fleece/main.py --host 0.0.0.0 --port 8001
+
+.PHONY: dev-fleece-otel
+dev-fleece-otel: $(INSTALL_STAMP)  ##  Run fleece locally with OTEL auto-instrumentation (mimics k8s operator)
+	OTEL_SERVICE_NAME=merino OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf $(UV) run opentelemetry-instrument fastapi run merino-fleece/merino_fleece/main.py --host 0.0.0.0 --port 8001
 
 .PHONY: run
 run: $(INSTALL_STAMP)  ##  Run merino locally

--- a/merino-common/merino_common/testing/metrics.py
+++ b/merino-common/merino_common/testing/metrics.py
@@ -10,6 +10,7 @@ from collections.abc import Iterator
 from opentelemetry.sdk.metrics.export import (
     Gauge,
     Histogram,
+    HistogramDataPoint,
     InMemoryMetricReader,
     Metric,
     NumberDataPoint,
@@ -63,10 +64,15 @@ def counter_value(reader: InMemoryMetricReader, name: str) -> float:
     return sum((point.value for point in number_points(reader, name)), 0.0)
 
 
-def histogram_count(reader: InMemoryMetricReader, name: str) -> int:
-    """Total number of observations recorded by the named histogram metric."""
-    total = 0
+def histogram_points(reader: InMemoryMetricReader, name: str) -> list[HistogramDataPoint]:
+    """Return the ``HistogramDataPoint``s for the named histogram metric."""
+    points: list[HistogramDataPoint] = []
     for metric in _iter_metrics(reader):
         if metric.name == name and isinstance(metric.data, Histogram):
-            total += sum(point.count for point in metric.data.data_points)
-    return total
+            points.extend(metric.data.data_points)
+    return points
+
+
+def histogram_count(reader: InMemoryMetricReader, name: str) -> int:
+    """Total number of observations recorded by the named histogram metric."""
+    return sum((point.count for point in histogram_points(reader, name)), 0)

--- a/merino-common/merino_common/utils/async_batch_queue.py
+++ b/merino-common/merino_common/utils/async_batch_queue.py
@@ -198,6 +198,10 @@ class AsyncBatchQueue(Generic[T]):
         """Return the number of items currently buffered in the queue."""
         return self._queue.qsize()
 
+    def remaining_capacity(self) -> int:
+        """Return how many more items the queue can accept before it is full."""
+        return max(0, self._max_queue_size - self._queue.qsize())
+
     def _collect_batch_sync(self) -> list[T]:
         """Pull up to ``max_batch_size`` items off the queue without waiting."""
         batch: list[T] = []

--- a/merino-common/tests/unit/utils/test_async_batch_queue.py
+++ b/merino-common/tests/unit/utils/test_async_batch_queue.py
@@ -697,3 +697,69 @@ async def test_error_callback_metric_records_failed_error_callback() -> None:
     assert attributes is not None
     # error.type reflects the error callback's own exception, not on_batch's.
     assert attributes["error.type"] == "RuntimeError"
+
+
+@pytest.mark.asyncio
+async def test_remaining_capacity_tracks_queue_headroom() -> None:
+    """`remaining_capacity` reports headroom, shrinking as items are queued and
+    never dropping below zero once the queue is full.
+
+    The batcher is deliberately not started, so nothing drains the queue and the
+    reported headroom is attributable solely to the puts.
+    """
+    batcher: AsyncBatchQueue[int] = AsyncBatchQueue(
+        on_batch=on_batch_noop,
+        max_batch_size=2,
+        max_queue_size=3,
+        collection_delay_s=LONG_COLLECTION_DELAY_S,
+        meter_provider=None,
+    )
+
+    assert batcher.remaining_capacity() == 3, "a fresh queue has its full capacity"
+
+    batcher.put(1)
+    assert batcher.remaining_capacity() == 2
+
+    batcher.put(2)
+    batcher.put(3)
+    assert batcher.remaining_capacity() == 0, "a full queue reports no headroom"
+
+    # The queue is full, so the next put is rejected rather than making the
+    # remaining capacity go negative.
+    with pytest.raises(QueueFullException):
+        batcher.put(4)
+    assert batcher.remaining_capacity() == 0
+
+
+@pytest.mark.asyncio
+async def test_remaining_capacity_recovers_as_batches_are_collected() -> None:
+    """Headroom is returned once queued items are collected into a batch, so a
+    producer that backs off on a full queue can make progress again.
+    """
+    processed: list[int] = []
+
+    async def on_batch(batch: list[int]) -> None:
+        processed.extend(batch)
+
+    batcher: AsyncBatchQueue[int] = AsyncBatchQueue(
+        on_batch=on_batch,
+        max_batch_size=2,
+        max_queue_size=2,
+        collection_delay_s=0.02,
+        meter_provider=None,
+    )
+    await batcher.start()
+
+    batcher.put(1)
+    batcher.put(2)
+    assert batcher.remaining_capacity() == 0
+
+    async def batch_collected() -> None:
+        while batcher.remaining_capacity() < 2:
+            await asyncio.sleep(0.005)
+
+    await asyncio.wait_for(batch_collected(), timeout=5.0)
+    await batcher.stop()
+
+    assert processed == [1, 2]
+    assert batcher.remaining_capacity() == 2

--- a/merino-fleece/CLAUDE.md
+++ b/merino-fleece/CLAUDE.md
@@ -6,8 +6,9 @@ A web service providing supporting functionalities that can be integrated by **M
 
 The main domain components are as follows:
 
-- **PII Detection API**, located in @merino-fleece/merino_fleece/pii/, the backend of the `api/v1/pii` endpoint defined in @merino-fleece/merino_fleece/api/v1/pii.py.
-- **Search Terms API**, the backend of the `api/v1/search-terms` endpoint defined in @merino-fleece/merino_fleece/api/v1/search_terms.py, which accepts search term submissions from **merino** for sanitization.
+- **PII Detection API**, located in @merino-fleece/merino_fleece/pii/, the backend of the `api/v1/pii` endpoint defined in @merino-fleece/merino_fleece/api/v1/pii.py. The package's `__init__.py` owns the singleton detector and thread pool along with the `detect_person` / `detect_person_batch` helpers, which are shared by the endpoint and the sanitization handler; both offload SpaCy NER to the shared thread pool.
+- **Search Terms API**, the backend of the `api/v1/search-terms` endpoint defined in @merino-fleece/merino_fleece/api/v1/search_terms.py, which accepts search term submissions from **merino** for sanitization. The endpoint only enqueues; it returns 503 if the queue cannot hold the whole submission.
+- **Search Terms Sanitization**, located in @merino-fleece/merino_fleece/message_handlers/search_terms/, the background handler that classifies the PII type of submitted search terms off the request path. It buffers terms in an `AsyncBatchQueue` and, per batch, runs pattern-based detection over every query before batching the survivors through SpaCy NER. Configured under `[default.sanitize]`.
 
 ## Testing
 

--- a/merino-fleece/merino_fleece/api/v1/pii.py
+++ b/merino-fleece/merino_fleece/api/v1/pii.py
@@ -1,25 +1,16 @@
 """PII / NER detection endpoint."""
 
-import asyncio
 from concurrent.futures import ThreadPoolExecutor
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, Query
-from opentelemetry import metrics
 from pydantic import BaseModel, Field
 
 from merino_fleece.configs import settings
-from merino_fleece.pii import get_detector, get_executor
+from merino_fleece.pii import detect_person, get_detector, get_executor
 from merino_fleece.pii.detector import PiiDetector
 
 QUERY_CHARACTER_MAX = settings.pii.query_character_max
-
-_meter = metrics.get_meter("fleece")
-_pii_detect_duration = _meter.create_histogram(
-    name="api.pii_detect.duration",
-    unit="ms",
-    description="Duration of PII PERSON detection in milliseconds.",
-)
 
 router = APIRouter(tags=["pii"])
 
@@ -38,21 +29,6 @@ class PiiResponse(BaseModel):
     pii: bool
 
 
-async def _detect_pii(q: str, detector: PiiDetector, executor: ThreadPoolExecutor) -> PiiResponse:
-    """Return whether `q` contains a PERSON named entity.
-
-    SpaCy NER is CPU-bound and synchronous; it runs in the shared thread pool so
-    it does not block the event loop and stall other concurrent requests.
-    """
-    loop = asyncio.get_running_loop()
-    started_at = loop.time()
-    try:
-        pii = await loop.run_in_executor(executor, detector.is_person, q)
-    finally:
-        _pii_detect_duration.record((loop.time() - started_at) * 1000)
-    return PiiResponse(pii=pii)
-
-
 @router.post(
     "/pii",
     tags=["pii"],
@@ -65,7 +41,7 @@ async def detect_pii(
     executor: ThreadPoolExecutor = Depends(get_executor),
 ) -> PiiResponse:
     """Return whether `body.q` contains a PERSON named entity."""
-    return await _detect_pii(body.q, detector, executor)
+    return PiiResponse(pii=await detect_person(body.q, detector, executor))
 
 
 @router.get(
@@ -87,4 +63,4 @@ async def detect_pii_get(
 
     Retained for backwards compatibility; prefer the POST endpoint.
     """
-    return await _detect_pii(q, detector, executor)
+    return PiiResponse(pii=await detect_person(q, detector, executor))

--- a/merino-fleece/merino_fleece/api/v1/search_terms.py
+++ b/merino-fleece/merino_fleece/api/v1/search_terms.py
@@ -1,15 +1,25 @@
 """Search terms submission endpoint."""
 
-from fastapi import APIRouter
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException
 from opentelemetry import metrics
 from pydantic import BaseModel
 
 from merino_common.models.suggest_logging import SearchTermsSubmission
+from merino_common.utils.async_batch_queue import AsyncBatchException
+from merino_fleece.message_handlers.search_terms import MessageHandler, get_message_handler
+
+logger = logging.getLogger(__name__)
 
 _meter = metrics.get_meter("fleece")
 _search_terms_received_counter = _meter.create_counter(
     name="api.search_terms.receive.count",
     description="Number of search terms received by the submission endpoint.",
+)
+_search_terms_rejected_counter = _meter.create_counter(
+    name="api.search_terms.reject.count",
+    description="Number of search terms rejected because they could not be queued.",
 )
 
 router = APIRouter(tags=["search-terms"])
@@ -28,13 +38,47 @@ class SearchTermsResponse(BaseModel):
     status_code=201,
     response_model=SearchTermsResponse,
 )
-async def submit_search_terms(body: SearchTermsSubmission) -> SearchTermsResponse:
-    """Accept a batch of search terms for sanitization.
+async def submit_search_terms(
+    body: SearchTermsSubmission,
+    handler: MessageHandler = Depends(get_message_handler),
+) -> SearchTermsResponse:
+    """Accept a batch of search terms and queue them for background sanitization.
 
-    The request body is validated by FastAPI and then discarded for now;
-    sanitization and logging will be added as a follow-up.
+    Sanitization happens off the request path, so a 201 means the terms were
+    accepted for processing, not that they have been sanitized.
+
+    Raises:
+        HTTPException: 503 when the terms cannot be queued, so the submitter can
+            back off rather than have its data silently dropped.
     """
     count = len(body.search_terms)
     _search_terms_received_counter.add(count)
+
+    # Admit the whole submission or none of it. Enqueuing term by term and failing
+    # partway would leave some terms queued while the submitter sees an error and
+    # drops the batch, so neither side's accounting would be right.
+    capacity = handler.remaining_capacity()
+    if capacity < count:
+        _search_terms_rejected_counter.add(count)
+        logger.warning(
+            "Rejected search term submission: insufficient queue capacity",
+            extra={"submitted_count": count, "remaining_capacity": capacity},
+        )
+        raise HTTPException(status_code=503, detail="Search term queue is at capacity")
+
+    for index, term in enumerate(body.search_terms):
+        try:
+            handler.put(term)
+        except (AsyncBatchException, RuntimeError) as ex:
+            # The capacity check above is exact for this request -- there is no await
+            # between it and these puts -- but concurrent requests can pass it and
+            # then compete for the same slots. Degrade to a partial enqueue rather
+            # than a 500.
+            _search_terms_rejected_counter.add(count - index)
+            logger.warning(
+                "Rejected search term submission: queue unavailable",
+                extra={"submitted_count": count, "accepted_count": index, "error": str(ex)},
+            )
+            raise HTTPException(status_code=503, detail="Search term queue is unavailable") from ex
 
     return SearchTermsResponse(submitted=count)

--- a/merino-fleece/merino_fleece/api/v1/search_terms.py
+++ b/merino-fleece/merino_fleece/api/v1/search_terms.py
@@ -48,8 +48,10 @@ async def submit_search_terms(
     accepted for processing, not that they have been sanitized.
 
     Raises:
-        HTTPException: 503 when the terms cannot be queued, so the submitter can
-            back off rather than have its data silently dropped.
+        - HTTPException: 503 when the terms cannot be queued, normally indicating
+          the service is overloaded and unable to accept more submissions, so the
+          submitter can retry via other means such as the backup Pub/Sub channel
+          rather than have its data silently dropped.
     """
     count = len(body.search_terms)
     _search_terms_received_counter.add(count)

--- a/merino-fleece/merino_fleece/app.py
+++ b/merino-fleece/merino_fleece/app.py
@@ -10,6 +10,7 @@ from merino_common.routers import dockerflow
 
 from merino_fleece.api.v1 import router as v1_router
 from merino_fleece.configs import settings
+from merino_fleece.message_handlers import search_terms
 from merino_fleece.pii import (
     init_detector,
     init_executor,
@@ -20,7 +21,12 @@ from merino_fleece.pii import (
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
-    """Initialize logging, Sentry, the SpaCy model, and the PII detection thread pool."""
+    """Initialize logging, Sentry, the SpaCy model, the PII detection thread pool, and
+    the background search term sanitization handler.
+
+    Shutdown order matters: the handler drains before the thread pool closes, since a
+    batch sanitized during the drain still offloads NER to that pool.
+    """
     configure_logging(
         log_format=settings.logging.format,
         level=settings.logging.level,
@@ -36,9 +42,11 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     )
     init_detector()
     init_executor()
+    await search_terms.start()
     try:
         yield
     finally:
+        await search_terms.stop()
         shutdown_executor()
         shutdown_detector()
 

--- a/merino-fleece/merino_fleece/configs/default.toml
+++ b/merino-fleece/merino_fleece/configs/default.toml
@@ -23,6 +23,37 @@ query_character_max = 500
 # bounded pool avoids GIL thrashing under load.
 executor_max_workers = 1
 
+[default.sanitize]
+# Queue settings for background search term sanitization. The queue tunables below
+# mirror merino's `[default.message_handler]` so producer and consumer batch at the
+# same cadence.
+
+# MERINO_FLEECE_SANITIZE__MAX_BATCH_SIZE
+# Max number of queued search terms to sanitize in a single batch.
+max_batch_size = 512
+
+# MERINO_FLEECE_SANITIZE__COLLECTION_DELAY_SEC
+# Max seconds to wait for a batch to fill before sanitizing a partial batch.
+collection_delay_sec = 5.0
+
+# MERINO_FLEECE_SANITIZE__SHUTDOWN_DEADLINE_SEC
+# Max seconds to spend draining the queue during graceful shutdown before any
+# remaining search terms are dropped.
+shutdown_deadline_sec = 30.0
+
+# MERINO_FLEECE_SANITIZE__MAX_QUEUE_SIZE
+# Max number of search terms to buffer in the queue. Submissions are rejected with
+# a 503 once this capacity is reached.
+max_queue_size = 10000
+
+# MERINO_FLEECE_SANITIZE__NER_CHUNK_SIZE
+# Number of queries handed to SpaCy's `nlp.pipe()` per thread pool hop. Larger
+# values amortize the model's per-call overhead further; smaller values release the
+# shared NER thread more often, so concurrent `/pii` requests are not stuck waiting
+# behind a long batch. Unrelated to `max_batch_size`: a 512-term batch becomes at
+# most 8 hops at the default.
+ner_chunk_size = 64
+
 [default.sentry]
 # MERINO_FLEECE_SENTRY__MODE
 # One of "disabled", "release", "debug". When "disabled", no Sentry client is initialized.

--- a/merino-fleece/merino_fleece/message_handlers/__init__.py
+++ b/merino-fleece/merino_fleece/message_handlers/__init__.py
@@ -1,0 +1,1 @@
+"""Background message handlers for merino-fleece."""

--- a/merino-fleece/merino_fleece/message_handlers/search_terms/__init__.py
+++ b/merino-fleece/merino_fleece/message_handlers/search_terms/__init__.py
@@ -1,0 +1,29 @@
+"""Public interface for the search term sanitization message handler.
+
+Exposes the process-wide ``MessageHandler`` singleton and its lifecycle functions.
+The handler is a singleton because its ``AsyncBatchQueue`` registers OpenTelemetry
+instruments for the life of the meter provider, so short-lived instances would pin
+them in memory and emit duplicate-instrument warnings.
+"""
+
+from merino_fleece.message_handlers.search_terms.handler import MessageHandler
+
+__all__ = ["MessageHandler", "message_handler", "start", "stop", "get_message_handler"]
+
+# The message handler singleton. Use `start()` and `stop()` to interact with it.
+message_handler: MessageHandler = MessageHandler()
+
+
+async def start() -> None:
+    """Start the message handler. This should only be called once at startup."""
+    await message_handler.start()
+
+
+async def stop() -> None:
+    """Drain and stop the message handler. This should only be called once at shutdown."""
+    await message_handler.stop()
+
+
+def get_message_handler() -> MessageHandler:
+    """Return the message handler singleton. Intended for use with ``fastapi.Depends``."""
+    return message_handler

--- a/merino-fleece/merino_fleece/message_handlers/search_terms/handler.py
+++ b/merino-fleece/merino_fleece/message_handlers/search_terms/handler.py
@@ -1,0 +1,145 @@
+"""The message handler for background search term sanitization."""
+
+import logging
+from collections import Counter
+from collections.abc import Awaitable, Callable
+
+from merino_common.models.suggest_logging import SuggestRequestParams
+from merino_common.utils.async_batch_queue import AsyncBatchQueue
+from merino_common.utils.query_processing.pii_detect import PIIType, basic_detect
+from opentelemetry import metrics
+
+from merino_fleece.configs import settings
+from merino_fleece.pii import detect_person_batch, get_detector, get_executor
+
+# identifier used to tag the queue's metrics.
+QUEUE_ID = "search_term_sanitization"
+
+# Queries reaching the queue are not length-bounded by a request model the way the
+# /pii endpoint's are, so they are truncated before detection.
+QUERY_CHARACTER_MAX = settings.pii.query_character_max
+
+logger = logging.getLogger(__name__)
+
+_meter = metrics.get_meter("fleece")
+_sanitize_counter = _meter.create_counter(
+    name="search_terms.sanitize",
+    unit="{item}",
+    description="Number of search terms sanitized, labeled by the detected PII type.",
+)
+
+
+class MessageHandler:
+    """Buffers submitted search terms and sanitizes them in batches.
+
+    Sanitization runs off the request path so submitters do not wait for it, and in
+    batches so SpaCy NER can be run over many queries per model invocation.
+
+    Args:
+        on_batch: async callback for each batch. Defaults to the sanitization pass;
+            override only in tests.
+    """
+
+    def __init__(
+        self,
+        on_batch: (Callable[[list[SuggestRequestParams]], Awaitable[object]] | None) = None,
+    ) -> None:
+        self._on_batch = on_batch
+        self._queue: AsyncBatchQueue[SuggestRequestParams] | None = None
+
+    async def start(self) -> None:
+        """Build the queue and start its background task."""
+        if self._queue is not None:
+            return
+        queue: AsyncBatchQueue[SuggestRequestParams] = AsyncBatchQueue(
+            on_batch=self._on_batch or self.sanitize_batch,
+            queue_id=QUEUE_ID,
+            max_batch_size=settings.sanitize.max_batch_size,
+            collection_delay_s=settings.sanitize.collection_delay_sec,
+            shutdown_deadline_s=settings.sanitize.shutdown_deadline_sec,
+            max_queue_size=settings.sanitize.max_queue_size,
+        )
+        await queue.start()
+        self._queue = queue
+
+    async def stop(self) -> None:
+        """Drain the queue, then stop its background task.
+
+        Buffered terms are sanitized before this returns, bounded by the configured
+        shutdown deadline.
+        """
+        if self._queue is not None:
+            await self._queue.stop()
+            self._queue = None
+
+    def put(self, message: SuggestRequestParams) -> None:
+        """Enqueue a search term for asynchronous sanitization.
+
+        Raises:
+            RuntimeError: If the handler has not been started.
+        """
+        if self._queue is None:
+            raise RuntimeError("The message handler is not running")
+        self._queue.put(message)
+
+    def remaining_capacity(self) -> int:
+        """Return how many more search terms the queue can accept.
+
+        Reports 0 when the handler is not running, so callers gating on capacity
+        reject submissions instead of having to handle a separate not-running case.
+        """
+        if self._queue is None:
+            return 0
+        return self._queue.remaining_capacity()
+
+    def is_running(self) -> bool:
+        """Return whether the message handler's queue is running."""
+        return self._queue is not None and self._queue.is_running()
+
+    async def sanitize_batch(self, batch: list[SuggestRequestParams]) -> None:
+        """Classify the PII type of every search term in the batch and record it in metrics.
+
+        Cheap pattern matching runs over every query first; only the queries it
+        clears reach SpaCy NER, which is batched via ``detect_person_batch``. The NER
+        pass is chunked so the shared thread pool is released between chunks and
+        concurrent `/pii` requests are not stuck behind one long batch.
+
+        Exceptions are left to propagate: ``AsyncBatchQueue`` logs them and counts the
+        batch as failed, which drops one batch rather than stopping the run loop.
+
+        Logging the sanitized search terms is left out for now, will implement
+        it in a followup.
+        """
+        types: list[PIIType] = []
+        # Queries still needing NER, and their positions in `types`.
+        candidates: list[str] = []
+        candidate_indices: list[int] = []
+
+        for term in batch:
+            query = (term.query or "")[:QUERY_CHARACTER_MAX]
+            pii_type = basic_detect(query)
+            if pii_type is PIIType.NON_PII and query:
+                candidate_indices.append(len(types))
+                candidates.append(query)
+            types.append(pii_type)
+
+        if candidates:
+            detector = get_detector()
+            executor = get_executor()
+            chunk_size = settings.sanitize.ner_chunk_size
+            for start in range(0, len(candidates), chunk_size):
+                indices = candidate_indices[start : start + chunk_size]
+                verdicts = await detect_person_batch(
+                    candidates[start : start + chunk_size], detector, executor
+                )
+                # `detect_person_batch` preserves input order, so verdicts align
+                # positionally with `indices`. strict=True makes any future
+                # violation of that contract fail loudly rather than mislabel terms.
+                for index, is_person in zip(indices, verdicts, strict=True):
+                    if is_person:
+                        types[index] = PIIType.PERSON
+
+        # Aggregate before recording so a 512-term batch costs one counter add per
+        # distinct PII type rather than one per term.
+        for type_name, count in Counter(pii_type.name.lower() for pii_type in types).items():
+            _sanitize_counter.add(count, {"type": type_name})

--- a/merino-fleece/merino_fleece/pii/__init__.py
+++ b/merino-fleece/merino_fleece/pii/__init__.py
@@ -1,4 +1,5 @@
-"""PII / NER detection. Owns the singleton PiiDetector and its thread pool.
+"""PII / NER detection. Owns the singleton PiiDetector and its thread pool, and the
+helpers that run detection on it.
 
 The detector is initialized once at app startup via :func:`init_detector` and
 served to request handlers through :func:`get_detector` (used with FastAPI
@@ -10,10 +11,18 @@ shared :class:`~concurrent.futures.ThreadPoolExecutor` created by
 :func:`init_executor` lets handlers offload that work off the loop. A thread
 pool (rather than a process pool) keeps the single loaded model shared and
 benefits from SpaCy releasing the GIL during its numeric work.
+
+:func:`detect_person` and :func:`detect_person_batch` wrap that offload and time
+it. They return plain values rather than response models, so callers that are not
+HTTP handlers -- notably the background search term sanitization handler -- can use
+them too.
 """
 
+import asyncio
 import logging
 from concurrent.futures import ThreadPoolExecutor
+
+from opentelemetry import metrics
 
 from merino_fleece.configs import settings
 from merino_fleece.pii.detector import PiiDetector, build_detector
@@ -22,6 +31,21 @@ logger = logging.getLogger(__name__)
 
 _detector: PiiDetector | None = None
 _executor: ThreadPoolExecutor | None = None
+
+_meter = metrics.get_meter("fleece")
+_ner_detect_duration = _meter.create_histogram(
+    name="pii.ner_detect.duration",
+    unit="ms",
+    description="Duration of PII PERSON detection in milliseconds.",
+)
+# Batch and single-query detection get separate histograms on purpose: a batch of
+# hundreds of queries and a single query are different units of work, so mixing
+# them would make the single-query latency percentiles meaningless.
+_ner_batch_detect_duration = _meter.create_histogram(
+    name="pii.ner_batch_detect.duration",
+    unit="ms",
+    description="Duration of batched PII PERSON detection in milliseconds.",
+)
 
 
 def init_detector() -> None:
@@ -65,3 +89,32 @@ def get_executor() -> ThreadPoolExecutor:
     if _executor is None:
         raise RuntimeError("PII executor is not initialized; init_executor() must run first")
     return _executor
+
+
+async def detect_person(q: str, detector: PiiDetector, executor: ThreadPoolExecutor) -> bool:
+    """Return whether `q` contains a PERSON named entity."""
+    loop = asyncio.get_running_loop()
+    started_at = loop.time()
+    try:
+        return await loop.run_in_executor(executor, detector.is_person, q)
+    finally:
+        _ner_detect_duration.record((loop.time() - started_at) * 1000)
+
+
+async def detect_person_batch(
+    texts: list[str], detector: PiiDetector, executor: ThreadPoolExecutor
+) -> list[bool]:
+    """Return, for each text, whether it contains a PERSON named entity.
+
+    Hands the whole batch to the detector in a single executor call, so the model's
+    per-call overhead is paid once rather than once per text. Verdicts are returned
+    in input order.
+    """
+    if not texts:
+        return []
+    loop = asyncio.get_running_loop()
+    started_at = loop.time()
+    try:
+        return await loop.run_in_executor(executor, detector.is_person_batch, texts)
+    finally:
+        _ner_batch_detect_duration.record((loop.time() - started_at) * 1000)

--- a/merino-fleece/merino_fleece/pii/detector.py
+++ b/merino-fleece/merino_fleece/pii/detector.py
@@ -35,6 +35,24 @@ class PiiDetector:
         doc = self.nlp(text)
         return any(ent.label_ == PERSON_LABEL for ent in doc.ents)
 
+    def is_person_batch(self, texts: list[str]) -> list[bool]:
+        """Return, for each text, whether it contains a PERSON named entity.
+
+        Batches the model's forward pass via SpaCy's ``nlp.pipe``, which is
+        considerably cheaper than calling :meth:`is_person` once per text. Verdicts
+        are returned in input order, as ``nlp.pipe`` preserves it.
+
+        ``n_process`` is left at its default of 1: callers already run this in a
+        worker thread and share a single loaded model, so forking processes would
+        duplicate the model for no gain.
+        """
+        if not texts:
+            return []
+        return [
+            any(ent.label_ == PERSON_LABEL for ent in doc.ents)
+            for doc in self.nlp.pipe(texts, batch_size=len(texts))
+        ]
+
 
 def build_detector(settings) -> PiiDetector:
     """Construct a PiiDetector from the merino-fleece Dynaconf settings."""

--- a/merino-fleece/metrics.yaml
+++ b/merino-fleece/metrics.yaml
@@ -14,13 +14,51 @@ search-terms:
       The "api/v1/search-terms" API endpoint of "merino-fleece".
     alert_policy: []
 
-pii:
-  api.pii_detect.duration:
+  api.search_terms.reject.count:
     description: |
-      A histogram recording the duration, in milliseconds, of each PII detection
-      call, emitted via OpenTelemetry Metrics (meter "fleece").
+      A counter recording the number of search terms rejected because they could
+      not be queued for sanitization, either because the queue lacked capacity for
+      the whole submission or because it was unavailable. Rejections counted here
+      never reach the queue, so they do not appear in
+      "async_batch_queue.rejected.count".
+    type: counter
+    labels: []
+    scope: |
+      The "api/v1/search-terms" API endpoint of "merino-fleece".
+    alert_policy: []
+
+  search_terms.sanitize:
+    description: |
+      A counter recording the number of search terms sanitized, labeled by the PII
+      type detected in each. Incremented by the background sanitization handler,
+      once per term per batch.
+    type: counter
+    labels:
+      - type: |
+          The detected PII type: one of "email", "numeric", "person", or "non_pii".
+    scope: |
+      The background search term sanitization handler of "merino-fleece".
+    alert_policy: []
+
+pii:
+  pii.ner_detect.duration:
+    description: |
+      A histogram recording the duration, in milliseconds, of each single-query PII
+      detection call, emitted via OpenTelemetry Metrics (meter "fleece").
     type: histogram
     labels: []
     scope: |
       The "api/v1/pii" API endpoint of "merino-fleece".
+    alert_policy: []
+
+  pii.ner_batch_detect.duration:
+    description: |
+      A histogram recording the duration, in milliseconds, of each batched PII
+      detection call. Kept separate from "pii.ner_detect.duration" because a batch
+      of many queries and a single query are different units of work, and mixing
+      them would distort the single-query latency distribution.
+    type: histogram
+    labels: []
+    scope: |
+      The background search term sanitization handler of "merino-fleece".
     alert_policy: []

--- a/merino-fleece/tests/unit/api/v1/test_pii.py
+++ b/merino-fleece/tests/unit/api/v1/test_pii.py
@@ -85,10 +85,10 @@ def test_pii_metrics(make_client, metric_reader: InMemoryMetricReader) -> None:
     time; the shared `metric_reader` fixture installs a MeterProvider so that proxy
     forwards to a real instrument we can read back.
     """
-    before = histogram_count(metric_reader, "api.pii_detect.duration")
+    before = histogram_count(metric_reader, "pii.ner_detect.duration")
 
     client = make_client(True)
     resp = client.post("/api/v1/pii", json={"q": "Alice Bob"})
 
     assert resp.status_code == 200
-    assert histogram_count(metric_reader, "api.pii_detect.duration") - before == 1
+    assert histogram_count(metric_reader, "pii.ner_detect.duration") - before == 1

--- a/merino-fleece/tests/unit/api/v1/test_search_terms.py
+++ b/merino-fleece/tests/unit/api/v1/test_search_terms.py
@@ -1,24 +1,78 @@
 """Tests for the FastAPI /api/v1/search-terms endpoint."""
 
+from collections.abc import Callable, Iterator
 from typing import Any
 
 import pytest
 from opentelemetry.sdk.metrics.export import InMemoryMetricReader
 
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from merino_common.models.suggest_logging import SuggestRequestParams
 from merino_common.testing.metrics import counter_value
+from merino_common.utils.async_batch_queue import QueueFullException
 from merino_fleece.app import create_app
+from merino_fleece.message_handlers.search_terms import get_message_handler
+
+LOGGER_NAME = "merino_fleece.api.v1.search_terms"
+
+
+class FakeHandler:
+    """Message handler stub recording enqueued terms, with injectable failures.
+
+    Args:
+        capacity: value reported by `remaining_capacity`.
+        raise_on_put: 0-based index of the put that should raise, if any. Models a
+            concurrent producer consuming the headroom after the capacity check.
+    """
+
+    def __init__(self, capacity: int = 1000, raise_on_put: int | None = None) -> None:
+        """Store the reported capacity and the optional failing put index."""
+        self.capacity = capacity
+        self.raise_on_put = raise_on_put
+        self.puts: list[SuggestRequestParams] = []
+
+    def remaining_capacity(self) -> int:
+        """Return the configured capacity."""
+        return self.capacity
+
+    def put(self, message: SuggestRequestParams) -> None:
+        """Record the term, or raise if this put is the configured failure point."""
+        if self.raise_on_put is not None and len(self.puts) == self.raise_on_put:
+            raise QueueFullException("The queue is full")
+        self.puts.append(message)
+
+
+# Factory yielded by `make_client`: builds a TestClient bound to a given handler.
+ClientFactory = Callable[[FakeHandler], TestClient]
 
 
 @pytest.fixture
-def client() -> TestClient:
-    """Yield a TestClient for the app.
+def make_client() -> Iterator[ClientFactory]:
+    """Yield a factory building a TestClient with the message handler overridden.
 
-    The search-terms route has no dependencies or app state, so no lifespan
-    context is needed.
+    No lifespan is run: the override supplies the handler, so the route never
+    touches app state or the real queue.
     """
-    return TestClient(create_app())
+    apps: list[FastAPI] = []
+
+    def _factory(handler: FakeHandler) -> TestClient:
+        app = create_app()
+        app.dependency_overrides[get_message_handler] = lambda: handler
+        apps.append(app)
+        return TestClient(app)
+
+    yield _factory
+
+    for app in apps:
+        app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def client(make_client: ClientFactory) -> TestClient:
+    """Yield a TestClient backed by a handler with ample capacity."""
+    return make_client(FakeHandler())
 
 
 def _search_term(**overrides: Any) -> dict[str, Any]:
@@ -36,12 +90,17 @@ def _search_term(**overrides: Any) -> dict[str, Any]:
     return payload
 
 
-def test_submit_search_terms(client: TestClient) -> None:
-    """A valid batch of search terms returns 201 and the submitted count."""
+def test_submit_search_terms(make_client: ClientFactory) -> None:
+    """A valid batch returns 201, the submitted count, and reaches the queue."""
+    handler = FakeHandler()
+    client = make_client(handler)
+
     body = {"search_terms": [_search_term(query="foo"), _search_term(query="bar")]}
     resp = client.post("/api/v1/search-terms", json=body)
+
     assert resp.status_code == 201
     assert resp.json() == {"submitted": 2}
+    assert [term.query for term in handler.puts] == ["foo", "bar"]
 
 
 def test_submit_empty_search_terms(client: TestClient) -> None:
@@ -63,7 +122,60 @@ def test_malformed_search_term(client: TestClient) -> None:
     assert resp.status_code == 422
 
 
-def test_search_terms_metrics(client: TestClient, metric_reader: InMemoryMetricReader) -> None:
+def test_insufficient_capacity_enqueues_nothing(
+    make_client: ClientFactory, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A submission larger than the remaining capacity is rejected atomically.
+
+    Nothing may be enqueued: partially accepting a batch the submitter then treats
+    as failed would leave the two sides disagreeing about what was processed.
+    """
+    handler = FakeHandler(capacity=2)
+    client = make_client(handler)
+
+    body = {"search_terms": [_search_term(query=f"q{i}") for i in range(3)]}
+    resp = client.post("/api/v1/search-terms", json=body)
+
+    assert resp.status_code == 503
+    assert handler.puts == [], "no term may be queued when the submission is rejected"
+    assert any(record.name == LOGGER_NAME for record in caplog.records)
+
+
+def test_handler_not_running_is_rejected(make_client: ClientFactory) -> None:
+    """A handler reporting no capacity (e.g. not started) rejects submissions."""
+    handler = FakeHandler(capacity=0)
+    client = make_client(handler)
+
+    resp = client.post("/api/v1/search-terms", json={"search_terms": [_search_term(query="foo")]})
+
+    assert resp.status_code == 503
+    assert handler.puts == []
+
+
+def test_queue_full_midway_is_rejected(
+    make_client: ClientFactory, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A put failing after the capacity check still returns 503.
+
+    Concurrent submissions can both clear the capacity check and then compete for
+    the same slots, so the per-put guard has to hold.
+    """
+    handler = FakeHandler(capacity=1000, raise_on_put=2)
+    client = make_client(handler)
+
+    body = {"search_terms": [_search_term(query=f"q{i}") for i in range(4)]}
+    resp = client.post("/api/v1/search-terms", json=body)
+
+    assert resp.status_code == 503
+    assert [term.query for term in handler.puts] == ["q0", "q1"]
+    records = [record for record in caplog.records if record.name == LOGGER_NAME]
+    assert records, "the partial enqueue must be logged"
+    assert getattr(records[0], "accepted_count") == 2
+
+
+def test_search_terms_metrics(
+    make_client: ClientFactory, metric_reader: InMemoryMetricReader
+) -> None:
     """The receive counter records the batch size via a real OpenTelemetry reader.
 
     The endpoint's counter is created against the global (proxy) meter at import
@@ -71,9 +183,27 @@ def test_search_terms_metrics(client: TestClient, metric_reader: InMemoryMetricR
     forwards to a real instrument we can read back.
     """
     before = counter_value(metric_reader, "api.search_terms.receive.count")
+    client = make_client(FakeHandler())
 
     body = {"search_terms": [_search_term(), _search_term(), _search_term()]}
     resp = client.post("/api/v1/search-terms", json=body)
 
     assert resp.status_code == 201
     assert counter_value(metric_reader, "api.search_terms.receive.count") - before == 3
+
+
+def test_rejected_metric(make_client: ClientFactory, metric_reader: InMemoryMetricReader) -> None:
+    """Capacity rejections are counted, since they never reach the queue's own metrics.
+
+    The pre-check bypasses `put`, so `async_batch_queue.rejected.count` cannot see
+    these; without this counter the loss would only be visible as a gap between
+    received terms and queue throughput.
+    """
+    before = counter_value(metric_reader, "api.search_terms.reject.count")
+    client = make_client(FakeHandler(capacity=0))
+
+    body = {"search_terms": [_search_term(), _search_term()]}
+    resp = client.post("/api/v1/search-terms", json=body)
+
+    assert resp.status_code == 503
+    assert counter_value(metric_reader, "api.search_terms.reject.count") - before == 2

--- a/merino-fleece/tests/unit/message_handlers/search_terms/test_sanitize_handler.py
+++ b/merino-fleece/tests/unit/message_handlers/search_terms/test_sanitize_handler.py
@@ -1,0 +1,311 @@
+"""Unit tests for the search term sanitization message handler."""
+
+from collections.abc import Callable, Iterator
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+
+from merino_common.models.suggest_logging import SuggestRequestParams
+from merino_common.testing.metrics import number_points
+from merino_common.utils.async_batch_queue import QueueFullException
+from merino_fleece.message_handlers.search_terms import handler as handler_module
+from merino_fleece.message_handlers.search_terms.handler import MessageHandler
+
+ParamsFactory = Callable[[str | None], SuggestRequestParams]
+
+SANITIZE_METRIC = "search_terms.sanitize"
+
+
+@pytest.fixture(name="params")
+def fixture_params() -> ParamsFactory:
+    """Return a factory that builds a minimal SuggestRequestParams for a given query."""
+
+    def _build(query: str | None) -> SuggestRequestParams:
+        return SuggestRequestParams(
+            query=query,
+            code=200,
+            rid="rid",
+            client_variants="",
+            requested_providers="",
+            browser="Firefox",
+            os_family="macos",
+            form_factor="desktop",
+        )
+
+    return _build
+
+
+@pytest.fixture
+def executor() -> Iterator[ThreadPoolExecutor]:
+    """Yield a single-worker pool mirroring the app's default NER pool size."""
+    pool = ThreadPoolExecutor(max_workers=1, thread_name_prefix="test-pii-detect")
+    yield pool
+    pool.shutdown(wait=True)
+
+
+class RecordingDetector:
+    """Detector stub returning preset verdicts and recording every batch it receives."""
+
+    def __init__(self, verdicts: dict[str, bool] | None = None) -> None:
+        """Store per-query verdicts (defaulting to False) and init the call log."""
+        self.verdicts = verdicts or {}
+        self.batch_calls: list[list[str]] = []
+
+    def is_person_batch(self, texts: list[str]) -> list[bool]:
+        """Record the batch and return each text's configured verdict."""
+        self.batch_calls.append(list(texts))
+        return [self.verdicts.get(text, False) for text in texts]
+
+    @property
+    def seen_queries(self) -> list[str]:
+        """Every query handed to the detector, flattened across chunks."""
+        return [query for call in self.batch_calls for query in call]
+
+
+@pytest.fixture
+def detector(monkeypatch: pytest.MonkeyPatch, executor: ThreadPoolExecutor) -> RecordingDetector:
+    """Install a recording detector and the test pool as the handler's NER singletons.
+
+    The handler looks these up per batch rather than capturing them at start, so
+    patching the module's accessors is enough -- no app lifespan required.
+    """
+    stub = RecordingDetector()
+    monkeypatch.setattr(handler_module, "get_detector", lambda: stub)
+    monkeypatch.setattr(handler_module, "get_executor", lambda: executor)
+    return stub
+
+
+def counter_by_type(reader: InMemoryMetricReader) -> dict[str, float]:
+    """Return the sanitize counter's current value per `type` attribute."""
+    totals: dict[str, float] = {}
+    for point in number_points(reader, SANITIZE_METRIC):
+        attributes = point.attributes or {}
+        pii_type = str(attributes.get("type"))
+        totals[pii_type] = totals.get(pii_type, 0.0) + point.value
+    return totals
+
+
+def delta(before: dict[str, float], after: dict[str, float], pii_type: str) -> float:
+    """Return how much the counter for `pii_type` grew between two snapshots."""
+    return after.get(pii_type, 0.0) - before.get(pii_type, 0.0)
+
+
+@pytest.mark.asyncio
+async def test_lifecycle(detector: RecordingDetector, params: ParamsFactory) -> None:
+    """The handler starts, accepts terms, and stops."""
+    handler = MessageHandler()
+    assert handler.is_running() is False
+
+    await handler.start()
+    await handler.start()  # idempotent
+    assert handler.is_running() is True
+
+    handler.put(params("weather"))
+    await handler.stop()
+    assert handler.is_running() is False
+
+
+@pytest.mark.asyncio
+async def test_put_before_start_raises(params: ParamsFactory) -> None:
+    """Enqueuing before startup is a programming error, not a silent drop."""
+    handler = MessageHandler()
+    with pytest.raises(RuntimeError):
+        handler.put(params("weather"))
+
+
+def test_remaining_capacity_before_start_is_zero() -> None:
+    """A handler that is not running reports no capacity rather than raising."""
+    assert MessageHandler().remaining_capacity() == 0
+
+
+@pytest.mark.asyncio
+async def test_remaining_capacity_tracks_queue(params: ParamsFactory) -> None:
+    """Once started, reported capacity reflects the terms buffered in the queue."""
+    batches: list[list[SuggestRequestParams]] = []
+
+    async def on_batch(batch: list[SuggestRequestParams]) -> None:
+        batches.append(batch)
+
+    handler = MessageHandler(on_batch=on_batch)
+    await handler.start()
+    try:
+        capacity = handler.remaining_capacity()
+        assert capacity > 0
+        handler.put(params("weather"))
+        assert handler.remaining_capacity() == capacity - 1
+    finally:
+        await handler.stop()
+
+
+@pytest.mark.parametrize(
+    ("query", "is_person", "expected_type", "expects_ner"),
+    [
+        pytest.param("alice@example.com", False, "email", False, id="email"),
+        pytest.param("iphone 15 review", False, "numeric", False, id="numeric"),
+        pytest.param("barack obama", True, "person", True, id="person"),
+        pytest.param("the weather today", False, "non_pii", True, id="non_pii"),
+        pytest.param("", False, "non_pii", False, id="empty"),
+        pytest.param(None, False, "non_pii", False, id="none"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_classification(
+    detector: RecordingDetector,
+    params: ParamsFactory,
+    metric_reader: InMemoryMetricReader,
+    query: str | None,
+    is_person: bool,
+    expected_type: str,
+    expects_ner: bool,
+) -> None:
+    """Each search term is counted under its detected PII type.
+
+    `expects_ner` pins the short-circuit: only queries the cheap pattern pass clears
+    should reach SpaCy, since NER is by far the expensive step.
+    """
+    if is_person:
+        detector.verdicts[str(query)] = True
+    before = counter_by_type(metric_reader)
+
+    await MessageHandler().sanitize_batch([params(query)])
+
+    after = counter_by_type(metric_reader)
+    assert delta(before, after, expected_type) == 1
+    assert detector.seen_queries == ([query] if expects_ner else [])
+
+
+@pytest.mark.asyncio
+async def test_mixed_batch_maps_verdicts_to_the_right_terms(
+    detector: RecordingDetector,
+    params: ParamsFactory,
+    metric_reader: InMemoryMetricReader,
+) -> None:
+    """Every term in a mixed batch is counted under its own type.
+
+    Only a subset of the batch reaches NER, so verdicts are indexed against the
+    filtered candidate list rather than the batch itself. This is the case that
+    catches an off-by-one in that mapping: `charlie chaplin` is the only PERSON, and
+    it sits after two terms that skipped NER entirely.
+    """
+    detector.verdicts["charlie chaplin"] = True
+    batch = [
+        params("the weather today"),  # non_pii, goes to NER
+        params("alice@example.com"),  # email, skips NER
+        params("iphone 15"),  # numeric, skips NER
+        params("charlie chaplin"),  # person, goes to NER
+        params(None),  # non_pii, skips NER
+        params("best pizza"),  # non_pii, goes to NER
+    ]
+    before = counter_by_type(metric_reader)
+
+    await MessageHandler().sanitize_batch(batch)
+
+    after = counter_by_type(metric_reader)
+    assert delta(before, after, "email") == 1
+    assert delta(before, after, "numeric") == 1
+    assert delta(before, after, "person") == 1
+    assert delta(before, after, "non_pii") == 3
+    assert detector.seen_queries == ["the weather today", "charlie chaplin", "best pizza"]
+
+
+@pytest.mark.asyncio
+async def test_ner_is_chunked(
+    monkeypatch: pytest.MonkeyPatch,
+    detector: RecordingDetector,
+    params: ParamsFactory,
+    metric_reader: InMemoryMetricReader,
+) -> None:
+    """Candidates are split into `ner_chunk_size` calls, and verdicts still land right.
+
+    Chunking releases the shared NER thread between calls so concurrent /pii requests
+    are not stuck behind one long batch. The PERSON hit is in the final, partial chunk
+    to prove the index mapping survives chunk boundaries.
+    """
+    monkeypatch.setitem(handler_module.settings.sanitize, "ner_chunk_size", 2)
+    detector.verdicts["ada lovelace"] = True
+    queries = ["one", "two", "three", "four", "ada lovelace"]
+    before = counter_by_type(metric_reader)
+
+    await MessageHandler().sanitize_batch([params(query) for query in queries])
+
+    assert [len(call) for call in detector.batch_calls] == [2, 2, 1]
+    assert detector.seen_queries == queries
+    after = counter_by_type(metric_reader)
+    assert delta(before, after, "person") == 1
+    assert delta(before, after, "non_pii") == 4
+
+
+@pytest.mark.asyncio
+async def test_long_query_is_truncated(
+    monkeypatch: pytest.MonkeyPatch,
+    detector: RecordingDetector,
+    params: ParamsFactory,
+) -> None:
+    """Overlong queries are truncated before detection.
+
+    Nothing on the queue path bounds query length the way the /pii request model
+    does, and one pathological query would otherwise slow its whole NER chunk.
+    """
+    monkeypatch.setattr(handler_module, "QUERY_CHARACTER_MAX", 5)
+
+    await MessageHandler().sanitize_batch([params("abcdefghij")])
+
+    assert detector.seen_queries == ["abcde"]
+
+
+@pytest.mark.asyncio
+async def test_empty_batch_skips_detection(detector: RecordingDetector) -> None:
+    """An empty batch does no work and records nothing."""
+    await MessageHandler().sanitize_batch([])
+    assert detector.batch_calls == []
+
+
+@pytest.mark.asyncio
+async def test_sanitization_runs_via_the_queue(
+    detector: RecordingDetector,
+    params: ParamsFactory,
+    metric_reader: InMemoryMetricReader,
+) -> None:
+    """Terms put on the queue are sanitized by the background task.
+
+    Covers the wiring between `start`, `put`, and `sanitize_batch` that the direct
+    `sanitize_batch` tests bypass.
+    """
+    detector.verdicts["barack obama"] = True
+    before = counter_by_type(metric_reader)
+
+    handler = MessageHandler()
+    await handler.start()
+    handler.put(params("barack obama"))
+    handler.put(params("alice@example.com"))
+    await handler.stop()
+
+    after = counter_by_type(metric_reader)
+    assert delta(before, after, "person") == 1
+    assert delta(before, after, "email") == 1
+
+
+@pytest.mark.asyncio
+async def test_queue_full_rejects_puts(
+    monkeypatch: pytest.MonkeyPatch, detector: RecordingDetector, params: ParamsFactory
+) -> None:
+    """A full queue rejects further terms rather than buffering without bound.
+
+    A long collection delay keeps the run loop from draining the single slot before
+    the second put, making the rejection deterministic. `stop()` still returns
+    promptly because the collection wait races against the shutdown event.
+    """
+    monkeypatch.setitem(handler_module.settings.sanitize, "max_queue_size", 1)
+    monkeypatch.setitem(handler_module.settings.sanitize, "max_batch_size", 1)
+    monkeypatch.setitem(handler_module.settings.sanitize, "collection_delay_sec", 30.0)
+
+    handler = MessageHandler()
+    await handler.start()
+    try:
+        handler.put(params("weather"))
+        assert handler.remaining_capacity() == 0
+        with pytest.raises(QueueFullException):
+            handler.put(params("pizza"))
+    finally:
+        await handler.stop()

--- a/merino-fleece/tests/unit/pii/test_detect.py
+++ b/merino-fleece/tests/unit/pii/test_detect.py
@@ -1,0 +1,135 @@
+"""Unit tests for the merino_fleece.pii package detection helpers.
+
+The detector is stubbed so these tests cover the offload-and-measure wrapper
+rather than SpaCy's behavior, which `test_detector.py` covers against the real
+model.
+"""
+
+from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor
+from typing import cast
+
+import pytest
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+
+from merino_common.testing.metrics import histogram_count
+from merino_fleece.pii import detect_person, detect_person_batch
+from merino_fleece.pii.detector import PiiDetector
+
+
+class StubDetector:
+    """Detector stub that records its calls and returns preset verdicts."""
+
+    def __init__(self, verdicts: list[bool] | None = None) -> None:
+        """Store the verdicts to return and initialize the call log."""
+        self.verdicts = verdicts if verdicts is not None else []
+        self.single_calls: list[str] = []
+        self.batch_calls: list[list[str]] = []
+
+    def is_person(self, text: str) -> bool:
+        """Record the call and return the first configured verdict."""
+        self.single_calls.append(text)
+        return self.verdicts[0]
+
+    def is_person_batch(self, texts: list[str]) -> list[bool]:
+        """Record the call and return the configured verdicts."""
+        self.batch_calls.append(list(texts))
+        return self.verdicts[: len(texts)]
+
+
+def as_detector(stub: StubDetector) -> PiiDetector:
+    """Present the stub as a PiiDetector for the service's type signature."""
+    return cast(PiiDetector, stub)
+
+
+@pytest.fixture
+def executor() -> Iterator[ThreadPoolExecutor]:
+    """Yield a single-worker pool mirroring the app's default NER pool size."""
+    pool = ThreadPoolExecutor(max_workers=1, thread_name_prefix="test-pii-detect")
+    yield pool
+    pool.shutdown(wait=True)
+
+
+@pytest.mark.asyncio
+async def test_detect_person_returns_verdict(executor: ThreadPoolExecutor) -> None:
+    """The detector's verdict is returned and the query reaches it unchanged."""
+    stub = StubDetector([True])
+
+    assert await detect_person("Alice Bob", as_detector(stub), executor) is True
+    assert stub.single_calls == ["Alice Bob"]
+
+
+@pytest.mark.asyncio
+async def test_detect_person_records_duration(
+    executor: ThreadPoolExecutor, metric_reader: InMemoryMetricReader
+) -> None:
+    """Single-query detection records one observation on the endpoint histogram."""
+    before = histogram_count(metric_reader, "pii.ner_detect.duration")
+
+    await detect_person("Alice Bob", as_detector(StubDetector([False])), executor)
+
+    assert histogram_count(metric_reader, "pii.ner_detect.duration") - before == 1
+
+
+@pytest.mark.asyncio
+async def test_detect_person_batch_returns_verdicts_in_order(
+    executor: ThreadPoolExecutor,
+) -> None:
+    """Verdicts come back positionally aligned with the submitted texts."""
+    stub = StubDetector([False, True, False])
+
+    verdicts = await detect_person_batch(
+        ["weather", "Alice Bob", "pizza"], as_detector(stub), executor
+    )
+
+    assert verdicts == [False, True, False]
+
+
+@pytest.mark.asyncio
+async def test_detect_person_batch_uses_a_single_detector_call(
+    executor: ThreadPoolExecutor,
+) -> None:
+    """The whole batch is handed to the detector at once.
+
+    Batching exists to pay the model's per-call overhead once instead of once per
+    text, so a regression to per-text calls must fail here.
+    """
+    stub = StubDetector([False, False, False, False])
+    texts = ["a", "b", "c", "d"]
+
+    await detect_person_batch(texts, as_detector(stub), executor)
+
+    assert stub.batch_calls == [texts], "expected exactly one batched call"
+    assert stub.single_calls == [], "per-text detection defeats the point of batching"
+
+
+@pytest.mark.asyncio
+async def test_detect_person_batch_records_its_own_duration(
+    executor: ThreadPoolExecutor, metric_reader: InMemoryMetricReader
+) -> None:
+    """Batch detection records one observation, on its own histogram.
+
+    The batch histogram is separate from `pii.ner_detect.duration` so batch timings
+    cannot distort the single-query latency distribution.
+    """
+    single_before = histogram_count(metric_reader, "pii.ner_detect.duration")
+    batch_before = histogram_count(metric_reader, "pii.ner_batch_detect.duration")
+
+    await detect_person_batch(["a", "b", "c"], as_detector(StubDetector([False] * 3)), executor)
+
+    assert histogram_count(metric_reader, "pii.ner_batch_detect.duration") - batch_before == 1
+    assert histogram_count(metric_reader, "pii.ner_detect.duration") == single_before
+
+
+@pytest.mark.asyncio
+async def test_detect_person_batch_empty(
+    executor: ThreadPoolExecutor, metric_reader: InMemoryMetricReader
+) -> None:
+    """An empty batch short-circuits without touching the detector or the histogram."""
+    stub = StubDetector()
+    before = histogram_count(metric_reader, "pii.ner_batch_detect.duration")
+
+    assert await detect_person_batch([], as_detector(stub), executor) == []
+
+    assert stub.batch_calls == []
+    assert histogram_count(metric_reader, "pii.ner_batch_detect.duration") == before

--- a/merino-fleece/tests/unit/pii/test_detector.py
+++ b/merino-fleece/tests/unit/pii/test_detector.py
@@ -21,3 +21,36 @@ def test_detects_person(detector: PiiDetector) -> None:
 def test_no_person(detector: PiiDetector) -> None:
     """Text without a PERSON entity is not flagged."""
     assert detector.is_person("The weather is nice today.") is False
+
+
+def test_is_person_batch_preserves_input_order(detector: PiiDetector) -> None:
+    """Batch verdicts line up positionally with the input texts.
+
+    Callers map verdicts back onto their inputs by index, so a reordering bug would
+    silently mislabel unrelated search terms. The PERSON hits sit at interior,
+    non-symmetric positions so an off-by-one or reversal cannot pass.
+    """
+    texts = [
+        "The weather is nice today.",
+        "Barack Obama visited Berlin.",
+        "best pizza recipe",
+        "Ada Lovelace wrote the first algorithm.",
+        "how tall is the eiffel tower",
+    ]
+
+    assert detector.is_person_batch(texts) == [False, True, False, True, False]
+
+
+def test_is_person_batch_agrees_with_is_person(detector: PiiDetector) -> None:
+    """Batched and single-text detection reach the same verdict for the same text."""
+    for text in ("Barack Obama visited Berlin.", "The weather is nice today."):
+        assert detector.is_person_batch([text]) == [detector.is_person(text)]
+
+
+def test_is_person_batch_empty(detector: PiiDetector) -> None:
+    """An empty batch returns no verdicts without invoking the pipeline.
+
+    SpaCy rejects `batch_size=0`, so the empty case must short-circuit rather than
+    reach `nlp.pipe`.
+    """
+    assert detector.is_person_batch([]) == []

--- a/merino-fleece/tests/unit/test_app.py
+++ b/merino-fleece/tests/unit/test_app.py
@@ -1,0 +1,80 @@
+"""Tests for the merino-fleece app factory and lifespan."""
+
+from typing import Any
+
+import pytest
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+
+from fastapi.testclient import TestClient
+
+from merino_common.testing.metrics import counter_value
+from merino_fleece import app as app_module
+from merino_fleece import pii
+from merino_fleece.app import create_app
+from merino_fleece.message_handlers import search_terms
+
+
+@pytest.fixture(autouse=True)
+def _stub_global_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Neutralize the lifespan's logging and Sentry setup.
+
+    `configure_logging` applies a `dictConfig`, which replaces the process-wide
+    logging configuration and so strips the handler `caplog` installs -- breaking log
+    assertions in every test that runs afterwards. Both are covered by their own unit
+    tests; this module is about the lifespan's resource wiring.
+    """
+    monkeypatch.setattr(app_module, "configure_logging", lambda **kwargs: None)
+    monkeypatch.setattr(app_module, "configure_sentry", lambda **kwargs: None)
+
+
+def _search_term(query: str) -> dict[str, Any]:
+    """Build a valid SuggestRequestParams payload carrying `query`."""
+    return {
+        "query": query,
+        "code": 200,
+        "rid": "1b11844c52b34c33a6ad54b7bc2eb7c7",
+        "client_variants": "",
+        "requested_providers": "",
+        "browser": "Firefox(103.0)",
+        "os_family": "macos",
+        "form_factor": "desktop",
+    }
+
+
+def test_lifespan_initializes_and_tears_down_dependencies(
+    metric_reader: InMemoryMetricReader,
+) -> None:
+    """The lifespan starts the detector, thread pool, and sanitization handler, and
+    tears all three down on exit.
+
+    This also pins the shutdown ordering. A submission held by the queue's collection
+    delay is only sanitized during the shutdown drain, and that drain offloads NER to
+    the thread pool -- so the sanitize counter only advances if the handler drains
+    *before* the pool is closed. Closing the pool first would leave the drain unable
+    to schedule work, which `AsyncBatchQueue` would swallow as a failed batch.
+
+    Loads the real SpaCy model, unlike the dependency-overridden route tests.
+    """
+    before = counter_value(metric_reader, "search_terms.sanitize")
+
+    app = create_app()
+    with TestClient(app) as client:
+        assert search_terms.get_message_handler().is_running() is True
+        assert pii.get_detector() is not None
+        assert pii.get_executor() is not None
+
+        resp = client.post(
+            "/api/v1/search-terms",
+            json={"search_terms": [_search_term("barack obama"), _search_term("iphone 15")]},
+        )
+        assert resp.status_code == 201
+
+    assert search_terms.get_message_handler().is_running() is False
+    with pytest.raises(RuntimeError):
+        pii.get_detector()
+    with pytest.raises(RuntimeError):
+        pii.get_executor()
+
+    assert counter_value(metric_reader, "search_terms.sanitize") - before == 2, (
+        "queued terms must be sanitized during the shutdown drain"
+    )


### PR DESCRIPTION
## References

JIRA: [DISCO-4339](https://mozilla-hub.atlassian.net/browse/DISCO-4339)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->

This implements full search term sanitization (email, digit, and NER) for Fleece.

Change summaries:
- Sanitization is performed in the background off the path of the `search-terms` handler.
- Modeled after the `search_terms` message handler for message queuing and batch processing.
- Add a new method to the pii module for batch inference via `spaCy.nlp()`. All NER detection calls are executed on a thread pool to avoid blocking the main thread / event loop.

For reviewers:
- Commits are divided into logically related units, feel free to check them out in that order.
- Logging sanitized search terms is left out in this PR, will do that in a followup.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2503)


[DISCO-4339]: https://mozilla-hub.atlassian.net/browse/DISCO-4339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ