### PR TITLE
[HNT-2162] Remove unused latency metric

### DIFF
--- a/apps/merino/merino/providers/rss/wikimedia_potd/provider.py
+++ b/apps/merino/merino/providers/rss/wikimedia_potd/provider.py
@@ -117,8 +117,7 @@ class WikimediaPictureOfTheDayProvider(BaseRssProvider):
 
     async def upload_picture_of_the_day(self) -> bool:
         """Execute the upload flow. This method is called by the job cli command only."""
-        with self.metrics_client.timeit("potd.provider.upload.timing"):
-            return await self.backend.upload_picture_of_the_day()
+        return await self.backend.upload_picture_of_the_day()
 
     async def shutdown(self) -> None:
         """Shut down the provider."""

--- a/apps/merino/metrics.yaml
+++ b/apps/merino/metrics.yaml
@@ -486,15 +486,6 @@ providers/manifest:
     alert_policy: []
 
 providers/rss/wikimedia_potd:
-  potd.provider.upload.timing:
-    description: |
-      A timer covering a full run of the Wikimedia picture of the day updater job.
-    type: timing
-    labels: [] # no labels
-    scope: |
-      The "picture_of_the_day update-wikimedia-potd" job.
-    alert_policy: []
-
   potd.provider.cached.none:
     description: |
       A counter incremented when the provider has no picture of the day to serve at

--- a/apps/merino/tests/unit/providers/rss/wikimedia_potd/test_provider.py
+++ b/apps/merino/tests/unit/providers/rss/wikimedia_potd/test_provider.py
@@ -118,8 +118,6 @@ async def test_upload_picture_of_the_day_delegates_to_backend(
 
     assert result is True
     backend_mock.upload_picture_of_the_day.assert_awaited_once()
-    # the whole job run is timed
-    statsd_mock.timeit.assert_called_once_with("potd.provider.upload.timing")
 
 
 @freezegun.freeze_time("2026-06-07")


### PR DESCRIPTION
## References

JIRA: [HNT-2162](https://mozilla-hub.atlassian.net/browse/HNT-2162)

## Description
Follow up to an already merged change. Removing an unused latency metric.

## PR Review Checklist

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/apps/merino/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2549)


[HNT-2162]: https://mozilla-hub.atlassian.net/browse/HNT-2162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ