### PR TITLE
[HNT-2920] feat: remove the large tile from Popular Today for all users

### DIFF
--- a/merino/curated_recommendations/layouts.py
+++ b/merino/curated_recommendations/layouts.py
@@ -146,62 +146,7 @@ layout_6_tiles = Layout(
     ],
 )
 
-# Layout 4: Layout with 8 tiles, with an ad in each row, 2nd & 6th position
-layout_7_tiles_2_ads = Layout(
-    name="7-double-row-2-ad",
-    responsiveLayouts=[
-        ResponsiveLayout(
-            columnCount=4,
-            tiles=[
-                Tile(size=TileSize.LARGE, position=0, hasAd=False, hasExcerpt=True),
-                Tile(size=TileSize.MEDIUM, position=2, hasAd=False, hasExcerpt=True),
-                Tile(size=TileSize.MEDIUM, position=1, hasAd=True, hasExcerpt=False),
-                Tile(size=TileSize.MEDIUM, position=3, hasAd=False, hasExcerpt=False),
-                Tile(size=TileSize.MEDIUM, position=5, hasAd=False, hasExcerpt=True),
-                Tile(size=TileSize.MEDIUM, position=4, hasAd=True, hasExcerpt=True),
-                Tile(size=TileSize.MEDIUM, position=6, hasAd=False, hasExcerpt=True),
-            ],
-        ),
-        ResponsiveLayout(
-            columnCount=3,
-            tiles=[
-                Tile(size=TileSize.MEDIUM, position=0, hasAd=False, hasExcerpt=True),
-                Tile(size=TileSize.MEDIUM, position=2, hasAd=True, hasExcerpt=True),
-                Tile(size=TileSize.MEDIUM, position=1, hasAd=False, hasExcerpt=False),
-                Tile(size=TileSize.MEDIUM, position=3, hasAd=False, hasExcerpt=False),
-                Tile(size=TileSize.MEDIUM, position=5, hasAd=True, hasExcerpt=True),
-                Tile(size=TileSize.SMALL, position=4, hasAd=False, hasExcerpt=False),
-                Tile(size=TileSize.SMALL, position=6, hasAd=False, hasExcerpt=False),
-            ],
-        ),
-        ResponsiveLayout(
-            columnCount=2,
-            tiles=[
-                Tile(size=TileSize.LARGE, position=0, hasAd=False, hasExcerpt=True),
-                Tile(size=TileSize.MEDIUM, position=1, hasAd=True, hasExcerpt=True),
-                Tile(size=TileSize.MEDIUM, position=2, hasAd=False, hasExcerpt=False),
-                Tile(size=TileSize.MEDIUM, position=3, hasAd=False, hasExcerpt=False),
-                Tile(size=TileSize.MEDIUM, position=4, hasAd=False, hasExcerpt=True),
-                Tile(size=TileSize.MEDIUM, position=5, hasAd=True, hasExcerpt=True),
-                Tile(size=TileSize.MEDIUM, position=6, hasAd=False, hasExcerpt=True),
-            ],
-        ),
-        ResponsiveLayout(
-            columnCount=1,
-            tiles=[
-                Tile(size=TileSize.MEDIUM, position=0, hasAd=False, hasExcerpt=True),
-                Tile(size=TileSize.MEDIUM, position=1, hasAd=True, hasExcerpt=True),
-                Tile(size=TileSize.MEDIUM, position=2, hasAd=False, hasExcerpt=False),
-                Tile(size=TileSize.MEDIUM, position=3, hasAd=False, hasExcerpt=False),
-                Tile(size=TileSize.MEDIUM, position=4, hasAd=False, hasExcerpt=True),
-                Tile(size=TileSize.MEDIUM, position=5, hasAd=True, hasExcerpt=True),
-                Tile(size=TileSize.MEDIUM, position=6, hasAd=False, hasExcerpt=True),
-            ],
-        ),
-    ],
-)
-
-# Layout 5: Layout with 8 tiles and no large tile, with an ad in each row, 2nd & 6th position.
+# Layout 4: Layout with 8 tiles and no large tile, with an ad in each row, 2nd & 6th position.
 layout_8_tiles_2_ads = Layout(
     name="8-double-row-2-ad",
     responsiveLayouts=[
@@ -220,7 +165,9 @@ layout_8_tiles_2_ads = Layout(
                 Tile(size=TileSize.MEDIUM, position=7, hasAd=False, hasExcerpt=True),
             ],
         ),
-        # Renders as layout 4 does, plus an 8th tile that lands in a row the client hides.
+        # This breakpoint had no large tile to drop, so its tiles are unchanged from the layout
+        # this one replaces. The 8th tile keeps the position set consistent across breakpoints,
+        # and lands alone in a trailing row that the client hides.
         ResponsiveLayout(
             columnCount=3,
             tiles=[

--- a/merino/curated_recommendations/protocol.py
+++ b/merino/curated_recommendations/protocol.py
@@ -107,9 +107,6 @@ class ExperimentName(str, Enum):
     CONTEXTUAL_AD_RELEASE_EXPERIMENT = "new-tab-contextual-ad-updates-release"
     CONTEXTUAL_AD_V2_RELEASE_EXPERIMENT = "new-tab-contextual-ad-updates-v2-release"
     NEW_TAB_CUSTOM_SECTIONS_EXPERIMENT = "new-tab-custom-sections"
-    # Experiment to remove the large tile from Popular Today, so the 2-column layout shows an
-    # ad in its first row instead of a full-width large tile (HNT-2920).
-    NO_LARGE_CARD_EXPERIMENT = "new-tab-2-column-no-large-card"
     INFERRED_TIME_ZONE_EXPERIMENT = "new-tab-stories-time-zone-based-ranking"
     # Experiment to measure the impact of editorial sections by hiding them in the treatment branch
     EDITORIAL_SECTIONS_EXPERIMENT = "editorial-sections-experiment"

--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -18,7 +18,6 @@ from merino.curated_recommendations.layouts import (
     layout_4_medium,
     layout_4_large,
     layout_6_tiles,
-    layout_7_tiles_2_ads,
     layout_8_tiles_2_ads,
 )
 from merino.curated_recommendations.localization import get_translation
@@ -360,16 +359,6 @@ def is_contextual_ads_experiment(request: CuratedRecommendationsRequest) -> bool
     return any(
         is_enrolled_in_experiment(request, exp_name, "treatment")
         for exp_name in contextual_ads_experiments
-    )
-
-
-def is_no_large_card_experiment(request: CuratedRecommendationsRequest) -> bool:
-    """Return True if Popular Today should drop its large tile (HNT-2920).
-
-    Gated on an internal experiment so the layout can be QA'd before it reaches users.
-    """
-    return is_enrolled_in_experiment(
-        request, ExperimentName.NO_LARGE_CARD_EXPERIMENT.value, "treatment"
     )
 
 
@@ -962,11 +951,9 @@ async def get_sections(
     # 8. Split top stories from the globally ranked recommendations
     # Use 2-row layout as default for Popular Today
     top_stories_count = DOUBLE_ROW_TOP_STORIES_COUNT
-    popular_today_layout = layout_7_tiles_2_ads
+    popular_today_layout = layout_8_tiles_2_ads
 
-    if is_no_large_card_experiment(request):
-        popular_today_layout = layout_8_tiles_2_ads
-    elif is_contextual_ads_experiment(request):
+    if is_contextual_ads_experiment(request):
         popular_today_layout = layout_4_large
 
     prior = ranker.get_regional_prior(region, engagement_region)

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -1570,7 +1570,7 @@ class TestSections:
 
         # the first layouts for the subtopic sections should be a double-row layout, after which it should cycle.
         layout_names = [sec["layout"]["name"] for sec in sections.values()]
-        assert layout_names[0] == "7-double-row-2-ad"  # top_stories double‐row layout
+        assert layout_names[0] == "8-double-row-2-ad"  # top_stories double‐row layout
         assert layout_names[1] == "6-small-medium-1-ad"  # first ML section
         assert layout_names[2] == "4-large-small-medium-1-ad"  # second ML section
 
@@ -1882,14 +1882,6 @@ class TestSections:
                 "experimentName": ExperimentName.CONTEXTUAL_AD_V2_RELEASE_EXPERIMENT.value,
                 "experimentBranch": "treatment",
             },
-            {
-                "experimentName": ExperimentName.NO_LARGE_CARD_EXPERIMENT.value,
-                "experimentBranch": "treatment",
-            },
-            {
-                "experimentName": ExperimentName.NO_LARGE_CARD_EXPERIMENT.value,
-                "experimentBranch": "control",
-            },
         ],
     )
     def test_sections_layouts(self, sections_payload, experiment_payload, client: TestClient):
@@ -1914,19 +1906,9 @@ class TestSections:
 
         # Assert layout of the first section (Popular Today).
         assert first_section["title"] == "Popular Today"
-        experiment_name = experiment_payload.get("experimentName")
-        experiment_branch = experiment_payload.get("experimentBranch")
-        if (
-            experiment_name == ExperimentName.NO_LARGE_CARD_EXPERIMENT.value
-            and experiment_branch == "treatment"
-        ):
-            # HNT-2920: Popular Today drops its large tile in the treatment branch
+        if experiment_payload.get("experimentName") is None:
+            # HNT-2920: Popular Today has no large tile
             assert first_section["layout"]["name"] == "8-double-row-2-ad"
-        elif experiment_name in (
-            None,
-            ExperimentName.NO_LARGE_CARD_EXPERIMENT.value,
-        ):
-            assert first_section["layout"]["name"] == "7-double-row-2-ad"
         else:
             # If contextual ads experiment, Popular Today should be 1 row
             assert first_section["layout"]["name"] == "4-large-small-medium-1-ad"

--- a/tests/unit/curated_recommendations/test_sections.py
+++ b/tests/unit/curated_recommendations/test_sections.py
@@ -59,7 +59,6 @@ from merino.curated_recommendations.sections import (
     dedupe_experiment_sections,
     exclude_recommendations_from_blocked_sections,
     is_daily_briefing_experiment,
-    is_no_large_card_experiment,
     should_exclude_editorial_sections,
     should_show_popular_today_with_daily_briefing,
     update_received_feed_rank,
@@ -409,28 +408,6 @@ class TestDailyBriefingExperiment:
         """Test that should_show_popular_today_with_daily_briefing returns True only for briefing-with-popular."""
         req = SimpleNamespace(experimentName=name, experimentBranch=branch, inferredInterests=None)
         assert should_show_popular_today_with_daily_briefing(req) is expected
-
-
-class TestNoLargeCardExperiment:
-    """Tests covering is_no_large_card_experiment (HNT-2920)."""
-
-    @pytest.mark.parametrize(
-        "name,branch,expected",
-        [
-            # treatment branch drops the large tile from Popular Today
-            (ExperimentName.NO_LARGE_CARD_EXPERIMENT.value, "treatment", True),
-            # control branch keeps the current layout
-            (ExperimentName.NO_LARGE_CARD_EXPERIMENT.value, "control", False),
-            # other experiment does not affect this
-            ("other-experiment", "treatment", False),
-            # no experiment keeps the current layout
-            (None, None, False),
-        ],
-    )
-    def test_is_no_large_card_experiment(self, name, branch, expected):
-        """Test that is_no_large_card_experiment returns True only for the treatment branch."""
-        req = SimpleNamespace(experimentName=name, experimentBranch=branch, inferredInterests=None)
-        assert is_no_large_card_experiment(req) is expected
 
 
 class TestEditorialSectionsExperiment:


### PR DESCRIPTION
## References

- JIRA: [HNT-2920](https://mozilla-hub.atlassian.net/browse/HNT-2920)
- Follow-up to #1720, which added this layout behind a Nimbus gate
- Nimbus: [new-tab-2-column-no-large-card](https://experimenter.services.mozilla.com/nimbus/new-tab-2-column-no-large-card) — the gate being removed

## Description

#1720 added `layout_8_tiles_2_ads`, a Popular Today layout without the full-width large tile, and served it only to the `treatment` branch of `new-tab-2-column-no-large-card` so front-end, product and design could QA it before it reached users. That QA is documented on #1720. This removes the gate and makes the layout the default for everyone.

### Notes for review

- **Contextual ads keep `layout_4_large`.** Under the gate, the treatment branch took precedence over `is_contextual_ads_experiment`; here it does not. [`new-tab-contextual-ad-updates-v2-release`](https://experimenter.services.mozilla.com/nimbus/new-tab-contextual-ad-updates-v2-release) is still live with no end date, and `layout_8_tiles_2_ads` has two ad slots where `layout_4_large` has one, so switching those clients now would change the inventory that experiment is measuring. Worth a follow-up once it ends — the epic is *Remove Large Card Layouts*, and `layout_4_large` still leads with one at 4 and 2 columns.
- **`layout_7_tiles_2_ads` is deleted**, since nothing reads it once the gate is gone. `layout_4_large` stays: it is still in `LAYOUT_CYCLE` for the other sections.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)

[HNT-2920]: https://mozilla-hub.atlassian.net/browse/HNT-2920
