### PR TITLE
chore(ci): DISCO-4436 Harden CI and Docker publishing

### DIFF
--- a/.github/actions/weave/action.yaml
+++ b/.github/actions/weave/action.yaml
@@ -1,4 +1,5 @@
 name: Set Up to Run Merino
+description: Install the pinned Python toolchain and system dependencies for Merino CI
 inputs:
   workspace-path:
     description: "The directory path to store test results"

--- a/.github/workflows/build-dockerhub-app-image.yaml
+++ b/.github/workflows/build-dockerhub-app-image.yaml
@@ -2,25 +2,27 @@ name: build-dockerhub-app-image
 
 on:
   workflow_call:
-    inputs:
-      image_tag:
-        required: true
-        type: string
-    secrets:
-      DOCKERHUB_REPO:
-        required: true
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
+      - name: Create version.json
+        run: |
+          printf '{"commit":"%s","version":"%s","source":"%s","build":"%s"}\n' \
+          "$GITHUB_SHA" \
+          "$GITHUB_REF_NAME" \
+          "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" \
+          "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" > version.json
+      - name: Output version.json
+        run: cat version.json
       - name: Build Merino app image
         run: make docker-build
-      - name: Tag image for Docker Hub
-        run: docker tag app:build ${{ secrets.DOCKERHUB_REPO }}:${{ inputs.image_tag }}
       - name: Save image artifact
-        run: docker save ${{ secrets.DOCKERHUB_REPO }}:${{ inputs.image_tag }} | gzip > merino-app.tar.gz
+        run: docker save app:build | gzip > merino-app.tar.gz
       - name: Upload image artifact
         uses: actions/upload-artifact@v6
         with:

--- a/.github/workflows/build-gar-image-fleece.yaml
+++ b/.github/workflows/build-gar-image-fleece.yaml
@@ -2,17 +2,12 @@ name: build-gar-image-fleece
 
 on:
   workflow_call:
-    inputs:
-      image_tag:
-        required: true
-        type: string
-    secrets:
-      DOCKER_IMAGE_PATH:
-        required: true
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
       - name: Get info

--- a/.github/workflows/build-gar-image-locust.yaml
+++ b/.github/workflows/build-gar-image-locust.yaml
@@ -2,25 +2,18 @@ name: build-gar-image-locust
 
 on:
   workflow_call:
-    inputs:
-      image_tag:
-        required: true
-        type: string
-    secrets:
-      DOCKER_IMAGE_PATH:
-        required: true
 
 jobs:
   build-locust:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
       - name: Build Locust Docker image
-        run: docker build -t merino-locust -f ./tests/load/Dockerfile .
-      - name: Tag with GAR path
-        run: docker tag merino-locust ${{ secrets.DOCKER_IMAGE_PATH }}/merino-locust:${{ inputs.image_tag }}
+        run: docker build -t merino-locust:build -f ./tests/load/Dockerfile .
       - name: Save image
-        run: docker save ${{ secrets.DOCKER_IMAGE_PATH }}/merino-locust:${{ inputs.image_tag }} | gzip > locust-image.tar.gz
+        run: docker save merino-locust:build | gzip > locust-image.tar.gz
       - name: Upload image artifact
         uses: actions/upload-artifact@v6
         with:

--- a/.github/workflows/build-gar-image.yaml
+++ b/.github/workflows/build-gar-image.yaml
@@ -2,17 +2,12 @@ name: build-gar-image
 
 on:
   workflow_call:
-    inputs:
-      image_tag:
-        required: true
-        type: string
-    secrets:
-      DOCKER_IMAGE_PATH:
-        required: true
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
       - name: Get info

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -8,6 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+      - name: Lint GitHub Actions workflows
+        uses: docker://rhysd/actionlint:1.7.12
+        with:
+          args: -color
       - name: Set up to run
         uses: ./.github/actions/weave
       - name: Run Code Linting

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -9,9 +9,17 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Lint GitHub Actions workflows
-        uses: docker://rhysd/actionlint:1.7.12
-        with:
-          args: -color
+        env:
+          ACTIONLINT_VERSION: "1.7.12"
+          ACTIONLINT_SHA256: "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
+        run: |
+          actionlint_archive="$RUNNER_TEMP/actionlint.tar.gz"
+          curl --fail --location --silent --show-error \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
+            --output "$actionlint_archive"
+          printf '%s  %s\n' "$ACTIONLINT_SHA256" "$actionlint_archive" | sha256sum --check --strict -
+          tar -xzf "$actionlint_archive" --directory "$RUNNER_TEMP" actionlint
+          "$RUNNER_TEMP/actionlint" -color
       - name: Set up to run
         uses: ./.github/actions/weave
       - name: Run Code Linting

--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: Setup Build docs
         run: |
           mkdir -p bin
-          echo "PATH=$(pwd)/bin:$PATH" >> $GITHUB_ENV
+          echo "PATH=$(pwd)/bin:$PATH" >> "$GITHUB_ENV"
           curl -sSL \
             https://github.com/rust-lang/mdBook/releases/download/v0.4.24/mdbook-v0.4.24-x86_64-unknown-linux-gnu.tar.gz \
             | tar -xz --directory=bin

--- a/.github/workflows/main-workflow.yaml
+++ b/.github/workflows/main-workflow.yaml
@@ -31,12 +31,8 @@ jobs:
     uses: ./.github/workflows/docs-publish-github-pages.yaml
   run-build-gar-image:
     uses: ./.github/workflows/build-gar-image.yaml
-    with:
-      image_tag: latest
-    secrets:
-      DOCKER_IMAGE_PATH: ${{ secrets.DOCKER_IMAGE_PATH }}
   run-publish-gar-image:
-    needs: run-build-gar-image
+    needs: [run-checks, run-tests, run-build-gar-image]
     uses: ./.github/workflows/publish-gar-image.yaml
     with:
       image_tag: latest
@@ -46,12 +42,8 @@ jobs:
       DOCKER_IMAGE_PATH: ${{ secrets.DOCKER_IMAGE_PATH }}
   run-build-gar-image-fleece:
     uses: ./.github/workflows/build-gar-image-fleece.yaml
-    with:
-      image_tag: latest
-    secrets:
-      DOCKER_IMAGE_PATH: ${{ secrets.DOCKER_IMAGE_PATH }}
   run-publish-gar-image-fleece:
-    needs: run-build-gar-image-fleece
+    needs: [run-checks, run-tests, run-build-gar-image-fleece]
     uses: ./.github/workflows/publish-gar-image-fleece.yaml
     with:
       image_tag: latest
@@ -61,12 +53,8 @@ jobs:
       DOCKER_IMAGE_PATH: ${{ secrets.DOCKER_IMAGE_PATH }}
   run-build-gar-image-locust:
     uses: ./.github/workflows/build-gar-image-locust.yaml
-    with:
-      image_tag: latest
-    secrets:
-      DOCKER_IMAGE_PATH: ${{ secrets.DOCKER_IMAGE_PATH }}
   run-publish-gar-image-locust:
-    needs: run-build-gar-image-locust
+    needs: [run-checks, run-tests, run-build-gar-image-locust]
     uses: ./.github/workflows/publish-gar-image-locust.yaml
     with:
       image_tag: latest
@@ -76,12 +64,8 @@ jobs:
       DOCKER_IMAGE_PATH: ${{ secrets.DOCKER_IMAGE_PATH }}
   run-build-dockerhub-app:
     uses: ./.github/workflows/build-dockerhub-app-image.yaml
-    with:
-      image_tag: ${{ github.sha }}
-    secrets:
-      DOCKERHUB_REPO: ${{ secrets.DOCKERHUB_REPO }}
   run-publish-dockerhub-app:
-    needs: run-build-dockerhub-app
+    needs: [run-checks, run-tests, run-build-dockerhub-app]
     uses: ./.github/workflows/publish-dockerhub-app-image.yaml
     with:
       image_tag: ${{ github.sha }}

--- a/.github/workflows/pr-workflow.yaml
+++ b/.github/workflows/pr-workflow.yaml
@@ -2,6 +2,9 @@ name: pr-workflow
 
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
   run-checks:
     uses: ./.github/workflows/checks.yaml
@@ -11,19 +14,7 @@ jobs:
     uses: ./.github/workflows/docs-build.yaml
   run-build-gar-image:
     uses: ./.github/workflows/build-gar-image.yaml
-    with:
-      image_tag: latest
-    secrets:
-      DOCKER_IMAGE_PATH: ${{ secrets.DOCKER_IMAGE_PATH }}
   run-build-gar-image-fleece:
     uses: ./.github/workflows/build-gar-image-fleece.yaml
-    with:
-      image_tag: latest
-    secrets:
-      DOCKER_IMAGE_PATH: ${{ secrets.DOCKER_IMAGE_PATH }}
   run-build-gar-image-locust:
     uses: ./.github/workflows/build-gar-image-locust.yaml
-    with:
-      image_tag: latest
-    secrets:
-      DOCKER_IMAGE_PATH: ${{ secrets.DOCKER_IMAGE_PATH }}

--- a/.github/workflows/publish-dockerhub-app-image.yaml
+++ b/.github/workflows/publish-dockerhub-app-image.yaml
@@ -18,6 +18,8 @@ jobs:
   publish:
     environment: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
 
@@ -28,8 +30,6 @@ jobs:
           path: .
       - name: Load Docker image
         run: gunzip -c merino-app.tar.gz | docker load
-      - name: Re-tag image as app:build
-        run: docker tag ${{ secrets.DOCKERHUB_REPO }}:${{ inputs.image_tag }} app:build
       - name: Login to Docker Hub
         uses: docker/login-action@v4
         with:
@@ -41,11 +41,11 @@ jobs:
           msg=$(git log -1 --pretty=%B)
           echo "msg=$msg"
           if echo "$msg" | grep -q '\[load test: abort\]'; then
-            echo "tag=stage-loadtest-abort-${{ inputs.image_tag }}" >> $GITHUB_OUTPUT
+            echo "tag=stage-loadtest-abort-${{ inputs.image_tag }}" >> "$GITHUB_OUTPUT"
           elif echo "$msg" | grep -q '\[load test: skip\]'; then
-            echo "tag=stage-${{ inputs.image_tag }}" >> $GITHUB_OUTPUT
+            echo "tag=stage-${{ inputs.image_tag }}" >> "$GITHUB_OUTPUT"
           else
-            echo "tag=stage-loadtest-warn-${{ inputs.image_tag }}" >> $GITHUB_OUTPUT
+            echo "tag=stage-loadtest-warn-${{ inputs.image_tag }}" >> "$GITHUB_OUTPUT"
           fi
       - name: Tag and push to Docker Hub
         run: |

--- a/.github/workflows/publish-gar-image-locust.yaml
+++ b/.github/workflows/publish-gar-image-locust.yaml
@@ -17,20 +17,36 @@ on:
         required: true
 
 jobs:
+  check-directive:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      skip: ${{ steps.directive.outputs.skip }}
+    steps:
+      - uses: actions/checkout@v5
+      - name: Resolve load-test directive
+        id: directive
+        run: |
+          message="$(git log -1 --pretty=%B)"
+          if printf '%s\n' "$message" | grep -q '\[load test: abort\]'; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          elif printf '%s\n' "$message" | grep -q '\[load test: skip\]'; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Skipping Locust image publish due to [load test: skip] directive."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
   publish-locust:
+    needs: check-directive
+    if: needs.check-directive.outputs.skip != 'true'
     environment: build
     runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v5
-      - name: Check for [load test skip] directive
-        run: |
-          if git log -1 --pretty=%B | grep -qi '\[load test: skip\]'; then
-            echo "Skipping Locust image publish due to [load test: skip] directive."
-            exit 0
-          fi
       - name: Download Locust image artifact
         uses: actions/download-artifact@v7
         with:
@@ -38,13 +54,11 @@ jobs:
           path: .
       - name: Load Locust Docker image
         run: gunzip -c locust-image.tar.gz | docker load
-      - name: Tag image as latest
-        run: docker tag ${{ secrets.DOCKER_IMAGE_PATH }}/merino-locust:${{ inputs.image_tag }} ${{ secrets.DOCKER_IMAGE_PATH }}/merino-locust:latest
       - name: Push Locust image to GAR
         uses: mozilla/deploy-actions/docker-push@v3.11.1
         with:
-          local_image: ${{ secrets.DOCKER_IMAGE_PATH }}/merino-locust:latest
+          local_image: merino-locust:build
           image_repo_path: ${{ secrets.DOCKER_IMAGE_PATH }}/merino-locust
-          image_tag: latest
+          image_tag: ${{ inputs.image_tag }}
           workload_identity_pool_project_number: ${{ inputs.workload_identity_pool_project_number }}
           project_id: ${{ inputs.project_id }}

--- a/.github/workflows/upload-test-artifacts-to-gcs.yaml
+++ b/.github/workflows/upload-test-artifacts-to-gcs.yaml
@@ -48,12 +48,13 @@ jobs:
           path: ${{ inputs.source }}
       - name: Upload Artifacts to GCS
         run: |
-          FILES="${{ inputs.source }}/*"
+          shopt -s nullglob
+          files=("${{ inputs.source }}"/*)
           if [ -n "${{ inputs.extension }}" ]; then
-            FILES="${{ inputs.source }}/*.${{ inputs.extension }}"
+            files=("${{ inputs.source }}"/*."${{ inputs.extension }}")
           fi
-          if ! ls -1 $FILES >/dev/null 2>&1; then
+          if [ "${#files[@]}" -eq 0 ]; then
             echo "No ${{ inputs.extension }} files found in ${{ inputs.source }}/"
             exit 1
           fi
-          gcloud storage cp $FILES ${{ inputs.destination }}/
+          gcloud storage cp "${files[@]}" "${{ inputs.destination }}/"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Merino [![CircleCI](https://dl.circleci.com/status-badge/img/gh/mozilla-services/merino-py/tree/main.svg?style=shield)](https://dl.circleci.com/status-badge/redirect/gh/mozilla-services/merino-py/tree/main)
+# Merino [![GitHub Actions](https://github.com/mozilla-services/merino-py/actions/workflows/main-workflow.yaml/badge.svg?branch=main)](https://github.com/mozilla-services/merino-py/actions/workflows/main-workflow.yaml)
 
 A service to provide address bar suggestions to Firefox. For more details, see
 the [service docs](https://mozilla-services.github.io/merino-py/).

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -5,7 +5,6 @@ metadata:
   annotations:
     github.com/project-slug: mozilla-services/merino-py
     github.com/team-slug: mozilla-services/teams/context-services
-    circleci.com/project-slug: github/mozilla-services/merino-py
     sentry.io/project-slug: mozilla/merino-py
   description: Service to provide address bar suggestions to Firefox.
   tags:

--- a/docs/dev/release-process.md
+++ b/docs/dev/release-process.md
@@ -4,17 +4,14 @@ This project currently follows a [Continuous Deployment][continuous_deployment] 
 
 [continuous_deployment]: https://en.wikipedia.org/wiki/Continuous_deployment
 
-Whenever a commit is pushed to this repository's `main` branch, a CircleCI workflow is triggered
-which performs code checks and runs automated tests. The workflow additionally builds a new Docker
-image of the service and pushes that Docker image to the Docker Hub registry (this requires all
-previous jobs to pass).
+Whenever a commit is pushed to this repository's `main` branch, the GitHub Actions
+`main-workflow` performs code checks, runs automated tests, and builds the service images. Image
+publication requires the checks, tests, and corresponding image build to succeed.
 
 Pushing a new Docker image to the Docker Hub registry triggers a webhook that starts the Jenkins
 deployment pipeline (the Docker image tag determines the target environment). The deployment
 pipeline first deploys to the [`stage` environment][stage_environment] and subsequently to the
 [`production` environment][production_environment].
-
-![Activity diagram of CircleCI main-workflow][activity_circleci_main_workflow]
 
 After the deployment is complete, accessing the [`__version__` endpoint][stage_version] will show
 the commit hash of the deployed version, which will eventually match to the one of the latest commit
@@ -23,7 +20,6 @@ down).
 
 [stage_environment]: ../firefox.md#stage
 [production_environment]: ../firefox.md#production
-[activity_circleci_main_workflow]: ./circleci_main_workflow.jpg
 [stage_version]: https://merino.services.allizom.org/__version__
 
 ## Release Best Practices
@@ -45,7 +41,9 @@ load tests are run against the staging environment before Merino-py is promoted 
 
 Load tests in continuous deployment are controlled by adding a specific label to the commit message
 being deployed. The format for the label is `[load test: (abort|skip|warn)]`. Typically, this label
-is added to the merge commit created when a GitHub pull request is integrated.
+is added to the merge commit created when a GitHub pull request is integrated. Directives are
+case-sensitive and should use the lowercase form shown here. Use at most one directive; if multiple
+directives are accidentally present, precedence is `abort`, then `skip`, then `warn`.
 
 - `abort`: Stops the deployment if the load test fails.
 - `skip`: Skips load testing entirely during deployment.

--- a/docs/operations/testfailures.md
+++ b/docs/operations/testfailures.md
@@ -1,7 +1,7 @@
 # What to do with test failures in CI?
 
 1. Investigate the cause of the test failure
-    - For unit or integration, logs can be found on [CircleCI][circleci]
+    - For unit or integration, logs can be found in [GitHub Actions][github_actions]
     - For performance tests (load), insights can be found on [Grafana][merino_app_info] and in the
       Locust logs. To access the Locust logs see the [Distributed GCP Exection - CI Trigger][load_tests]
       section of the load test documentation.
@@ -16,10 +16,10 @@
       ```
 3. Re-Deploy
     - A fix or mitigation will most likely require a PR merge to the `main` branch that will
-      automatically trigger the deployment process. If this is not possible, a re-deployment can be
-      initiated manually by triggering the CI pipeline in [CircleCI][circleci].
+      automatically trigger the deployment process. This repository does not expose a manual
+      deployment workflow; if a merge is not possible, coordinate recovery with the service owners.
 
-[circleci]: https://app.circleci.com/pipelines/github/mozilla-services/merino-py
+[github_actions]: https://github.com/mozilla-services/merino-py/actions
 [merino_app_info]: https://earthangel-b40313e5.influxcloud.net/d/rQAfYKIVk/wip-merino-py-application-and-infrastructure?orgId=1&from=now-24h&to=now&var-environment=prodpy&refresh=1m
 [merino_gcp_stage]: https://console.cloud.google.com/kubernetes/list/overview?project=moz-fx-merino-nonprod-ee93
 [pytest_xfail]: https://docs.pytest.org/en/latest/how-to/skipping.html

--- a/tests/unit/test_ci_workflows.py
+++ b/tests/unit/test_ci_workflows.py
@@ -1,0 +1,187 @@
+"""Policy tests for release-critical GitHub Actions workflows."""
+
+from pathlib import Path
+from typing import Any, cast
+
+import yaml
+
+
+WORKSPACE_ROOT = Path(__file__).parents[2]
+WORKFLOW_ROOT = WORKSPACE_ROOT / ".github" / "workflows"
+
+PUBLISH_REQUIREMENTS = {
+    "run-publish-gar-image": {
+        "run-checks",
+        "run-tests",
+        "run-build-gar-image",
+    },
+    "run-publish-gar-image-fleece": {
+        "run-checks",
+        "run-tests",
+        "run-build-gar-image-fleece",
+    },
+    "run-publish-gar-image-locust": {
+        "run-checks",
+        "run-tests",
+        "run-build-gar-image-locust",
+    },
+    "run-publish-dockerhub-app": {
+        "run-checks",
+        "run-tests",
+        "run-build-dockerhub-app",
+    },
+}
+
+PR_IMAGE_BUILD_JOBS = {
+    "run-build-gar-image",
+    "run-build-gar-image-fleece",
+    "run-build-gar-image-locust",
+}
+
+IMAGE_BUILD_WORKFLOWS = {
+    "build-dockerhub-app-image.yaml",
+    "build-gar-image.yaml",
+    "build-gar-image-fleece.yaml",
+    "build-gar-image-locust.yaml",
+}
+
+
+def _load_workflow(filename: str) -> dict[str, Any]:
+    """Load a workflow and normalize YAML 1.1's boolean ``on`` key."""
+    workflow = yaml.safe_load((WORKFLOW_ROOT / filename).read_text())
+    assert isinstance(workflow, dict)
+
+    if True in workflow and "on" not in workflow:
+        workflow["on"] = workflow.pop(True)
+
+    return cast(dict[str, Any], workflow)
+
+
+def test_publish_jobs_require_checks_tests_and_their_image_build() -> None:
+    """Prevent a successful image build from bypassing failed validation."""
+    workflow = _load_workflow("main-workflow.yaml")
+    jobs = cast(dict[str, dict[str, Any]], workflow["jobs"])
+
+    for job_name, expected_needs in PUBLISH_REQUIREMENTS.items():
+        needs = cast(list[str], jobs[job_name]["needs"])
+        assert set(needs) == expected_needs
+        assert "if" not in jobs[job_name]
+
+
+def test_pull_request_image_builds_receive_no_secrets() -> None:
+    """Keep registry credentials out of workflows that execute pull-request code."""
+    workflow = _load_workflow("pr-workflow.yaml")
+    jobs = cast(dict[str, dict[str, Any]], workflow["jobs"])
+
+    assert workflow["permissions"] == {"contents": "read"}
+    for job_name in PR_IMAGE_BUILD_JOBS:
+        assert "secrets" not in jobs[job_name]
+
+
+def test_image_build_workflows_declare_no_registry_secrets() -> None:
+    """Require registry credentials only in protected publishing workflows."""
+    for filename in IMAGE_BUILD_WORKFLOWS:
+        workflow = _load_workflow(filename)
+        triggers = cast(dict[str, Any], workflow["on"])
+        workflow_call = triggers["workflow_call"]
+
+        assert workflow_call is None or "secrets" not in workflow_call
+
+
+def test_load_test_skip_directive_conditions_the_locust_publisher() -> None:
+    """Ensure the load-test skip directive bypasses the complete publishing job."""
+    workflow = _load_workflow("publish-gar-image-locust.yaml")
+    jobs = cast(dict[str, dict[str, Any]], workflow["jobs"])
+    check_job = jobs["check-directive"]
+    publish_job = jobs["publish-locust"]
+
+    assert check_job["outputs"] == {"skip": "${{ steps.directive.outputs.skip }}"}
+    check_steps = cast(list[dict[str, Any]], check_job["steps"])
+    directive_step = next(step for step in check_steps if step.get("id") == "directive")
+    directive_script = cast(str, directive_step["run"])
+    abort_check = "grep -q '\\[load test: abort\\]'"
+    skip_check = "grep -q '\\[load test: skip\\]'"
+    assert abort_check in directive_script
+    assert skip_check in directive_script
+    assert directive_script.index(abort_check) < directive_script.index(skip_check)
+    assert "grep -qi" not in directive_script
+
+    abort_branch, remaining_script = directive_script.split("elif", maxsplit=1)
+    skip_branch, default_branch = remaining_script.split("else", maxsplit=1)
+    assert 'echo "skip=false"' in abort_branch
+    assert 'echo "skip=true"' in skip_branch
+    assert 'echo "skip=false"' in default_branch
+
+    dockerhub_workflow = _load_workflow("publish-dockerhub-app-image.yaml")
+    dockerhub_jobs = cast(dict[str, dict[str, Any]], dockerhub_workflow["jobs"])
+    dockerhub_steps = cast(list[dict[str, Any]], dockerhub_jobs["publish"]["steps"])
+    dockerhub_directive_step = next(
+        step for step in dockerhub_steps if step.get("name") == "Parse load test directive"
+    )
+    dockerhub_script = cast(str, dockerhub_directive_step["run"])
+    assert dockerhub_script.index(abort_check) < dockerhub_script.index(skip_check)
+    assert "grep -qi" not in dockerhub_script
+
+    assert publish_job["needs"] == "check-directive"
+    assert publish_job["if"] == "needs.check-directive.outputs.skip != 'true'"
+
+
+def test_dockerhub_build_generates_versioned_artifact_for_publishing() -> None:
+    """Keep deployed version metadata and the build/publish artifact contract intact."""
+    build_workflow = _load_workflow("build-dockerhub-app-image.yaml")
+    build_jobs = cast(dict[str, dict[str, Any]], build_workflow["jobs"])
+    build_steps = cast(list[dict[str, Any]], build_jobs["build"]["steps"])
+    create_index = next(
+        index
+        for index, step in enumerate(build_steps)
+        if step.get("name") == "Create version.json"
+    )
+    build_index = next(
+        index
+        for index, step in enumerate(build_steps)
+        if step.get("name") == "Build Merino app image"
+    )
+    save_index = next(
+        index
+        for index, step in enumerate(build_steps)
+        if step.get("name") == "Save image artifact"
+    )
+    upload_index = next(
+        index
+        for index, step in enumerate(build_steps)
+        if step.get("name") == "Upload image artifact"
+    )
+    assert create_index < build_index < save_index < upload_index
+
+    create_script = cast(str, build_steps[create_index]["run"])
+    save_script = cast(str, build_steps[save_index]["run"])
+    assert "$GITHUB_SHA" in create_script
+    assert "> version.json" in create_script
+    assert save_script == "docker save app:build | gzip > merino-app.tar.gz"
+
+    upload_step = next(step for step in build_steps if step.get("name") == "Upload image artifact")
+    upload_config = cast(dict[str, str], upload_step["with"])
+
+    publish_workflow = _load_workflow("publish-dockerhub-app-image.yaml")
+    publish_jobs = cast(dict[str, dict[str, Any]], publish_workflow["jobs"])
+    publish_steps = cast(list[dict[str, Any]], publish_jobs["publish"]["steps"])
+    download_step = next(
+        step for step in publish_steps if step.get("name") == "Download app image"
+    )
+    download_config = cast(dict[str, str], download_step["with"])
+
+    assert upload_config == {"name": "merino-app-image", "path": "merino-app.tar.gz"}
+    assert download_config == {"name": "merino-app-image", "path": "."}
+
+
+def test_checks_run_pinned_actionlint() -> None:
+    """Validate workflow syntax and expressions with a reproducible actionlint version."""
+    workflow = _load_workflow("checks.yaml")
+    jobs = cast(dict[str, dict[str, Any]], workflow["jobs"])
+    steps = cast(list[dict[str, Any]], jobs["checks"]["steps"])
+    actionlint_step = next(
+        step for step in steps if step.get("name") == "Lint GitHub Actions workflows"
+    )
+
+    assert actionlint_step["uses"] == "docker://rhysd/actionlint:1.7.12"
+    assert actionlint_step["with"] == {"args": "-color"}

--- a/tests/unit/test_ci_workflows.py
+++ b/tests/unit/test_ci_workflows.py
@@ -175,7 +175,7 @@ def test_dockerhub_build_generates_versioned_artifact_for_publishing() -> None:
 
 
 def test_checks_run_pinned_actionlint() -> None:
-    """Validate workflow syntax and expressions with a reproducible actionlint version."""
+    """Validate workflows with a pinned, checksum-verified actionlint binary."""
     workflow = _load_workflow("checks.yaml")
     jobs = cast(dict[str, dict[str, Any]], workflow["jobs"])
     steps = cast(list[dict[str, Any]], jobs["checks"]["steps"])
@@ -183,5 +183,11 @@ def test_checks_run_pinned_actionlint() -> None:
         step for step in steps if step.get("name") == "Lint GitHub Actions workflows"
     )
 
-    assert actionlint_step["uses"] == "docker://rhysd/actionlint:1.7.12"
-    assert actionlint_step["with"] == {"args": "-color"}
+    assert actionlint_step["env"] == {
+        "ACTIONLINT_VERSION": "1.7.12",
+        "ACTIONLINT_SHA256": "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8",
+    }
+    actionlint_script = cast(str, actionlint_step["run"])
+    assert "actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" in actionlint_script
+    assert "sha256sum --check --strict" in actionlint_script
+    assert '"$RUNNER_TEMP/actionlint" -color' in actionlint_script


### PR DESCRIPTION
## Summary

- Require checks, tests, and the matching image build to pass before any Merino, Fleece, Locust, or Docker Hub image is published.
- Remove registry paths and credentials from image-build workflows, including all pull-request builds; builders now produce local image artifacts and publishers retain registry access.
- Make the load-test skip the complete Locust publisher
- Generate version metadata in the Docker Hub image before building so the deployed version endpoint reports the actual commit.
- Add pinned actionlint validation and focused policy tests for the release-critical workflow contracts.
- Replace active CircleCI references in release and failure documentation with the current GitHub Actions process.

## Why this PR comes first

This establishes a safe deployment baseline before Moon introduces affected-project execution. Selective CI must never allow a failed validation job, a skipped dependency, or pull-request code with registry credentials to reach a publisher.

## Ticket

[DISCO-4436](https://mozilla-hub.atlassian.net/browse/DISCO-4436)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2536)


[DISCO-4436]: https://mozilla-hub.atlassian.net/browse/DISCO-4436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ