### PR TITLE
[DISCO-4372] wiki offline eu locales add

### DIFF
--- a/apps/merino/merino/jobs/wikipedia_offline_uploader/__init__.py
+++ b/apps/merino/merino/jobs/wikipedia_offline_uploader/__init__.py
@@ -15,11 +15,27 @@ logger = logging.getLogger(__name__)
 RECORD_TYPE = "wikipedia"
 
 LOCALES_MAPPING = {
-    "en": ["en-US", "en-CA", "en-GB"],
-    "fr": ["fr", "fr-FR"],
+    "ca": ["ca", "ca-valencia"],
+    "cs": ["cs"],
+    "da": ["da"],
     "de": ["de", "de-DE"],
+    "en": ["en-US", "en-CA", "en-GB"],
+    "es": ["es-ES", "es-MX", "es-AR"],
+    "eu": ["eu"],
+    "fi": ["fi"],
+    "fr": ["fr", "fr-FR"],
+    "ga": ["ga-IE"],
+    "gl": ["gl"],
+    "hu": ["hu"],
     "it": ["it", "it-IT"],
+    "nl": ["nl"],
+    "nn": ["nn-NO"],
+    "no": ["nb-NO"],
     "pl": ["pl", "pl-PL"],
+    "pt": ["pt-PT", "pt-BR"],
+    "rm": ["rm"],
+    "sk": ["sk"],
+    "sv": ["sv-SE"],
 }
 
 DEFAULT_LANGUAGES = ",".join(LOCALES_MAPPING.keys())


### PR DESCRIPTION
## References

JIRA: [DISCO-4372](https://mozilla-hub.atlassian.net/browse/DISCO-4372)

## Description
Add the EU wiki languages and associated firefox locales to the job.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


[DISCO-4372]: https://mozilla-hub.atlassian.net/browse/DISCO-4372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ