### PR TITLE
[DISCO-4416] suggest: limit number of regions to try for weather

### DIFF
--- a/merino/providers/suggest/weather/backends/accuweather/pathfinder.py
+++ b/merino/providers/suggest/weather/backends/accuweather/pathfinder.py
@@ -11,6 +11,9 @@ from merino.providers.suggest.weather.backends.protocol import WeatherContext
 MaybeStr = Optional[str]
 
 LOCALITY_SUFFIX_PATTERN: re.Pattern = re.compile(r"\s+(city|municipality|town)$", re.IGNORECASE)
+
+# Cap on how many regions the fallback path tries
+MAX_FALLBACK_REGIONS: int = 5
 SUCCESSFUL_REGIONS_MAPPING: dict[tuple[str, str], str | None] = {
     ("AR", "El Sombrero"): None,
     ("BR", "Barcellos"): None,
@@ -578,9 +581,11 @@ CITY_NAME_NORMALIZERS: list[Callable[[str], str]] = [
 
 
 def compass(location: Location) -> Generator[MaybeStr, None, None]:
-    """Generate all the regions based on a `Location`.
+    """Generate candidate regions based on a `Location`.
 
     It will generate ones that are more likely to produce a valid result based on heuristics.
+    For countries without a known region heuristic, at most `MAX_FALLBACK_REGIONS` regions are
+    tried (most specific first), followed by `None`.
 
     Params:
       - location {Location}: a location object.
@@ -606,8 +611,8 @@ def compass(location: Location) -> Generator[MaybeStr, None, None]:
                 yield regions[0]
             case (country_code, _) if country_code in KNOWN_REGION_COUNTRIES:
                 yield regions[-1]  # use the least specific region
-            case _:  # Fall back to try all regions
-                regions_to_try = [*regions, None]
+            case _:  # Fall back to MAX_FALLBACK num of regions, then no region at all
+                regions_to_try = [*regions[:MAX_FALLBACK_REGIONS], None]
                 for region in regions_to_try:
                     yield region
     else:

--- a/tests/unit/providers/suggest/weather/backends/test_pathfinder.py
+++ b/tests/unit/providers/suggest/weather/backends/test_pathfinder.py
@@ -117,7 +117,7 @@ def test_compass(location: Location, expected_region_and_city: str) -> None:
                 ),
                 languages=["en-US"],
             ),
-            5,
+            6,
         ),
     ],
 )

--- a/tests/unit/providers/suggest/weather/backends/test_pathfinder.py
+++ b/tests/unit/providers/suggest/weather/backends/test_pathfinder.py
@@ -101,6 +101,24 @@ def test_compass(location: Location, expected_region_and_city: str) -> None:
             ),
             3,
         ),
+        (
+            WeatherContext(
+                Location(
+                    country="GB",
+                    regions=[
+                        "ENG",
+                        "WNH",
+                        "ABC",
+                        "DEF",
+                        "GHI",
+                        "JKL",
+                    ],
+                    city="Northampton",
+                ),
+                languages=["en-US"],
+            ),
+            5,
+        ),
     ],
 )
 @pytest.mark.asyncio


### PR DESCRIPTION
## References

JIRA: [DISCO-4416](https://mozilla-hub.atlassian.net/browse/DISCO-4416)

## Description
Limit the number of regions to try, so that we can avoid bad actors abusing the region param to make multiple requests to for weather locations.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2531)


[DISCO-4416]: https://mozilla-hub.atlassian.net/browse/DISCO-4416?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ