### PR TITLE
[DISCO-4427] fix: add required headers for wikipedia requests

### DIFF
--- a/merino/jobs/wikipedia_indexer/filemanager.py
+++ b/merino/jobs/wikipedia_indexer/filemanager.py
@@ -16,18 +16,13 @@ from google.cloud.storage.fileio import BlobReader, BlobWriter
 
 from merino.exceptions import FilemanagerError
 from merino.jobs.wikipedia_indexer.utils import ProgressReporter
+from merino.utils.wikipedia import WIKIMEDIA_REQUEST_HEADERS
 from google.api_core.exceptions import GoogleAPIError
 
 
 logger = logging.getLogger(__name__)
 
 SUPPORTED_LANGUAGES = set(settings.suggest_supported_languages)
-
-# Wikipedia requires the following HTTP headers when requesting content
-# from their sites.
-REQUEST_HEADERS = {
-    "User-Agent": "requests/2.34",
-}
 
 
 class DirectoryParser(HTMLParser):
@@ -91,7 +86,7 @@ class FileManager:
 
         # 1. Try current/
         try:
-            resp = requests.get(self.base_url, headers=REQUEST_HEADERS)  # nosec
+            resp = requests.get(self.base_url, headers=WIKIMEDIA_REQUEST_HEADERS)  # nosec
             parser = DirectoryParser(self.file_pattern)
             parser.feed(str(resp.content))
             links = parser.file_paths
@@ -107,7 +102,7 @@ class FileManager:
         # 2. Fallback to dated directory (bandaid)
         fallback_url = "https://dumps.wikimedia.org/other/cirrussearch/20251229/"
         try:
-            resp = requests.get(fallback_url, headers=REQUEST_HEADERS)  # nosec
+            resp = requests.get(fallback_url, headers=WIKIMEDIA_REQUEST_HEADERS)  # nosec
             parser = DirectoryParser(self.file_pattern)
             parser.feed(str(resp.content))
             links = parser.file_paths
@@ -178,7 +173,7 @@ class FileManager:
         name = "{}/{}".format(self.object_prefix, dump_url.split("/")[-1])
         blob = self.client.bucket(self.gcs_bucket).blob(name, chunk_size=chunk_size)
         try:
-            with requests.get(dump_url, stream=True, headers=REQUEST_HEADERS) as resp:  # nosec
+            with requests.get(dump_url, stream=True, headers=WIKIMEDIA_REQUEST_HEADERS) as resp:  # nosec
                 content_len = int(resp.headers.get("Content-Length", 0))
                 resp.raise_for_status()
                 logger.info("Writing to GCS: gs://{}/{}".format(self.gcs_bucket, blob.name))

--- a/merino/jobs/wikipedia_indexer/filemanager.py
+++ b/merino/jobs/wikipedia_indexer/filemanager.py
@@ -23,6 +23,12 @@ logger = logging.getLogger(__name__)
 
 SUPPORTED_LANGUAGES = set(settings.suggest_supported_languages)
 
+# Wikipedia requires the following HTTP headers when requesting content
+# from their sites.
+REQUEST_HEADERS = {
+    "User-Agent": "requests/2.34",
+}
+
 
 class DirectoryParser(HTMLParser):
     """Parse the directory listing to find the specified file."""
@@ -85,7 +91,7 @@ class FileManager:
 
         # 1. Try current/
         try:
-            resp = requests.get(self.base_url)  # nosec
+            resp = requests.get(self.base_url, headers=REQUEST_HEADERS)  # nosec
             parser = DirectoryParser(self.file_pattern)
             parser.feed(str(resp.content))
             links = parser.file_paths
@@ -101,7 +107,7 @@ class FileManager:
         # 2. Fallback to dated directory (bandaid)
         fallback_url = "https://dumps.wikimedia.org/other/cirrussearch/20251229/"
         try:
-            resp = requests.get(fallback_url)  # nosec
+            resp = requests.get(fallback_url, headers=REQUEST_HEADERS)  # nosec
             parser = DirectoryParser(self.file_pattern)
             parser.feed(str(resp.content))
             links = parser.file_paths
@@ -172,7 +178,7 @@ class FileManager:
         name = "{}/{}".format(self.object_prefix, dump_url.split("/")[-1])
         blob = self.client.bucket(self.gcs_bucket).blob(name, chunk_size=chunk_size)
         try:
-            with requests.get(dump_url, stream=True) as resp:  # nosec
+            with requests.get(dump_url, stream=True, headers=REQUEST_HEADERS) as resp:  # nosec
                 content_len = int(resp.headers.get("Content-Length", 0))
                 resp.raise_for_status()
                 logger.info("Writing to GCS: gs://{}/{}".format(self.gcs_bucket, blob.name))

--- a/merino/jobs/wikipedia_offline_uploader/downloader.py
+++ b/merino/jobs/wikipedia_offline_uploader/downloader.py
@@ -11,16 +11,14 @@ import requests
 from merino.jobs.wikipedia_offline_uploader.make_suggestions import make_suggestions
 from merino.jobs.wikipedia_offline_uploader.top_n_by_frequency import get_top_n_frequency
 from merino.jobs.wikipedia_offline_uploader.top_n_by_recency import get_top_n_recency
+from merino.utils.wikipedia import WIKIMEDIA_REQUEST_HEADERS
 
 TOP_N = 7000
 
 
 async def fetch_url(url, output_path) -> None:
     """Make a request to the specified URL and save the response."""
-    # wikimedia asks to have a unique user agent https://www.mediawiki.org/wiki/Wikimedia_REST_API
-    response = requests.get(
-        url, headers={"User-Agent": "Mozilla/5.0 disco-team@mozilla.com"}, timeout=5
-    )
+    response = requests.get(url, headers=WIKIMEDIA_REQUEST_HEADERS, timeout=5)
     response.raise_for_status()
     with open(output_path, "w") as f:
         f.write(json.dumps(response.json()))

--- a/merino/providers/rss/wikimedia_potd/backends/utils.py
+++ b/merino/providers/rss/wikimedia_potd/backends/utils.py
@@ -9,11 +9,6 @@ from merino.providers.rss.wikimedia_potd.backends.protocol import (
     WikimediaPotdError,
 )
 
-# This is needed to prevent Wikimedia from blocking our requests as bot requests.
-WIKIMEDIA_REQUEST_HEADERS = {
-    "User-Agent": "Mozilla/5.0 (compatible; Merino/1.0; +https://github.com/mozilla-services/merino-py)"
-}
-
 # Commons stores each language's POTD description on its own template subpage titled
 # "Template:Potd/{date} ({lang})", so the trailing parenthesized code is the language.
 # The bare "Template:Potd/{date}" page (the file selector) has no suffix and is ignored.

--- a/merino/providers/rss/wikimedia_potd/backends/wikimedia_potd.py
+++ b/merino/providers/rss/wikimedia_potd/backends/wikimedia_potd.py
@@ -20,8 +20,8 @@ from merino.providers.rss.wikimedia_potd.backends.protocol import (
 )
 from merino.utils.gcs.gcs_uploader import GcsUploader
 from merino.utils.gcs.models import Image
+from merino.utils.wikipedia import WIKIMEDIA_REQUEST_HEADERS
 from merino.providers.rss.wikimedia_potd.backends.utils import (
-    WIKIMEDIA_REQUEST_HEADERS,
     parse_potd,
     extract_image_description_with_lang_code,
     parse_discovered_languages,

--- a/merino/utils/wikipedia.py
+++ b/merino/utils/wikipedia.py
@@ -1,0 +1,8 @@
+"""Shared utilities for requesting content from Wikipedia and other Wikimedia sites."""
+
+# Wikimedia asks callers to identify themselves with a unique user agent, otherwise our
+# requests can be blocked as bot traffic.
+# See https://www.mediawiki.org/wiki/Wikimedia_REST_API
+WIKIMEDIA_REQUEST_HEADERS = {
+    "User-Agent": "Mozilla/5.0 (compatible; Merino/1.0; +https://github.com/mozilla-services/merino-py)"
+}

--- a/tests/unit/jobs/wikipedia_indexer/test_filemanager.py
+++ b/tests/unit/jobs/wikipedia_indexer/test_filemanager.py
@@ -13,6 +13,7 @@ from merino.jobs.wikipedia_indexer.filemanager import (
     FileManager,
     WikipediaFilemanagerError,
 )
+from merino.utils.wikipedia import WIKIMEDIA_REQUEST_HEADERS
 
 
 def test_get_latest_gcs_returns_latest_blob():
@@ -151,7 +152,9 @@ def test_stream_dump_to_gcs_success(mock_get):
     assert mock_writer.write.call_count == 2
     mock_blob.open.assert_called_once()
     mock_get.assert_called_once_with(
-        "http://mock-url/frwiki-20240501-cirrussearch-content.json.gz", stream=True
+        "http://mock-url/frwiki-20240501-cirrussearch-content.json.gz",
+        stream=True,
+        headers=WIKIMEDIA_REQUEST_HEADERS,
     )
 
 

--- a/tests/unit/providers/rss/wikimedia_potd/backends/test_wikimedia_potd_backend.py
+++ b/tests/unit/providers/rss/wikimedia_potd/backends/test_wikimedia_potd_backend.py
@@ -20,7 +20,7 @@ from merino.providers.rss.wikimedia_potd.backends.protocol import (
     WikimediaPotdError,
 )
 from merino.utils.gcs.gcs_uploader import GcsUploader
-from merino.providers.rss.wikimedia_potd.backends.utils import WIKIMEDIA_REQUEST_HEADERS
+from merino.utils.wikipedia import WIKIMEDIA_REQUEST_HEADERS
 from merino.providers.rss.wikimedia_potd.backends.wikimedia_potd import (
     WikimediaPictureOfTheDayBackend,
 )


### PR DESCRIPTION
## References

JIRA: [DISCO-4427](https://mozilla-hub.atlassian.net/browse/DISCO-4427)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->

Wikipedia requires the U-A header for all requests to their sites.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2527)


[DISCO-4427]: https://mozilla-hub.atlassian.net/browse/DISCO-4427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ