### PR TITLE
fix(wikipedia): add successful search count metric

### DIFF
--- a/merino/providers/suggest/wikipedia/backends/elastic.py
+++ b/merino/providers/suggest/wikipedia/backends/elastic.py
@@ -110,7 +110,9 @@ class ElasticBackend:
             raise BackendError(
                 f"Failed to search from Elasticsearch for {language_code}: {e}"
             ) from e
-
+        self._metrics_client.increment(
+            f"{ES_SEARCH_METRIC_NAME}.count", tags={"index": index_id}
+        )
         if "suggest" in res:
             return [
                 self.build_article(q, doc, language_code)

--- a/merino/providers/suggest/wikipedia/backends/elastic.py
+++ b/merino/providers/suggest/wikipedia/backends/elastic.py
@@ -86,9 +86,7 @@ class ElasticBackend:
             }
         }
 
-        # Add this if wikipedia gets more than one index; for now it's covered by the provider
-        # search count
-        # self._metrics_client.increment(f"{ES_SEARCH_METRIC_NAME}.count", tags={"index": index_id})
+        self._metrics_client.increment(f"{ES_SEARCH_METRIC_NAME}.count", tags={"index": index_id})
         try:
             res = await self.elasticsearch.search(
                 index=index_id,
@@ -110,7 +108,7 @@ class ElasticBackend:
             raise BackendError(
                 f"Failed to search from Elasticsearch for {language_code}: {e}"
             ) from e
-        self._metrics_client.increment(f"{ES_SEARCH_METRIC_NAME}.count", tags={"index": index_id})
+
         if "suggest" in res:
             return [
                 self.build_article(q, doc, language_code)

--- a/merino/providers/suggest/wikipedia/backends/elastic.py
+++ b/merino/providers/suggest/wikipedia/backends/elastic.py
@@ -110,9 +110,7 @@ class ElasticBackend:
             raise BackendError(
                 f"Failed to search from Elasticsearch for {language_code}: {e}"
             ) from e
-        self._metrics_client.increment(
-            f"{ES_SEARCH_METRIC_NAME}.count", tags={"index": index_id}
-        )
+        self._metrics_client.increment(f"{ES_SEARCH_METRIC_NAME}.count", tags={"index": index_id})
         if "suggest" in res:
             return [
                 self.build_article(q, doc, language_code)

--- a/tests/unit/providers/suggest/wikipedia/backends/test_elastic.py
+++ b/tests/unit/providers/suggest/wikipedia/backends/test_elastic.py
@@ -306,6 +306,23 @@ async def test_es_backend_search_error_metric_on_exception(
 
 
 @pytest.mark.asyncio
+async def test_es_backend_search_count_metric_on_success(
+    mocker: MockerFixture,
+    es_backend: ElasticBackend,
+    statsd_mock: Any,
+) -> None:
+    """Test that a successful search increments the count metric."""
+    async_mock = AsyncMock(return_value={"suggest": {SUGGEST_ID: [{"options": []}]}})
+    mocker.patch.object(AsyncElasticSearchAdapter, "search", side_effect=async_mock)
+
+    await es_backend.search("foo", "en")
+
+    statsd_mock.increment.assert_called_once_with(
+        "es.search.count", tags={"index": INDICES["en"]}
+    )
+
+
+@pytest.mark.asyncio
 async def test_es_backend_shutdown(mocker: MockerFixture, es_backend: ElasticBackend) -> None:
     """Test the shutdown method of the ES backend."""
     spy = mocker.spy(AsyncElasticSearchAdapter, "shutdown")

--- a/tests/unit/providers/suggest/wikipedia/backends/test_elastic.py
+++ b/tests/unit/providers/suggest/wikipedia/backends/test_elastic.py
@@ -317,9 +317,7 @@ async def test_es_backend_search_count_metric_on_success(
 
     await es_backend.search("foo", "en")
 
-    statsd_mock.increment.assert_called_once_with(
-        "es.search.count", tags={"index": INDICES["en"]}
-    )
+    statsd_mock.increment.assert_called_once_with("es.search.count", tags={"index": INDICES["en"]})
 
 
 @pytest.mark.asyncio

--- a/tests/unit/providers/suggest/wikipedia/backends/test_elastic.py
+++ b/tests/unit/providers/suggest/wikipedia/backends/test_elastic.py
@@ -264,7 +264,7 @@ async def test_es_backend_search_error_metric_on_api_error(
     es_backend: ElasticBackend,
     statsd_mock: Any,
 ) -> None:
-    """Test that an ApiError increments the error metric with the HTTP status code."""
+    """Test that an ApiError increments both the count and error metrics."""
     api_error = ApiError(
         message="service unavailable",
         meta=ApiResponseMeta(
@@ -281,7 +281,8 @@ async def test_es_backend_search_error_metric_on_api_error(
     with pytest.raises(BackendError):
         await es_backend.search("foo", "en")
 
-    statsd_mock.increment.assert_called_once_with(
+    statsd_mock.increment.assert_any_call("es.search.count", tags={"index": INDICES["en"]})
+    statsd_mock.increment.assert_any_call(
         "es.search.error", tags={"index": INDICES["en"], "status": 503}
     )
 
@@ -292,7 +293,7 @@ async def test_es_backend_search_error_metric_on_exception(
     es_backend: ElasticBackend,
     statsd_mock: Any,
 ) -> None:
-    """Test that a generic exception increments the error metric with status 'unknown'."""
+    """Test that a generic exception increments both the count and error metrics."""
     mocker.patch.object(
         AsyncElasticSearchAdapter, "search", side_effect=Exception("connection reset")
     )
@@ -300,7 +301,8 @@ async def test_es_backend_search_error_metric_on_exception(
     with pytest.raises(BackendError):
         await es_backend.search("foo", "en")
 
-    statsd_mock.increment.assert_called_once_with(
+    statsd_mock.increment.assert_any_call("es.search.count", tags={"index": INDICES["en"]})
+    statsd_mock.increment.assert_any_call(
         "es.search.error", tags={"index": INDICES["en"], "status": "unknown"}
     )
 


### PR DESCRIPTION


## References

JIRA: [DISCO-4430]

## Description
Add successful search count so the % requests resulting in error can be derived. This was already implemented for sports.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2534)


[DISCO-4430]: https://mozilla-hub.atlassian.net/browse/DISCO-4430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ