### PR TITLE
[DISCO-4449] refactor(common): overhaul sensitive data redaction for sentry

### DIFF
--- a/merino-common/merino_common/app_configs/config_sentry.py
+++ b/merino-common/merino_common/app_configs/config_sentry.py
@@ -2,10 +2,12 @@
 
 import json
 import logging
-from collections.abc import Mapping
+from collections.abc import Iterator, Mapping
+from typing import Any
 
 import sentry_sdk
 from sentry_sdk.integrations.fastapi import FastApiIntegration
+from sentry_sdk.integrations.logging import ignore_logger
 from sentry_sdk.integrations.starlette import StarletteIntegration
 from sentry_sdk.types import Event, Hint
 
@@ -14,6 +16,49 @@ from merino_common.utils.version import fetch_app_version_from_file
 logger = logging.getLogger(__name__)
 
 REDACTED_TEXT = "[REDACTED]"
+
+# Keys whose values are, or contain, a raw user query. Matched at any depth of a nested
+# structure: request bodies, breadcrumb data and log record extras.
+SENSITIVE_KEYS: frozenset[str] = frozenset({"q", "query", "search_terms", "submission"})
+
+# Modules on the search term submission & sanitization path. Every frame local in these
+# modules is redacted unless its name is in `SAFE_VAR_NAMES`.
+SEARCH_TERM_MODULES: tuple[str, ...] = (
+    "merino.message_handlers.search_terms",
+    "merino.middleware.logging",
+    "merino.utils.log_data_creators",
+    "merino_common.models.suggest_logging",
+    "merino_common.utils.async_batch_queue",
+    "merino_common.utils.query_processing",
+    "merino_fleece",
+)
+
+# The same modules as file paths, for frames where Sentry reports a filename but no module.
+SEARCH_TERM_PATHS: tuple[str, ...] = tuple(
+    module.replace(".", "/") for module in SEARCH_TERM_MODULES
+)
+
+# Frame locals in `SEARCH_TERM_MODULES` are redacted wholesale. On that path a local holds
+# a user query, or something derived from one, often enough that enumerating the exceptions
+# is not worth the risk of missing one. Name a local here to opt it back in for debugging.
+EXEMPT_VAR_NAMES: frozenset[str] = frozenset()
+
+# Substrings that identify a serialized search term payload wherever it surfaces. Used for
+# frames outside `SEARCH_TERM_MODULES` -- httpx, FastAPI, pydantic, Pub/Sub and
+# Elasticsearch all carry the payload in their own locals -- and for exception messages.
+PAYLOAD_MARKERS: tuple[str, ...] = (
+    "search_terms",
+    "SuggestRequestParams",
+    "SearchTermsSubmission",
+    "SanitizedSearchTermLog",
+    # The Elasticsearch query built from a Wikipedia suggest query.
+    "suggest-on-title",
+)
+
+# Loggers that exist solely to emit structured search term records to stdout for downstream
+# ingestion. Their `extra=` payloads carry raw queries, and Sentry's logging integration
+# would otherwise turn every record into a breadcrumb attached to later events.
+SEARCH_TERM_LOGGERS: tuple[str, ...] = ("web.suggest.request", "web.suggest.sanitized")
 
 
 def configure_sentry(
@@ -53,56 +98,175 @@ def configure_sentry(
         # We recommend adjusting this value in production,
         traces_sample_rate=traces_sample_rate,
     )
+    ignore_search_term_loggers()
     if default_tags:
         sentry_sdk.set_tags(default_tags)
 
 
+def ignore_search_term_loggers() -> None:
+    """Stop the search term loggers from feeding Sentry breadcrumbs and events.
+
+    These loggers emit a raw user query in the record's ``extra``, which Sentry's logging
+    integration copies into ``breadcrumb["data"]``. Without this, one suggest request log
+    attaches a query to every event the process sends afterwards. They carry no diagnostic
+    value in Sentry, so drop them at the source rather than scrub them per event.
+    """
+    for name in SEARCH_TERM_LOGGERS:
+        ignore_logger(name)
+
+
+def _redact_keys(value: Any) -> None:
+    """Redact the values of `SENSITIVE_KEYS` anywhere within `value`, in place.
+
+    Recursion is unbounded by design: Sentry serializes the event before `before_send` runs,
+    so `value` is an acyclic structure of primitives already capped at the SDK's max depth.
+    """
+    if isinstance(value, dict):
+        for key, item in list(value.items()):
+            if isinstance(key, str) and key in SENSITIVE_KEYS:
+                value[key] = REDACTED_TEXT
+            else:
+                _redact_keys(item)
+    elif isinstance(value, list):
+        for item in value:
+            _redact_keys(item)
+
+
+def _contains_payload(value: Any) -> bool:
+    """Return whether `value` looks like a serialized search term payload.
+
+    Fails closed: a value that cannot be serialized is treated as sensitive.
+    """
+    try:
+        serialized = json.dumps(value, default=str)
+    except TypeError, ValueError:
+        return True
+    return any(marker in serialized for marker in PAYLOAD_MARKERS)
+
+
+def _iter_frames(event: Event) -> Iterator[dict[str, Any]]:
+    """Yield every stack frame in the event.
+
+    Covers all exception values, not just the first: `raise X from Y` reports two, and the
+    frames of the raised exception are in the last one. Thread stacktraces are included as
+    well, since a `logger.error()` call without `exc_info` reports its locals there.
+    """
+    containers: list[dict[str, Any]] = [
+        *event.get("exception", {}).get("values", []),
+        *event.get("threads", {}).get("values", []),
+    ]
+    for container in containers:
+        stacktrace = container.get("stacktrace")
+        if not isinstance(stacktrace, dict):
+            continue
+        yield from stacktrace.get("frames") or []
+
+
+def _is_search_term_frame(frame: dict[str, Any]) -> bool:
+    """Return whether the frame belongs to the search term submission path."""
+    module = frame.get("module")
+    if isinstance(module, str) and module.startswith(SEARCH_TERM_MODULES):
+        return True
+    filename = frame.get("filename")
+    return isinstance(filename, str) and any(path in filename for path in SEARCH_TERM_PATHS)
+
+
+def _redact_suggest_vars(frame_vars: dict[str, Any]) -> None:
+    """Redact the suggest query out of the frame locals that are known to carry it."""
+    match frame_vars:
+        case {"q": _}:
+            frame_vars["q"] = REDACTED_TEXT
+        case {"srequest": _, "query": _}:
+            frame_vars["srequest"] = REDACTED_TEXT
+            frame_vars["query"] = REDACTED_TEXT
+        case {"query": _}:
+            frame_vars["query"] = REDACTED_TEXT
+        case {"values": {"q": _}, "solved_result": [{"q": _}, *_]}:
+            frame_vars["values"]["q"] = REDACTED_TEXT
+            frame_vars["solved_result"][0]["q"] = REDACTED_TEXT
+        case {"values": {"q": _}}:
+            frame_vars["values"]["q"] = REDACTED_TEXT
+        case _:
+            pass
+
+
+def _redact_auth_vars(frame_vars: dict[str, Any]) -> None:
+    """Redact third-party API credentials out of the frame locals that carry them."""
+    args = frame_vars.get("args")
+    if isinstance(args, dict) and "key" in args:
+        args["key"] = REDACTED_TEXT
+
+    headers = frame_vars.get("headers")
+    if isinstance(headers, dict):
+        for header in headers:
+            if str(header).lower() == "ocp-apim-subscription-key":
+                headers[header] = REDACTED_TEXT
+
+
+def _redact_frame(frame: dict[str, Any]) -> None:
+    """Redact sensitive locals out of a single stack frame."""
+    frame_vars = frame.get("vars")
+    if not isinstance(frame_vars, dict):
+        return
+
+    if _is_search_term_frame(frame):
+        for name in frame_vars.keys() - EXEMPT_VAR_NAMES:
+            frame_vars[name] = REDACTED_TEXT
+        return
+
+    _redact_suggest_vars(frame_vars)
+    _redact_auth_vars(frame_vars)
+    # Third-party frames (httpx, FastAPI, pydantic, Pub/Sub, Elasticsearch) hold the
+    # payload under names we cannot enumerate, so match on the content instead.
+    for name, value in list(frame_vars.items()):
+        if value != REDACTED_TEXT and _contains_payload(value):
+            frame_vars[name] = REDACTED_TEXT
+
+
 def strip_sensitive_data(event: Event, hint: Hint) -> Event | None:
-    """Filter out sensitive data from Sentry events."""
-    #  See: https://docs.sentry.io/platforms/python/configuration/filtering/
-    if event.get("request", {}).get("query_string", {}):
-        event["request"]["query_string"] = REDACTED_TEXT
+    """Filter out sensitive data from Sentry events.
 
-        event_exception_values = event.get("exception", {}).get("values", [])
-        if len(event_exception_values):
-            for entry in event_exception_values[0].get("stacktrace", {}).get("frames", []):
-                vars = entry.get("vars", {})
+    A user query reaches an event through more than one channel, so every part of the
+    event that can carry one is swept: the request (query string and captured body), the
+    frame locals of every exception and thread stacktrace, the exception messages, and the
+    log record extras and breadcrumbs.
 
-                match vars:
-                    case {"q": _}:
-                        vars["q"] = REDACTED_TEXT
-                    case {"srequest": _, "query": _}:
-                        vars["srequest"] = REDACTED_TEXT
-                        vars["query"] = REDACTED_TEXT
-                    case {"query": _}:
-                        vars["query"] = REDACTED_TEXT
-                    case {"values": {"q": _}, "solved_result": [{"q": _}, *_]}:
-                        vars["values"]["q"] = REDACTED_TEXT
-                        vars["solved_result"][0]["q"] = REDACTED_TEXT
-                    case {"values": {"q": _}}:
-                        vars["values"]["q"] = REDACTED_TEXT
-                    case _:
-                        pass
+    Two matching strategies are combined, because neither covers the payload alone.
+      - Frames on the search term path (`SEARCH_TERM_MODULES`) are redacted by default.
+      - Everywhere else -- third-party frames, request bodies, breadcrumbs -- names cannot be
+        enumerated, so values are matched on their content instead, against `SENSITIVE_KEYS`
+        for structured data and `PAYLOAD_MARKERS` for anything already serialized to text.
 
-                # Redact the query sent to Elasticsearch.
-                # This just redacts all the variables that contains a part of the
-                # Elasticsearch query.
-                for key, value in entry["vars"].items():
-                    if "suggest-on-title" in json.dumps(value):
-                        entry["vars"][key] = REDACTED_TEXT
+    Runs as Sentry's `before_send` hook, which means it runs after the SDK has serialized
+    the event: `event` is an acyclic structure of primitives, and is redacted in place. It
+    must not raise -- Sentry swallows the error and drops the whole event -- so missing or
+    unexpected keys are tolerated throughout and unserializable values fail closed.
 
-    event_exception_values = event.get("exception", {}).get("values", [])
-    if len(event_exception_values):
-        for entry in event_exception_values[0].get("stacktrace", {}).get("frames", []):
-            vars = entry.get("vars", {})
-            args = vars.get("args")
-            if isinstance(args, dict) and "key" in args:
-                args["key"] = REDACTED_TEXT
+    See: https://docs.sentry.io/platforms/python/configuration/filtering/
+    """
+    request = event.get("request")
+    if isinstance(request, dict):
+        if request.get("query_string"):
+            request["query_string"] = REDACTED_TEXT
+        # Sentry's Starlette integration captures the parsed JSON body, which for the
+        # search terms submission endpoint is the whole batch of raw queries.
+        _redact_keys(request.get("data"))
 
-            headers = vars.get("headers")
-            if isinstance(headers, dict):
-                for header in headers:
-                    if str(header).lower() == "ocp-apim-subscription-key":
-                        headers[header] = REDACTED_TEXT
+    for frame in _iter_frames(event):
+        _redact_frame(frame)
+
+    # A pydantic ValidationError embeds the offending input in its message, and every
+    # search term model is constructed from user query data.
+    for entry in event.get("exception", {}).get("values", []):
+        if isinstance(entry, dict) and _contains_payload(entry.get("value")):
+            entry["value"] = REDACTED_TEXT
+
+    # Records from a logger that is not in `SEARCH_TERM_LOGGERS` can still carry a query
+    # in their `extra`; those land here.
+    _redact_keys(event.get("extra"))
+    breadcrumbs = event.get("breadcrumbs")
+    if isinstance(breadcrumbs, dict):
+        for crumb in breadcrumbs.get("values", []):
+            _redact_keys(crumb.get("data"))
 
     return event

--- a/merino-common/tests/unit/app_configs/test_config_sentry.py
+++ b/merino-common/tests/unit/app_configs/test_config_sentry.py
@@ -6,10 +6,13 @@
 
 import typing
 
+from sentry_sdk.integrations.logging import _IGNORED_LOGGERS, unignore_logger
 from sentry_sdk.types import Event
 
 from merino_common.app_configs.config_sentry import (
     REDACTED_TEXT,
+    SEARCH_TERM_LOGGERS,
+    ignore_search_term_loggers,
     strip_sensitive_data,
 )
 
@@ -267,3 +270,187 @@ def test_strip_sensitive_data_redacts_sportsdata_auth_locals() -> None:
     assert frame_vars["args"]["key"] == REDACTED_TEXT
     assert frame_vars["args"]["league"] == "nfl"
     assert frame_vars["headers"]["Ocp-Apim-Subscription-Key"] == REDACTED_TEXT
+
+
+def test_strip_sensitive_data_redacts_search_term_frame_locals() -> None:
+    """Test search term locals are redacted from every exception value, not just the first."""
+    event: Event = {
+        "exception": {
+            "values": [
+                {
+                    "type": "HTTPStatusError",
+                    "value": "Server error '500 Internal Server Error'",
+                    "stacktrace": {"frames": [{"module": "httpx._client", "vars": {}}]},
+                },
+                {
+                    "type": "FleeceError",
+                    "value": "Fleece returned an unexpected status 500 Internal Server Error",
+                    "stacktrace": {
+                        "frames": [
+                            {
+                                "module": "merino.message_handlers.search_terms.fleece",
+                                "filename": "merino/message_handlers/search_terms/fleece.py",
+                                "vars": {
+                                    "self": "<merino.message_handlers.search_terms."
+                                    "fleece.FleeceClient object at 0x10974cc20>",
+                                    "search_terms": [
+                                        "SuggestRequestParams(query='how to file taxes')"
+                                    ],
+                                    "submission": "SearchTermsSubmission(search_terms=[...])",
+                                    "outcome": "'error'",
+                                    "start": "1234.5",
+                                },
+                            }
+                        ]
+                    },
+                },
+            ]
+        }
+    }
+
+    sanitized_event = typing.cast(Event, strip_sensitive_data(event, mock_sentry_hint))
+
+    # Every local on this path goes, not just the ones known to hold a query.
+    frame_vars = sanitized_event["exception"]["values"][1]["stacktrace"]["frames"][0]["vars"]
+    assert set(frame_vars) == {"self", "search_terms", "submission", "outcome", "start"}
+    assert set(frame_vars.values()) == {REDACTED_TEXT}
+    # A message that carries no payload is left intact for grouping and triage.
+    assert sanitized_event["exception"]["values"][1]["value"].startswith("Fleece returned")
+
+
+def test_strip_sensitive_data_redacts_payload_in_third_party_frame() -> None:
+    """Test a search term payload is redacted from frames outside the search term modules."""
+    event: Event = {
+        "exception": {
+            "values": [
+                {
+                    "stacktrace": {
+                        "frames": [
+                            {
+                                "module": "httpx._content",
+                                "vars": {
+                                    "json": {"search_terms": [{"query": "how to file taxes"}]},
+                                    # A local json.dumps cannot handle: fail closed rather
+                                    # than raise, which would drop the whole event.
+                                    "headers_by_pair": {("accept", "json"): "1"},
+                                    "boundary": "b'a1b2c3'",
+                                },
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+
+    sanitized_event = typing.cast(Event, strip_sensitive_data(event, mock_sentry_hint))
+
+    frame_vars = sanitized_event["exception"]["values"][0]["stacktrace"]["frames"][0]["vars"]
+    assert frame_vars["json"] == REDACTED_TEXT
+    assert frame_vars["headers_by_pair"] == REDACTED_TEXT
+    assert frame_vars["boundary"] == "b'a1b2c3'"
+
+
+def test_strip_sensitive_data_redacts_request_body_extras_and_breadcrumbs() -> None:
+    """Test queries are redacted from the request body, log record extras and breadcrumbs."""
+    event: Event = {
+        "request": {
+            "method": "POST",
+            "url": "http://merino-fleece/api/v1/search-terms",
+            "data": {"search_terms": [{"query": "how to file taxes", "country": "US"}]},
+        },
+        "extra": {"query": "how to file taxes", "submitted_count": 3},
+        "breadcrumbs": {
+            "values": [
+                {
+                    "category": "web.suggest.sanitized",
+                    "data": {
+                        "terms": [{"query": "how to file taxes"}],
+                        "country": "US",
+                    },
+                }
+            ]
+        },
+    }
+
+    sanitized_event = typing.cast(Event, strip_sensitive_data(event, mock_sentry_hint))
+
+    request_data = typing.cast(dict, sanitized_event["request"]["data"])
+    assert request_data["search_terms"] == REDACTED_TEXT
+    assert sanitized_event["extra"]["query"] == REDACTED_TEXT
+    assert sanitized_event["extra"]["submitted_count"] == 3
+    breadcrumbs = typing.cast(dict, sanitized_event["breadcrumbs"])
+    breadcrumb_data = breadcrumbs["values"][0]["data"]
+    assert breadcrumb_data["terms"][0]["query"] == REDACTED_TEXT
+    assert breadcrumb_data["country"] == "US"
+
+
+def test_strip_sensitive_data_redacts_payload_bearing_exception_message() -> None:
+    """Test a validation error message that embeds the submitted query is redacted."""
+    event: Event = {
+        "exception": {
+            "values": [
+                {
+                    "type": "ValidationError",
+                    "value": (
+                        "1 validation error for SearchTermsSubmission\n"
+                        "search_terms.0.code\n  Input should be a valid integer "
+                        "[input_value={'query': 'how to file taxes'}]"
+                    ),
+                }
+            ]
+        }
+    }
+
+    sanitized_event = typing.cast(Event, strip_sensitive_data(event, mock_sentry_hint))
+
+    assert sanitized_event["exception"]["values"][0]["value"] == REDACTED_TEXT
+
+
+def test_strip_sensitive_data_handles_missing_keys_and_thread_frames() -> None:
+    """Test frames without vars are tolerated and thread stacktraces are redacted.
+
+    A raised `before_send` is swallowed by Sentry and drops the whole event, so a frame
+    without `vars` must not be an error.
+    """
+    event: Event = {
+        "exception": {"values": [{"type": "RuntimeError", "value": "boom"}]},
+        "threads": {
+            "values": [
+                {
+                    "stacktrace": {
+                        "frames": [
+                            {"module": "merino_common.utils.async_batch_queue"},
+                            {
+                                "module": "merino_common.utils.async_batch_queue",
+                                "vars": {
+                                    "batch": ["SuggestRequestParams(query='taxes')"],
+                                    "self": "<merino_common.utils.async_batch_queue."
+                                    "AsyncBatchQueue object at 0x104e2b110>",
+                                },
+                            },
+                        ]
+                    }
+                }
+            ]
+        },
+    }
+
+    sanitized_event = typing.cast(Event, strip_sensitive_data(event, mock_sentry_hint))
+
+    frames = sanitized_event["threads"]["values"][0]["stacktrace"]["frames"]
+    assert "vars" not in frames[0]
+    assert frames[1]["vars"]["batch"] == REDACTED_TEXT
+    assert frames[1]["vars"]["self"] == REDACTED_TEXT
+    assert sanitized_event["exception"]["values"][0]["value"] == "boom"
+
+
+def test_ignore_search_term_loggers() -> None:
+    """Test the search term loggers are excluded from Sentry breadcrumbs and events."""
+    try:
+        ignore_search_term_loggers()
+        for name in SEARCH_TERM_LOGGERS:
+            assert name in _IGNORED_LOGGERS
+    finally:
+        for name in SEARCH_TERM_LOGGERS:
+            unignore_logger(name)


### PR DESCRIPTION


## References

JIRA: [DISCO-4449](https://mozilla-hub.atlassian.net/browse/DISCO-4449)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->

Our current Sentry sensitive data redaction is quite "leaky" and it can barely handle the new code for search term sanitization. This gives it an overhaul and hopefully would make it more future-proof.

Change summaries:
- Drop log records of the loggers`web.suggest.request` and `web.suggest.sanitized` from Sentry's logging integration before they become breadcrumbs and events for Sentry. Those loggers are used by Merino and Fleece to log raw and sanitized search terms.
- Redact ALL frame locals in the sensitive data packed modules (`SEARCH_TERM_MODULES`). Cherrypicking redaction has proven to be fragile and hard to maintain, so we will do wholesale on those paths. Note that an exemption list is provided for debugging, but that needs additional opt-in.   

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2544)


[DISCO-4449]: https://mozilla-hub.atlassian.net/browse/DISCO-4449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ