### PR TITLE
chore: wiki blocklist update

### DIFF
--- a/merino/jobs/wikipedia_offline_uploader/page_ignore.csv
+++ b/merino/jobs/wikipedia_offline_uploader/page_ignore.csv
@@ -20,3 +20,6 @@ dHlwZXNfb2ZfcHJvc3RpdHV0aW9uX2luX21vZGVybl9qYXBhbg==
 dmlldG5hbV93YXI=
 d2lraXBlZGlh
 eG54eA==
+ZGVhdGhzX2luXzIwMjY=
+ZGVhdGhzIGluIDIwMjc=
+ZGVhdGhzIGluIDIwMjg=


### PR DESCRIPTION
## References


## Description
Block list add. This is to mitigate wiki offline suggestions to map "de" to "death in 2026".  Added 2027 and 2028 just to avoid future occurrences.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2539)
