### PR TITLE
[HNT-2162] Add metrics for potd

### DIFF
--- a/merino/providers/rss/wikimedia_potd/provider.py
+++ b/merino/providers/rss/wikimedia_potd/provider.py
@@ -104,10 +104,8 @@ class WikimediaPictureOfTheDayProvider(BaseRssProvider):
         if not self._is_todays_potd(self.potd):
             await self._refresh_potd()
 
-        # TODO @herraj jira: [HNT-2162]
-        # add a metric to track when we serve a stale (previous-day) potd here
-        # because today's picture isn't yet available in the gcs bucket.
         if self.potd is None:
+            self.metrics_client.increment("potd.provider.cached.none")
             return None
 
         localized = self._select_description(self.potd, accepted_languages)
@@ -119,7 +117,8 @@ class WikimediaPictureOfTheDayProvider(BaseRssProvider):
 
     async def upload_picture_of_the_day(self) -> bool:
         """Execute the upload flow. This method is called by the job cli command only."""
-        return await self.backend.upload_picture_of_the_day()
+        with self.metrics_client.timeit("potd.upload.timing"):
+            return await self.backend.upload_picture_of_the_day()
 
     async def shutdown(self) -> None:
         """Shut down the provider."""

--- a/merino/providers/rss/wikimedia_potd/provider.py
+++ b/merino/providers/rss/wikimedia_potd/provider.py
@@ -117,7 +117,7 @@ class WikimediaPictureOfTheDayProvider(BaseRssProvider):
 
     async def upload_picture_of_the_day(self) -> bool:
         """Execute the upload flow. This method is called by the job cli command only."""
-        with self.metrics_client.timeit("potd.upload.timing"):
+        with self.metrics_client.timeit("potd.provider.upload.timing"):
             return await self.backend.upload_picture_of_the_day()
 
     async def shutdown(self) -> None:

--- a/metrics.yaml
+++ b/metrics.yaml
@@ -486,7 +486,7 @@ providers/manifest:
     alert_policy: []
 
 providers/rss/wikimedia_potd:
-  potd.upload.timing:
+  potd.provider.upload.timing:
     description: |
       A timer covering a full run of the Wikimedia picture of the day updater job.
     type: timing

--- a/metrics.yaml
+++ b/metrics.yaml
@@ -485,6 +485,26 @@ providers/manifest:
       Any provider that uses the shared manifest metrics namespace.
     alert_policy: []
 
+providers/rss/wikimedia_potd:
+  potd.upload.timing:
+    description: |
+      A timer covering a full run of the Wikimedia picture of the day updater job.
+    type: timing
+    labels: [] # no labels
+    scope: |
+      The "picture_of_the_day update-wikimedia-potd" job.
+    alert_policy: []
+
+  potd.provider.cached.none:
+    description: |
+      A counter incremented when the provider has no picture of the day to serve at
+      all.
+    type: counter
+    labels: [] # no labels
+    scope: |
+      The "api/v1/rss/picture-of-the-day" API endpoint.
+    alert_policy: []
+
 utils/synced_gcs_blob_v2:
   gcs.sync.data.not_ready:
     description: |

--- a/tests/unit/providers/rss/wikimedia_potd/test_provider.py
+++ b/tests/unit/providers/rss/wikimedia_potd/test_provider.py
@@ -119,7 +119,7 @@ async def test_upload_picture_of_the_day_delegates_to_backend(
     assert result is True
     backend_mock.upload_picture_of_the_day.assert_awaited_once()
     # the whole job run is timed
-    statsd_mock.timeit.assert_called_once_with("potd.upload.timing")
+    statsd_mock.timeit.assert_called_once_with("potd.provider.upload.timing")
 
 
 @freezegun.freeze_time("2026-06-07")

--- a/tests/unit/providers/rss/wikimedia_potd/test_provider.py
+++ b/tests/unit/providers/rss/wikimedia_potd/test_provider.py
@@ -109,7 +109,7 @@ async def test_shutdown(provider: WikimediaPictureOfTheDayProvider) -> None:
 
 @pytest.mark.asyncio
 async def test_upload_picture_of_the_day_delegates_to_backend(
-    provider: WikimediaPictureOfTheDayProvider, backend_mock
+    provider: WikimediaPictureOfTheDayProvider, backend_mock, statsd_mock
 ) -> None:
     """Test that upload_picture_of_the_day delegates to the backend and returns its result."""
     backend_mock.upload_picture_of_the_day.return_value = True
@@ -118,6 +118,8 @@ async def test_upload_picture_of_the_day_delegates_to_backend(
 
     assert result is True
     backend_mock.upload_picture_of_the_day.assert_awaited_once()
+    # the whole job run is timed
+    statsd_mock.timeit.assert_called_once_with("potd.upload.timing")
 
 
 @freezegun.freeze_time("2026-06-07")
@@ -184,7 +186,7 @@ async def test_get_picture_of_the_day_refetches_when_cached_potd_is_stale(
 @freezegun.freeze_time("2026-06-08")
 @pytest.mark.asyncio
 async def test_get_picture_of_the_day_serves_stale_potd_when_refetch_misses(
-    provider: WikimediaPictureOfTheDayProvider, backend_mock, test_potd
+    provider: WikimediaPictureOfTheDayProvider, backend_mock, statsd_mock, test_potd
 ) -> None:
     """Test that a stale cached potd is served when today's potd cannot be fetched."""
     # cached test_potd is published 2026-06-07, a day old compared to the freeze time
@@ -195,6 +197,7 @@ async def test_get_picture_of_the_day_serves_stale_potd_when_refetch_misses(
 
     backend_mock.fetch_potd_from_gcs_bucket.assert_called_once()
     assert potd is test_potd
+    statsd_mock.increment.assert_not_called()
 
 
 @freezegun.freeze_time("2026-06-07")
@@ -280,7 +283,7 @@ async def test_get_picture_of_the_day_keeps_default_when_no_accepted_languages(
 @freezegun.freeze_time("2026-06-08")
 @pytest.mark.asyncio
 async def test_get_picture_of_the_day_refetches_on_every_miss(
-    provider: WikimediaPictureOfTheDayProvider, backend_mock
+    provider: WikimediaPictureOfTheDayProvider, backend_mock, statsd_mock
 ) -> None:
     """Test that each request re-fetches while nothing is cached and no potd is available."""
     backend_mock.fetch_potd_from_gcs_bucket.return_value = None
@@ -290,3 +293,6 @@ async def test_get_picture_of_the_day_refetches_on_every_miss(
 
     # No throttling: the re-fetch is attempted on every request.
     assert backend_mock.fetch_potd_from_gcs_bucket.call_count == 2
+    # every request that serves nothing is counted
+    assert statsd_mock.increment.call_count == 2
+    statsd_mock.increment.assert_called_with("potd.provider.cached.none")


### PR DESCRIPTION
## References

JIRA: [HNT-2162](https://mozilla-hub.atlassian.net/browse/HNT-2162)

## Description
Adding two metrics for the picture of the day requests:
- Latency metric for the write job that makes various network calls.
- Count metric for when the provider returns a `None`. This will be used to set up an alert in Grafana.



## PR Review Checklist
- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2509)


[HNT-2162]: https://mozilla-hub.atlassian.net/browse/HNT-2162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ