### PR TITLE
[HNT-2876] feat: Gate German editorial sections behind experiment treatment branch

### DIFF
--- a/merino/curated_recommendations/protocol.py
+++ b/merino/curated_recommendations/protocol.py
@@ -108,8 +108,6 @@ class ExperimentName(str, Enum):
     CONTEXTUAL_AD_V2_RELEASE_EXPERIMENT = "new-tab-contextual-ad-updates-v2-release"
     NEW_TAB_CUSTOM_SECTIONS_EXPERIMENT = "new-tab-custom-sections"
     INFERRED_TIME_ZONE_EXPERIMENT = "new-tab-stories-time-zone-based-ranking"
-    # Experiment to measure the impact of editorial sections by hiding them in the treatment branch
-    EDITORIAL_SECTIONS_EXPERIMENT = "editorial-sections-experiment"
     # Germany rollout of editorial sections: the treatment branch is the one that shows them
     EDITORIAL_SECTIONS_GERMANY_EXPERIMENT = "editorial-sections-experiment-germany"
     # Experiment to serve the cross-Europe English sections surface (NEW_TAB_EN_XE)
@@ -136,13 +134,10 @@ class DailyBriefingBranch(str, Enum):
 
 
 class EditorialSectionsBranch(str, Enum):
-    """Treatment branches for the Editorial Sections experiments (HNT-2182, HNT-2876)."""
+    """Treatment branches for the German Editorial Sections experiment."""
 
-    # US (HNT-2182): remove editorial sections; keep ML sections + Popular Today.
-    NO_EDITORIAL_SECTIONS = "no-editorial-sections"
-
-    # Germany (HNT-2876): the 80% branch that receives editorial sections. This inverts the US
-    # experiment: in DE editorial sections are hidden unless the user is on this branch.
+    # The 80% branch that receives editorial sections. Editorial sections are hidden in Germany
+    # unless the user is on this branch.
     GERMANY_TREATMENT = "treatment"
 
 

--- a/merino/curated_recommendations/protocol.py
+++ b/merino/curated_recommendations/protocol.py
@@ -110,6 +110,8 @@ class ExperimentName(str, Enum):
     INFERRED_TIME_ZONE_EXPERIMENT = "new-tab-stories-time-zone-based-ranking"
     # Experiment to measure the impact of editorial sections by hiding them in the treatment branch
     EDITORIAL_SECTIONS_EXPERIMENT = "editorial-sections-experiment"
+    # Germany rollout of editorial sections: the treatment branch is the one that shows them
+    EDITORIAL_SECTIONS_GERMANY_EXPERIMENT = "editorial-sections-experiment-germany"
     # Experiment to serve the cross-Europe English sections surface (NEW_TAB_EN_XE)
     SECTIONS_IN_EN_EUROPE_EXPERIMENT = "sections-in-en-europe"
     # Experiment to serve the global Spanish sections surface (NEW_TAB_ES_XA)
@@ -134,10 +136,14 @@ class DailyBriefingBranch(str, Enum):
 
 
 class EditorialSectionsBranch(str, Enum):
-    """Treatment branches for the Editorial Sections experiment (HNT-2182)."""
+    """Treatment branches for the Editorial Sections experiments (HNT-2182, HNT-2876)."""
 
-    # Remove editorial (manually curated) sections; keep ML sections + Popular Today.
+    # US (HNT-2182): remove editorial sections; keep ML sections + Popular Today.
     NO_EDITORIAL_SECTIONS = "no-editorial-sections"
+
+    # Germany (HNT-2876): the 80% branch that receives editorial sections. This inverts the US
+    # experiment: in DE editorial sections are hidden unless the user is on this branch.
+    GERMANY_TREATMENT = "treatment"
 
 
 # Maximum tileId that Firefox can support. Firefox uses Javascript to store this value. The max

--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -410,17 +410,38 @@ def is_custom_sections_experiment(request: CuratedRecommendationsRequest) -> boo
     )
 
 
-def should_exclude_editorial_sections(request: CuratedRecommendationsRequest) -> bool:
-    """Return True if editorial (manually curated) sections must be hidden (HNT-2182).
+def should_exclude_editorial_sections(
+    request: CuratedRecommendationsRequest,
+    surface_id: SurfaceId | None = None,
+) -> bool:
+    """Return True if editorial (manually curated) sections must be hidden.
 
-    True only for the `no-editorial-sections` branch of the editorial sections experiment.
-    Popular Today and ML sections are unaffected.
+    Two experiments feed into this, with opposite polarity:
+
+    - US (HNT-2182): sections are shown by default and hidden only on the
+      `no-editorial-sections` branch of the editorial sections experiment.
+    - Germany (HNT-2876): editorial sections are a new, experiment-gated feature, so on
+      NEW_TAB_DE_DE they are hidden unless the request is on the `treatment` branch of the
+      German experiment. The 20% holdback and any unenrolled DE client see no editorial
+      sections.
+
+    Popular Today, Daily Briefing and ML sections are unaffected either way.
     """
-    return is_enrolled_in_experiment(
+    if is_enrolled_in_experiment(
         request,
         ExperimentName.EDITORIAL_SECTIONS_EXPERIMENT.value,
         EditorialSectionsBranch.NO_EDITORIAL_SECTIONS.value,
-    )
+    ):
+        return True
+
+    if surface_id == SurfaceId.NEW_TAB_DE_DE:
+        return not is_enrolled_in_experiment(
+            request,
+            ExperimentName.EDITORIAL_SECTIONS_GERMANY_EXPERIMENT.value,
+            EditorialSectionsBranch.GERMANY_TREATMENT.value,
+        )
+
+    return False
 
 
 def get_ranking_rescaler_for_branch(
@@ -847,7 +868,7 @@ async def get_sections(
         surface_id=surface_id,
         min_feed_rank=1,
         include_subtopics=True,
-        exclude_editorial_sections=should_exclude_editorial_sections(request),
+        exclude_editorial_sections=should_exclude_editorial_sections(request, surface_id),
     )
 
     # Determine if we should include daily briefing based on experiment

--- a/merino/curated_recommendations/sections.py
+++ b/merino/curated_recommendations/sections.py
@@ -412,36 +412,25 @@ def is_custom_sections_experiment(request: CuratedRecommendationsRequest) -> boo
 
 def should_exclude_editorial_sections(
     request: CuratedRecommendationsRequest,
-    surface_id: SurfaceId | None = None,
+    surface_id: SurfaceId,
 ) -> bool:
     """Return True if editorial (manually curated) sections must be hidden.
 
-    Two experiments feed into this, with opposite polarity:
+    Editorial sections are being introduced in Germany as an experiment-gated feature, so on
+    NEW_TAB_DE_DE they are hidden unless the request is on the `treatment` branch of the German
+    experiment. The 20% holdback and any unenrolled DE client see no editorial sections. All
+    other surfaces show them unconditionally.
 
-    - US (HNT-2182): sections are shown by default and hidden only on the
-      `no-editorial-sections` branch of the editorial sections experiment.
-    - Germany (HNT-2876): editorial sections are a new, experiment-gated feature, so on
-      NEW_TAB_DE_DE they are hidden unless the request is on the `treatment` branch of the
-      German experiment. The 20% holdback and any unenrolled DE client see no editorial
-      sections.
-
-    Popular Today, Daily Briefing and ML sections are unaffected either way.
+    Popular Today, Daily Briefing and ML sections are unaffected.
     """
-    if is_enrolled_in_experiment(
+    if surface_id != SurfaceId.NEW_TAB_DE_DE:
+        return False
+
+    return not is_enrolled_in_experiment(
         request,
-        ExperimentName.EDITORIAL_SECTIONS_EXPERIMENT.value,
-        EditorialSectionsBranch.NO_EDITORIAL_SECTIONS.value,
-    ):
-        return True
-
-    if surface_id == SurfaceId.NEW_TAB_DE_DE:
-        return not is_enrolled_in_experiment(
-            request,
-            ExperimentName.EDITORIAL_SECTIONS_GERMANY_EXPERIMENT.value,
-            EditorialSectionsBranch.GERMANY_TREATMENT.value,
-        )
-
-    return False
+        ExperimentName.EDITORIAL_SECTIONS_GERMANY_EXPERIMENT.value,
+        EditorialSectionsBranch.GERMANY_TREATMENT.value,
+    )
 
 
 def get_ranking_rescaler_for_branch(

--- a/tests/unit/curated_recommendations/test_sections.py
+++ b/tests/unit/curated_recommendations/test_sections.py
@@ -411,35 +411,7 @@ class TestDailyBriefingExperiment:
 
 
 class TestEditorialSectionsExperiment:
-    """Tests covering should_exclude_editorial_sections (HNT-2182, HNT-2876)."""
-
-    @pytest.mark.parametrize(
-        "name,branch,expected",
-        [
-            # Treatment branch hides editorial sections.
-            (
-                ExperimentName.EDITORIAL_SECTIONS_EXPERIMENT.value,
-                EditorialSectionsBranch.NO_EDITORIAL_SECTIONS.value,
-                True,
-            ),
-            # Forced-enrollment (optin-) variant also activates the treatment.
-            (
-                f"optin-{ExperimentName.EDITORIAL_SECTIONS_EXPERIMENT.value}",
-                EditorialSectionsBranch.NO_EDITORIAL_SECTIONS.value,
-                True,
-            ),
-            # Control branch keeps editorial sections.
-            (ExperimentName.EDITORIAL_SECTIONS_EXPERIMENT.value, "control", False),
-            # Unrelated experiment does nothing.
-            ("other-experiment", "treatment", False),
-            # No experiment does nothing.
-            (None, None, False),
-        ],
-    )
-    def test_should_exclude_editorial_sections(self, name, branch, expected):
-        """Editorial sections are only excluded on the no-editorial-sections branch."""
-        req = SimpleNamespace(experimentName=name, experimentBranch=branch, inferredInterests=None)
-        assert should_exclude_editorial_sections(req) is expected
+    """Tests covering should_exclude_editorial_sections."""
 
     @pytest.mark.parametrize(
         "name,branch,surface_id,expected",
@@ -480,7 +452,7 @@ class TestEditorialSectionsExperiment:
             ),
         ],
     )
-    def test_should_exclude_editorial_sections_germany(self, name, branch, surface_id, expected):
+    def test_should_exclude_editorial_sections(self, name, branch, surface_id, expected):
         """In DE editorial sections are hidden unless the request is on the treatment branch."""
         req = SimpleNamespace(experimentName=name, experimentBranch=branch, inferredInterests=None)
         assert should_exclude_editorial_sections(req, surface_id) is expected

--- a/tests/unit/curated_recommendations/test_sections.py
+++ b/tests/unit/curated_recommendations/test_sections.py
@@ -478,7 +478,7 @@ class TestEditorialSectionsExperiment:
                 SurfaceId.NEW_TAB_EN_US,
                 False,
             ),
-            # A missing surface_id keeps the pre-HNT-2876 behaviour.
+            # The default behavior is to not exclude editorial sections.
             (None, None, None, False),
         ],
     )
@@ -486,15 +486,6 @@ class TestEditorialSectionsExperiment:
         """In DE editorial sections are hidden unless the request is on the treatment branch."""
         req = SimpleNamespace(experimentName=name, experimentBranch=branch, inferredInterests=None)
         assert should_exclude_editorial_sections(req, surface_id) is expected
-
-    def test_us_experiment_still_hides_sections_on_de_treatment(self):
-        """The US opt-out wins even if the request is on the German treatment branch."""
-        req = SimpleNamespace(
-            experimentName=ExperimentName.EDITORIAL_SECTIONS_EXPERIMENT.value,
-            experimentBranch=EditorialSectionsBranch.NO_EDITORIAL_SECTIONS.value,
-            inferredInterests=None,
-        )
-        assert should_exclude_editorial_sections(req, SurfaceId.NEW_TAB_DE_DE) is True
 
 
 class TestFilterSectionsByExperiment:

--- a/tests/unit/curated_recommendations/test_sections.py
+++ b/tests/unit/curated_recommendations/test_sections.py
@@ -478,8 +478,6 @@ class TestEditorialSectionsExperiment:
                 SurfaceId.NEW_TAB_EN_US,
                 False,
             ),
-            # The default behavior is to not exclude editorial sections.
-            (None, None, None, False),
         ],
     )
     def test_should_exclude_editorial_sections_germany(self, name, branch, surface_id, expected):

--- a/tests/unit/curated_recommendations/test_sections.py
+++ b/tests/unit/curated_recommendations/test_sections.py
@@ -411,7 +411,7 @@ class TestDailyBriefingExperiment:
 
 
 class TestEditorialSectionsExperiment:
-    """Tests covering should_exclude_editorial_sections (HNT-2182)."""
+    """Tests covering should_exclude_editorial_sections (HNT-2182, HNT-2876)."""
 
     @pytest.mark.parametrize(
         "name,branch,expected",
@@ -440,6 +440,61 @@ class TestEditorialSectionsExperiment:
         """Editorial sections are only excluded on the no-editorial-sections branch."""
         req = SimpleNamespace(experimentName=name, experimentBranch=branch, inferredInterests=None)
         assert should_exclude_editorial_sections(req) is expected
+
+    @pytest.mark.parametrize(
+        "name,branch,surface_id,expected",
+        [
+            # DE treatment branch is the only way to see editorial sections in Germany.
+            (
+                ExperimentName.EDITORIAL_SECTIONS_GERMANY_EXPERIMENT.value,
+                EditorialSectionsBranch.GERMANY_TREATMENT.value,
+                SurfaceId.NEW_TAB_DE_DE,
+                False,
+            ),
+            # Forced-enrollment (optin-) variant also shows them.
+            (
+                f"optin-{ExperimentName.EDITORIAL_SECTIONS_GERMANY_EXPERIMENT.value}",
+                EditorialSectionsBranch.GERMANY_TREATMENT.value,
+                SurfaceId.NEW_TAB_DE_DE,
+                False,
+            ),
+            # The 20% holdback sees no editorial sections.
+            (
+                ExperimentName.EDITORIAL_SECTIONS_GERMANY_EXPERIMENT.value,
+                "control",
+                SurfaceId.NEW_TAB_DE_DE,
+                True,
+            ),
+            # Unenrolled DE clients also see none.
+            (None, None, SurfaceId.NEW_TAB_DE_DE, True),
+            # The DE gate is scoped to Germany: de-AT is unaffected.
+            (None, None, SurfaceId.NEW_TAB_DE_AT, False),
+            # ...and so is de-CH.
+            (None, None, SurfaceId.NEW_TAB_DE_CH, False),
+            # The German experiment does not leak into other surfaces.
+            (
+                ExperimentName.EDITORIAL_SECTIONS_GERMANY_EXPERIMENT.value,
+                "control",
+                SurfaceId.NEW_TAB_EN_US,
+                False,
+            ),
+            # A missing surface_id keeps the pre-HNT-2876 behaviour.
+            (None, None, None, False),
+        ],
+    )
+    def test_should_exclude_editorial_sections_germany(self, name, branch, surface_id, expected):
+        """In DE editorial sections are hidden unless the request is on the treatment branch."""
+        req = SimpleNamespace(experimentName=name, experimentBranch=branch, inferredInterests=None)
+        assert should_exclude_editorial_sections(req, surface_id) is expected
+
+    def test_us_experiment_still_hides_sections_on_de_treatment(self):
+        """The US opt-out wins even if the request is on the German treatment branch."""
+        req = SimpleNamespace(
+            experimentName=ExperimentName.EDITORIAL_SECTIONS_EXPERIMENT.value,
+            experimentBranch=EditorialSectionsBranch.NO_EDITORIAL_SECTIONS.value,
+            inferredInterests=None,
+        )
+        assert should_exclude_editorial_sections(req, SurfaceId.NEW_TAB_DE_DE) is True
 
 
 class TestFilterSectionsByExperiment:


### PR DESCRIPTION
## References

JIRA: [HNT-2876](https://mozilla-hub.atlassian.net/browse/HNT-2876)
Experimenter: https://experimenter.services.mozilla.com/nimbus/editorial-sections-experiment-germany/summary/
Cleans up: #1502 ([HNT-2182](https://mozilla-hub.atlassian.net/browse/HNT-2182))

## Description

Gates editorial (manually curated) sections in Germany behind the `treatment` branch of
[`editorial-sections-experiment-germany`](https://experimenter.services.mozilla.com/nimbus/editorial-sections-experiment-germany/summary/), so we can roll them out to 80% of DE users with a 20% holdback.

**The polarity is the opposite of the US experiment.** In the US, editorial sections shipped
globally first and #1502 later added a `no-editorial-sections` branch to remove them for some
users. Germany has never had editorial sections, so here they are hidden by default and only
the `treatment` branch sees them.

| Surface | Enrollment | Editorial sections |
|---|---|---|
| `NEW_TAB_DE_DE` | `editorial-sections-experiment-germany` / `treatment` | **shown** |
| `NEW_TAB_DE_DE` | holdback branch, or not enrolled | **hidden** |
| everything else | — | shown (unchanged) |

Popular Today, Daily Briefing and ML sections are unaffected. de-AT and de-CH are
deliberately out of scope even though they share German content — the gate is scoped to
`NEW_TAB_DE_DE` only.

The legacy (non-sections) grid needs no change: `sections_adapter.py` filters to legacy
topics, so custom-named editorial sections such as Erklärt and In Zahlen can't reach it.

### Also: removes the completed US experiment

`editorial-sections-experiment` (HNT-2182) has concluded and editorial sections remain
enabled in the US, which is the default behaviour, so the `no-editorial-sections` gate, its
enum members and its tests are removed. `should_exclude_editorial_sections` is now purely the
German gate, and its `surface_id` parameter is required rather than defaulting to `None`,
since the only caller always supplies it.

### Not included: crawled sections

The Experimenter treatment branch covers **editorial *and* crawled** sections. Only the
editorial half is here. Crawled sections are identified by an `externalId` ending in `_crawl`
and are dropped unconditionally in `sections_backend.py`, inside the per-surface TTL-cached
`fetch()` — so they never reach the request path and can't currently be varied per request.
Enabling them for the treatment branch means moving that filter downstream rather than
flipping a flag, and resolving how `_crawl` sections interact with the existing
`experimentVariant` / `alternateSection` handling, dedupe, and `receivedFeedRank`. Tracking
separately; **this PR alone is not sufficient to launch the experiment as specified.**

### Test instructions

Force enrollment from a DE client with `optin-editorial-sections-experiment-germany` /
`treatment` and confirm manually curated sections appear; the same request without the
experiment should return ML sections and Popular Today only.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[HNT-2876]: https://mozilla-hub.atlassian.net/browse/HNT-2876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HNT-2182]: https://mozilla-hub.atlassian.net/browse/HNT-2182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ