### PR TITLE
[DISCO-4417] Add max token cap normalization to prevent CPU blocking

### DIFF
--- a/merino/utils/query_processing/normalization/pipeline.py
+++ b/merino/utils/query_processing/normalization/pipeline.py
@@ -99,6 +99,9 @@ def _try_join_normalize(tokens: list[str], canonical: set[str]) -> str | None:
 # Step 4: segment query into tokens with wordsegment
 _WORDSEGMENT_CACHE_SIZE: int = settings.query_normalization.wordsegment_cache_size
 
+# Cap token length for the super-linear segmentation steps (DoS guard).
+_MAX_SEGMENT_TOKEN_LEN: int = 20
+
 
 @functools.lru_cache(maxsize=_WORDSEGMENT_CACHE_SIZE)
 def _ws_segment(tok: str) -> str:
@@ -113,7 +116,7 @@ def _try_wordsegment(tokens: list[str], canonical: set[str]) -> str | None:
     portion alone is in canonical.
     """
     for i, tok in enumerate(tokens):
-        if len(tok) < 5 or tok in canonical:
+        if len(tok) < 5 or len(tok) > _MAX_SEGMENT_TOKEN_LEN or tok in canonical:
             continue
         segmented = _ws_segment(tok)
         if segmented == tok:
@@ -163,7 +166,7 @@ def _try_split_token(token: str, canonical: set[str], max_splits: int = 4) -> st
 def _try_split_normalize(tokens: list[str], canonical: set[str]) -> str | None:
     """Split each fused token; return canonical hit."""
     for i, tok in enumerate(tokens):
-        if len(tok) < 5 or tok in canonical:
+        if len(tok) < 5 or len(tok) > _MAX_SEGMENT_TOKEN_LEN or tok in canonical:
             continue
 
         split = _try_split_token(tok, canonical)

--- a/tests/unit/query_normalization/test_pipeline.py
+++ b/tests/unit/query_normalization/test_pipeline.py
@@ -1,7 +1,9 @@
 """Unit tests for the query normalization pipeline."""
 
 import pytest
+from pytest_mock import MockerFixture
 
+import merino.utils.query_processing.normalization.pipeline as pipeline_mod
 from merino.utils.query_processing.normalization.pipeline import (
     BM25Index,
     NormalizePipeline,
@@ -358,6 +360,27 @@ def test_pipeline_prefix_then_bm25_reorder() -> None:
 def test_pipeline_long_query_skips_split(pipeline: NormalizePipeline) -> None:
     """Queries with more than 2 tokens should skip split step."""
     assert pipeline.normalize("this is a long query") == "this is a long query"
+
+
+@pytest.mark.parametrize(
+    "length, expect_called",
+    [
+        (pipeline_mod._MAX_SEGMENT_TOKEN_LEN, True),
+        (pipeline_mod._MAX_SEGMENT_TOKEN_LEN + 1, False),
+    ],
+    ids=["at-cap-processed", "over-cap-skipped"],
+)
+def test_overlong_token_skips_segmentation(
+    mocker: MockerFixture, pipeline: NormalizePipeline, length: int, expect_called: bool
+) -> None:
+    """DoS guard: tokens over the length cap bypass the super-linear segmentation steps."""
+    ws_spy = mocker.spy(pipeline_mod, "_ws_segment")
+    split_spy = mocker.spy(pipeline_mod, "_try_split_token")
+
+    pipeline.normalize("z" * length)
+
+    assert ws_spy.called is expect_called
+    assert split_spy.called is expect_called
 
 
 # update_mars_terms


### PR DESCRIPTION
## References

JIRA: [DISCO-4417](https://mozilla-hub.atlassian.net/browse/DISCO-4417)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->

Add max token limit for normalization path (word segmentation and splitting) to reduce CPU load for long length tokens.

Results before / after:


Query | Metric | Before (no cap) | After (cap=20)
-- | -- | -- | --
Benign weather | p50 | 0.005 ms | 0.005 ms
Benign weather | p99 | 0.013 ms | 0.006 ms
Attack — 50-char token | p50 | 20.3 ms | 0.002 ms
Attack — 50-char token | p99 | 30.6 ms | 0.002 ms
Attack | Mean | 20.5 ms | 0.002 ms
Attack | Req/s to saturate 1 core | ~49 | ~609,000
Attack | Amplification vs. benign | ~4,050× | ~0.4× (now cheaper than benign)


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2520)


[DISCO-4417]: https://mozilla-hub.atlassian.net/browse/DISCO-4417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ