### PR TITLE
[DISCO-4413] feat(merino): add search term prefiltering before submission

### DIFF
--- a/docs/data.md
+++ b/docs/data.md
@@ -91,8 +91,10 @@ log inspection interfaces.
 
   - `sensitive` - Always set to true to ensure proper routing. Not a statement
     about the sanitization verdict, which is `NON_PII` for every logged record.
-  - `query` - The text the user typed, in full. Sanitization truncates the query
-    before running detection over it, but the untruncated term is logged.
+  - `query` - The text the user typed, in full. Sanitization detects over the query
+    as submitted. Merino prefilters its submissions, so empty (or whitespace-only)
+    queries and queries longer than `web.api.v1.query_character_max` -- which the
+    suggest endpoint rejects with HTTP 400 anyway -- never reach sanitization.
   - `request_id` - The request ID of the originating suggest request.
   - `timestamp` - The UTC instant Merino submitted the search term to merino-fleece,
     not when merino-fleece sanitized or logged it. An ISO-8601 string with a `+00:00`

--- a/merino-fleece/merino_fleece/message_handlers/search_terms/handler.py
+++ b/merino-fleece/merino_fleece/message_handlers/search_terms/handler.py
@@ -17,10 +17,6 @@ from merino_fleece.sanitize import exempts
 # identifier used to tag the queue's metrics.
 QUEUE_ID = "search_term_sanitization"
 
-# Queries reaching the queue are not length-bounded by a request model the way the
-# /pii endpoint's are, so they are truncated before detection.
-QUERY_CHARACTER_MAX = settings.pii.query_character_max
-
 # Whether to log `web.suggest.sanitized`.
 LOG_SEARCH_TERMS: bool = settings.sanitize.log_search_terms
 
@@ -114,6 +110,9 @@ class MessageHandler:
         pool is released between chunks and concurrent `/pii` requests are not stuck
         behind one long batch.
 
+        Queries are detected over as submitted; bounding their length is the submitter's
+        responsibility (Merino prefilters empty and overlong queries before submitting).
+
         Exceptions are left to propagate: ``AsyncBatchQueue`` logs them and counts the
         batch as failed, which drops one batch rather than stopping the run loop.
 
@@ -127,7 +126,7 @@ class MessageHandler:
         candidate_indices: list[int] = []
 
         for term in batch:
-            query = (term.query or "")[:QUERY_CHARACTER_MAX]
+            query = term.query or ""
 
             # Exemption wins over detection by definition, and is the cheaper check.
             if query and exempts.is_exempt(query):

--- a/merino-fleece/tests/unit/message_handlers/search_terms/test_sanitize_handler.py
+++ b/merino-fleece/tests/unit/message_handlers/search_terms/test_sanitize_handler.py
@@ -350,22 +350,6 @@ async def test_non_exempt_terms_in_a_mixed_batch_are_still_sanitized(
 
 
 @pytest.mark.asyncio
-async def test_exemption_is_checked_against_the_truncated_query(
-    monkeypatch: pytest.MonkeyPatch,
-    detector: RecordingDetector,
-    params: ParamsFactory,
-    register_exempt: Callable[..., None],
-) -> None:
-    """Exemption sees the same truncated query the detectors would have seen."""
-    monkeypatch.setattr(handler_module, "QUERY_CHARACTER_MAX", 5)
-    register_exempt("abcde")
-
-    await MessageHandler().sanitize_batch([params("abcdefghij")])
-
-    assert detector.seen_queries == []
-
-
-@pytest.mark.asyncio
 async def test_ner_is_chunked(
     monkeypatch: pytest.MonkeyPatch,
     detector: RecordingDetector,
@@ -390,24 +374,6 @@ async def test_ner_is_chunked(
     after = counter_by_type(metric_reader)
     assert delta(before, after, "person") == 1
     assert delta(before, after, "non_pii") == 4
-
-
-@pytest.mark.asyncio
-async def test_long_query_is_truncated(
-    monkeypatch: pytest.MonkeyPatch,
-    detector: RecordingDetector,
-    params: ParamsFactory,
-) -> None:
-    """Overlong queries are truncated before detection.
-
-    Nothing on the queue path bounds query length the way the /pii request model
-    does, and one pathological query would otherwise slow its whole NER chunk.
-    """
-    monkeypatch.setattr(handler_module, "QUERY_CHARACTER_MAX", 5)
-
-    await MessageHandler().sanitize_batch([params("abcdefghij")])
-
-    assert detector.seen_queries == ["abcde"]
 
 
 @pytest.mark.asyncio

--- a/merino/middleware/logging.py
+++ b/merino/middleware/logging.py
@@ -42,12 +42,32 @@ SUBMIT_SEARCH_TERMS: bool = settings.message_handler.enabled
 # Excluded providers for logging
 EXCLUDED_PROVIDERS: frozenset[str] = frozenset(settings.logging.excluded_providers)
 
+# Queries longer than this are rejected by the suggest endpoint with HTTP 400, so they
+# are never worth submitting.
+QUERY_CHARACTER_MAX: int = settings.web.api.v1.query_character_max
+
 _meter = metrics.get_meter("merino.middleware.logging")
 _enqueue_counter = _meter.create_counter(
     name="search_term.enqueue.count",
     unit="{search_term}",
-    description="Search terms enqueued for submission to merino-fleece, labeled by outcome.",
+    description=(
+        "Search terms enqueued for submission to merino-fleece, labeled by outcome: "
+        "`success`, `error` (the queue rejected it) or `skipped` (prefiltered out)."
+    ),
 )
+
+
+def _skip_reason(query: str | None) -> str | None:
+    """Return why a search term should not be submitted, or None to submit it.
+
+    Terms without a usable query carry no analytical value, and overlong ones only reach
+    here on requests the suggest endpoint has already rejected with HTTP 400.
+    """
+    if query is None or not query.strip():
+        return "empty"
+    if len(query) > QUERY_CHARACTER_MAX:
+        return "too_long"
+    return None
 
 
 def _submit_search_term(request_params: SuggestRequestParams) -> None:
@@ -101,7 +121,14 @@ class LoggingMiddleware:
                     ):
                         suggest_request_logger.info("", extra=suggest_log_data.model_dump())
                     if SUBMIT_SEARCH_TERMS and FeatureFlags().is_enabled(SUBMISSION_FLAG):
-                        _submit_search_term(suggest_log_data.request_params)
+                        request_params = suggest_log_data.request_params
+                        # Prefilter after the gate above, so skips are only counted for
+                        # terms that would otherwise have been submitted.
+                        reason = _skip_reason(request_params.query)
+                        if reason is None:
+                            _submit_search_term(request_params)
+                        else:
+                            _enqueue_counter.add(1, {"outcome": "skipped", "reason": reason})
 
             await send(message)
 

--- a/tests/unit/middleware/test_logging.py
+++ b/tests/unit/middleware/test_logging.py
@@ -12,7 +12,8 @@ from pytest import LogCaptureFixture
 from pytest_mock import MockerFixture
 from starlette.types import Receive, Scope, Send
 
-from merino.middleware.logging import LoggingMiddleware
+from merino.middleware import logging as middleware_logging
+from merino.middleware.logging import QUERY_CHARACTER_MAX, LoggingMiddleware
 from merino.utils.featureflags import FeatureFlags
 from merino_common.models.suggest_logging import (
     MozlogDataModel,
@@ -264,7 +265,7 @@ async def test_submits_regardless_of_pii_flag(
     assert not any(record.name == "web.suggest.request" for record in caplog.records)
 
 
-def _suggest_log_data() -> SuggestLogDataModel:
+def _suggest_log_data(query: str | None = "apple") -> SuggestLogDataModel:
     """Return log data carrying real request params, so `submitted_at` is observable."""
     return SuggestLogDataModel(
         sensitive=True,
@@ -275,7 +276,7 @@ def _suggest_log_data() -> SuggestLogDataModel:
             method="GET",
         ),
         request_params=SuggestRequestParams(
-            query="apple",
+            query=query,
             code=200,
             rid="rid",
             client_variants="",
@@ -338,3 +339,44 @@ async def test_no_timestamp_when_term_is_not_submitted(
     records = [record for record in caplog.records if record.name == "web.suggest.request"]
     assert len(records) == 1
     assert not hasattr(records[0], "submitted_at")
+
+
+@pytest.mark.parametrize(
+    ("query", "reason"),
+    [
+        (None, "empty"),
+        ("", "empty"),
+        ("   ", "empty"),
+        ("a" * (QUERY_CHARACTER_MAX + 1), "too_long"),
+    ],
+    ids=["missing", "empty", "whitespace-only", "too-long"],
+)
+@pytest.mark.asyncio
+async def test_no_submission_for_prefiltered_query(
+    mocker: MockerFixture,
+    receive_mock: Receive,
+    send_mock: Send,
+    query: str | None,
+    reason: str,
+) -> None:
+    """Test that terms without a usable query are not submitted, and the skip is counted.
+
+    Overlong queries are rejected by the suggest endpoint with HTTP 400, so submitting
+    them would only add data Merino never served a suggestion for.
+    """
+    log_data = _suggest_log_data(query)
+    mocker.patch("merino.middleware.logging.create_suggest_log_data", return_value=log_data)
+    mocker.patch("merino.middleware.logging.SUBMIT_SEARCH_TERMS", True)
+    mocker.patch.object(FeatureFlags, "is_enabled", return_value=True)
+    mocker.patch("merino.middleware.logging.LOG_SUGGEST_REQUEST", False)
+    handler = mocker.MagicMock()
+    mocker.patch("merino.middleware.logging.get_message_handler", return_value=handler)
+    add = mocker.patch.object(middleware_logging._enqueue_counter, "add")
+
+    logging_middleware: LoggingMiddleware = LoggingMiddleware(app)
+    await logging_middleware(_suggest_scope(), receive_mock, send_mock)
+
+    handler.put.assert_not_called()
+    add.assert_called_once_with(1, {"outcome": "skipped", "reason": reason})
+    # The timestamp describes a submission, so a prefiltered term never carries one.
+    assert log_data.request_params.submitted_at is None


### PR DESCRIPTION
## References

JIRA: [DISCO-4413](https://mozilla-hub.atlassian.net/browse/DISCO-4413)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->

Empty and too long queries will not be processed by Merino hence are of no interest for Fleece to sanitize and log.

Note that this is distinct from the existing raw search term logging in Merino, which causes a lot trouble in data processing and analytics.   

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2535)


[DISCO-4413]: https://mozilla-hub.atlassian.net/browse/DISCO-4413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ