### PR TITLE
[AIMOD-1408] Pause the use of stratified engagement

### DIFF
--- a/merino/curated_recommendations/utils.py
+++ b/merino/curated_recommendations/utils.py
@@ -38,6 +38,7 @@ EN_XE_REGIONS: frozenset[str] = frozenset({"DE", "FR", "AT", "CH", "BE", "IT", "
 PUBLISHER_CONSTRAINT_IN_GERMANY_REGION = "DE"
 PUBLISHER_CONSTRAINT_IN_GERMANY_BRANCHES: frozenset[str] = frozenset({"control", "treatment"})
 PUBLISHER_CONSTRAINT_IN_GERMANY_ENGAGEMENT_REGION_PREFIX = "DE-publisher-constraint-in-germany"
+PUBLISHER_CONSTRAINT_IN_GERMANY_BRANCH_ENGAGEMENT_ENABLED = False
 
 
 def get_recommendation_surface_id(
@@ -164,7 +165,8 @@ def derive_engagement_region(request: CuratedRecommendationsRequest) -> str | No
     branch = request.experimentBranch
 
     if (
-        region == PUBLISHER_CONSTRAINT_IN_GERMANY_REGION
+        PUBLISHER_CONSTRAINT_IN_GERMANY_BRANCH_ENGAGEMENT_ENABLED
+        and region == PUBLISHER_CONSTRAINT_IN_GERMANY_REGION
         and branch is not None
         and branch in PUBLISHER_CONSTRAINT_IN_GERMANY_BRANCHES
         and is_enrolled_in_experiment(

--- a/tests/unit/curated_recommendations/test_provider.py
+++ b/tests/unit/curated_recommendations/test_provider.py
@@ -150,6 +150,11 @@ class TestRankRecommendationsEngagementRegion:
             return recommendations
 
         monkeypatch.setattr(ThompsonSamplingRanker, "rank_items", fake_rank_items)
+        monkeypatch.setattr(
+            "merino.curated_recommendations.utils."
+            "PUBLISHER_CONSTRAINT_IN_GERMANY_BRANCH_ENGAGEMENT_ENABLED",
+            True,
+        )
         provider = CuratedRecommendationsProvider.__new__(CuratedRecommendationsProvider)
         provider.engagement_backend = object()
         provider.prior_backend = object()

--- a/tests/unit/curated_recommendations/test_utils.py
+++ b/tests/unit/curated_recommendations/test_utils.py
@@ -115,6 +115,17 @@ class TestCuratedRecommendationsProviderDeriveRegion:
 class TestCuratedRecommendationsProviderDeriveEngagementRegion:
     """Unit tests for derive_engagement_region."""
 
+    def test_germany_publisher_constraint_uses_country_region_by_default(self):
+        """Germany publisher constraint branches use country-level engagement by default."""
+        request = CuratedRecommendationsRequest(
+            locale=Locale.DE_DE,
+            region="DE",
+            experimentName=_GERMANY_PUBLISHER_CONSTRAINT,
+            experimentBranch="treatment",
+        )
+
+        assert derive_engagement_region(request) == "DE"
+
     @pytest.mark.parametrize(
         "branch, expected",
         [
@@ -123,9 +134,14 @@ class TestCuratedRecommendationsProviderDeriveEngagementRegion:
         ],
     )
     def test_germany_publisher_constraint_branches_use_branch_region(
-        self, branch: str, expected: str
+        self, monkeypatch, branch: str, expected: str
     ):
         """Germany publisher constraint branches use branch-specific engagement keys."""
+        monkeypatch.setattr(
+            "merino.curated_recommendations.utils."
+            "PUBLISHER_CONSTRAINT_IN_GERMANY_BRANCH_ENGAGEMENT_ENABLED",
+            True,
+        )
         request = CuratedRecommendationsRequest(
             locale=Locale.DE_DE,
             region="DE",
@@ -135,8 +151,13 @@ class TestCuratedRecommendationsProviderDeriveEngagementRegion:
 
         assert derive_engagement_region(request) == expected
 
-    def test_optin_germany_publisher_constraint_uses_branch_region(self):
+    def test_optin_germany_publisher_constraint_uses_branch_region(self, monkeypatch):
         """Opt-in experiment enrollment follows the same branch-specific routing."""
+        monkeypatch.setattr(
+            "merino.curated_recommendations.utils."
+            "PUBLISHER_CONSTRAINT_IN_GERMANY_BRANCH_ENGAGEMENT_ENABLED",
+            True,
+        )
         request = CuratedRecommendationsRequest(
             locale=Locale.DE_DE,
             region="DE",


### PR DESCRIPTION
## References

JIRA: [AIMOD-1408](https://mozilla-hub.atlassian.net/browse/AIMOD-1408)

## Description
If we don't pause the use of the stratified engagement tables, we will effectively be cold starting DE. We can make the transition smoother by only using the stratified tables after they are healthy.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2506)


[AIMOD-1408]: https://mozilla-hub.atlassian.net/browse/AIMOD-1408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ