### PR TITLE
[DISCO-4409] chore(merino): enable top_pick_promotion w/o client_vari…

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -115,7 +115,7 @@ client_variant_character_max = 100
 
 # MERINO_WEB__API__V1__CLIENT_VARIANT_ALLOW_LIST
 # list of client variants the merino will be aware about
-client_variant_allow_list = ["engagement_guided_suggestions", "query_norm_treatment", "top_pick_promotion", "amp-fuzzy-matching-treatment"]
+client_variant_allow_list = ["engagement_guided_suggestions", "query_norm_treatment", "amp-fuzzy-matching-treatment"]
 
 # MERINO_WEB__API__V1__HEADER_CHARACTER_MAX
 # A non-negative integer that limits the string character length of a given header string,

--- a/merino/providers/suggest/adm/provider.py
+++ b/merino/providers/suggest/adm/provider.py
@@ -58,9 +58,7 @@ FORM_FACTORS_FALLBACK_MAPPING = {
 
 FALLBACK_FORM_FACTOR: str = "other"
 FALLBACK_COUNTRY_CODE: str = "US"
-CLIENT_VARIANTS_ALLOW_LIST = frozenset(settings.web.api.v1.client_variant_allow_list)
 TS_DRY_RUN: bool = settings.providers.adm.thompson.dry_run
-TOP_PICK_PROMOTION: str = "top_pick_promotion"
 # Experiment treatment variant that opts a request into the ED1 fuzzy fallback.
 AMP_FUZZY_VARIANT: str = "amp-fuzzy-matching-treatment"
 # toggle fuzzy matching for AMP suggestions
@@ -371,11 +369,10 @@ class Provider(BaseProvider):
         ):
             is_sponsored = res.iab_category == IABCategory.SHOPPING
 
-            # A suggestion gets the "top pick" UI treatment when the request
-            # opted into `top_pick_promotion` and the record's `top_pick_prefix`
-            # appears in the query.
+            # A suggestion gets the "top pick" UI treatment when the query starts with
+            # `top_pick_prefix` if specified by MARS.
             is_top_pick = None
-            if TOP_PICK_PROMOTION in client_variants and res.top_pick_prefix is not None:
+            if res.top_pick_prefix is not None:
                 is_top_pick = q.startswith(res.top_pick_prefix)
                 if is_top_pick:
                     self.metrics_client.increment(

--- a/tests/unit/providers/suggest/adm/test_provider.py
+++ b/tests/unit/providers/suggest/adm/test_provider.py
@@ -414,18 +414,14 @@ async def test_query_with_missing_key(
 
 
 @pytest.mark.parametrize(
-    ("query", "client_variants", "expected_is_top_pick"),
+    ("query", "expected_is_top_pick"),
     [
-        ("firefox", ["top_pick_promotion"], True),
-        ("mozilla", ["top_pick_promotion"], False),
-        ("firefox", [], None),
-        ("firefox", ["some_other_variant"], None),
+        ("firefox", True),
+        ("mozilla", False),
     ],
     ids=[
-        "opted-in-prefix-in-query",
-        "opted-in-prefix-not-in-query",
-        "opted-out-no-variants",
-        "opted-out-other-variant",
+        "prefix-in-query",
+        "prefix-not-in-query",
     ],
 )
 @pytest.mark.asyncio
@@ -433,17 +429,14 @@ async def test_query_is_top_pick(
     srequest: SuggestionRequestFixture,
     adm_top_pick: Provider,
     query: str,
-    client_variants: list[str],
     expected_is_top_pick: bool,
 ) -> None:
-    """`is_top_pick` is True only when the request opts into `top_pick_promotion`
-    AND the record's `top_pick_prefix` is a substring of the query.
-    """
+    """`is_top_pick` is True only when `top_pick_prefix` is a prefix of the query."""
     await adm_top_pick.initialize()
     user_agent = UserAgent(form_factor="desktop", browser="firefox", os_family="macos")
     geolocation = Location(country="US")
 
-    res = await adm_top_pick.query(srequest(query, geolocation, user_agent, client_variants))
+    res = await adm_top_pick.query(srequest(query, geolocation, user_agent, None))
 
     assert len(res) == 1
     assert res[0].is_top_pick is expected_is_top_pick
@@ -461,7 +454,7 @@ async def test_top_pick_promotion_metric_emitted_on_match(
     user_agent = UserAgent(form_factor="desktop", browser="firefox", os_family="macos")
     geolocation = Location(country="US")
 
-    await adm_top_pick.query(srequest("firefox", geolocation, user_agent, ["top_pick_promotion"]))
+    await adm_top_pick.query(srequest("firefox", geolocation, user_agent, None))
 
     adm_top_pick.metrics_client.increment.assert_called_once_with(  # type: ignore[attr-defined]
         "providers.adm.top_pick_promotion",
@@ -473,29 +466,26 @@ async def test_top_pick_promotion_metric_emitted_on_match(
 
 
 @pytest.mark.parametrize(
-    ("query", "client_variants"),
+    ("query",),
     [
-        ("mozilla", ["top_pick_promotion"]),
-        ("firefox", []),
-        ("firefox", ["some_other_variant"]),
+        ("mozilla",),
     ],
-    ids=["opted-in-prefix-not-in-query", "opted-out-no-variants", "opted-out-other-variant"],
+    ids=[
+        "prefix-not-in-query",
+    ],
 )
 @pytest.mark.asyncio
 async def test_top_pick_promotion_metric_not_emitted(
     srequest: SuggestionRequestFixture,
     adm_top_pick: Provider,
     query: str,
-    client_variants: list[str],
 ) -> None:
-    """The `top_pick_promotion` counter is not emitted when the prefix doesn't match
-    or the client did not opt in.
-    """
+    """The `top_pick_promotion` counter is not emitted when the prefix doesn't match."""
     await adm_top_pick.initialize()
     user_agent = UserAgent(form_factor="desktop", browser="firefox", os_family="macos")
     geolocation = Location(country="US")
 
-    await adm_top_pick.query(srequest(query, geolocation, user_agent, client_variants))
+    await adm_top_pick.query(srequest(query, geolocation, user_agent, None))
 
     adm_top_pick.metrics_client.increment.assert_not_called()  # type: ignore[attr-defined]
 


### PR DESCRIPTION
…ants check

## References

JIRA: [DISCO-4409](https://mozilla-hub.atlassian.net/browse/DISCO-4409)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->

The experiment is proved successful, the team wants to enable it now.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2510)


[DISCO-4409]: https://mozilla-hub.atlassian.net/browse/DISCO-4409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ