### PR TITLE
HNT-2939: add circuit breaker to corpus recommendations fetches

### DIFF
--- a/merino/configs/default.toml
+++ b/merino/configs/default.toml
@@ -1502,6 +1502,18 @@ cache_ttl_min = 110
 # The values here will give an average of 140s cache TTL.
 cache_ttl_max = 170
 
+# MERINO__CURATED_RECOMMENDATIONS_CORPUS_API__CIRCUIT_BREAKER_FAILURE_THRESHOLD
+# The circuit breaker will open when the failure is over this threshold.
+# Note that Corpus calls are behind a tenacity retry decorator, which only
+# returns one failure per retry set - we want the circuit breaker to open if
+# only one retry cycle fails - if all retries fail, we can assume the service
+# is down and shouldn't be hit until the circuit breaker times out.
+circuit_breaker_failure_threshold = 1
+
+# MERINO__CURATED_RECOMMENDATIONS_CORPUS_API__CIRCUIT_BREAKER_RECOVER_TIMEOUT_SEC
+# The circuit breaker will stay open for this period of time until the next recovery attempt.
+circuit_breaker_recover_timeout_sec = 30
+
 
 [default.jobs.wikipedia_indexer]
 # MERINO_JOBS__WIKIPEDIA_INDEXER__ES_URL

--- a/merino/curated_recommendations/corpus_backends/caching.py
+++ b/merino/curated_recommendations/corpus_backends/caching.py
@@ -165,11 +165,6 @@ async def _get_or_update_cache(
         cache_obj[key] = entry
 
         async with entry.lock:
-            if datetime.now() < entry.expiration and entry.value is not None:
-                # The entry is specifically given a value of None above - so
-                # will this return ever happen? Can we drop this if block?
-                return entry.value
-
             return await _fetch_and_store(func, entry, args, kwargs, wait_expiration)
 
 

--- a/merino/curated_recommendations/corpus_backends/caching.py
+++ b/merino/curated_recommendations/corpus_backends/caching.py
@@ -125,6 +125,12 @@ async def _get_or_update_cache(
     if key in cache_obj:
         entry = cache_obj[key]
         if datetime.now() > entry.expiration and not entry.lock.locked():
+            # If the cache has expired, kick off an async task to update it and
+            # try to return the stale value while the update is in progress.
+            # This is the "stale while revalidate" part.
+            #
+            # If the current cache entry has a value of None (e.g. on a cold
+            # start error), BackendError is raised.
             task = asyncio.create_task(
                 _update_cache(func, key, args, kwargs, wait_expiration, cache_obj)
             )
@@ -142,15 +148,28 @@ async def _get_or_update_cache(
                     # This line is reached if the background task successfully updated the cache.
                     return entry.value  # type: ignore[unreachable]
                 else:
-                    # This line is reached if the update failed, and there was no stale value.
+                    # This line is reached if the update failed OR if the update
+                    # is still in progress, and there was no stale value.
+                    #
+                    # In the case of a cold start with an initial failure (as
+                    # seen during merino deploys, which double pod count), the
+                    # cache key will exist with a value of None (see the `else`
+                    # block below). Subsequent calls to _update_cache (line 132
+                    # above) spawn a background task which is specifically
+                    # *not* awaited. While this background task executes, an
+                    # error will continue to be raised here.
                     raise BackendError(f"Failed to obtain value for {key}")
     else:
         # This is the first request for this cache key, so an entry must be created.
         entry = CacheEntry(value=None, expiration=datetime.min, lock=asyncio.Lock())
         cache_obj[key] = entry
+
         async with entry.lock:
             if datetime.now() < entry.expiration and entry.value is not None:
+                # The entry is specifically given a value of None above - so
+                # will this return ever happen? Can we drop this if block?
                 return entry.value
+
             return await _fetch_and_store(func, entry, args, kwargs, wait_expiration)
 
 
@@ -173,16 +192,29 @@ async def _update_cache(
         cache_obj: The cache storage.
     """
     entry = cache_obj[key]
+
     async with entry.lock:
+        # If the cache entry hasn't expired and has a value, return it - no
+        # need to make an API call.
         if datetime.now() < entry.expiration and entry.value is not None:
             return
+
         try:
+            # Calls the decorated fetch function and stores the results in the
+            # cache entry.
             await _fetch_and_store(func, entry, args, kwargs, wait_expiration)
         except Exception as e:
+            # If calling the decorated fetch function raises...
+
+            # If we have an existing (albeit expired) value in the cache,
+            # extend its expiration time (stale data is better than no data),
+            # and log the error.
             if entry.value is not None:
                 entry.expiration = wait_expiration()
                 logger.error(f"Error updating cache for key {key}: {e}. Returning stale data.")
             else:
+                # If the stale cache entry is empty, we have nothing to return,
+                # so we need to raise.
                 raise
 
 

--- a/merino/curated_recommendations/corpus_backends/circuitbreaker.py
+++ b/merino/curated_recommendations/corpus_backends/circuitbreaker.py
@@ -13,7 +13,7 @@ from merino.exceptions import BackendError
 from httpx import HTTPError
 
 
-async def curated_recommendations_circuitbreaker(*args, **kwargs) -> None:  # pragma: no cover
+async def curated_recommendations_circuitbreaker(*args, **kwargs) -> None:
     """Raise a generic BackendError while the circuit breaker is open."""
     raise BackendError("Corpus backend circuitbreaker")
 

--- a/merino/curated_recommendations/corpus_backends/circuitbreaker.py
+++ b/merino/curated_recommendations/corpus_backends/circuitbreaker.py
@@ -1,0 +1,54 @@
+"""This module defines all the circuit breakers for Curated Recommendations.
+
+This module is separate from the merino/governance/circuitbreakers.py file due
+to the application startup chain and curated recommendations being outside of
+the "providers" pattern.
+"""
+
+from circuitbreaker import CircuitBreaker
+
+from merino.configs import settings
+from merino.curated_recommendations.corpus_backends.utils import CorpusGraphQLError
+from merino.exceptions import BackendError
+from httpx import HTTPError
+
+
+async def curated_recommendations_circuitbreaker(*args, **kwargs) -> None:  # pragma: no cover
+    """Raise a generic BackendError while the circuit breaker is open."""
+    raise BackendError("Corpus backend circuitbreaker")
+
+
+class CuratedRecommendationsCircuitBreaker(CircuitBreaker):
+    """Circuit breaker for the Curated Recommendations backends.
+
+    this circuit breaker is intended to avoid a thundering herd problem
+    when merino deploys - which doubles the pod count, all of which exist
+    in a cold-start/empty cache state.
+
+    this decorator sits between two other decorators on the `fetch` functions
+    of any corpus backend (sections and scheduled surfaces, currently). the
+    decorator chain (first applied to last applied is):
+
+    1. @retry - decorates with retry logic, only final result of final
+      attempt of the wrapped fetch function is returned.
+
+    2. { this decorator } - will return the FALLBACK_FUNCTION value for the
+      given timeout if the final result of @retry above fails with an
+      HTTPError or a CorpusGraphQLError. FALLBACK_FUNCTION must raise in
+      order to tell the @stale_while_revalidate decorator below to return
+      stale cache values (if present).
+
+    3. @stale_while_revalidate - adds a check for in-memory, (ideally)
+      non-expired cache value prior to calling the wrapped fetch function.
+    """
+
+    FAILURE_THRESHOLD = (
+        settings.curated_recommendations.corpus_api.circuit_breaker_failure_threshold
+    )
+    RECOVERY_TIMEOUT = (
+        settings.curated_recommendations.corpus_api.circuit_breaker_recover_timeout_sec
+    )
+
+    # Decorated fetch call should be circruit broken for the below API-related errors:
+    EXPECTED_EXCEPTION = (HTTPError, CorpusGraphQLError)
+    FALLBACK_FUNCTION = curated_recommendations_circuitbreaker

--- a/merino/curated_recommendations/corpus_backends/scheduled_surface_backend.py
+++ b/merino/curated_recommendations/corpus_backends/scheduled_surface_backend.py
@@ -47,9 +47,11 @@ class ScheduledSurfaceBackend(ScheduledSurfaceProtocol):
     metrics_client: aiodogstatsd.Client
     manifest_provider: ManifestProvider
 
-    # Time-to-live was chosen because 2 minutes (+/- 10 s) is short enough that updates by curators
-    # such as breaking news or editorial corrections propagate fast enough, and that the request
-    # rate to the scheduledSurface query stays close to the historic rate of ~100 requests/minute.
+    # Time-to-live was chosen because 2 minutes and 20 seconds (+/- 30 s) is
+    # short enough that updates by curators such as breaking news or editorial
+    # corrections propagate fast enough, and that the request rate to the
+    # scheduledSurface query stays close to the historic rate of ~100
+    # requests/minute.
     cache_time_to_live_min = timedelta(
         seconds=settings.curated_recommendations.corpus_api.cache_ttl_min
     )

--- a/merino/curated_recommendations/corpus_backends/sections_backend.py
+++ b/merino/curated_recommendations/corpus_backends/sections_backend.py
@@ -33,6 +33,10 @@ from merino.curated_recommendations.corpus_backends.utils import (
 from merino.curated_recommendations.ml_backends.protocol import SpindleBackendProtocol
 from merino.providers.manifest import Provider as ManifestProvider
 
+from merino.curated_recommendations.corpus_backends.circuitbreaker import (
+    CuratedRecommendationsCircuitBreaker,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -57,13 +61,19 @@ def parse_section_external_id(raw_external_id: str) -> tuple[str, int]:
 class SectionsBackend(SectionsProtocol):
     """Backend for fetching corpus sections using the getSections query."""
 
-    http_client: AsyncClient
-    graph_config: CorpusApiGraphConfig
-    metrics_client: aiodogstatsd.Client
-    manifest_provider: ManifestProvider
-
-    _cache: dict
     _background_tasks: set[asyncio.Task]
+    _cache: dict
+    cache_time_to_live_max = timedelta(
+        seconds=settings.curated_recommendations.corpus_api.cache_ttl_max
+    )
+    cache_time_to_live_min = timedelta(
+        seconds=settings.curated_recommendations.corpus_api.cache_ttl_min
+    )
+    graph_config: CorpusApiGraphConfig
+    http_client: AsyncClient
+    manifest_provider: ManifestProvider
+    metrics_client: aiodogstatsd.Client
+    retry_count = settings.curated_recommendations.corpus_api.retry_count
 
     def __init__(
         self,
@@ -83,20 +93,18 @@ class SectionsBackend(SectionsProtocol):
         self._background_tasks = set()
 
     @stale_while_revalidate(
-        wait_expiration=WaitRandomExpiration(
-            timedelta(seconds=settings.curated_recommendations.corpus_api.cache_ttl_min),
-            timedelta(seconds=settings.curated_recommendations.corpus_api.cache_ttl_max),
-        ),
+        wait_expiration=WaitRandomExpiration(cache_time_to_live_min, cache_time_to_live_max),
         cache=lambda self: self._cache,
         jobs=lambda self: self._background_tasks,
     )
+    @CuratedRecommendationsCircuitBreaker(name="curated_recommendations_sections_circuit_breaker")
     @retry(
         wait=wait_exponential_jitter(
             initial=settings.curated_recommendations.corpus_api.retry_wait_initial_seconds,
             jitter=settings.curated_recommendations.corpus_api.retry_wait_jitter_seconds,
         ),
-        stop=stop_after_attempt(settings.curated_recommendations.corpus_api.retry_count),
-        retry=retry_if_exception_type((CorpusGraphQLError, HTTPError, ValueError)),
+        stop=stop_after_attempt(retry_count),
+        retry=retry_if_exception_type((CorpusGraphQLError, HTTPError)),
         reraise=True,
         before_sleep=before_sleep_log(logger, logging.WARNING),
     )
@@ -138,6 +146,7 @@ class SectionsBackend(SectionsProtocol):
             }
         """
         variables = {"filters": {"scheduledSurfaceGuid": surface_id}}
+
         with self.metrics_client.timeit("corpus_api.get_sections.timing"):
             res = await self.http_client.post(
                 self.graph_config.endpoint,
@@ -147,14 +156,19 @@ class SectionsBackend(SectionsProtocol):
 
         # Error handling for HTTP and GraphQL errors
         self.metrics_client.increment(f"corpus_api.get_sections.status_codes.{res.status_code}")
+
         res.raise_for_status()
+
         data = res.json()
+
         if "errors" in data:
             self.metrics_client.increment("corpus_api.get_sections.graphql_error")
             raise CorpusGraphQLError(f"Sections API returned GraphQL errors {data['errors']}")
 
         utm_source = get_utm_source(surface_id)
+
         parsed_sections = []
+
         for section in data["data"]["getSections"]:
             if not section.get("active") or section.get("externalId", "").endswith("_crawl"):
                 logger.info(f"Skipping inactive section {section['externalId']} for {surface_id}")

--- a/tests/integration/api/v1/curated_recommendations/corpus_backends/test_sections_backend.py
+++ b/tests/integration/api/v1/curated_recommendations/corpus_backends/test_sections_backend.py
@@ -2,31 +2,29 @@
 
 import asyncio
 import copy
+import freezegun
+import logging
+import pytest
+
+from httpx import AsyncClient, HTTPStatusError, Response
+from pytest_mock import MockerFixture
+from tests.types import FilterCaplogFixture
 from unittest.mock import AsyncMock
 
-import pytest
-from httpx import AsyncClient, Response
+from circuitbreaker import STATE_HALF_OPEN, CircuitBreakerMonitor
 
 from merino.curated_recommendations import SectionsBackend
-from merino.curated_recommendations.corpus_backends.protocol import CreateSource, SurfaceId
-from merino.curated_recommendations.corpus_backends.utils import CorpusApiGraphConfig
-from merino.curated_recommendations.ml_backends.protocol import SpindleBackendProtocol
-from merino.utils.metrics import get_metrics_client
-
-import logging
-from datetime import datetime
-from time import monotonic
-
-from circuitbreaker import STATE_HALF_OPEN, CircuitBreakerMonitor
-from httpx import HTTPStatusError
-from pytest_mock import MockerFixture
-
 from merino.curated_recommendations.corpus_backends.circuitbreaker import (
     CuratedRecommendationsCircuitBreaker,
 )
-from merino.curated_recommendations.corpus_backends.utils import CorpusGraphQLError
+from merino.curated_recommendations.corpus_backends.protocol import CreateSource, SurfaceId
+from merino.curated_recommendations.corpus_backends.utils import (
+    CorpusApiGraphConfig,
+    CorpusGraphQLError,
+)
+from merino.curated_recommendations.ml_backends.protocol import SpindleBackendProtocol
 from merino.exceptions import BackendError
-from tests.types import FilterCaplogFixture
+from merino.utils.metrics import get_metrics_client
 
 
 @pytest.fixture()
@@ -393,26 +391,39 @@ class TestSectionsCircuitBreaker:
     ):
         """The fallback must raise so @stale_while_revalidate can serve stale data."""
         caplog.set_level(logging.ERROR)
+
         backend = make_sections_backend(sections_http_client)
-        fresh = await backend.fetch(SurfaceId.NEW_TAB_EN_US)
-        assert sections_http_client.post.call_count == 1
 
-        # Expire the cached value, then open the breaker.
-        for entry in backend._cache.values():
-            entry.expiration = datetime.min
-        await trip_breaker(make_sections_backend, fixture_request_data)
+        # control time so we can expire the SWR cache
+        with freezegun.freeze_time(tick=True) as time_gem:
+            # populate the SWR cache
+            cache_fresh = await backend.fetch(SurfaceId.NEW_TAB_EN_US)
 
-        stale = await backend.fetch(SurfaceId.NEW_TAB_EN_US)
-        assert stale == fresh
+            assert sections_http_client.post.call_count == 1
 
-        # The background revalidation is short-circuited too, so no second API call.
-        await asyncio.gather(*list(backend._background_tasks))
-        assert sections_http_client.post.call_count == 1
+            # fast-forward time so the cache expires
+            time_gem.tick(delta=SectionsBackend.cache_time_to_live_max)
 
-        records = filter_caplog(
-            caplog.records, "merino.curated_recommendations.corpus_backends.caching"
-        )
-        assert any("Returning stale data" in record.message for record in records)
+            # open the circuit breaker
+            await trip_breaker(make_sections_backend, fixture_request_data)
+
+            # with the circuit breaker open, we should get the expired cache
+            cache_stale = await backend.fetch(SurfaceId.NEW_TAB_EN_US)
+
+            assert cache_stale == cache_fresh
+
+            # await the async call spawned by the cache so we can verify if an http
+            # call was made
+            await asyncio.gather(*list(backend._background_tasks))
+
+            # with the breaker open, we should still only have 1 http call
+            # (from the initial successful fetch)
+            assert sections_http_client.post.call_count == 1
+
+            records = filter_caplog(
+                caplog.records, "merino.curated_recommendations.corpus_backends.caching"
+            )
+            assert any("Returning stale data" in record.message for record in records)
 
     @pytest.mark.asyncio
     async def test_breaker_recovers_after_timeout(
@@ -424,17 +435,22 @@ class TestSectionsCircuitBreaker:
         sections_circuit_breaker,
     ):
         """After the recovery timeout the breaker half-opens, then closes on a good fetch."""
-        await trip_breaker(make_sections_backend, fixture_request_data)
-        assert sections_circuit_breaker.opened
+        with freezegun.freeze_time(tick=True) as time_gem:
+            await trip_breaker(make_sections_backend, fixture_request_data)
 
-        # circuitbreaker measures the recovery window with time.monotonic().
-        mocker.patch("circuitbreaker.monotonic", return_value=monotonic() + RECOVERY_TIMEOUT + 1)
-        assert sections_circuit_breaker.state == STATE_HALF_OPEN
+            assert sections_circuit_breaker.opened
 
-        backend = make_sections_backend(sections_http_client)
-        sections = await backend.fetch(SurfaceId.NEW_TAB_EN_US)
+            # advance time so the circuit breaker recovers
+            time_gem.tick(RECOVERY_TIMEOUT + 5)
 
-        assert sections
-        sections_http_client.post.assert_called_once()
-        assert sections_circuit_breaker.closed
-        assert sections_circuit_breaker.failure_count == 0
+            assert sections_circuit_breaker.state == STATE_HALF_OPEN
+
+            backend = make_sections_backend(sections_http_client)
+            sections = await backend.fetch(SurfaceId.NEW_TAB_EN_US)
+
+            assert sections
+
+            sections_http_client.post.assert_called_once()
+
+            assert sections_circuit_breaker.closed
+            assert sections_circuit_breaker.failure_count == 0

--- a/tests/integration/api/v1/curated_recommendations/corpus_backends/test_sections_backend.py
+++ b/tests/integration/api/v1/curated_recommendations/corpus_backends/test_sections_backend.py
@@ -13,6 +13,80 @@ from merino.curated_recommendations.corpus_backends.utils import CorpusApiGraphC
 from merino.curated_recommendations.ml_backends.protocol import SpindleBackendProtocol
 from merino.utils.metrics import get_metrics_client
 
+import logging
+from datetime import datetime
+from time import monotonic
+
+from circuitbreaker import STATE_HALF_OPEN, CircuitBreakerMonitor
+from httpx import HTTPStatusError
+from pytest_mock import MockerFixture
+
+from merino.curated_recommendations.corpus_backends.circuitbreaker import (
+    CuratedRecommendationsCircuitBreaker,
+)
+from merino.curated_recommendations.corpus_backends.utils import CorpusGraphQLError
+from merino.exceptions import BackendError
+from tests.types import FilterCaplogFixture
+
+
+@pytest.fixture()
+def make_sections_backend(manifest_provider):
+    """Return a factory for SectionsBackend instances with a given HTTP client.
+
+    Each instance gets its own empty stale-while-revalidate cache, but they all
+    share the class-level circuit breaker.
+    """
+
+    def _make(http_client: AsyncMock) -> SectionsBackend:
+        return SectionsBackend(
+            http_client=http_client,
+            graph_config=CorpusApiGraphConfig(),
+            metrics_client=get_metrics_client(),
+            manifest_provider=manifest_provider,
+        )
+
+    return _make
+
+
+@pytest.fixture()
+def sections_circuit_breaker():
+    """Return the sections circuit breaker, closed before and after the test.
+
+    The breaker decorates SectionsBackend.fetch at class-definition time, so a
+    single instance is shared by every backend instance and every test.
+    """
+    breaker = CircuitBreakerMonitor.get(SECTIONS_BREAKER_NAME)
+
+    breaker.reset()
+
+    yield breaker
+
+    breaker.reset()
+
+
+def make_http_client(
+    response: Response | None = None, error: Exception | None = None
+) -> AsyncMock:
+    """Build a mock HTTP client that returns a fixed response or raises a fixed error."""
+    http_client = AsyncMock(spec=AsyncClient)
+
+    if error is not None:
+        http_client.post.side_effect = error
+    else:
+        http_client.post.return_value = response
+
+    return http_client
+
+
+async def trip_breaker(make_sections_backend, fixture_request_data) -> None:
+    """Drive the shared breaker open through a real fetch against a failing API."""
+    backend = make_sections_backend(
+        make_http_client(Response(status_code=503, request=fixture_request_data))
+    )
+
+    with pytest.raises(HTTPStatusError):
+        await backend.fetch(SurfaceId.NEW_TAB_EN_US)
+
 
 @pytest.mark.asyncio
 async def test_fetch(sections_backend: SectionsBackend):
@@ -81,25 +155,22 @@ async def test_fetch_ie_strips_locale_suffix(sections_ie_backend: SectionsBacken
 
 @pytest.mark.asyncio
 async def test_fetch_preserves_experiment_suffix(
-    sections_response_data, fixture_request_data, manifest_provider
+    sections_response_data, fixture_request_data, make_sections_backend
 ):
     """Experiment suffixes should be parsed into a canonical section with an alternate slate."""
     response_data = copy.deepcopy(sections_response_data)
     response_data["data"]["getSections"][0]["externalId"] = "government-test"
     response_data["data"]["getSections"][1]["externalId"] = "government-test__exp5050"
 
-    http_client = AsyncMock(spec=AsyncClient)
-    http_client.post.return_value = Response(
-        status_code=200,
-        json=response_data,
-        request=fixture_request_data,
+    http_client = make_http_client(
+        Response(
+            status_code=200,
+            json=response_data,
+            request=fixture_request_data,
+        )
     )
-    backend = SectionsBackend(
-        http_client=http_client,
-        graph_config=CorpusApiGraphConfig(),
-        metrics_client=get_metrics_client(),
-        manifest_provider=manifest_provider,
-    )
+
+    backend = make_sections_backend(http_client)
 
     sections = await backend.fetch(SurfaceId.NEW_TAB_EN_US)
 
@@ -111,25 +182,22 @@ async def test_fetch_preserves_experiment_suffix(
 
 @pytest.mark.asyncio
 async def test_fetch_strips_locale_suffix_after_experiment_suffix(
-    sections_response_data, fixture_request_data, manifest_provider
+    sections_response_data, fixture_request_data, make_sections_backend
 ):
     """Locale stripping should preserve experiment metadata when linking the alternate slate."""
     response_data = copy.deepcopy(sections_response_data)
     response_data["data"]["getSections"][0]["externalId"] = "government-test"
     response_data["data"]["getSections"][1]["externalId"] = "government-test__exp5050__lDE_DE"
 
-    http_client = AsyncMock(spec=AsyncClient)
-    http_client.post.return_value = Response(
-        status_code=200,
-        json=response_data,
-        request=fixture_request_data,
+    http_client = make_http_client(
+        Response(
+            status_code=200,
+            json=response_data,
+            request=fixture_request_data,
+        )
     )
-    backend = SectionsBackend(
-        http_client=http_client,
-        graph_config=CorpusApiGraphConfig(),
-        metrics_client=get_metrics_client(),
-        manifest_provider=manifest_provider,
-    )
+
+    backend = make_sections_backend(http_client)
 
     sections = await backend.fetch(SurfaceId.NEW_TAB_EN_US)
 
@@ -141,25 +209,22 @@ async def test_fetch_strips_locale_suffix_after_experiment_suffix(
 
 @pytest.mark.asyncio
 async def test_fetch_links_experiment_variant_to_base_section(
-    sections_response_data, fixture_request_data, manifest_provider
+    sections_response_data, fixture_request_data, make_sections_backend
 ):
     """A base/variant pair should be returned as one canonical section with an alternate slate."""
     response_data = copy.deepcopy(sections_response_data)
     response_data["data"]["getSections"][0]["externalId"] = "government-test"
     response_data["data"]["getSections"][1]["externalId"] = "government-test__exp5050"
 
-    http_client = AsyncMock(spec=AsyncClient)
-    http_client.post.return_value = Response(
-        status_code=200,
-        json=response_data,
-        request=fixture_request_data,
+    http_client = make_http_client(
+        Response(
+            status_code=200,
+            json=response_data,
+            request=fixture_request_data,
+        )
     )
-    backend = SectionsBackend(
-        http_client=http_client,
-        graph_config=CorpusApiGraphConfig(),
-        metrics_client=get_metrics_client(),
-        manifest_provider=manifest_provider,
-    )
+
+    backend = make_sections_backend(http_client)
 
     sections = await backend.fetch(SurfaceId.NEW_TAB_EN_US)
 
@@ -197,11 +262,12 @@ async def test_fetch_schedules_spindle_refresh(
     sections_response_data, fixture_request_data, manifest_provider
 ):
     """Sections fetch should fire a background spindle refresh containing all items."""
-    http_client = AsyncMock(spec=AsyncClient)
-    http_client.post.return_value = Response(
-        status_code=200,
-        json=sections_response_data,
-        request=fixture_request_data,
+    http_client = make_http_client(
+        Response(
+            status_code=200,
+            json=sections_response_data,
+            request=fixture_request_data,
+        )
     )
     spindle = _StubSpindle()
     backend = SectionsBackend(
@@ -218,3 +284,157 @@ async def test_fetch_schedules_spindle_refresh(
 
     expected_count = sum(len(s.sectionItems) for s in sections)
     assert spindle.calls == [(expected_count, SurfaceId.NEW_TAB_EN_US)]
+
+
+SECTIONS_BREAKER_NAME = "curated_recommendations_sections_circuit_breaker"
+FAILURE_THRESHOLD = CuratedRecommendationsCircuitBreaker.FAILURE_THRESHOLD
+RECOVERY_TIMEOUT = CuratedRecommendationsCircuitBreaker.RECOVERY_TIMEOUT
+
+
+class TestSectionsCircuitBreaker:
+    """Tests covering the circuit breaker wrapped around SectionsBackend.fetch."""
+
+    @pytest.mark.asyncio
+    async def test_breaker_stays_closed_on_success(
+        self, sections_backend: SectionsBackend, sections_circuit_breaker
+    ):
+        """A successful fetch should leave the breaker closed with no failures recorded."""
+        sections = await sections_backend.fetch(SurfaceId.NEW_TAB_EN_US)
+
+        assert sections
+        assert sections_circuit_breaker.closed
+        assert sections_circuit_breaker.failure_count == 0
+
+    @pytest.mark.asyncio
+    async def test_breaker_opens_on_http_error(
+        self, make_sections_backend, fixture_request_data, sections_circuit_breaker
+    ):
+        """An HTTP error should exhaust the retries below the breaker, then open it."""
+        http_client = make_http_client(Response(status_code=503, request=fixture_request_data))
+        backend = make_sections_backend(http_client)
+
+        with pytest.raises(HTTPStatusError):
+            await backend.fetch(SurfaceId.NEW_TAB_EN_US)
+
+        # @retry is applied below the breaker, so the breaker only sees one
+        # failure once every attempt has been used up.
+        assert http_client.post.call_count == SectionsBackend.retry_count
+        assert sections_circuit_breaker.failure_count == FAILURE_THRESHOLD
+        assert sections_circuit_breaker.opened
+
+    @pytest.mark.asyncio
+    async def test_breaker_opens_on_graphql_error(
+        self,
+        make_sections_backend,
+        fixture_graphql_200ok_with_error_response,
+        fixture_request_data,
+        sections_circuit_breaker,
+    ):
+        """A 200 response carrying GraphQL errors should also open the breaker."""
+        http_client = make_http_client(
+            Response(
+                status_code=200,
+                json=fixture_graphql_200ok_with_error_response,
+                request=fixture_request_data,
+            )
+        )
+        backend = make_sections_backend(http_client)
+
+        with pytest.raises(CorpusGraphQLError):
+            await backend.fetch(SurfaceId.NEW_TAB_EN_US)
+
+        assert http_client.post.call_count == SectionsBackend.retry_count
+        assert sections_circuit_breaker.opened
+
+    @pytest.mark.asyncio
+    async def test_breaker_ignores_unexpected_exceptions(
+        self, make_sections_backend, sections_circuit_breaker
+    ):
+        """Errors outside EXPECTED_EXCEPTION should neither be retried nor open the breaker."""
+        http_client = make_http_client(error=RuntimeError("not a corpus API error"))
+        backend = make_sections_backend(http_client)
+
+        with pytest.raises(RuntimeError):
+            await backend.fetch(SurfaceId.NEW_TAB_EN_US)
+
+        assert http_client.post.call_count == 1
+        assert sections_circuit_breaker.failure_count == 0
+        assert sections_circuit_breaker.closed
+
+    @pytest.mark.asyncio
+    async def test_breaker_short_circuits_while_open(
+        self,
+        make_sections_backend,
+        sections_http_client: AsyncMock,
+        fixture_request_data,
+        sections_circuit_breaker,
+    ):
+        """While open, fetch should fail fast with BackendError and skip the API entirely."""
+        await trip_breaker(make_sections_backend, fixture_request_data)
+        assert sections_circuit_breaker.opened
+
+        # A brand new backend with an empty cache and a healthy HTTP client is
+        # still short-circuited: the breaker is shared across all instances.
+        healthy_backend = make_sections_backend(sections_http_client)
+
+        with pytest.raises(BackendError, match="circuitbreaker"):
+            await healthy_backend.fetch(SurfaceId.NEW_TAB_EN_US)
+
+        sections_http_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_open_breaker_serves_stale_cache(
+        self,
+        make_sections_backend,
+        sections_http_client: AsyncMock,
+        fixture_request_data,
+        caplog,
+        filter_caplog: FilterCaplogFixture,
+    ):
+        """The fallback must raise so @stale_while_revalidate can serve stale data."""
+        caplog.set_level(logging.ERROR)
+        backend = make_sections_backend(sections_http_client)
+        fresh = await backend.fetch(SurfaceId.NEW_TAB_EN_US)
+        assert sections_http_client.post.call_count == 1
+
+        # Expire the cached value, then open the breaker.
+        for entry in backend._cache.values():
+            entry.expiration = datetime.min
+        await trip_breaker(make_sections_backend, fixture_request_data)
+
+        stale = await backend.fetch(SurfaceId.NEW_TAB_EN_US)
+        assert stale == fresh
+
+        # The background revalidation is short-circuited too, so no second API call.
+        await asyncio.gather(*list(backend._background_tasks))
+        assert sections_http_client.post.call_count == 1
+
+        records = filter_caplog(
+            caplog.records, "merino.curated_recommendations.corpus_backends.caching"
+        )
+        assert any("Returning stale data" in record.message for record in records)
+
+    @pytest.mark.asyncio
+    async def test_breaker_recovers_after_timeout(
+        self,
+        mocker: MockerFixture,
+        make_sections_backend,
+        sections_http_client: AsyncMock,
+        fixture_request_data,
+        sections_circuit_breaker,
+    ):
+        """After the recovery timeout the breaker half-opens, then closes on a good fetch."""
+        await trip_breaker(make_sections_backend, fixture_request_data)
+        assert sections_circuit_breaker.opened
+
+        # circuitbreaker measures the recovery window with time.monotonic().
+        mocker.patch("circuitbreaker.monotonic", return_value=monotonic() + RECOVERY_TIMEOUT + 1)
+        assert sections_circuit_breaker.state == STATE_HALF_OPEN
+
+        backend = make_sections_backend(sections_http_client)
+        sections = await backend.fetch(SurfaceId.NEW_TAB_EN_US)
+
+        assert sections
+        sections_http_client.post.assert_called_once()
+        assert sections_circuit_breaker.closed
+        assert sections_circuit_breaker.failure_count == 0

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -1326,6 +1326,7 @@ class TestCorpusApiCaching:
 
             for item in scheduled_surface_response_data["data"]["scheduledSurface"]["items"]:
                 item["corpusItem"]["title"] += " (NEW)"  # Change all the titles
+
             scheduled_surface_http_client.post.return_value = Response(
                 status_code=200,
                 json=scheduled_surface_response_data,
@@ -1340,10 +1341,13 @@ class TestCorpusApiCaching:
             fetch_pl_pl(client)
             await asyncio.sleep(0.01)  # Allow asyncio background task to make an API request
 
-            # Next fetch should get the new data
+            # Next fetch should get the new data from the cache
             new_response = fetch_pl_pl(client)
+
             assert scheduled_surface_http_client.post.call_count == 2
+
             new_data = new_response.json()
+
             assert new_data["recommendedAt"] > initial_data["recommendedAt"]
             assert all("NEW" in item["title"] for item in new_data["data"])
 
@@ -1775,9 +1779,6 @@ class TestSections:
     def test_sections_inferred_contextual_ranking_result_for_cohort(
         self,
         ml_recommendations_backend,
-        engagement_backend,
-        sections_backend,
-        cohort_model_backend,
         client: TestClient,
     ):
         """Test end to end content ranking based on cohort and tz offset. Note that engagement_backend is required
@@ -2194,7 +2195,7 @@ class TestSections:
         assert sections["top_stories_section"]["receivedFeedRank"] == 0
 
     def test_curated_recommendations_with_sections_feed_removes_blocked_topics(
-        self, caplog, client: TestClient
+        self, client: TestClient
     ):
         """Test that when topic sections are blocked, those recommendations don't show up, not even
         in other sections like Popular Today.

--- a/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -1240,7 +1240,7 @@ class TestCorpusApiCaching:
     @pytest.mark.parametrize(
         "error_type, expected_warning",
         [
-            # ("graphql", 'Could not find Scheduled Surface with id of "NEW_TAB_EN_UX".'),
+            ("graphql", 'Could not find Scheduled Surface with id of "NEW_TAB_EN_UX".'),
             ("http", "'503 Service Unavailable' for url 'https://client-api.getpocket.com'"),
         ],
     )


### PR DESCRIPTION
## References

JIRA: [HNT-2939](https://mozilla-hub.atlassian.net/browse/HNT-2939)

## Description

the overall intent of this PR is to reduce corpus load/down time during a merino deploy, which doubles the k8s pod count, which can overwhelm the corpus with requests. importantly, the intent is _not_ to reduce the number of errors reported - the circuitbreaker decorator will continue to raise, just without a corpus API call.

this PR makes two notable changes:

1. adds a circuitbreaker decorator to the sections backend `fetch` method.

the circuitbreaker decorator sits between the retry decorator and the stale while revalidate decorator. the intention is to stop attempting to hit the corpus while the circuitbreaker is open, which will happen after one round of retries (currently scoped at 3) fails.

the circuitbreaker must raise, as any other return value will be cached by the stale while revalidate decorator.

2. stops retrying `fetch` failures on the sections backend `fetch` method if a `ValueError` raises

a `ValueError` while processing the results of the `fetch` call (e.g. parsing JSON) should not be retried, as there is very little chance a retry will help anything. a `ValueError` would be better raised immediately rather than making 2 more requests against the corpus.

## Testing

...or the lack thereof.

due to the stale while revalidate decorator, testing the circuitbreaker end to end is challenging. the ideal imo is to test the interplay of the decorators, but the combined complexity makes this onerous - retries must fail and the circuitbreaker must open and the SWR cache must handle both cold start and warmed scenarios. testing is also error prone due to the SWR decorator implementation, which kicks off async API requests that are specifically _not_ awaited (making timing/call counts flaky).

the circuitbreaker itself is basic in its configuration and functionality - i'm not sure any test directly against the circuitbreaker would do more than verify the python circuitbreaker package works.

while i don't feel great having _no_ tests here, i am hard pressed to come up with a testing scenario that is both meaningful and predictable given the implementation of the SWR decorator. i'm open to ideas.

### Update

had the claude robot take a swing at adding tests, and it did a good job of finding ways to verify the circuit breaker directly (using the circuitbreaker package API) in addition to testing HTTP call counts. cleaner than modeling after other approaches/patterns. (though i did clean up some of the implementation.)

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2533)


[HNT-2939]: https://mozilla-hub.atlassian.net/browse/HNT-2939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ