### PR TITLE
[DISCO-4408] Update the data source for Wikipedia Indexer job

### DIFF
--- a/docs/operations/jobs/dynamic-wiki-indexer.md
+++ b/docs/operations/jobs/dynamic-wiki-indexer.md
@@ -14,6 +14,19 @@ The reasons to keep the job code close to the application code are:
 If your reason for re-running the job is needing to update the blocklist to avoid certain suggestions from being displayed,
 please see the [wikipedia blocklist runbook][wiki_blocklist_runbook].
 
+## Where the exports come from
+
+The `copy-export` step reads Wikimedia's CirrusSearch index dumps from
+<https://dumps.wikimedia.org/other/cirrus_search_index/>. That listing holds one directory per
+weekly snapshot (`20260816/`), and within each snapshot one directory per index
+(`index_name=enwiki_content/`). Upstream shards each index into many bzip2 files to parallelize
+dump generation, so the job traverses snapshots newest-first and concatenates the shards of the first
+complete one into a single object on GCS, named `<lang>wiki-<date>-cirrussearch-content.json.bz2`.
+bzip2 streams may be concatenated, so no recompression happens during the copy.
+
+A snapshot only counts as complete once Wikimedia writes a `_SUCCESS` marker beside its shards,
+which happens roughly 12 hours after the directory first appears. A snapshot without the marker is skipped in favour of the previous one, so a run logging `Currently up to date` shortly after a new snapshot appears is expected rather than a failure.
+
 ## Running the job in Airflow
 Normally, the job is set as a cron to run at set intervals as a [DAG in Airflow][airflow_docs].
 There may be instances you need to manually re-run the job from the Airflow dashboard.

--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -1551,7 +1551,7 @@ gcp_project = ""
 
 # MERINO_JOBS__WIKIPEDIA_INDEXER__EXPORT_BASE_URL
 # Wikipedia export base URL.
-export_base_url = "https://dumps.wikimedia.org/other/cirrussearch/current/"
+export_base_url = "https://dumps.wikimedia.org/other/cirrus_search_index/"
 
 # MERINO_JOBS__WIKIPEDIA_INDEXER__BLOCKLIST_FILE_URL
 # Blocklist file as CSV. Contains a list of the categories for articles that we want to block.

--- a/merino/jobs/wikipedia_indexer/__init__.py
+++ b/merino/jobs/wikipedia_indexer/__init__.py
@@ -97,5 +97,5 @@ def copy_export(
     latest = file_manager.stream_latest_dump_to_gcs()
     if latest is None or not getattr(latest, "name", ""):
         raise RuntimeError(
-            f"No {language} CirrusSearch dump found in current/ or fallback (20251027)."
+            f"No complete {language} CirrusSearch export found under {export_base_url}."
         )

--- a/merino/jobs/wikipedia_indexer/filemanager.py
+++ b/merino/jobs/wikipedia_indexer/filemanager.py
@@ -1,12 +1,12 @@
 """Manage files between Wikimedia exports and gcs bucket"""
 
+import bz2
 import logging
 import re
 from datetime import datetime as dt
-from gzip import GzipFile
 from html.parser import HTMLParser
 from typing import Generator, Optional, Pattern
-from urllib.parse import urljoin
+from urllib.parse import unquote, urljoin
 from merino.configs import settings
 
 
@@ -24,26 +24,34 @@ logger = logging.getLogger(__name__)
 
 SUPPORTED_LANGUAGES = set(settings.suggest_supported_languages)
 
+# Dated snapshot directories in the export listing, e.g. "20260816/".
+DATE_DIR_PATTERN = re.compile(r"^(\d{8})/$")
+
+# Wikimedia writes this marker only once every shard of an index has been published.
+# A snapshot directory without it is still being built and must not be ingested.
+SUCCESS_MARKER = "_SUCCESS"
+
+# Timeout for directory listing requests. Dump downloads stream are not bounded here.
+LISTING_TIMEOUT = 60
+
 
 class DirectoryParser(HTMLParser):
-    """Parse the directory listing to find the specified file."""
+    """Collect the percent-decoded hrefs from a directory listing."""
 
-    filter: Pattern[str]
     file_paths: list[str]
 
-    def __init__(self, filter_wildcard: Pattern[str]) -> None:
+    def __init__(self) -> None:
         super().__init__()
         self.file_paths = []
-        self.filter = re.compile(filter_wildcard)
-
-    def _is_href(self, k: str, v: str) -> bool:
-        return k == "href" and re.search(self.filter, v) is not None
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, Optional[str]]]) -> None:
-        """When the parser encounters a start tag check for Anchor and push into list."""
+        """When the parser encounters an anchor, push its href into the list."""
         if tag == "a":
-            hrefs = [v for k, v in attrs if v is not None and self._is_href(k, v)]
-            self.file_paths.extend(hrefs)
+            for k, v in attrs:
+                # Listings we read hold plain filenames, but Wikimedia percent-encodes
+                # links to the "index_name=<wiki>_content/" directories, so decode either.
+                if k == "href" and v is not None:
+                    self.file_paths.append(unquote(v))
 
 
 class WikipediaFilemanagerError(FilemanagerError):
@@ -57,6 +65,7 @@ class FileManager:
     gcs_bucket: str
     object_prefix: str
     file_pattern: Pattern
+    shard_pattern: Pattern
     client: Client
     language: str
 
@@ -68,9 +77,13 @@ class FileManager:
                 f"Unsupported language '{language}'. Must be one of: {', '.join(SUPPORTED_LANGUAGES)}"
             )
 
+        # Name of the reassembled dump as we store it on GCS. Upstream ships the export as
+        # many shards, which we concatenate into a single object.
         self.file_pattern = re.compile(
-            rf"(?:.*/|^){language}wiki-(\d+)-cirrussearch-content.json.gz"
+            rf"(?:.*/|^){language}wiki-(\d+)-cirrussearch-content\.json\.bz2$"
         )
+        # An individual upstream shard, e.g. "enwiki_content-20260816-00000.json.bz2".
+        self.shard_pattern = re.compile(rf"^{language}wiki_content-(\d+)-(\d+)\.json\.bz2$")
         self.client = Client(gcs_project)
         self.base_url = export_base_url
         self.language = language
@@ -80,43 +93,71 @@ class FileManager:
             self.gcs_bucket = gcs_bucket
             self.object_prefix = ""
 
-    def get_latest_dump(self, latest_gcs: Optional[Blob]) -> Optional[str]:
-        """Find the latest export that's newer than the latest on GCS (if any)."""
+    def get_latest_dump_shards(self, latest_gcs: Optional[Blob]) -> list[str]:
+        """Find the shards of the latest complete export newer than the latest on GCS.
+
+        Returns the shard URLs in order, or an empty list when GCS is already up to date.
+        """
         last_gcs_date = self._parse_date(str(latest_gcs.name)) if latest_gcs else dt.min
 
-        # 1. Try current/
-        try:
-            resp = requests.get(self.base_url, headers=WIKIMEDIA_REQUEST_HEADERS)  # nosec
-            parser = DirectoryParser(self.file_pattern)
-            parser.feed(str(resp.content))
-            links = parser.file_paths
-            if len(links) == 1:
-                name = links[0]
-                url = urljoin(self.base_url, name)
-                link_date = self._parse_date(name)
-                if link_date > last_gcs_date:
-                    return url
-        except Exception as e:
-            logger.warning(f"Failed to fetch listing from {self.base_url}: {e}")
+        for snapshot_url, snapshot_date in self._list_snapshots():
+            if snapshot_date <= last_gcs_date:
+                # Snapshots are traversed newest first, so nothing older can qualify either.
+                break
+            try:
+                shards = self._list_shards(snapshot_url)
+            except requests.RequestException as e:
+                logger.warning(f"Failed to list shards under {snapshot_url}: {e}")
+                continue
+            if shards:
+                return shards
 
-        # 2. Fallback to dated directory (bandaid)
-        fallback_url = "https://dumps.wikimedia.org/other/cirrussearch/20251229/"
-        try:
-            resp = requests.get(fallback_url, headers=WIKIMEDIA_REQUEST_HEADERS)  # nosec
-            parser = DirectoryParser(self.file_pattern)
-            parser.feed(str(resp.content))
-            links = parser.file_paths
-            if len(links) == 1:
-                name = links[0]
-                url = urljoin(fallback_url, name)
-                link_date = self._parse_date(name)
-                if link_date > last_gcs_date:
-                    logger.info(f"Using bandaid fallback dump from {fallback_url}")
-                    return url
-        except Exception as e:
-            logger.warning(f"Fallback fetch failed: {e}")
+        return []
 
-        return None
+    def _list_snapshots(self) -> list[tuple[str, dt]]:
+        """List the dated snapshot directories in the export listing, newest first."""
+        snapshots: list[tuple[str, dt]] = []
+        for href in self._list_hrefs(self.base_url):
+            match = DATE_DIR_PATTERN.match(href)
+            if not match:
+                continue
+            try:
+                snapshot_date = dt.strptime(match.group(1), "%Y%m%d")
+            except ValueError:
+                logger.warning(f"Skipping unparseable snapshot directory: {href}")
+                continue
+            snapshots.append((urljoin(self.base_url, href), snapshot_date))
+
+        snapshots.sort(key=lambda pair: pair[1], reverse=True)
+        return snapshots
+
+    def _list_shards(self, snapshot_url: str) -> list[str]:
+        """List the ordered shard URLs for this language within a snapshot.
+
+        Returns an empty list if the export is missing or not yet fully published.
+        """
+        index_url = urljoin(snapshot_url, f"index_name={self.language}wiki_content/")
+        hrefs = self._list_hrefs(index_url)
+
+        if SUCCESS_MARKER not in hrefs:
+            logger.warning(
+                "Skipping export without a success marker",
+                extra={"url": index_url, "language": self.language},
+            )
+            return []
+
+        matches = [m for m in (self.shard_pattern.match(h) for h in hrefs) if m]
+
+        matches.sort(key=lambda m: int(m.group(2)))
+        return [urljoin(index_url, m.group(0)) for m in matches]
+
+    def _list_hrefs(self, url: str) -> list[str]:
+        """Fetch a directory listing and return every href it contains."""
+        resp = requests.get(url, timeout=LISTING_TIMEOUT, headers=WIKIMEDIA_REQUEST_HEADERS)  # nosec
+        resp.raise_for_status()
+        parser = DirectoryParser()
+        parser.feed(resp.text)
+        return parser.file_paths
 
     def _parse_date(self, filename: str) -> dt:
         """Parse datestring out of filename"""
@@ -143,7 +184,7 @@ class FileManager:
         blobs.sort(key=lambda b: self._parse_date(str(b.name)))
         return blobs[-1]
 
-    def stream_latest_dump_to_gcs(self, latest_gcs: Optional[Blob] = None) -> Blob:
+    def stream_latest_dump_to_gcs(self, latest_gcs: Optional[Blob] = None) -> Optional[Blob]:
         """Stream the latest Wikimedia dump to GCS"""
         try:
             if not latest_gcs:
@@ -154,10 +195,13 @@ class FileManager:
             )
             latest_gcs = None
 
-        latest_dump_url = self.get_latest_dump(latest_gcs)
-        logger.info("latest_dump_url", extra={"ldurl": latest_dump_url})
-        if latest_dump_url:
-            self._stream_dump_to_gcs(latest_dump_url)
+        shard_urls = self.get_latest_dump_shards(latest_gcs)
+        logger.info(
+            "latest_dump_shards",
+            extra={"shard_count": len(shard_urls), "first_shard": shard_urls[:1]},
+        )
+        if shard_urls:
+            self._stream_dump_to_gcs(shard_urls)
             # Recompute latest_gcs after upload
             latest_gcs = self.get_latest_gcs()
         else:
@@ -165,25 +209,63 @@ class FileManager:
 
         return latest_gcs
 
-    def _stream_dump_to_gcs(self, dump_url: str) -> None:
-        """Write latest to GCS without storing locally"""
+    def _dump_blob_name(self, shard_url: str) -> str:
+        """Build the GCS object name for the reassembled dump from a shard URL."""
+        match = self.shard_pattern.match(shard_url.split("/")[-1])
+        if not match:
+            raise WikipediaFilemanagerError(f"Unrecognized shard name: {shard_url}")
+        return f"{self.language}wiki-{match.group(1)}-cirrussearch-content.json.bz2"
+
+    def _total_shard_size(self, shard_urls: list[str]) -> int:
+        """Sum the sizes of the shards, for progress reporting. Returns 0 if unavailable."""
+        total = 0
+        for url in shard_urls:
+            try:
+                resp = requests.head(
+                    url, timeout=LISTING_TIMEOUT, headers=WIKIMEDIA_REQUEST_HEADERS
+                )  # nosec
+                resp.raise_for_status()
+                total += int(resp.headers.get("Content-Length", 0))
+            except (requests.RequestException, ValueError) as e:
+                logger.warning(f"Could not determine size of {url}: {e}")
+                return 0
+        return total
+
+    def _stream_dump_to_gcs(self, shard_urls: list[str]) -> None:
+        """Concatenate the upstream shards into a single blob on GCS.
+
+        Each shard is an independent bzip2 stream. bzip2 permits streams to be
+        concatenated, so the raw bytes are copied through verbatim and the result reads
+        back as one continuous file. Nothing is decompressed or stored locally here.
+        """
         # 40 MB chunk_size. This is the default Blob chunk size.
         # Having the same size will cause reads and writes to synchronize.
         chunk_size = 40 * 1024 * 1024
-        name = "{}/{}".format(self.object_prefix, dump_url.split("/")[-1])
+        name = "{}/{}".format(self.object_prefix, self._dump_blob_name(shard_urls[0]))
         blob = self.client.bucket(self.gcs_bucket).blob(name, chunk_size=chunk_size)
         try:
-            with requests.get(dump_url, stream=True, headers=WIKIMEDIA_REQUEST_HEADERS) as resp:  # nosec
-                content_len = int(resp.headers.get("Content-Length", 0))
-                resp.raise_for_status()
-                logger.info("Writing to GCS: gs://{}/{}".format(self.gcs_bucket, blob.name))
-                logger.info("Total File Size: {}".format(content_len))
-                reporter = ProgressReporter(logger, "Copy", dump_url, name, content_len)
-                writer: BlobWriter
-                with blob.open("wb") as writer:
-                    for chunk in resp.iter_content(chunk_size=chunk_size):
-                        completed = writer.write(chunk)
-                        reporter.report(completed)
+            content_len = self._total_shard_size(shard_urls)
+            logger.info("Writing to GCS: gs://{}/{}".format(self.gcs_bucket, blob.name))
+            logger.info("Total File Size: {}".format(content_len))
+            logger.info("Shard count: {}".format(len(shard_urls)))
+
+            reporter = (
+                ProgressReporter(logger, "Copy", self.base_url, name, content_len)
+                if content_len > 0
+                else None
+            )
+            completed = 0
+            writer: BlobWriter
+            with blob.open("wb") as writer:
+                for shard_url in shard_urls:
+                    with requests.get(  # nosec
+                        shard_url, stream=True, headers=WIKIMEDIA_REQUEST_HEADERS
+                    ) as resp:
+                        resp.raise_for_status()
+                        for chunk in resp.iter_content(chunk_size=chunk_size):
+                            completed += writer.write(chunk)
+                            if reporter:
+                                reporter.report(completed)
 
         except Exception as e:
             logger.error(f"Unexpected error during GCS streaming for {name}: {e}")
@@ -202,6 +284,6 @@ class FileManager:
         """Streaming reader from GCS"""
         reader: BlobReader
         with blob.open("rb") as reader:
-            with GzipFile(fileobj=reader) as gz:
-                for line in gz:
+            with bz2.BZ2File(reader) as stream:
+                for line in stream:
                     yield line

--- a/tests/integration/jobs/wikipedia_indexer/test_filemanager.py
+++ b/tests/integration/jobs/wikipedia_indexer/test_filemanager.py
@@ -1,6 +1,5 @@
 """FileManager tests"""
 
-import re
 from datetime import datetime as dt
 from unittest.mock import MagicMock, patch
 
@@ -12,6 +11,18 @@ from merino.jobs.wikipedia_indexer.filemanager import (
     FileManager,
     WikipediaFilemanagerError,
 )
+
+BASE_URL = "http://test.com/"
+
+
+def _index_url(date: str, language: str = "en") -> str:
+    """Build the URL of a language's content index within a dated snapshot."""
+    return f"{BASE_URL}{date}/index_name={language}wiki_content/"
+
+
+def _links(hrefs: list[str]) -> str:
+    """Render a directory listing for the given hrefs."""
+    return "".join(f"<a href='{href}'>{href}</a>" for href in hrefs)
 
 
 @pytest.fixture
@@ -47,11 +58,11 @@ def test_directory_parser():
     <a href="456.json" />
     """
 
-    parser = DirectoryParser(re.compile("\\d+.json"))
+    parser = DirectoryParser()
     parser.feed(html_directory)
 
-    assert len(parser.file_paths) == 2
-    assert parser.file_paths[0] == "123.json"
+    # Every anchor href is collected; non-anchor tags are ignored.
+    assert parser.file_paths == ["some_file.json", "123.json", "456.json"]
 
 
 @pytest.mark.usefixtures("mock_gcs_client")
@@ -59,11 +70,13 @@ def test_directory_parser():
     ["file_name", "expected_datetime"],
     [
         ("just-some-file.json", dt(1, 1, 1)),
-        ("enwiki-20220101-cirrussearch-content.json.gz", dt(2022, 1, 1)),
-        ("enwiki-19890101-cirrussearch-content.json.gz", dt(1989, 1, 1)),
-        ("foo/bar/enwiki-19890101-cirrussearch-content.json.gz", dt(1989, 1, 1)),
-        ("enwiki-20190132-cirrussearch-content.json.gz", dt(1, 1, 1)),
-        ("enwiki-1234-cirrussearch-content.json.gz", dt(1, 1, 1)),
+        ("enwiki-20220101-cirrussearch-content.json.bz2", dt(2022, 1, 1)),
+        ("enwiki-19890101-cirrussearch-content.json.bz2", dt(1989, 1, 1)),
+        ("foo/bar/enwiki-19890101-cirrussearch-content.json.bz2", dt(1989, 1, 1)),
+        ("enwiki-20190132-cirrussearch-content.json.bz2", dt(1, 1, 1)),
+        ("enwiki-1234-cirrussearch-content.json.bz2", dt(1, 1, 1)),
+        # The deprecated gzip layout is no longer recognized.
+        ("enwiki-20220101-cirrussearch-content.json.gz", dt(1, 1, 1)),
     ],
 )
 def test_parse_date(file_name, expected_datetime):
@@ -94,39 +107,72 @@ def test_parse_gcs_bucket(gcs_bucket, expected_bucket, expected_prefix):
 
 @pytest.mark.usefixtures("mock_gcs_client")
 @pytest.mark.parametrize(
-    ["file_date", "gcs_date", "expected"],
+    ["snapshot_date", "gcs_date", "expected_shard_count"],
     [
-        (
-            "20220101",
-            "20210101",
-            "http://test.com/enwiki-20220101-cirrussearch-content.json.gz",
-        ),
-        (
-            "20210101",
-            "20220101",
-            None,
-        ),
+        ("20220101", "20210101", 3),
+        ("20210101", "20220101", 0),
     ],
+    ids=["snapshot_is_newer", "snapshot_is_older"],
 )
-def test_get_latest_dump(requests_mock, file_date, gcs_date, expected):
-    """Test directory parser and date comparisons of get_latest_dump"""
-    base_url = "http://test.com"
-    file_name = f"enwiki-{file_date}-cirrussearch-content.json.gz"
-    latest_gcs = Blob(f"bar/enwiki-{gcs_date}-cirrussearch-content.json.gz", "foo")
-    html_directory = f"<a href='{file_name}' />"
-    requests_mock.get(base_url, text=html_directory)  # nosec
+def test_get_latest_dump_shards(requests_mock, snapshot_date, gcs_date, expected_shard_count):
+    """Test snapshot traversal and date comparisons of get_latest_dump_shards"""
+    shard_names = [f"enwiki_content-{snapshot_date}-{i:05d}.json.bz2" for i in range(3)]
+    latest_gcs = Blob(f"bar/enwiki-{gcs_date}-cirrussearch-content.json.bz2", "foo")
 
-    file_manager = FileManager("foo/bar", "a-project", base_url, "en")
+    requests_mock.get(BASE_URL, text=_links([f"{snapshot_date}/"]))  # nosec
+    requests_mock.get(  # nosec
+        _index_url(snapshot_date), text=_links([*shard_names, "_SUCCESS"])
+    )
 
-    latest_dump_url = file_manager.get_latest_dump(latest_gcs)
+    file_manager = FileManager("foo/bar", "a-project", BASE_URL, "en")
 
-    assert latest_dump_url == expected
+    shard_urls = file_manager.get_latest_dump_shards(latest_gcs)
+
+    assert len(shard_urls) == expected_shard_count
+    assert shard_urls == [
+        f"{_index_url(snapshot_date)}{name}" for name in shard_names[:expected_shard_count]
+    ]
+
+
+@pytest.mark.usefixtures("mock_gcs_client")
+def test_get_latest_dump_shards_requires_success_marker(requests_mock):
+    """Skip a snapshot whose shards are published but not yet marked complete."""
+    requests_mock.get(BASE_URL, text=_links(["20220101/"]))  # nosec
+    requests_mock.get(  # nosec
+        _index_url("20220101"),
+        text=_links(["enwiki_content-20220101-00000.json.bz2"]),
+    )
+
+    file_manager = FileManager("foo/bar", "a-project", BASE_URL, "en")
+
+    assert file_manager.get_latest_dump_shards(None) == []
+
+
+@pytest.mark.usefixtures("mock_gcs_client")
+def test_get_latest_dump_shards_prefers_newest_complete_snapshot(requests_mock):
+    """Pick the newest complete snapshot, skipping newer incomplete ones."""
+    requests_mock.get(BASE_URL, text=_links(["20220101/", "20220108/"]))  # nosec
+    # Newest snapshot is still being written.
+    requests_mock.get(  # nosec
+        _index_url("20220108"),
+        text=_links(["enwiki_content-20220108-00000.json.bz2"]),
+    )
+    requests_mock.get(  # nosec
+        _index_url("20220101"),
+        text=_links(["enwiki_content-20220101-00000.json.bz2", "_SUCCESS"]),
+    )
+
+    file_manager = FileManager("foo/bar", "a-project", BASE_URL, "en")
+
+    shard_urls = file_manager.get_latest_dump_shards(None)
+
+    assert shard_urls == [f"{_index_url('20220101')}enwiki_content-20220101-00000.json.bz2"]
 
 
 def test_get_latest_gcs(mock_gcs_client):
     """Test sorting logic for get_latest_gcs method"""
-    blob1 = Blob("enwiki-20220101-cirrussearch-content.json.gz", "foo")
-    blob2 = Blob("enwiki-20210101-cirrussearch-content.json.gz", "foo")
+    blob1 = Blob("enwiki-20220101-cirrussearch-content.json.bz2", "foo")
+    blob2 = Blob("enwiki-20210101-cirrussearch-content.json.bz2", "foo")
 
     mock_bucket = mock_gcs_client.bucket.return_value
     mock_bucket.list_blobs.return_value = [blob1, blob2]
@@ -137,16 +183,24 @@ def test_get_latest_gcs(mock_gcs_client):
     assert latest_gcs == blob1
 
 
+@patch("requests.head")
 @patch("requests.get")
-def test_stream_dump_to_gcs_success(mock_requests, mock_gcs_client, mock_wiki_http_response):
-    """Test successful streaming of wiki dump to GCS"""
-    base_url = "http://test.com"
-    dump_url = "http://test.com/enwiki-20220101-cirrussearch-content.json.gz"
+def test_stream_dump_to_gcs_success(
+    mock_requests, mock_head, mock_gcs_client, mock_wiki_http_response
+):
+    """Test successful streaming of the sharded wiki dump into a single GCS blob"""
+    shard_urls = [
+        f"{_index_url('20220101')}enwiki_content-20220101-00000.json.bz2",
+        f"{_index_url('20220101')}enwiki_content-20220101-00001.json.bz2",
+    ]
 
     chunks = [b"chunk1", b"chunk2", b"chunk3"]
 
     mock_resp = mock_wiki_http_response(chunks)
     mock_requests.return_value.__enter__.return_value = mock_resp
+
+    mock_head.return_value.headers = {"Content-Length": "18"}
+    mock_head.return_value.raise_for_status.return_value = None
 
     mock_bucket = MagicMock()
     mock_gcs_client.bucket.return_value = mock_bucket
@@ -159,27 +213,33 @@ def test_stream_dump_to_gcs_success(mock_requests, mock_gcs_client, mock_wiki_ht
     mock_blob.open.return_value.__enter__.return_value = mock_blob_writer
     mock_blob.open.return_value.__exit__.return_value = None
 
-    file_manager = FileManager(mock_bucket, "a-project", base_url, "en")
-    file_manager._stream_dump_to_gcs(dump_url)
+    file_manager = FileManager(mock_bucket, "a-project", BASE_URL, "en")
+    file_manager._stream_dump_to_gcs(shard_urls)
 
+    # A single blob receives the concatenation of every shard.
     mock_blob.open.assert_called_once_with("wb")
 
     mock_blob_writer.write.assert_any_call(b"chunk1")
     mock_blob_writer.write.assert_any_call(b"chunk2")
     mock_blob_writer.write.assert_any_call(b"chunk3")
 
-    assert mock_blob_writer.write.call_count == len(chunks)
+    assert mock_blob_writer.write.call_count == len(chunks) * len(shard_urls)
 
 
+@patch("requests.head")
 @patch("requests.get")
-def test_stream_dump_to_gcs_blob_deletion(mock_requests, mock_gcs_client, mock_wiki_http_response):
+def test_stream_dump_to_gcs_blob_deletion(
+    mock_requests, mock_head, mock_gcs_client, mock_wiki_http_response
+):
     """Test deletion of partial upload on unsuccessful streaming of wiki dump to GCS"""
-    base_url = "http://test.com"
-    dump_url = "http://test.com/enwiki-20220101-cirrussearch-content.json.gz"
+    shard_urls = [f"{_index_url('20220101')}enwiki_content-20220101-00000.json.bz2"]
 
     chunks = [b"chunk1", b"chunk2", b"chunk3"]
     mock_resp = mock_wiki_http_response(chunks)
     mock_requests.return_value.__enter__.return_value = mock_resp
+
+    mock_head.return_value.headers = {"Content-Length": "18"}
+    mock_head.return_value.raise_for_status.return_value = None
 
     mock_bucket = MagicMock()
     mock_gcs_client.bucket.return_value = mock_bucket
@@ -197,60 +257,10 @@ def test_stream_dump_to_gcs_blob_deletion(mock_requests, mock_gcs_client, mock_w
     # raise an exception during streaming
     mock_blob_writer.write.side_effect = Exception("failed to write chunk")
 
-    file_manager = FileManager(mock_bucket, "a-project", base_url, "en")
+    file_manager = FileManager(mock_bucket, "a-project", BASE_URL, "en")
 
     with pytest.raises(WikipediaFilemanagerError, match="Failed to stream dump to GCS"):
-        file_manager._stream_dump_to_gcs(dump_url)
+        file_manager._stream_dump_to_gcs(shard_urls)
 
     mock_blob.exists.assert_called_once()
     mock_blob.delete.assert_called_once()
-
-
-@pytest.mark.usefixtures("mock_gcs_client")
-def test_get_latest_dump_fallback_used_when_current_empty(requests_mock):
-    """Use the bandaid fallback directory when current/ has no matching link."""
-    base_url = "http://test.com"
-    # current/ listing has no match
-    requests_mock.get(base_url, text="<html><body>No matches</body></html>")  # nosec
-
-    # fallback listing has one match
-    fallback_url = "https://dumps.wikimedia.org/other/cirrussearch/20251229/"
-    file_name = "enwiki-20251027-cirrussearch-content.json.gz"
-    requests_mock.get(
-        fallback_url,
-        text=f"<html><body><a href='{file_name}'>{file_name}</a></body></html>",
-    )  # nosec
-
-    # First run (no GCS blob yet)
-    latest_gcs = None
-
-    fm = FileManager("foo/bar", "a-project", base_url, "en")
-    latest_dump_url = fm.get_latest_dump(latest_gcs)
-
-    assert latest_dump_url == f"{fallback_url}{file_name}"
-
-
-@pytest.mark.usefixtures("mock_gcs_client")
-def test_get_latest_dump_fallback_skips_if_not_newer(requests_mock):
-    """Return None if fallback file exists but isn't newer than the GCS blob."""
-    base_url = "http://test.com"
-    # current/ listing has no match
-    requests_mock.get(base_url, text="<html><body>No matches</body></html>")  # nosec
-
-    # fallback listing has one match, but it's older than GCS
-    fallback_url = "https://dumps.wikimedia.org/other/cirrussearch/20251027/"
-    older_file = "enwiki-20240101-cirrussearch-content.json.gz"
-    requests_mock.get(
-        fallback_url,
-        text=f"<html><body><a href='{older_file}'>{older_file}</a></body></html>",
-    )  # nosec
-
-    # GCS already has a newer dump (2024-02-01)
-    from google.cloud.storage import Blob
-
-    latest_gcs = Blob("foo/enwiki-20240201-cirrussearch-content.json.gz", "bucket")
-
-    fm = FileManager("foo/bar", "a-project", base_url, "en")
-    latest_dump_url = fm.get_latest_dump(latest_gcs)
-
-    assert latest_dump_url is None

--- a/tests/integration/jobs/wikipedia_indexer/test_indexer.py
+++ b/tests/integration/jobs/wikipedia_indexer/test_indexer.py
@@ -129,7 +129,7 @@ def test_index_from_export_fail_on_existing_index(
 ):
     """Test that Exception is emitted."""
     file_manager.get_latest_gcs.return_value = Blob(
-        "foo/enwiki-20220101-cirrussearch-content.json.gz", "bar"
+        "foo/enwiki-20220101-cirrussearch-content.json.bz2", "bar"
     )
     es_adapter.index_exists.return_value = False
     es_adapter.create_index.return_value = False
@@ -207,7 +207,7 @@ def test_index_from_export(
 ):
     """Test full index from export flow."""
     file_manager.get_latest_gcs.return_value = Blob(
-        "foo/enwiki-20220101-cirrussearch-content.json.gz", "bar"
+        "foo/enwiki-20220101-cirrussearch-content.json.bz2", "bar"
     )
 
     es_adapter.bulk.return_value = {
@@ -252,7 +252,7 @@ def test_index_from_export_with_category_blocklist_content_filter(
 ):
     """Test content moderation removes blocked categories from category blocklist."""
     file_manager.get_latest_gcs.return_value = Blob(
-        "foo/enwiki-20220101-cirrussearch-content.json.gz", "bar"
+        "foo/enwiki-20220101-cirrussearch-content.json.bz2", "bar"
     )
 
     def check_bulk_side_effect(operations):
@@ -319,7 +319,7 @@ def test_index_from_export_with_title_blocklist_content_filter(
     Also verifies that matching results are not case sensitive, given a title.
     """
     file_manager.get_latest_gcs.return_value = Blob(
-        "foo/enwiki-20220101-cirrussearch-content.json.gz", "bar"
+        "foo/enwiki-20220101-cirrussearch-content.json.bz2", "bar"
     )
 
     def check_bulk_side_effect(operations):

--- a/tests/unit/jobs/wikipedia_indexer/test_filemanager.py
+++ b/tests/unit/jobs/wikipedia_indexer/test_filemanager.py
@@ -4,16 +4,52 @@
 
 """Unit tests for the wikipedia indexer filemanager module."""
 
+import bz2
 from datetime import datetime
+from io import BytesIO
 from unittest.mock import MagicMock, patch
 
 import pytest
-from requests import HTTPError
+from google.api_core.exceptions import GoogleAPIError
+from requests import ConnectionError, HTTPError
 from merino.jobs.wikipedia_indexer.filemanager import (
+    DirectoryParser,
     FileManager,
     WikipediaFilemanagerError,
 )
 from merino.utils.wikipedia import WIKIMEDIA_REQUEST_HEADERS
+
+BASE_URL = "http://mock-url/"
+
+
+def _listing(hrefs: list[str]) -> str:
+    """Render an Apache-style directory listing for the given hrefs."""
+    links = "".join(f'<a href="{href}">{href}</a>' for href in hrefs)
+    return f"<html><body><a href='../'>../</a>{links}</body></html>"
+
+
+def _index_url(date: str, language: str = "fr") -> str:
+    """Build the URL of a language's content index within a dated snapshot."""
+    return f"{BASE_URL}{date}/index_name={language}wiki_content/"
+
+
+def _shards(date: str, count: int, language: str = "fr") -> list[str]:
+    """Build shard filenames as upstream publishes them."""
+    return [f"{language}wiki_content-{date}-{i:05d}.json.bz2" for i in range(count)]
+
+
+def _serve(pages: dict[str, list[str]]):
+    """Build a requests.get side effect that serves directory listings by URL."""
+
+    def _get(url, *args, **kwargs):
+        if url not in pages:
+            raise AssertionError(f"unexpected listing request: {url}")
+        resp = MagicMock()
+        resp.text = _listing(pages[url])
+        resp.raise_for_status.return_value = None
+        return resp
+
+    return _get
 
 
 def test_get_latest_gcs_returns_latest_blob():
@@ -22,10 +58,10 @@ def test_get_latest_gcs_returns_latest_blob():
     mock_bucket = MagicMock()
 
     mock_blob_old = MagicMock()
-    mock_blob_old.name = "frwiki-20240101-cirrussearch-content.json.gz"
+    mock_blob_old.name = "frwiki-20240101-cirrussearch-content.json.bz2"
 
     mock_blob_new = MagicMock()
-    mock_blob_new.name = "frwiki-20240401-cirrussearch-content.json.gz"
+    mock_blob_new.name = "frwiki-20240401-cirrussearch-content.json.bz2"
 
     mock_bucket.list_blobs.return_value = [mock_blob_old, mock_blob_new]
     mock_client.bucket.return_value = mock_bucket
@@ -43,10 +79,10 @@ def test_get_latest_gcs_filters_by_language():
     mock_bucket = MagicMock()
 
     fr_blob = MagicMock()
-    fr_blob.name = "frwiki-20240301-cirrussearch-content.json.gz"
+    fr_blob.name = "frwiki-20240301-cirrussearch-content.json.bz2"
 
     en_blob = MagicMock()
-    en_blob.name = "enwiki-20240301-cirrussearch-content.json.gz"
+    en_blob.name = "enwiki-20240301-cirrussearch-content.json.bz2"
 
     random_blob = MagicMock()
     random_blob.name = "unrelated-file.txt"
@@ -62,13 +98,31 @@ def test_get_latest_gcs_filters_by_language():
     assert result == fr_blob
 
 
+def test_get_latest_gcs_ignores_deprecated_gzip_dumps():
+    """Ignores dumps left over from the deprecated gzip export layout."""
+    mock_client = MagicMock()
+    mock_bucket = MagicMock()
+
+    legacy_blob = MagicMock()
+    legacy_blob.name = "frwiki-20251229-cirrussearch-content.json.gz"
+
+    mock_bucket.list_blobs.return_value = [legacy_blob]
+    mock_client.bucket.return_value = mock_bucket
+
+    with patch("merino.jobs.wikipedia_indexer.filemanager.Client", return_value=mock_client):
+        fm = FileManager("gcs-bucket", "gcs-project", "", language="fr")
+
+        with pytest.raises(RuntimeError, match="No matching dump files found"):
+            fm.get_latest_gcs()
+
+
 def test_get_latest_gcs_raises_runtime_error_if_no_matches():
     """Raises RuntimeError when no blobs match the language-specific pattern."""
     mock_client = MagicMock()
     mock_bucket = MagicMock()
 
     en_blob = MagicMock()
-    en_blob.name = "enwiki-20240301-cirrussearch-content.json.gz"
+    en_blob.name = "enwiki-20240301-cirrussearch-content.json.bz2"
 
     unrelated_blob = MagicMock()
     unrelated_blob.name = "somefile.txt"
@@ -83,53 +137,288 @@ def test_get_latest_gcs_raises_runtime_error_if_no_matches():
             fm.get_latest_gcs()
 
 
-@patch("requests.get")
-def test_get_latest_dump_returns_url_if_newer(mock_get):
-    """Returns a full download URL if the dump is newer than the one in GCS."""
-    mock_client = MagicMock()
-    # HTML content with a single matching link
-    html = '<a href="frwiki-20240401-cirrussearch-content.json.gz">download</a>'
-    mock_get.return_value.content = html
+def test_directory_parser_decodes_percent_encoded_hrefs():
+    """Decodes percent-encoded hrefs, as used for the 'index_name=' subdirectories."""
+    parser = DirectoryParser()
+    parser.feed('<a href="index_name%3Dfrwiki_content/" class="dir">frwiki_content</a>')
+
+    assert parser.file_paths == ["index_name=frwiki_content/"]
+
+
+def test_directory_parser_ignores_valueless_attributes():
+    """Ignores anchors whose href attribute carries no value."""
+    parser = DirectoryParser()
+    parser.feed('<a href>empty</a><a href="20240401/">20240401/</a>')
+
+    assert parser.file_paths == ["20240401/"]
+
+
+def test_directory_parser_collects_every_href():
+    """Collects all anchor hrefs, including navigation, and ignores other tags."""
+    parser = DirectoryParser()
+    parser.feed(
+        "<html><body><a href='../'>../</a><img src='icon.png'/>"
+        "<a href='20240401/'>20240401/</a><a href='_SUCCESS'>_SUCCESS</a></body></html>"
+    )
+
+    assert parser.file_paths == ["../", "20240401/", "_SUCCESS"]
+
+
+@patch("merino.jobs.wikipedia_indexer.filemanager.requests.get")
+def test_get_latest_dump_shards_returns_ordered_shards(mock_get):
+    """Returns every shard of the newest complete snapshot, in shard order."""
+    mock_get.side_effect = _serve(
+        {
+            BASE_URL: ["20240301/", "20240401/"],
+            _index_url("20240401"): [*_shards("20240401", 3), "_SUCCESS"],
+        }
+    )
 
     mock_blob = MagicMock()
-    mock_blob.name = "frwiki-20240301-cirrussearch-content.json.gz"  # older GCS file
+    mock_blob.name = "frwiki-20240301-cirrussearch-content.json.bz2"  # older GCS file
 
-    with patch("merino.jobs.wikipedia_indexer.filemanager.Client", return_value=mock_client):
-        fm = FileManager("gcs-bucket", "gcs-project", "http://mock-url/", "fr")
-        result = fm.get_latest_dump(mock_blob)
-
-    assert result == "http://mock-url/frwiki-20240401-cirrussearch-content.json.gz"
-
-
-@patch("requests.get")
-def test_get_latest_dump_returns_none_if_not_newer(mock_get):
-    """Returns None when the latest dump in GCS is up to date or newer."""
     mock_client = MagicMock()
-    # File in HTML is same date or older
-    html = '<a href="frwiki-20240301-cirrussearch-content.json.gz">download</a>'
-    mock_get.return_value.content = html
+    with patch("merino.jobs.wikipedia_indexer.filemanager.Client", return_value=mock_client):
+        fm = FileManager("gcs-bucket", "gcs-project", BASE_URL, "fr")
+        result = fm.get_latest_dump_shards(mock_blob)
+
+    index_url = _index_url("20240401")
+    assert result == [
+        f"{index_url}frwiki_content-20240401-00000.json.bz2",
+        f"{index_url}frwiki_content-20240401-00001.json.bz2",
+        f"{index_url}frwiki_content-20240401-00002.json.bz2",
+    ]
+
+
+@patch("merino.jobs.wikipedia_indexer.filemanager.requests.get")
+def test_get_latest_dump_shards_orders_numerically_not_lexically(mock_get):
+    """Orders shards by shard number so a padding width change cannot reorder them."""
+    mock_get.side_effect = _serve(
+        {
+            BASE_URL: ["20240401/"],
+            _index_url("20240401"): [
+                "frwiki_content-20240401-10.json.bz2",
+                "frwiki_content-20240401-9.json.bz2",
+                "frwiki_content-20240401-00002.json.bz2",
+                "_SUCCESS",
+            ],
+        }
+    )
+
+    mock_client = MagicMock()
+    with patch("merino.jobs.wikipedia_indexer.filemanager.Client", return_value=mock_client):
+        fm = FileManager("gcs-bucket", "gcs-project", BASE_URL, "fr")
+        result = fm.get_latest_dump_shards(None)
+
+    assert [url.rsplit("-", 1)[-1] for url in result] == [
+        "00002.json.bz2",
+        "9.json.bz2",
+        "10.json.bz2",
+    ]
+
+
+@patch("merino.jobs.wikipedia_indexer.filemanager.requests.get")
+def test_get_latest_dump_shards_when_gcs_is_none(mock_get):
+    """Returns the newest snapshot's shards on first run when no GCS file exists."""
+    mock_get.side_effect = _serve(
+        {
+            BASE_URL: ["20250512/"],
+            _index_url("20250512", "de"): [*_shards("20250512", 1, "de"), "_SUCCESS"],
+        }
+    )
+
+    mock_client = MagicMock()
+    with patch("merino.jobs.wikipedia_indexer.filemanager.Client", return_value=mock_client):
+        fm = FileManager("gcs-bucket", "gcs-project", BASE_URL, "de")
+        result = fm.get_latest_dump_shards(latest_gcs=None)
+
+    assert result == [f"{_index_url('20250512', 'de')}dewiki_content-20250512-00000.json.bz2"]
+
+
+@patch("merino.jobs.wikipedia_indexer.filemanager.requests.get")
+def test_get_latest_dump_shards_returns_empty_if_not_newer(mock_get):
+    """Returns no shards when the latest snapshot is not newer than the GCS dump."""
+    mock_get.side_effect = _serve({BASE_URL: ["20240301/"]})
 
     mock_blob = MagicMock()
-    mock_blob.name = "frwiki-20240301-cirrussearch-content.json.gz"  # same date
+    mock_blob.name = "frwiki-20240301-cirrussearch-content.json.bz2"  # same date
 
+    mock_client = MagicMock()
     with patch("merino.jobs.wikipedia_indexer.filemanager.Client", return_value=mock_client):
-        fm = FileManager("gcs-bucket", "gcs-project", "http://mock-url/", "fr")
-        result = fm.get_latest_dump(mock_blob)
+        fm = FileManager("gcs-bucket", "gcs-project", BASE_URL, "fr")
+        result = fm.get_latest_dump_shards(mock_blob)
 
-    assert result is None
+    assert result == []
 
 
-@patch("requests.get")
-def test_stream_dump_to_gcs_success(mock_get):
-    """Streams and writes a remote dump to GCS successfully."""
+@patch("merino.jobs.wikipedia_indexer.filemanager.requests.get")
+def test_get_latest_dump_shards_skips_snapshot_without_success_marker(mock_get):
+    """Falls back to the previous snapshot when the newest is not fully published."""
+    mock_get.side_effect = _serve(
+        {
+            BASE_URL: ["20240301/", "20240401/"],
+            # Newest snapshot is still being written: shards present, no marker.
+            _index_url("20240401"): _shards("20240401", 2),
+            _index_url("20240301"): [*_shards("20240301", 1), "_SUCCESS"],
+        }
+    )
+
+    mock_client = MagicMock()
+    with patch("merino.jobs.wikipedia_indexer.filemanager.Client", return_value=mock_client):
+        fm = FileManager("gcs-bucket", "gcs-project", BASE_URL, "fr")
+        result = fm.get_latest_dump_shards(None)
+
+    assert result == [f"{_index_url('20240301')}frwiki_content-20240301-00000.json.bz2"]
+
+
+@patch("merino.jobs.wikipedia_indexer.filemanager.requests.get")
+def test_get_latest_dump_shards_returns_empty_when_no_snapshot_is_complete(mock_get):
+    """Returns no shards when every available snapshot is still incomplete."""
+    mock_get.side_effect = _serve(
+        {
+            BASE_URL: ["20240301/", "20240401/"],
+            _index_url("20240401"): _shards("20240401", 2),  # no marker
+            _index_url("20240301"): [],  # export missing entirely
+        }
+    )
+
+    mock_client = MagicMock()
+    with patch("merino.jobs.wikipedia_indexer.filemanager.Client", return_value=mock_client):
+        fm = FileManager("gcs-bucket", "gcs-project", BASE_URL, "fr")
+        result = fm.get_latest_dump_shards(None)
+
+    assert result == []
+
+
+@patch("merino.jobs.wikipedia_indexer.filemanager.requests.get")
+def test_get_latest_dump_shards_does_not_walk_past_gcs_date(mock_get):
+    """Stops at the GCS dump's date rather than re-copying an older snapshot."""
+    # _serve raises if the 20240301 listing is requested, which it must not be.
+    mock_get.side_effect = _serve(
+        {
+            BASE_URL: ["20240301/", "20240401/"],
+            _index_url("20240401"): _shards("20240401", 2),  # incomplete, no marker
+        }
+    )
+
+    mock_blob = MagicMock()
+    mock_blob.name = "frwiki-20240301-cirrussearch-content.json.bz2"
+
+    mock_client = MagicMock()
+    with patch("merino.jobs.wikipedia_indexer.filemanager.Client", return_value=mock_client):
+        fm = FileManager("gcs-bucket", "gcs-project", BASE_URL, "fr")
+        result = fm.get_latest_dump_shards(mock_blob)
+
+    assert result == []
+
+
+@patch("merino.jobs.wikipedia_indexer.filemanager.requests.get")
+def test_get_latest_dump_shards_skips_snapshot_that_fails_to_list(mock_get):
+    """Skips to an older snapshot when listing the newest one errors."""
+    serve = _serve(
+        {
+            BASE_URL: ["20240301/", "20240401/"],
+            _index_url("20240301"): [*_shards("20240301", 1), "_SUCCESS"],
+        }
+    )
+
+    def _get(url, *args, **kwargs):
+        if url == _index_url("20240401"):
+            raise ConnectionError("Simulated listing failure")
+        return serve(url)
+
+    mock_get.side_effect = _get
+
+    mock_client = MagicMock()
+    with patch("merino.jobs.wikipedia_indexer.filemanager.Client", return_value=mock_client):
+        fm = FileManager("gcs-bucket", "gcs-project", BASE_URL, "fr")
+        result = fm.get_latest_dump_shards(None)
+
+    assert result == [f"{_index_url('20240301')}frwiki_content-20240301-00000.json.bz2"]
+
+
+@patch("merino.jobs.wikipedia_indexer.filemanager.requests.get")
+def test_get_latest_dump_shards_ignores_non_snapshot_entries(mock_get):
+    """Ignores directory entries that are not dated snapshots."""
+    mock_get.side_effect = _serve(
+        {
+            # "99999999/" has the right shape but is not a real date.
+            BASE_URL: ["DEPRECATED.txt", "current/", "99999999/", "20240401/"],
+            _index_url("20240401"): [*_shards("20240401", 1), "_SUCCESS"],
+        }
+    )
+
+    mock_client = MagicMock()
+    with patch("merino.jobs.wikipedia_indexer.filemanager.Client", return_value=mock_client):
+        fm = FileManager("gcs-bucket", "gcs-project", BASE_URL, "fr")
+        result = fm.get_latest_dump_shards(None)
+
+    assert result == [f"{_index_url('20240401')}frwiki_content-20240401-00000.json.bz2"]
+
+
+@patch("merino.jobs.wikipedia_indexer.filemanager.requests.head")
+@patch("merino.jobs.wikipedia_indexer.filemanager.requests.get")
+def test_stream_dump_to_gcs_concatenates_shards(mock_get, mock_head):
+    """Copies each shard's raw bytes into a single blob named for the snapshot date."""
     mock_chunk = b"x" * 1024
 
-    mock_response = MagicMock()
-    mock_response.__enter__.return_value = mock_response
-    mock_response.iter_content.return_value = [mock_chunk, mock_chunk]
-    mock_response.headers = {"Content-Length": str(len(mock_chunk) * 2)}
-    mock_response.raise_for_status.return_value = None
-    mock_get.return_value = mock_response
+    def _shard_response(url, *args, **kwargs):
+        resp = MagicMock()
+        resp.__enter__.return_value = resp
+        resp.iter_content.return_value = [mock_chunk]
+        resp.raise_for_status.return_value = None
+        return resp
+
+    mock_get.side_effect = _shard_response
+
+    head_resp = MagicMock()
+    head_resp.headers = {"Content-Length": str(len(mock_chunk))}
+    head_resp.raise_for_status.return_value = None
+    mock_head.return_value = head_resp
+
+    mock_writer = MagicMock()
+    mock_writer.write.side_effect = lambda chunk: len(chunk)
+
+    mock_blob = MagicMock()
+    mock_blob.open.return_value.__enter__.return_value = mock_writer
+
+    mock_bucket = MagicMock()
+    mock_bucket.blob.return_value = mock_blob
+
+    mock_client = MagicMock()
+    mock_client.bucket.return_value = mock_bucket
+
+    index_url = _index_url("20240501")
+    shard_urls = [f"{index_url}{name}" for name in _shards("20240501", 2)]
+
+    with patch("merino.jobs.wikipedia_indexer.filemanager.Client", return_value=mock_client):
+        fm = FileManager("gcs-bucket/exports", "gcs-project", BASE_URL, "fr")
+        fm._stream_dump_to_gcs(shard_urls)
+
+    # One write per shard, into a single blob opened once for the whole concatenation.
+    assert mock_writer.write.call_count == 2
+    mock_blob.open.assert_called_once()
+    assert mock_get.call_count == 2
+    # Wikimedia 403s requests that do not identify themselves.
+    mock_get.assert_any_call(shard_urls[0], stream=True, headers=WIKIMEDIA_REQUEST_HEADERS)
+    # The reassembled dump keeps the historical single-file naming convention.
+    assert (
+        mock_bucket.blob.call_args.args[0]
+        == "exports/frwiki-20240501-cirrussearch-content.json.bz2"
+    )
+
+
+@patch("merino.jobs.wikipedia_indexer.filemanager.requests.head")
+@patch("merino.jobs.wikipedia_indexer.filemanager.requests.get")
+def test_stream_dump_to_gcs_copies_when_size_unknown(mock_get, mock_head):
+    """Still copies the shards when shard sizes cannot be read for progress reporting."""
+    mock_head.side_effect = ConnectionError("Simulated HEAD failure")
+
+    resp = MagicMock()
+    resp.__enter__.return_value = resp
+    resp.iter_content.return_value = [b"y" * 512]
+    resp.raise_for_status.return_value = None
+    mock_get.return_value = resp
 
     mock_writer = MagicMock()
     mock_writer.write.side_effect = lambda chunk: len(chunk)
@@ -144,27 +433,24 @@ def test_stream_dump_to_gcs_success(mock_get):
     mock_client.bucket.return_value = mock_bucket
 
     with patch("merino.jobs.wikipedia_indexer.filemanager.Client", return_value=mock_client):
-        fm = FileManager("gcs-bucket", "gcs-project", "http://mock-url/", "fr")
-        fm._stream_dump_to_gcs("http://mock-url/frwiki-20240501-cirrussearch-content.json.gz")
+        fm = FileManager("gcs-bucket", "gcs-project", BASE_URL, "fr")
+        fm._stream_dump_to_gcs([f"{_index_url('20240501')}frwiki_content-20240501-00000.json.bz2"])
 
-    # Assertions
-    mock_writer.write.assert_called()
-    assert mock_writer.write.call_count == 2
-    mock_blob.open.assert_called_once()
-    mock_get.assert_called_once_with(
-        "http://mock-url/frwiki-20240501-cirrussearch-content.json.gz",
-        stream=True,
-        headers=WIKIMEDIA_REQUEST_HEADERS,
-    )
+    mock_writer.write.assert_called_once()
 
 
-@patch("requests.get")
-def test_stream_dump_to_gcs_handles_stream_failure_and_deletes_blob(mock_get):
+@patch("merino.jobs.wikipedia_indexer.filemanager.requests.head")
+@patch("merino.jobs.wikipedia_indexer.filemanager.requests.get")
+def test_stream_dump_to_gcs_handles_stream_failure_and_deletes_blob(mock_get, mock_head):
     """Handles stream failure by deleting the partial GCS blob and raising an error."""
+    head_resp = MagicMock()
+    head_resp.headers = {"Content-Length": "1024"}
+    head_resp.raise_for_status.return_value = None
+    mock_head.return_value = head_resp
+
     mock_response = MagicMock()
     mock_response.__enter__.return_value = mock_response
     mock_response.raise_for_status.side_effect = HTTPError("Simulated HTTP error")
-
     mock_get.return_value = mock_response
 
     mock_blob = MagicMock()
@@ -177,49 +463,146 @@ def test_stream_dump_to_gcs_handles_stream_failure_and_deletes_blob(mock_get):
     mock_client.bucket.return_value = mock_bucket
 
     with patch("merino.jobs.wikipedia_indexer.filemanager.Client", return_value=mock_client):
-        fm = FileManager("gcs-bucket", "gcs-project", "http://mock-url/", "fr")
+        fm = FileManager("gcs-bucket", "gcs-project", BASE_URL, "fr")
 
         with pytest.raises(WikipediaFilemanagerError, match="Failed to stream dump to GCS"):
-            fm._stream_dump_to_gcs("http://mock-url/frwiki-20240501-cirrussearch-content.json.gz")
+            fm._stream_dump_to_gcs(
+                [f"{_index_url('20240501')}frwiki_content-20240501-00000.json.bz2"]
+            )
 
     mock_blob.exists.assert_called_once()
     mock_blob.delete.assert_called_once()
 
 
+@patch("merino.jobs.wikipedia_indexer.filemanager.requests.head")
+@patch("merino.jobs.wikipedia_indexer.filemanager.requests.get")
+def test_stream_dump_to_gcs_skips_delete_when_no_partial_blob(mock_get, mock_head):
+    """Does not attempt a delete when the failed copy left no blob behind."""
+    mock_head.side_effect = ConnectionError("Simulated HEAD failure")
+
+    mock_response = MagicMock()
+    mock_response.__enter__.return_value = mock_response
+    mock_response.raise_for_status.side_effect = HTTPError("Simulated HTTP error")
+    mock_get.return_value = mock_response
+
+    mock_blob = MagicMock()
+    mock_blob.exists.return_value = False
+
+    mock_bucket = MagicMock()
+    mock_bucket.blob.return_value = mock_blob
+
+    mock_client = MagicMock()
+    mock_client.bucket.return_value = mock_bucket
+
+    with patch("merino.jobs.wikipedia_indexer.filemanager.Client", return_value=mock_client):
+        fm = FileManager("gcs-bucket", "gcs-project", BASE_URL, "fr")
+
+        with pytest.raises(WikipediaFilemanagerError, match="Failed to stream dump to GCS"):
+            fm._stream_dump_to_gcs(
+                [f"{_index_url('20240501')}frwiki_content-20240501-00000.json.bz2"]
+            )
+
+    mock_blob.delete.assert_not_called()
+
+
+@patch("merino.jobs.wikipedia_indexer.filemanager.requests.head")
+@patch("merino.jobs.wikipedia_indexer.filemanager.requests.get")
+def test_stream_dump_to_gcs_still_raises_when_cleanup_fails(mock_get, mock_head):
+    """Reports the streaming failure even when deleting the partial upload also fails."""
+    mock_head.side_effect = ConnectionError("Simulated HEAD failure")
+
+    mock_response = MagicMock()
+    mock_response.__enter__.return_value = mock_response
+    mock_response.raise_for_status.side_effect = HTTPError("Simulated HTTP error")
+    mock_get.return_value = mock_response
+
+    mock_blob = MagicMock()
+    mock_blob.exists.return_value = True
+    mock_blob.delete.side_effect = GoogleAPIError("Simulated delete failure")
+
+    mock_bucket = MagicMock()
+    mock_bucket.blob.return_value = mock_blob
+
+    mock_client = MagicMock()
+    mock_client.bucket.return_value = mock_bucket
+
+    with patch("merino.jobs.wikipedia_indexer.filemanager.Client", return_value=mock_client):
+        fm = FileManager("gcs-bucket", "gcs-project", BASE_URL, "fr")
+
+        with pytest.raises(WikipediaFilemanagerError, match="Failed to stream dump to GCS"):
+            fm._stream_dump_to_gcs(
+                [f"{_index_url('20240501')}frwiki_content-20240501-00000.json.bz2"]
+            )
+
+    mock_blob.delete.assert_called_once()
+
+
+def test_stream_dump_to_gcs_rejects_unrecognized_shard_name():
+    """Raises rather than guessing when a shard URL does not match the expected form."""
+    mock_client = MagicMock()
+    with patch("merino.jobs.wikipedia_indexer.filemanager.Client", return_value=mock_client):
+        fm = FileManager("gcs-bucket", "gcs-project", BASE_URL, "fr")
+
+        with pytest.raises(WikipediaFilemanagerError, match="Unrecognized shard name"):
+            fm._stream_dump_to_gcs(["http://mock-url/not-a-shard.json.bz2"])
+
+
 @patch.object(FileManager, "_stream_dump_to_gcs")
-@patch.object(FileManager, "get_latest_dump")
+@patch.object(FileManager, "get_latest_dump_shards")
 @patch.object(FileManager, "get_latest_gcs")
 def test_stream_latest_dump_triggers_stream(
-    mock_get_latest_gcs, mock_get_latest_dump, mock_stream
+    mock_get_latest_gcs, mock_get_latest_shards, mock_stream
 ):
     """Triggers dump streaming when a newer remote dump is available."""
     mock_client = MagicMock()
     mock_blob = MagicMock()
     mock_get_latest_gcs.return_value = mock_blob
-    mock_get_latest_dump.return_value = "http://mock-url/frwiki-latest.json.gz"
+    shard_urls = [f"{_index_url('20240501')}frwiki_content-20240501-00000.json.bz2"]
+    mock_get_latest_shards.return_value = shard_urls
 
     with patch("merino.jobs.wikipedia_indexer.filemanager.Client", return_value=mock_client):
-        fm = FileManager("gcs-bucket", "gcs-project", "http://mock-url/", "fr")
+        fm = FileManager("gcs-bucket", "gcs-project", BASE_URL, "fr")
         returned_blob = fm.stream_latest_dump_to_gcs()
 
-    mock_stream.assert_called_once_with("http://mock-url/frwiki-latest.json.gz")
+    mock_stream.assert_called_once_with(shard_urls)
     assert returned_blob == mock_blob
 
 
 @patch.object(FileManager, "_stream_dump_to_gcs")
-@patch.object(FileManager, "get_latest_dump")
+@patch.object(FileManager, "get_latest_dump_shards")
+@patch.object(FileManager, "get_latest_gcs")
+def test_stream_latest_dump_uses_caller_supplied_blob(
+    mock_get_latest_gcs, mock_get_latest_shards, mock_stream
+):
+    """Does not re-list GCS when the caller already knows the latest blob."""
+    mock_client = MagicMock()
+    caller_blob = MagicMock()
+    caller_blob.name = "frwiki-20240301-cirrussearch-content.json.bz2"
+    mock_get_latest_shards.return_value = []
+
+    with patch("merino.jobs.wikipedia_indexer.filemanager.Client", return_value=mock_client):
+        fm = FileManager("gcs-bucket", "gcs-project", BASE_URL, "fr")
+        returned_blob = fm.stream_latest_dump_to_gcs(latest_gcs=caller_blob)
+
+    mock_get_latest_gcs.assert_not_called()
+    mock_get_latest_shards.assert_called_once_with(caller_blob)
+    assert returned_blob == caller_blob
+
+
+@patch.object(FileManager, "_stream_dump_to_gcs")
+@patch.object(FileManager, "get_latest_dump_shards")
 @patch.object(FileManager, "get_latest_gcs")
 def test_stream_latest_dump_skips_if_up_to_date(
-    mock_get_latest_gcs, mock_get_latest_dump, mock_stream
+    mock_get_latest_gcs, mock_get_latest_shards, mock_stream
 ):
     """Skips dump streaming when no newer dump is available."""
     mock_client = MagicMock()
     mock_blob = MagicMock()
     mock_get_latest_gcs.return_value = mock_blob
-    mock_get_latest_dump.return_value = None  # No newer dump
+    mock_get_latest_shards.return_value = []  # No newer dump
 
     with patch("merino.jobs.wikipedia_indexer.filemanager.Client", return_value=mock_client):
-        fm = FileManager("gcs-bucket", "gcs-project", "http://mock-url/", "fr")
+        fm = FileManager("gcs-bucket", "gcs-project", BASE_URL, "fr")
         returned_blob = fm.stream_latest_dump_to_gcs()
 
     mock_stream.assert_not_called()
@@ -227,9 +610,11 @@ def test_stream_latest_dump_skips_if_up_to_date(
 
 
 @patch.object(FileManager, "_stream_dump_to_gcs")
-@patch.object(FileManager, "get_latest_dump")
+@patch.object(FileManager, "get_latest_dump_shards")
 @patch.object(FileManager, "get_latest_gcs")
-def test_stream_latest_dump_when_gcs_empty(mock_get_latest_gcs, mock_get_latest_dump, mock_stream):
+def test_stream_latest_dump_when_gcs_empty(
+    mock_get_latest_gcs, mock_get_latest_shards, mock_stream
+):
     """Triggers streaming when no prior GCS dump exists (first-time run)."""
     mock_client = MagicMock()
 
@@ -241,58 +626,46 @@ def test_stream_latest_dump_when_gcs_empty(mock_get_latest_gcs, mock_get_latest_
         RuntimeError("No matching dump files found"),
         mock_blob,
     ]
-    mock_get_latest_dump.return_value = (
-        "http://mock-url/dewiki-20250512-cirrussearch-content.json.gz"
-    )
+    shard_urls = [f"{_index_url('20250512', 'de')}dewiki_content-20250512-00000.json.bz2"]
+    mock_get_latest_shards.return_value = shard_urls
 
     with patch("merino.jobs.wikipedia_indexer.filemanager.Client", return_value=mock_client):
-        fm = FileManager("gcs-bucket", "gcs-project", "http://mock-url/", "de")
+        fm = FileManager("gcs-bucket", "gcs-project", BASE_URL, "de")
         returned_blob = fm.stream_latest_dump_to_gcs()
 
-    mock_stream.assert_called_once_with(
-        "http://mock-url/dewiki-20250512-cirrussearch-content.json.gz"
-    )
+    mock_stream.assert_called_once_with(shard_urls)
     assert returned_blob.name == "BlobMock"
 
 
-@patch("merino.jobs.wikipedia_indexer.filemanager.requests.get")
-@patch("merino.jobs.wikipedia_indexer.filemanager.Client")
-def test_get_latest_dump_when_gcs_is_none(mock_storage_client, mock_requests_get):
-    """Returns remote dump URL on first run when no GCS file exists."""
-    html = """
-    <html>
-      <body>
-        <a href="dewiki-20250512-cirrussearch-content.json.gz">dewiki-20250512-cirrussearch-content.json.gz</a>
-      </body>
-    </html>
-    """
-    mock_response = MagicMock()
-    mock_response.content = html
-    mock_requests_get.return_value = mock_response
+def test_stream_from_gcs_reads_concatenated_bz2_shards():
+    """Reads a blob of concatenated bzip2 shards as one continuous line stream."""
+    first = bz2.compress(b'{"index": {"_id": 1}}\n{"title": "One"}\n')
+    second = bz2.compress(b'{"index": {"_id": 2}}\n{"title": "Two"}\n')
 
-    mock_client_instance = MagicMock()
-    mock_storage_client.return_value = mock_client_instance
+    mock_blob = MagicMock()
+    mock_blob.name = "frwiki-20240501-cirrussearch-content.json.bz2"
+    mock_blob.open.return_value.__enter__.return_value = BytesIO(first + second)
 
-    # --- FileManager setup
-    fm = FileManager(
-        gcs_bucket="gcs-bucket",
-        gcs_project="gcs-project",
-        export_base_url="http://mock-url/",
-        language="de",
-    )
+    mock_client = MagicMock()
+    with patch("merino.jobs.wikipedia_indexer.filemanager.Client", return_value=mock_client):
+        fm = FileManager("gcs-bucket", "gcs-project", BASE_URL, "fr")
+        lines = list(fm.stream_from_gcs(mock_blob))
 
-    result = fm.get_latest_dump(latest_gcs=None)
-
-    assert result == "http://mock-url/dewiki-20250512-cirrussearch-content.json.gz"
+    assert lines == [
+        b'{"index": {"_id": 1}}\n',
+        b'{"title": "One"}\n',
+        b'{"index": {"_id": 2}}\n',
+        b'{"title": "Two"}\n',
+    ]
 
 
 def test_parse_date_returns_correct_datetime():
     """Parses and returns the correct datetime from a valid filename."""
     mock_client = MagicMock()
     with patch("merino.jobs.wikipedia_indexer.filemanager.Client", return_value=mock_client):
-        fm = FileManager("gcs-bucket", "gcs-project", "http://mock-url/", "fr")
+        fm = FileManager("gcs-bucket", "gcs-project", BASE_URL, "fr")
 
-        filename = "frwiki-20240501-cirrussearch-content.json.gz"
+        filename = "frwiki-20240501-cirrussearch-content.json.bz2"
         result = fm._parse_date(filename)
 
         assert isinstance(result, datetime)
@@ -303,10 +676,22 @@ def test_parse_date_returns_default_on_invalid_filename():
     """Returns the default fallback datetime when the filename is invalid."""
     mock_client = MagicMock()
     with patch("merino.jobs.wikipedia_indexer.filemanager.Client", return_value=mock_client):
-        fm = FileManager("gcs-bucket", "gcs-project", "http://mock-url/", "fr")
+        fm = FileManager("gcs-bucket", "gcs-project", BASE_URL, "fr")
 
         filename = "invalid-file-name.txt"
         result = fm._parse_date(filename)
+
+        assert result == datetime(1, 1, 1)
+
+
+def test_parse_date_returns_default_on_impossible_date():
+    """Returns the default fallback datetime when a well-formed name holds a bad date."""
+    mock_client = MagicMock()
+    with patch("merino.jobs.wikipedia_indexer.filemanager.Client", return_value=mock_client):
+        fm = FileManager("gcs-bucket", "gcs-project", BASE_URL, "fr")
+
+        # January 32nd: matches the pattern but is not a date.
+        result = fm._parse_date("frwiki-20240132-cirrussearch-content.json.bz2")
 
         assert result == datetime(1, 1, 1)
 
@@ -315,72 +700,3 @@ def test_filemanager_rejects_invalid_language():
     """Raises ValueError if FileManager is initialized with an unsupported language."""
     with pytest.raises(ValueError, match="Unsupported language 'es'"):
         FileManager("gcs-bucket", "gcs-project", "http://mock-url", language="es")
-
-
-@patch("merino.jobs.wikipedia_indexer.filemanager.requests.get")
-def test_get_latest_dump_uses_fallback_when_current_has_no_match(mock_get):
-    """Fall back to the dated directory when current/ has no matching link."""
-    # current/ listing: no matching links
-    resp_current = MagicMock()
-    resp_current.content = "<html><body>No matches here</body></html>"
-
-    # fallback listing: one matching link
-    resp_fallback = MagicMock()
-    resp_fallback.content = """
-    <html><body>
-      <a href="frwiki-20251229-cirrussearch-content.json.gz">frwiki-20251229-cirrussearch-content.json.gz</a>
-    </body></html>
-    """
-
-    # First call -> current/, second call -> fallback
-    mock_get.side_effect = [resp_current, resp_fallback]
-
-    mock_client = MagicMock()
-    with patch("merino.jobs.wikipedia_indexer.filemanager.Client", return_value=mock_client):
-        fm = FileManager(
-            gcs_bucket="gcs-bucket",
-            gcs_project="gcs-project",
-            export_base_url="http://mock-url/",
-            language="fr",
-        )
-        # No GCS blob yet (first run)
-        result = fm.get_latest_dump(latest_gcs=None)
-
-    assert (
-        result
-        == "https://dumps.wikimedia.org/other/cirrussearch/20251229/frwiki-20251229-cirrussearch-content.json.gz"
-    )
-
-
-@patch("merino.jobs.wikipedia_indexer.filemanager.requests.get")
-def test_get_latest_dump_fallback_skips_if_not_newer_than_gcs(mock_get):
-    """Return None when fallback file exists but is not newer than the GCS blob."""
-    # current/ listing: no matching links
-    resp_current = MagicMock()
-    resp_current.content = "<html><body>No matches here</body></html>"
-
-    # fallback listing: one matching link, but it's older/equal to GCS date
-    resp_fallback = MagicMock()
-    resp_fallback.content = """
-    <html><body>
-      <a href="frwiki-20240101-cirrussearch-content.json.gz">frwiki-20240101-cirrussearch-content.json.gz</a>
-    </body></html>
-    """
-
-    mock_get.side_effect = [resp_current, resp_fallback]
-
-    # GCS already has a newer file (or same date)
-    mock_blob = MagicMock()
-    mock_blob.name = "frwiki-20240201-cirrussearch-content.json.gz"
-
-    mock_client = MagicMock()
-    with patch("merino.jobs.wikipedia_indexer.filemanager.Client", return_value=mock_client):
-        fm = FileManager(
-            gcs_bucket="gcs-bucket",
-            gcs_project="gcs-project",
-            export_base_url="http://mock-url/",
-            language="fr",
-        )
-        result = fm.get_latest_dump(latest_gcs=mock_blob)
-
-    assert result is None


### PR DESCRIPTION
## References

JIRA: [DISCO-4408](https://mozilla-hub.atlassian.net/browse/DISCO-4408)

## Description
- Upstream notice: https://dumps.wikimedia.org/other/cirrussearch/DEPRECATED.txt
- New location: https://dumps.wikimedia.org/other/cirrus_search_index/

Wikimedia relocated and reshaped the CirrusSearch index dumps, so the
`wikipedia-indexer copy-export` job can no longer find them.

This PR updates the data source to use the new location with the following approach:
- `copy-export` traverses the dated snapshots newest-first and takes the first one
that is both newer than what's on GCS and complete (`_SUCCESS` present)
- The shards are concatenated into one GCS object byte-for-byte. bzip2 allows
compressed streams to be joined and still read as a single file, so no
decompress/recompress happens during the copy



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2530)


[DISCO-4408]: https://mozilla-hub.atlassian.net/browse/DISCO-4408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ