### PR TITLE
[AIMOD-1438] Reduce AMP Provider Test Runtime

### DIFF
--- a/tests/unit/providers/suggest/adm/conftest.py
+++ b/tests/unit/providers/suggest/adm/conftest.py
@@ -24,6 +24,22 @@ from merino.providers.suggest.adm.backends.protocol import FormFactor
 from merino.providers.suggest.adm.provider import Provider
 
 
+@pytest.fixture(autouse=True)
+def mock_engagement_storage_client(mocker: MockerFixture) -> None:
+    """Keep initialize() from building a real gcloud-aio Storage client.
+
+    tests/conftest.py autouse-resets the shared storage client every test, so each
+    initialize() -> _fetch_engagement_data() -> get_storage_client() rebuilds
+    Storage() and hangs ~11s on the GCE metadata-server auth lookup. Stubbing it
+    avoids the network call; the engagement fetch itself is covered explicitly in
+    the test_fetch_engagement_data_* tests, which patch get_file directly.
+    """
+    mocker.patch(
+        "merino.utils.gcs.engagement.filemanager.get_storage_client",
+        return_value=mocker.MagicMock(),
+    )
+
+
 @pytest.fixture(name="adm_parameters")
 def fixture_adm_parameters() -> dict[str, Any]:
     """Define provider parameters for test."""

--- a/tests/unit/providers/suggest/adm/conftest.py
+++ b/tests/unit/providers/suggest/adm/conftest.py
@@ -26,14 +26,7 @@ from merino.providers.suggest.adm.provider import Provider
 
 @pytest.fixture(autouse=True)
 def mock_engagement_storage_client(mocker: MockerFixture) -> None:
-    """Keep initialize() from building a real gcloud-aio Storage client.
-
-    tests/conftest.py autouse-resets the shared storage client every test, so each
-    initialize() -> _fetch_engagement_data() -> get_storage_client() rebuilds
-    Storage() and hangs ~11s on the GCE metadata-server auth lookup. Stubbing it
-    avoids the network call; the engagement fetch itself is covered explicitly in
-    the test_fetch_engagement_data_* tests, which patch get_file directly.
-    """
+    """Stub the GCS client so initialize() skips the ~11s metadata-auth hang building a real Storage()."""
     mocker.patch(
         "merino.utils.gcs.engagement.filemanager.get_storage_client",
         return_value=mocker.MagicMock(),


### PR DESCRIPTION
## References

JIRA: [AIMOD-1438](https://mozilla-hub.atlassian.net/browse/AIMOD-1438)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->

- Time taken to run has been reduced from `180s` to `2s`!

```
MERINO_ENV=testing uv run pytest tests/unit/providers/suggest/adm/test_provider.py
```


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2512)


[AIMOD-1438]: https://mozilla-hub.atlassian.net/browse/AIMOD-1438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ