### PR TITLE
fix(imageUrl): Fix image url validation logic for potd

### DIFF
--- a/merino/providers/rss/wikimedia_potd/backends/utils.py
+++ b/merino/providers/rss/wikimedia_potd/backends/utils.py
@@ -19,6 +19,9 @@ WIKIMEDIA_REQUEST_HEADERS = {
 # The bare "Template:Potd/{date}" page (the file selector) has no suffix and is ignored.
 POTD_DESCRIPTION_LANG_RE = re.compile(r"\(([\w-]+)\)$")
 
+# Image file extensions we accept for POTD assets.
+POTD_IMAGE_EXTENSIONS = frozenset({"jpg", "jpeg", "png", "webp"})
+
 
 def parse_potd(data: dict) -> PictureOfTheDay:
     """Parse the Wikimedia Featured API response into a PictureOfTheDay.
@@ -93,5 +96,8 @@ def build_potd_bucket_directory_path() -> str:
 
 
 def is_valid_potd_image_url(url: HttpUrl) -> bool:
-    """Validate url is an image url."""
-    return bool(str(url).split(".")[-1] in ["jpg", "jpeg", "png", "webp"])
+    """Validate url is an image url. Only the url path is inspected, so thumbnail urls carrying a query string or fragment
+    (e.g. the utm_* tracking params Wikimedia appends) are still recognized as images.
+    """
+    path = url.path or ""
+    return path.rsplit(".", 1)[-1].lower() in POTD_IMAGE_EXTENSIONS

--- a/tests/unit/providers/rss/wikimedia_potd/backends/test_utils.py
+++ b/tests/unit/providers/rss/wikimedia_potd/backends/test_utils.py
@@ -135,9 +135,39 @@ def test_parse_potd_uses_full_res_image_source_directly(featured: dict) -> None:
         (HttpUrl("http://www.test-image.com/image.jpg"), True),
         (HttpUrl("http://www.test-image.com/image.png"), True),
         (HttpUrl("http://www.test-image.com/image.webp"), True),
+        (HttpUrl("http://www.test-image.com/image.JPG"), True),
         (HttpUrl("http://www.test-image.com/image.text"), False),
+        (HttpUrl("http://www.test-image.com/image"), False),
+        (HttpUrl("http://www.test-image.com/"), False),
+        (HttpUrl("http://www.test-image.com/image.jpg?width=960"), True),
+        (HttpUrl("http://www.test-image.com/image.text?foo=image.jpg"), False),
+        (HttpUrl("http://www.test-image.com/image.png#fragment"), True),
+        (
+            HttpUrl(
+                "https://upload.wikimedia.org/wikipedia/commons/thumb/2/27/"
+                "Rom_%28IT%29%2C_Br%C3%BCcke_%E2%80%9EPonte_Vittorio_Emanuele_II%E2%80%9C"
+                "_--_2024_--_0732.jpg/960px-Rom_%28IT%29%2C_Br%C3%BCcke_"
+                "%E2%80%9EPonte_Vittorio_Emanuele_II%E2%80%9C_--_2024_--_0732.jpg"
+                "?utm_source=commons.wikimedia.org&utm_campaign=imageinfo"
+                "&utm_content=thumbnail"
+            ),
+            True,
+        ),
     ],
-    ids=["jpeg", "jpg", "png", "webp", "text"],
+    ids=[
+        "jpeg",
+        "jpg",
+        "png",
+        "webp",
+        "uppercase_extension",
+        "text",
+        "no_extension",
+        "no_path",
+        "query_string",
+        "non_image_with_image_in_query",
+        "fragment",
+        "wikimedia_thumbnail_with_utm_params",
+    ],
 )
 def test_is_valid_potd_image_url(url: HttpUrl, expected: bool) -> None:
     """Test is_valid_potd_image_url for each supported image extension."""


### PR DESCRIPTION
## References
N/A

## Description
This [Sentry error](https://mozilla.sentry.io/issues/7650719274/?project=6622434&query=is%3Aunresolved&referrer=issue-stream) caused a failed validation error for the image url. The url was correct however, we hadn't encountered a url with query params like this one, so we have to update our validation logic.



## PR Review Checklist
- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2505)
