### PR TITLE
HNT-3000 feat: add circuit breaker to corpus scheduled surface backend

### DIFF
--- a/merino/curated_recommendations/corpus_backends/scheduled_surface_backend.py
+++ b/merino/curated_recommendations/corpus_backends/scheduled_surface_backend.py
@@ -20,6 +20,9 @@ from merino.curated_recommendations.corpus_backends.caching import (
     stale_while_revalidate,
     WaitRandomExpiration,
 )
+from merino.curated_recommendations.corpus_backends.circuitbreaker import (
+    CuratedRecommendationsCircuitBreaker,
+)
 from merino.curated_recommendations.corpus_backends.protocol import (
     ScheduledSurfaceProtocol,
     CorpusItem,
@@ -42,11 +45,8 @@ class ScheduledSurfaceBackend(ScheduledSurfaceProtocol):
     Uses an in-memory cache and request coalescing to limit request rate to the backend.
     """
 
-    http_client: AsyncClient
-    graph_config: CorpusApiGraphConfig
-    metrics_client: aiodogstatsd.Client
-    manifest_provider: ManifestProvider
-
+    _background_tasks: set[asyncio.Task]
+    _cache: dict
     # Time-to-live was chosen because 2 minutes and 20 seconds (+/- 30 s) is
     # short enough that updates by curators such as breaking news or editorial
     # corrections propagate fast enough, and that the request rate to the
@@ -58,8 +58,11 @@ class ScheduledSurfaceBackend(ScheduledSurfaceProtocol):
     cache_time_to_live_max = timedelta(
         seconds=settings.curated_recommendations.corpus_api.cache_ttl_max
     )
-    _cache: dict
-    _background_tasks: set[asyncio.Task]
+    http_client: AsyncClient
+    graph_config: CorpusApiGraphConfig
+    manifest_provider: ManifestProvider
+    metrics_client: aiodogstatsd.Client
+    retry_count = settings.curated_recommendations.corpus_api.retry_count
 
     def __init__(
         self,
@@ -119,13 +122,16 @@ class ScheduledSurfaceBackend(ScheduledSurfaceProtocol):
         cache=lambda self: self._cache,
         jobs=lambda self: self._background_tasks,
     )
+    @CuratedRecommendationsCircuitBreaker(
+        name="curated_recommendations_scheduled_surface_circuit_breaker"
+    )
     @retry(
         wait=wait_exponential_jitter(
             initial=settings.curated_recommendations.corpus_api.retry_wait_initial_seconds,
             jitter=settings.curated_recommendations.corpus_api.retry_wait_jitter_seconds,
         ),
-        stop=stop_after_attempt(settings.curated_recommendations.corpus_api.retry_count),
-        retry=retry_if_exception_type((CorpusGraphQLError, HTTPError, ValueError)),
+        stop=stop_after_attempt(retry_count),
+        retry=retry_if_exception_type((CorpusGraphQLError, HTTPError)),
         reraise=True,
         before_sleep=before_sleep_log(logger, logging.WARNING),
     )

--- a/merino/curated_recommendations/corpus_backends/sections_backend.py
+++ b/merino/curated_recommendations/corpus_backends/sections_backend.py
@@ -1,10 +1,10 @@
 """Corpus Sections API backend for fetching section recommendations using the getSections GraphQL query."""
 
+import aiodogstatsd
 import asyncio
 import logging
-from datetime import timedelta
 
-import aiodogstatsd
+from datetime import timedelta
 from httpx import AsyncClient, HTTPError
 from tenacity import (
     retry,
@@ -13,11 +13,13 @@ from tenacity import (
     wait_exponential_jitter,
     before_sleep_log,
 )
-
 from merino.configs import settings
 from merino.curated_recommendations.corpus_backends.caching import (
     stale_while_revalidate,
     WaitRandomExpiration,
+)
+from merino.curated_recommendations.corpus_backends.circuitbreaker import (
+    CuratedRecommendationsCircuitBreaker,
 )
 from merino.curated_recommendations.corpus_backends.protocol import (
     SectionsProtocol,
@@ -33,9 +35,6 @@ from merino.curated_recommendations.corpus_backends.utils import (
 from merino.curated_recommendations.ml_backends.protocol import SpindleBackendProtocol
 from merino.providers.manifest import Provider as ManifestProvider
 
-from merino.curated_recommendations.corpus_backends.circuitbreaker import (
-    CuratedRecommendationsCircuitBreaker,
-)
 
 logger = logging.getLogger(__name__)
 

--- a/tests/integration/api/v1/curated_recommendations/corpus_backends/test_scheduled_surface_backend.py
+++ b/tests/integration/api/v1/curated_recommendations/corpus_backends/test_scheduled_surface_backend.py
@@ -1,25 +1,100 @@
 """Integration tests for merino/curated_recommendations/corpus_backends/scheduled_surface_backend.py"""
 
-from datetime import datetime
-
+import asyncio
+import freezegun
+import logging
 import pytest
-from httpx import Response
-from pydantic import HttpUrl
 
-from merino.curated_recommendations.corpus_backends.scheduled_surface_backend import (
-    ScheduledSurfaceBackend,
+from circuitbreaker import STATE_HALF_OPEN, CircuitBreakerMonitor
+from datetime import datetime
+from httpx import AsyncClient, HTTPStatusError, Response
+from pydantic import HttpUrl
+from tests.types import FilterCaplogFixture
+from unittest.mock import AsyncMock
+
+from merino.curated_recommendations.corpus_backends.circuitbreaker import (
+    CuratedRecommendationsCircuitBreaker,
 )
 from merino.curated_recommendations.corpus_backends.protocol import (
     SurfaceId,
     CorpusItem,
     Topic,
 )
+from merino.curated_recommendations.corpus_backends.scheduled_surface_backend import (
+    ScheduledSurfaceBackend,
+)
+from merino.curated_recommendations.corpus_backends.utils import (
+    CorpusApiGraphConfig,
+    CorpusGraphQLError,
+)
+from merino.exceptions import BackendError
+from merino.utils.metrics import get_metrics_client
+
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture()
+def make_scheduled_surface_backend(manifest_provider):
+    """Return a factory for ScheduledSurfaceBackend instances with a given HTTP client.
+
+    Each instance gets its own empty stale-while-revalidate cache, but they all
+    share the class-level circuit breaker.
+    """
+
+    def _make(http_client: AsyncMock) -> ScheduledSurfaceBackend:
+        return ScheduledSurfaceBackend(
+            http_client=http_client,
+            graph_config=CorpusApiGraphConfig(),
+            metrics_client=get_metrics_client(),
+            manifest_provider=manifest_provider,
+        )
+
+    return _make
+
+
+@pytest.fixture()
+def scheduled_surface_circuit_breaker():
+    """Return the scheduled surface circuit breaker, closed before and after the test.
+
+    The breaker decorates ScheduledSurfaceBackend.fetch at class-definition time, so a
+    single instance is shared by every backend instance and every test.
+    """
+    breaker = CircuitBreakerMonitor.get(SCHEDULED_SURFACE_BREAKER_NAME)
+
+    breaker.reset()
+
+    yield breaker
+
+    breaker.reset()
+
+
+def make_http_client(
+    response: Response | None = None, error: Exception | None = None
+) -> AsyncMock:
+    """Build a mock HTTP client that returns a fixed response or raises a fixed error."""
+    http_client = AsyncMock(spec=AsyncClient)
+
+    if error is not None:
+        http_client.post.side_effect = error
+    else:
+        http_client.post.return_value = response
+
+    return http_client
+
+
+async def trip_breaker(make_scheduled_surface_backend, fixture_request_data) -> None:
+    """Drive the shared breaker open through a real fetch against a failing API."""
+    backend = make_scheduled_surface_backend(
+        make_http_client(Response(status_code=503, request=fixture_request_data))
+    )
+
+    with pytest.raises(HTTPStatusError):
+        await backend.fetch(SurfaceId.NEW_TAB_EN_US)
 
 
 @pytest.mark.asyncio
-async def test_fetch(
-    scheduled_surface_backend: ScheduledSurfaceBackend, scheduled_surface_response_data
-):
+async def test_fetch(scheduled_surface_backend: ScheduledSurfaceBackend):
     """Test if the fetch method returns data from cache if available."""
     surface_id = SurfaceId.NEW_TAB_EN_US
 
@@ -108,3 +183,177 @@ async def test_fetch_days_since_today(
     results = await scheduled_surface_backend.fetch(surface_id, **test_input)
     assert len(results) == 1
     assert results[0].title == expected_title
+
+
+SCHEDULED_SURFACE_BREAKER_NAME = "curated_recommendations_scheduled_surface_circuit_breaker"
+FAILURE_THRESHOLD = CuratedRecommendationsCircuitBreaker.FAILURE_THRESHOLD
+RECOVERY_TIMEOUT = CuratedRecommendationsCircuitBreaker.RECOVERY_TIMEOUT
+
+
+class TestScheduledSurfaceCircuitBreaker:
+    """Tests covering the circuit breaker wrapped around SectionsBackend.fetch."""
+
+    @pytest.mark.asyncio
+    async def test_breaker_stays_closed_on_success(
+        self, sections_backend: ScheduledSurfaceBackend, scheduled_surface_circuit_breaker
+    ):
+        """A successful fetch should leave the breaker closed with no failures recorded."""
+        sections = await sections_backend.fetch(SurfaceId.NEW_TAB_EN_US)
+
+        assert sections
+        assert scheduled_surface_circuit_breaker.closed
+        assert scheduled_surface_circuit_breaker.failure_count == 0
+
+    @pytest.mark.asyncio
+    async def test_breaker_opens_on_http_error(
+        self,
+        make_scheduled_surface_backend,
+        fixture_request_data,
+        scheduled_surface_circuit_breaker,
+    ):
+        """An HTTP error should exhaust the retries below the breaker, then open it."""
+        http_client = make_http_client(Response(status_code=503, request=fixture_request_data))
+        backend = make_scheduled_surface_backend(http_client)
+
+        with pytest.raises(HTTPStatusError):
+            await backend.fetch(SurfaceId.NEW_TAB_EN_US)
+
+        # @retry is applied below the breaker, so the breaker only sees one
+        # failure once every attempt has been used up.
+        assert http_client.post.call_count == ScheduledSurfaceBackend.retry_count
+        assert scheduled_surface_circuit_breaker.failure_count == FAILURE_THRESHOLD
+        assert scheduled_surface_circuit_breaker.opened
+
+    @pytest.mark.asyncio
+    async def test_breaker_opens_on_graphql_error(
+        self,
+        make_scheduled_surface_backend,
+        fixture_graphql_200ok_with_error_response,
+        fixture_request_data,
+        scheduled_surface_circuit_breaker,
+    ):
+        """A 200 response carrying GraphQL errors should also open the breaker."""
+        http_client = make_http_client(
+            Response(
+                status_code=200,
+                json=fixture_graphql_200ok_with_error_response,
+                request=fixture_request_data,
+            )
+        )
+        backend = make_scheduled_surface_backend(http_client)
+
+        with pytest.raises(CorpusGraphQLError):
+            await backend.fetch(SurfaceId.NEW_TAB_EN_US)
+
+        assert http_client.post.call_count == ScheduledSurfaceBackend.retry_count
+        assert scheduled_surface_circuit_breaker.opened
+
+    @pytest.mark.asyncio
+    async def test_breaker_ignores_unexpected_exceptions(
+        self, make_scheduled_surface_backend, scheduled_surface_circuit_breaker
+    ):
+        """Errors outside EXPECTED_EXCEPTION should neither be retried nor open the breaker."""
+        http_client = make_http_client(error=RuntimeError("not a corpus API error"))
+        backend = make_scheduled_surface_backend(http_client)
+
+        with pytest.raises(RuntimeError):
+            await backend.fetch(SurfaceId.NEW_TAB_EN_US)
+
+        assert http_client.post.call_count == 1
+        assert scheduled_surface_circuit_breaker.failure_count == 0
+        assert scheduled_surface_circuit_breaker.closed
+
+    @pytest.mark.asyncio
+    async def test_breaker_short_circuits_while_open(
+        self,
+        make_scheduled_surface_backend,
+        sections_http_client: AsyncMock,
+        fixture_request_data,
+        scheduled_surface_circuit_breaker,
+    ):
+        """While open, fetch should fail fast with BackendError and skip the API entirely."""
+        await trip_breaker(make_scheduled_surface_backend, fixture_request_data)
+        assert scheduled_surface_circuit_breaker.opened
+
+        # A brand new backend with an empty cache and a healthy HTTP client is
+        # still short-circuited: the breaker is shared across all instances.
+        healthy_backend = make_scheduled_surface_backend(sections_http_client)
+
+        with pytest.raises(BackendError, match="circuitbreaker"):
+            await healthy_backend.fetch(SurfaceId.NEW_TAB_EN_US)
+
+        sections_http_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_open_breaker_serves_stale_cache(
+        self,
+        make_scheduled_surface_backend,
+        scheduled_surface_http_client: AsyncMock,
+        fixture_request_data,
+        caplog,
+        filter_caplog: FilterCaplogFixture,
+    ):
+        """The fallback must raise so @stale_while_revalidate can serve stale data."""
+        caplog.set_level(logging.ERROR)
+
+        backend = make_scheduled_surface_backend(scheduled_surface_http_client)
+
+        # control time so we can expire the SWR cache
+        with freezegun.freeze_time(tick=True) as time_gem:
+            # populate the SWR cache
+            cache_fresh = await backend.fetch(SurfaceId.NEW_TAB_EN_US)
+
+            assert scheduled_surface_http_client.post.call_count == 1
+
+            # fast-forward time so the cache expires
+            time_gem.tick(delta=ScheduledSurfaceBackend.cache_time_to_live_max)
+
+            # open the circuit breaker
+            await trip_breaker(make_scheduled_surface_backend, fixture_request_data)
+
+            # with the circuit breaker open, we should get the expired cache
+            cache_stale = await backend.fetch(SurfaceId.NEW_TAB_EN_US)
+
+            assert cache_stale == cache_fresh
+
+            # await the async call spawned by the cache so we can verify if an http
+            # call was made
+            await asyncio.gather(*list(backend._background_tasks))
+
+            # with the breaker open, we should still only have 1 http call
+            # (from the initial successful fetch)
+            assert scheduled_surface_http_client.post.call_count == 1
+
+            records = filter_caplog(
+                caplog.records, "merino.curated_recommendations.corpus_backends.caching"
+            )
+            assert any("Returning stale data" in record.message for record in records)
+
+    @pytest.mark.asyncio
+    async def test_breaker_recovers_after_timeout(
+        self,
+        make_scheduled_surface_backend,
+        scheduled_surface_http_client: AsyncMock,
+        fixture_request_data,
+        scheduled_surface_circuit_breaker,
+    ):
+        """After the recovery timeout the breaker half-opens, then closes on a good fetch."""
+        with freezegun.freeze_time(tick=True) as time_gem:
+            await trip_breaker(make_scheduled_surface_backend, fixture_request_data)
+
+            assert scheduled_surface_circuit_breaker.opened
+
+            # advance time so the circuit breaker recovers
+            time_gem.tick(RECOVERY_TIMEOUT + 5)
+
+            assert scheduled_surface_circuit_breaker.state == STATE_HALF_OPEN
+
+            backend = make_scheduled_surface_backend(scheduled_surface_http_client)
+            sections = await backend.fetch(SurfaceId.NEW_TAB_EN_US)
+
+            assert sections
+
+            scheduled_surface_http_client.post.assert_called_once()
+
+            assert scheduled_surface_circuit_breaker.closed
+            assert scheduled_surface_circuit_breaker.failure_count == 0

--- a/tests/integration/api/v1/curated_recommendations/corpus_backends/test_sections_backend.py
+++ b/tests/integration/api/v1/curated_recommendations/corpus_backends/test_sections_backend.py
@@ -7,7 +7,6 @@ import logging
 import pytest
 
 from httpx import AsyncClient, HTTPStatusError, Response
-from pytest_mock import MockerFixture
 from tests.types import FilterCaplogFixture
 from unittest.mock import AsyncMock
 
@@ -428,7 +427,6 @@ class TestSectionsCircuitBreaker:
     @pytest.mark.asyncio
     async def test_breaker_recovers_after_timeout(
         self,
-        mocker: MockerFixture,
         make_sections_backend,
         sections_http_client: AsyncMock,
         fixture_request_data,


### PR DESCRIPTION
## References

JIRA: [HNT-3000](https://mozilla-hub.atlassian.net/browse/HNT-3000)

## Description

add circuit breaker to the corpus scheduled surface backend. follow-up to #1732.

- stop retrying fetch on ValueError
- organize imports

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2546)


[HNT-3000]: https://mozilla-hub.atlassian.net/browse/HNT-3000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ