### PR TITLE
[DISCO-4435] feat: toggle sanitization feature flag in prod

### DIFF
--- a/merino-fleece/merino_fleece/configs/production.toml
+++ b/merino-fleece/merino_fleece/configs/production.toml
@@ -20,3 +20,7 @@ subscription = "projects/moz-fx-merino-prod-5de4/subscriptions/merino-fleece-san
 # external liveness probe (e.g. a Kubernetes exec probe). Empty disables the heartbeat.
 # Must be writable by the container's unprivileged `app` user (uid 10001)
 heartbeat_path = "/tmp/fleece/heartbeat"
+
+[production.sanitize]
+# MERINO_FLEECE_SANITIZE__LOG_SEARCH_TERMS
+log_search_terms = true

--- a/merino/configs/flags/production.toml
+++ b/merino/configs/flags/production.toml
@@ -4,4 +4,4 @@ dynaconf_merge = true
 # Search term submission to merino-fleece; off by default,
 # rolled out by raising `enabled` toward 1.
 [production.flags.search-term-submission]
-enabled = 0
+enabled = 0.03

--- a/merino/configs/production.toml
+++ b/merino/configs/production.toml
@@ -187,3 +187,7 @@ gcp_project = "moz-fx-merino-prod-5de4"
 
 # GCS bucket that contains the LinTS-interest safetensors bundle.
 bucket_name = "merino-ml-data-prod"
+
+[production.message_handler]
+# MERINO_MESSAGE_HANDLER__ENABLED
+enabled = true

--- a/merino/configs/stage.toml
+++ b/merino/configs/stage.toml
@@ -168,3 +168,7 @@ base_url = "https://ads.allizom.org/v1/suggest/"
 
 # MERINO_MARS__SEND_TEST_PADDING
 send_test_padding = true
+
+[stage.message_handler]
+# MERINO_MESSAGE_HANDLER__ENABLED
+enabled = true


### PR DESCRIPTION
## References

JIRA: [DISCO-4435](https://mozilla-hub.atlassian.net/browse/DISCO-4435)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->

Search terms sanitization has been verified in staging, moving on to enable 3% of suggest traffic to test this in production. Note that this does _not_ affect the existing raw suggest log logging in Merino, which will continue to be logged 100% until the cutover later.  

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2541)


[DISCO-4435]: https://mozilla-hub.atlassian.net/browse/DISCO-4435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ