### PR TITLE
[DISCO-4329] adm: is_top_pick is false if top_pick_prefix is None

### DIFF
--- a/merino/providers/suggest/adm/provider.py
+++ b/merino/providers/suggest/adm/provider.py
@@ -371,7 +371,7 @@ class Provider(BaseProvider):
 
             # A suggestion gets the "top pick" UI treatment when the query starts with
             # `top_pick_prefix` if specified by MARS.
-            is_top_pick = None
+            is_top_pick = False
             if res.top_pick_prefix is not None:
                 is_top_pick = q.startswith(res.top_pick_prefix)
                 if is_top_pick:

--- a/tests/unit/providers/suggest/adm/test_provider.py
+++ b/tests/unit/providers/suggest/adm/test_provider.py
@@ -156,6 +156,7 @@ async def test_query_fuzzy_rescues_typo_for_treatment(
             provider="adm",
             advertiser="Example.org",
             is_sponsored=False,
+            is_top_pick=False,
             icon="attachment-host/main-workspace/quicksuggest/icon-01",
             score=adm_parameters["score"],
             custom_details=CustomDetails(
@@ -348,6 +349,7 @@ async def test_query_success(
             provider="adm",
             advertiser="Example.org",
             is_sponsored=False,
+            is_top_pick=False,
             icon="attachment-host/main-workspace/quicksuggest/icon-01",
             score=adm_parameters["score"],
             custom_details=CustomDetails(
@@ -401,6 +403,7 @@ async def test_query_with_missing_key(
             provider="adm",
             advertiser="Example.org",
             is_sponsored=False,
+            is_top_pick=False,
             icon="attachment-host/main-workspace/quicksuggest/icon-01",
             score=adm_parameters["score"],
             custom_details=CustomDetails(
@@ -491,21 +494,20 @@ async def test_top_pick_promotion_metric_not_emitted(
 
 
 @pytest.mark.asyncio
-async def test_query_is_top_pick_none_when_record_has_no_prefix(
+async def test_query_is_top_pick_false_when_record_has_no_prefix(
     srequest: SuggestionRequestFixture,
     adm: Provider,
 ) -> None:
-    """`is_top_pick` is None when the client opts into
-    `top_pick_promotion` but the matched record has no `top_pick_prefix`.
+    """`is_top_pick` is False when matched record has no `top_pick_prefix`.
     """
     await adm.initialize()
     user_agent = UserAgent(form_factor="desktop", browser="firefox", os_family="macos")
     geolocation = Location(country="US")
 
-    res = await adm.query(srequest("firefox", geolocation, user_agent, ["top_pick_promotion"]))
+    res = await adm.query(srequest("firefox", geolocation, user_agent, []))
 
     assert len(res) == 1
-    assert res[0].is_top_pick is None
+    assert res[0].is_top_pick is False
     adm.metrics_client.increment.assert_not_called()  # type: ignore[attr-defined]
 
 

--- a/tests/unit/providers/suggest/adm/test_provider.py
+++ b/tests/unit/providers/suggest/adm/test_provider.py
@@ -498,8 +498,7 @@ async def test_query_is_top_pick_false_when_record_has_no_prefix(
     srequest: SuggestionRequestFixture,
     adm: Provider,
 ) -> None:
-    """`is_top_pick` is False when matched record has no `top_pick_prefix`.
-    """
+    """`is_top_pick` is False when matched record has no `top_pick_prefix`."""
     await adm.initialize()
     user_agent = UserAgent(form_factor="desktop", browser="firefox", os_family="macos")
     geolocation = Location(country="US")

--- a/tests/unit/providers/suggest/adm/test_provider_thompson.py
+++ b/tests/unit/providers/suggest/adm/test_provider_thompson.py
@@ -60,6 +60,7 @@ async def test_query_with_thompson_returns_suggestion(
             provider="adm",
             advertiser="Example.org",
             is_sponsored=False,
+            is_top_pick=False,
             icon="attachment-host/main-workspace/quicksuggest/icon-01",
             score=adm_parameters["score"],
             custom_details=CustomDetails(
@@ -152,6 +153,7 @@ async def test_query_with_thompson_min_attempted_count_returns_suggestion(
             provider="adm",
             advertiser="Example.org",
             is_sponsored=False,
+            is_top_pick=False,
             icon="attachment-host/main-workspace/quicksuggest/icon-01",
             score=adm_parameters["score"],
             custom_details=CustomDetails(
@@ -191,6 +193,7 @@ async def test_query_with_thompson_single_candidate_below_threshold_returns_sugg
             provider="adm",
             advertiser="Example.org",
             is_sponsored=False,
+            is_top_pick=False,
             icon="attachment-host/main-workspace/quicksuggest/icon-01",
             score=adm_parameters["score"],
             custom_details=CustomDetails(
@@ -231,6 +234,7 @@ async def test_query_with_thompson_without_engagement_data_skips_sampling(
             provider="adm",
             advertiser="Example.org",
             is_sponsored=False,
+            is_top_pick=False,
             icon="attachment-host/main-workspace/quicksuggest/icon-01",
             score=adm_parameters["score"],
             custom_details=CustomDetails(
@@ -268,6 +272,7 @@ async def test_query_with_thompson_returns_fallback_when_fallback_enabled(
             provider="adm",
             advertiser="Example.org",
             is_sponsored=False,
+            is_top_pick=False,
             icon="attachment-host/main-workspace/quicksuggest/icon-01",
             score=adm_parameters["score"],
             custom_details=CustomDetails(
@@ -313,6 +318,7 @@ async def test_query_with_thompson_dummy_return_suggestion_when_fallback_enabled
             provider="adm",
             advertiser="Example.org",
             is_sponsored=False,
+            is_top_pick=False,
             icon="attachment-host/main-workspace/quicksuggest/icon-01",
             score=adm_parameters["score"],
             custom_details=CustomDetails(


### PR DESCRIPTION
## References

JIRA: [DISCO-4329](https://mozilla-hub.atlassian.net/browse/DISCO-4329)

## Description
MARs will be returning top_pick_prefix for all suggestions, we need to return is_top_pick false for these.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2516)


[DISCO-4329]: https://mozilla-hub.atlassian.net/browse/DISCO-4329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ