### PR TITLE
[DISCO-4423] fix(merino): fix local test failures by pinning fake-gcs…

### DIFF
--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -26,7 +26,7 @@ services:
     ports:
       - 8081:8081
   fake-gcs:
-    image: fsouza/fake-gcs-server
+    image: fsouza/fake-gcs-server:1.55.1
     container_name: fake-gcs-server
     restart: always
     ports:

--- a/tests/integration/fixtures/gcs.py
+++ b/tests/integration/fixtures/gcs.py
@@ -23,9 +23,10 @@ def gcs_storage_container() -> Generator[DockerContainer, None, None]:
     os.environ.setdefault("STORAGE_EMULATOR_HOST", "http://localhost:4443")
 
     # create a docker container using the `fake-gcs-server` image, waiting for it
-    # to emit its startup log line before the fixture proceeds
+    # to emit its startup log line before the fixture proceeds. The tag is pinned so
+    # that a stale locally-cached `latest` can't drift from what CI pulls.
     container = (
-        DockerContainer("fsouza/fake-gcs-server")
+        DockerContainer("fsouza/fake-gcs-server:1.55.1")
         .with_command("-scheme http")
         .with_bind_ports(4443, 4443)
         .waiting_for(LogMessageWaitStrategy("server started at"))


### PR DESCRIPTION
…-server

## References

JIRA: [DISCO-4423](https://mozilla-hub.atlassian.net/browse/DISCO-4423)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->

Since we didn't pin the version for this image, it defaults to ":latest", docker will never pull the latest version if there is one present locally. I happened to have an old version which doesn't persist the `cacheControl` metadata and caused the test failures. Let's pin it to the latest version to avoid that in the future. 

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2525)


[DISCO-4423]: https://mozilla-hub.atlassian.net/browse/DISCO-4423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ