### PR TITLE
HNT-2923 fix: adjust corpus cache and retry values to lessen load during deploys

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -1483,7 +1483,22 @@ retry_wait_initial_seconds = 0.5
 
 # MERINO__CURATED_RECOMMENDATIONS__CORPUS_API__RETRY_WAIT_JITTER_SECONDS
 # Uniformly random time in seconds to add to the wait time before retrying corpus api requests.
-retry_wait_jitter_seconds = 0.2
+# This value should be higher than retry_wait_initial_seconds to provide
+# meaningful variance in retry attempts (to help avoid a thundering herd problem).
+retry_wait_jitter_seconds = 1.0
+
+# MERINO__CURATED_RECOMMENDATIONS_CORPUS_API__CACHE_TTL_MIN
+# Minimum number of seconds to cache results of a corpus API call.
+cache_ttl_min = 110
+
+# MERINO__CURATED_RECOMMENDATIONS_CORPUS_API__CACHE_TTL_MAX
+# Maximum number of seconds to cache results of a corpus API call.
+# We want to keep a balance of data freshness (e.g. to allow editorial fixes to
+# surface quickly) and expiration variance (to avoid overly synchronous cache
+# expiry, which exacerbates load problems, particularly during a deploy/cold
+# start).
+# The values here will give an average of 140s cache TTL.
+cache_ttl_max = 170
 
 
 [default.jobs.wikipedia_indexer]

--- a/merino/curated_recommendations/corpus_backends/scheduled_surface_backend.py
+++ b/merino/curated_recommendations/corpus_backends/scheduled_surface_backend.py
@@ -50,8 +50,12 @@ class ScheduledSurfaceBackend(ScheduledSurfaceProtocol):
     # Time-to-live was chosen because 2 minutes (+/- 10 s) is short enough that updates by curators
     # such as breaking news or editorial corrections propagate fast enough, and that the request
     # rate to the scheduledSurface query stays close to the historic rate of ~100 requests/minute.
-    cache_time_to_live_min = timedelta(seconds=110)
-    cache_time_to_live_max = timedelta(seconds=130)
+    cache_time_to_live_min = timedelta(
+        seconds=settings.curated_recommendations.corpus_api.cache_ttl_min
+    )
+    cache_time_to_live_max = timedelta(
+        seconds=settings.curated_recommendations.corpus_api.cache_ttl_max
+    )
     _cache: dict
     _background_tasks: set[asyncio.Task]
 

--- a/merino/curated_recommendations/corpus_backends/sections_backend.py
+++ b/merino/curated_recommendations/corpus_backends/sections_backend.py
@@ -83,7 +83,10 @@ class SectionsBackend(SectionsProtocol):
         self._background_tasks = set()
 
     @stale_while_revalidate(
-        wait_expiration=WaitRandomExpiration(timedelta(seconds=110), timedelta(seconds=130)),
+        wait_expiration=WaitRandomExpiration(
+            timedelta(seconds=settings.curated_recommendations.corpus_api.cache_ttl_min),
+            timedelta(seconds=settings.curated_recommendations.corpus_api.cache_ttl_max),
+        ),
         cache=lambda self: self._cache,
         jobs=lambda self: self._background_tasks,
     )


### PR DESCRIPTION
## References

JIRA: [HNT-2923](https://mozilla-hub.atlassian.net/browse/HNT-2923)

## Description

low hanging fruit PR to reduce some corpus load during merino deploys - which currently can cause a cold start/thundering herd problem.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2523)


[HNT-2923]: https://mozilla-hub.atlassian.net/browse/HNT-2923?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ