### PR TITLE
[DISCO-4364] feat(fleece:worker): add heartbeat file writer for k8s deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ COMMON_PACKAGE_DIR := merino-common/merino_common
 COMMON_TEST_DIR := merino-common/tests
 FLEECE_PACKAGE_DIR := merino-fleece/merino_fleece
 FLEECE_TEST_DIR := merino-fleece/tests
+FLEECE_WORKER_MAIN := $(FLEECE_PACKAGE_DIR)/sanitize/worker/main.py
 UNIT_TEST_DIR := $(TEST_DIR)/unit
 COMMON_UNIT_TEST_DIR := $(COMMON_TEST_DIR)/unit
 FLEECE_UNIT_TEST_DIR := $(FLEECE_TEST_DIR)/unit
@@ -91,12 +92,12 @@ run: $(INSTALL_STAMP)  ##  Run merino locally
 
 .PHONY: dev-fleece-worker
 dev-fleece-worker: $(INSTALL_STAMP)  ##  Run fleece worker locally (does not reload)
-	PUBSUB_EMULATOR_HOST=localhost:8085 $(UV) run $(FLEECE_PACKAGE_DIR)/worker/main.py
+	PUBSUB_EMULATOR_HOST=localhost:8085 $(UV) run $(FLEECE_WORKER_MAIN)
 
 
 .PHONY: dev-fleece-worker-otel
 dev-fleece-worker-otel: $(INSTALL_STAMP)  ##  Run fleece worker locally with OTEL auto-instrumentation (mimics k8s operator)
-	PUBSUB_EMULATOR_HOST=localhost:8085 OTEL_SERVICE_NAME=merino OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf $(UV) run opentelemetry-instrument $(UV) run $(FLEECE_PACKAGE_DIR)/worker/main.py
+	PUBSUB_EMULATOR_HOST=localhost:8085 OTEL_SERVICE_NAME=merino OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf $(UV) run opentelemetry-instrument $(UV) run $(FLEECE_WORKER_MAIN)
 
 
 .PHONY: test

--- a/merino-fleece/merino_fleece/configs/default.toml
+++ b/merino-fleece/merino_fleece/configs/default.toml
@@ -66,3 +66,15 @@ restart_stream = true
 # How long to wait before restarting stream after stream error
 # Only applicable if `restart_stream` is true
 restart_backoff = 10  # seconds
+
+# MERINO_FLEECE_PUBSUB__HEARTBEAT_PATH
+# Filesystem path the worker refreshes while the streaming pull is running, for an
+# external liveness probe (e.g. a Kubernetes exec probe). Parent directories are created
+# on demand. Must be writable by the container's unprivileged `app` user (uid 10001)
+# Empty disables the heartbeat.
+heartbeat_path = ""
+
+# MERINO_FLEECE_PUBSUB__HEARTBEAT_INTERVAL
+# How often to refresh the heartbeat file. Keep the probe's staleness threshold
+# comfortably above `heartbeat_interval + restart_backoff`.
+heartbeat_interval = 10  # seconds

--- a/merino-fleece/merino_fleece/configs/production.toml
+++ b/merino-fleece/merino_fleece/configs/production.toml
@@ -14,3 +14,9 @@ format = "mozlog"
 # MERINO_FLEECE_PUBSUB__SUBSCRIPTION
 # Subscription for the backup PubSub topic.
 subscription = "projects/moz-fx-merino-prod-5de4/subscriptions/merino-fleece-sanitization-prod"
+
+# MERINO_FLEECE_PUBSUB__HEARTBEAT_PATH
+# Filesystem path the worker refreshes while the streaming pull is running, for an
+# external liveness probe (e.g. a Kubernetes exec probe). Empty disables the heartbeat.
+# Must be writable by the container's unprivileged `app` user (uid 10001)
+heartbeat_path = "/tmp/fleece/heartbeat"

--- a/merino-fleece/merino_fleece/configs/stage.toml
+++ b/merino-fleece/merino_fleece/configs/stage.toml
@@ -14,3 +14,9 @@ format = "mozlog"
 # MERINO_FLEECE_PUBSUB__SUBSCRIPTION
 # Subscription for the backup PubSub topic.
 subscription = "projects/moz-fx-merino-nonprod-db57/subscriptions/merino-fleece-sanitization-stage"
+
+# MERINO_FLEECE_PUBSUB__HEARTBEAT_PATH
+# Filesystem path the worker refreshes while the streaming pull is running, for an
+# external liveness probe (e.g. a Kubernetes exec probe). Empty disables the heartbeat.
+# Must be writable by the container's unprivileged `app` user (uid 10001)
+heartbeat_path = "/tmp/fleece/heartbeat"

--- a/merino-fleece/merino_fleece/sanitize/worker/main.py
+++ b/merino-fleece/merino_fleece/sanitize/worker/main.py
@@ -8,11 +8,21 @@ from merino_fleece.configs import settings
 
 subscription = settings.pubsub.subscription
 restart_stream = settings.pubsub.restart_stream
+restart_backoff = settings.pubsub.restart_backoff
+# Normalize to None if path is empty (disabled)
+heartbeat_path = settings.pubsub.heartbeat_path or None
+heartbeat_interval = settings.pubsub.heartbeat_interval
 
 logger = logging.getLogger(__name__)
 
 if __name__ == "__main__":
-    worker = FleeceQueueWorker(subscription_name=subscription, restart_stream=restart_stream)
+    worker = FleeceQueueWorker(
+        subscription_name=subscription,
+        restart_stream=restart_stream,
+        restart_backoff=restart_backoff,
+        heartbeat_path=heartbeat_path,
+        heartbeat_interval=heartbeat_interval,
+    )
 
     def handle_exit(signum, frame):
         """Shutdown signal handler (SIGTERM + SIGINT)"""

--- a/merino-fleece/merino_fleece/sanitize/worker/worker.py
+++ b/merino-fleece/merino_fleece/sanitize/worker/worker.py
@@ -1,6 +1,8 @@
 """Pub/Sub worker for processing search term submissions."""
 
 import logging
+import os
+import threading
 import time
 
 import google.cloud.pubsub_v1 as pubsub_v1
@@ -16,6 +18,9 @@ logger = logging.getLogger(__name__)
 
 # Seconds to wait before reconnecting after a stream error.
 DEFAULT_RECONNECT_DELAY_SECONDS = 5
+
+# Seconds between heartbeat file refreshes.
+DEFAULT_HEARTBEAT_INTERVAL_SECONDS = 10
 
 
 def callback(message: Message) -> None:
@@ -46,6 +51,10 @@ class FleeceQueueWorker:
             pull after a stream error, looping until the process is terminated.
             When False, `start` returns on the first stream error.
         restart_backoff: Seconds to wait before reconnecting after a stream error.
+        heartbeat_path: File to refresh while the streaming pull is running, for an
+            external liveness probe (e.g. for k8s). Parent directories are created on
+            demand. When None, the heartbeat is disabled.
+        heartbeat_interval: Seconds between heartbeat refreshes.
     """
 
     def __init__(
@@ -53,11 +62,16 @@ class FleeceQueueWorker:
         subscription_name: str,
         restart_stream: bool = True,
         restart_backoff: int = DEFAULT_RECONNECT_DELAY_SECONDS,
+        heartbeat_path: str | None = None,
+        heartbeat_interval: int = DEFAULT_HEARTBEAT_INTERVAL_SECONDS,
     ) -> None:
         self.subscription_name = subscription_name
         self.restart_stream = restart_stream
         self.restart_backoff = restart_backoff
+        self.heartbeat_path = heartbeat_path
+        self.heartbeat_interval = heartbeat_interval
         self._stopping = False
+        self._heartbeat_stop = threading.Event()
         self._connect()
 
     def start(self) -> None:
@@ -68,6 +82,10 @@ class FleeceQueueWorker:
         looping indefinitely -- the worker is expected to run until the process is
         terminated (e.g. a Kubernetes SIGTERM/SIGKILL).
         """
+        if self.heartbeat_path is not None:
+            threading.Thread(
+                target=self._heartbeat_loop, name="fleece-heartbeat", daemon=True
+            ).start()
         logger.debug(
             "Listening for messages",
             extra={"subscription_name": self.subscription_name},
@@ -81,9 +99,54 @@ class FleeceQueueWorker:
             self.restart()
 
     def stop(self) -> None:
-        """Cancel the streaming pull, draining in-flight callbacks before shutdown."""
+        """Cancel the streaming pull, draining in-flight callbacks before shutdown.
+        If heartbeat is enabled, wake the heartbeat thread so it exits promptly.
+        """
         self._stopping = True
+        self._heartbeat_stop.set()
         self._future.cancel()
+
+    def _heartbeat_loop(self) -> None:
+        """Refresh the heartbeat file each interval tick while the streaming pull is running.
+
+        Runs on a daemon thread. Writes once up front so the file exists as soon as the
+        worker is up, then refreshes on each tick. The file is only refreshed while the
+        pull future has not completed, so a stream that errored out and a reconnect loop
+        stuck in backoff both let it go stale for an external liveness probe. Idle periods
+        with no messages still count as healthy, since the future keeps running.
+
+        Write failures are logged and retried on the next tick rather than killing the
+        thread. A transient failure (e.g. a full disk) recovers on a later tick; a
+        persistent one (e.g. a permissions error) leaves the file stale, so the liveness
+        probe restarts the pod.
+        """
+        self._refresh_heartbeat()
+        while not self._heartbeat_stop.wait(self.heartbeat_interval):
+            self._refresh_heartbeat()
+
+    def _refresh_heartbeat(self) -> None:
+        """Write the heartbeat if the streaming pull is still running, swallowing OS errors."""
+        if not self._future.running():
+            return
+        try:
+            self._write_heartbeat()
+        except OSError:
+            logger.exception(
+                "Failed to refresh heartbeat file",
+                extra={"heartbeat_path": self.heartbeat_path},
+            )
+
+    def _write_heartbeat(self) -> None:
+        """Atomically write the current epoch seconds to the heartbeat file."""
+        if self.heartbeat_path is None:
+            return
+        parent = os.path.dirname(self.heartbeat_path)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        tmp = f"{self.heartbeat_path}.tmp"
+        with open(tmp, "w") as fh:
+            fh.write(str(int(time.time())))
+        os.replace(tmp, self.heartbeat_path)  # atomic rename; probe never sees a partial write
 
     def restart(self) -> None:
         """Rebuild the subscriber and streaming pull after the client has closed.

--- a/merino-fleece/tests/unit/sanitize/worker/test_worker.py
+++ b/merino-fleece/tests/unit/sanitize/worker/test_worker.py
@@ -1,5 +1,6 @@
 """Unit tests for merino_fleece.sanitize.worker.worker."""
 
+from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -176,3 +177,132 @@ def test_restart_ignored_while_subscriber_open(
 
     subscriber_mock.subscribe.assert_not_called()
     assert "Ignored attempt to restart open subscription" in caplog.text
+
+
+def test_write_heartbeat_writes_epoch(subscriber_mock: MagicMock, tmp_path: Path) -> None:
+    """_write_heartbeat atomically writes the current epoch seconds to the file."""
+    path = tmp_path / "heartbeat"
+    worker = FleeceQueueWorker("my-subscription", heartbeat_path=str(path))
+
+    worker._write_heartbeat()
+
+    contents = path.read_text()
+    assert contents.isdigit()
+    assert int(contents) > 0
+    # No leftover temp file from the atomic rename
+    assert not (tmp_path / "heartbeat.tmp").exists()
+
+
+def test_heartbeat_loop_writes_while_running(
+    subscriber_mock: MagicMock, mocker: MockerFixture, tmp_path: Path
+) -> None:
+    """Each tick writes a fresh timestamp to the real file while the pull is running."""
+    path = tmp_path / "heartbeat"
+    worker = FleeceQueueWorker("my-subscription", heartbeat_path=str(path))
+    subscriber_mock.subscribe.return_value.running.return_value = True
+    # One working tick (False), then stop (True) -- exercises the real _write_heartbeat.
+    mocker.patch.object(worker._heartbeat_stop, "wait", side_effect=[False, True])
+
+    worker._heartbeat_loop()
+
+    contents = path.read_text()
+    assert contents.isdigit()
+    assert int(contents) > 0
+    assert not (tmp_path / "heartbeat.tmp").exists()  # no leftover tmp file
+
+
+def test_write_heartbeat_creates_missing_parent_dirs(
+    subscriber_mock: MagicMock, tmp_path: Path
+) -> None:
+    """_write_heartbeat creates the parent directory instead of failing on a missing one."""
+    path = tmp_path / "nested" / "dir" / "heartbeat"
+    worker = FleeceQueueWorker("my-subscription", heartbeat_path=str(path))
+
+    worker._write_heartbeat()
+
+    assert path.read_text().isdigit()
+
+
+def test_heartbeat_loop_writes_before_first_tick(
+    subscriber_mock: MagicMock, mocker: MockerFixture, tmp_path: Path
+) -> None:
+    """The file exists as soon as the loop starts, before the first interval elapses."""
+    path = tmp_path / "heartbeat"
+    worker = FleeceQueueWorker("my-subscription", heartbeat_path=str(path))
+    subscriber_mock.subscribe.return_value.running.return_value = True
+    # Stop on the very first wait, so only the pre-loop write can have happened.
+    mocker.patch.object(worker._heartbeat_stop, "wait", return_value=True)
+
+    worker._heartbeat_loop()
+
+    assert path.read_text().isdigit()
+
+
+def test_heartbeat_loop_survives_write_failure(
+    subscriber_mock: MagicMock, mocker: MockerFixture, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A failed write is logged and the loop keeps ticking rather than killing the thread."""
+    worker = FleeceQueueWorker("my-subscription", heartbeat_path="/heartbeat")
+    subscriber_mock.subscribe.return_value.running.return_value = True
+    write_mock = mocker.patch.object(
+        worker, "_write_heartbeat", side_effect=OSError("read-only file system")
+    )
+    mocker.patch.object(worker._heartbeat_stop, "wait", side_effect=[False, True])
+
+    with caplog.at_level("ERROR", logger="merino_fleece.sanitize.worker.worker"):
+        worker._heartbeat_loop()
+
+    # Pre-loop write plus one tick: the first failure did not abort the loop.
+    assert write_mock.call_count == 2
+    assert "Failed to refresh heartbeat file" in caplog.text
+
+
+def test_heartbeat_loop_skips_when_not_running(
+    subscriber_mock: MagicMock, mocker: MockerFixture, tmp_path: Path
+) -> None:
+    """A tick leaves the file untouched when the pull is not running."""
+    path = tmp_path / "heartbeat"
+    worker = FleeceQueueWorker("my-subscription", heartbeat_path=str(path))
+    # e.g. mid-reconnect or a stuck stream: the file must be allowed to go stale.
+    subscriber_mock.subscribe.return_value.running.return_value = False
+    mocker.patch.object(worker._heartbeat_stop, "wait", side_effect=[False, True])
+
+    worker._heartbeat_loop()
+
+    assert not path.exists()
+
+
+def test_start_spawns_heartbeat_thread_when_configured(
+    subscriber_mock: MagicMock, mocker: MockerFixture
+) -> None:
+    """start() launches the heartbeat daemon thread only when a path is configured."""
+    thread_cls = mocker.patch("merino_fleece.sanitize.worker.worker.threading.Thread")
+    worker = FleeceQueueWorker("my-subscription", heartbeat_path="/tmp/heartbeat")
+
+    worker.start()
+
+    thread_cls.assert_called_once_with(
+        target=worker._heartbeat_loop, name="fleece-heartbeat", daemon=True
+    )
+    thread_cls.return_value.start.assert_called_once_with()
+
+
+def test_start_no_heartbeat_thread_when_unconfigured(
+    subscriber_mock: MagicMock, mocker: MockerFixture
+) -> None:
+    """start() does not spawn a heartbeat thread when no path is configured."""
+    thread_cls = mocker.patch("merino_fleece.sanitize.worker.worker.threading.Thread")
+    worker = FleeceQueueWorker("my-subscription")
+
+    worker.start()
+
+    thread_cls.assert_not_called()
+
+
+def test_stop_signals_heartbeat_thread(subscriber_mock: MagicMock) -> None:
+    """stop() sets the heartbeat stop event so the daemon thread exits promptly."""
+    worker = FleeceQueueWorker("my-subscription", heartbeat_path="/tmp/heartbeat")
+
+    worker.stop()
+
+    assert worker._heartbeat_stop.is_set()

--- a/merino-fleece/tests/unit/sanitize/worker/test_worker.py
+++ b/merino-fleece/tests/unit/sanitize/worker/test_worker.py
@@ -273,11 +273,11 @@ def test_heartbeat_loop_skips_when_not_running(
 
 
 def test_start_spawns_heartbeat_thread_when_configured(
-    subscriber_mock: MagicMock, mocker: MockerFixture
+    subscriber_mock: MagicMock, mocker: MockerFixture, tmp_path: Path
 ) -> None:
     """start() launches the heartbeat daemon thread only when a path is configured."""
     thread_cls = mocker.patch("merino_fleece.sanitize.worker.worker.threading.Thread")
-    worker = FleeceQueueWorker("my-subscription", heartbeat_path="/tmp/heartbeat")
+    worker = FleeceQueueWorker("my-subscription", heartbeat_path=str(tmp_path / "heartbeat"))
 
     worker.start()
 
@@ -299,9 +299,9 @@ def test_start_no_heartbeat_thread_when_unconfigured(
     thread_cls.assert_not_called()
 
 
-def test_stop_signals_heartbeat_thread(subscriber_mock: MagicMock) -> None:
+def test_stop_signals_heartbeat_thread(subscriber_mock: MagicMock, tmp_path: Path) -> None:
     """stop() sets the heartbeat stop event so the daemon thread exits promptly."""
-    worker = FleeceQueueWorker("my-subscription", heartbeat_path="/tmp/heartbeat")
+    worker = FleeceQueueWorker("my-subscription", heartbeat_path=str(tmp_path / "heartbeat"))
 
     worker.stop()
 


### PR DESCRIPTION



## References

JIRA: 
[DISCO-4364]

## Description
Add heartbeat file writer for k8s deployment

Since this worker does not have an http server, need an alternate way to do a health check on the pods. Spawn a separate thread to atomically write a heartbeat file with a timestamp, as long as the pubsub subscription is active (not error'd out or stuck in retry/backoff).


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2504)


[DISCO-4364]: https://mozilla-hub.atlassian.net/browse/DISCO-4364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ