### PR TITLE
[HNT-3085] feat: serve NEW_TAB_EN_INTL (India) sections when requested

### DIFF
--- a/apps/merino/merino/curated_recommendations/corpus_backends/protocol.py
+++ b/apps/merino/merino/curated_recommendations/corpus_backends/protocol.py
@@ -47,7 +47,7 @@ class SurfaceId(str, Enum):
     NEW_TAB_EN_CA = "NEW_TAB_EN_CA"  # canada
     NEW_TAB_EN_GB = "NEW_TAB_EN_GB"  # great britain
     NEW_TAB_EN_IE = "NEW_TAB_EN_IE"  # irelane
-    NEW_TAB_EN_INTL = "NEW_TAB_EN_INTL"  # india(?)
+    NEW_TAB_EN_INTL = "NEW_TAB_EN_INTL"  # india (poorly named; India only)
     NEW_TAB_EN_US = "NEW_TAB_EN_US"  # united states
     NEW_TAB_EN_XE = "NEW_TAB_EN_XE"  # cross-europe english
     NEW_TAB_ES_ES = "NEW_TAB_ES_ES"  # spain

--- a/apps/merino/merino/curated_recommendations/localization.py
+++ b/apps/merino/merino/curated_recommendations/localization.py
@@ -31,6 +31,9 @@ LOCALIZED_SECTION_TITLES: LocalizedTopicSectionTitles = {
     SurfaceId.NEW_TAB_EN_IE: {
         "top-stories": "Popular Today",
     },
+    SurfaceId.NEW_TAB_EN_INTL: {
+        "top-stories": "Popular Today",
+    },
     SurfaceId.NEW_TAB_EN_US: {
         "top-stories": "Popular Today",
     },

--- a/apps/merino/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/apps/merino/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -2728,10 +2728,11 @@ class TestSections:
         [
             ("GB", SurfaceId.NEW_TAB_EN_GB.value),
             ("IE", SurfaceId.NEW_TAB_EN_IE.value),
+            ("IN", SurfaceId.NEW_TAB_EN_INTL.value),
         ],
     )
-    def test_uk_sections_enabled(self, region, expected_surface, client: TestClient):
-        """Test that UK/IE users with feeds=['sections'] get sections."""
+    def test_sections_enabled_by_region(self, region, expected_surface, client: TestClient):
+        """Test that GB/IE/IN users with feeds=['sections'] get sections."""
         response = client.post(
             "/api/v1/curated-recommendations",
             json={
@@ -2759,6 +2760,23 @@ class TestSections:
 
         # data array should be empty (all recommendations in feeds)
         assert len(data["data"]) == 0
+
+    def test_india_without_sections_feed_is_not_forced_into_sections(self, client: TestClient):
+        """Test that clients in India that do not request sections keep the legacy grid.
+
+        NEW_TAB_EN_INTL is not in ROLLED_OUT_SECTION_SURFACES, so non-sections requests are
+        still served from the scheduled surface backend.
+        """
+        response = client.post(
+            "/api/v1/curated-recommendations",
+            json={"locale": "en-US", "region": "IN"},
+        )
+        data = response.json()
+
+        assert response.status_code == 200
+        assert data["surfaceId"] == SurfaceId.NEW_TAB_EN_INTL.value
+        assert data["feeds"] is None
+        assert len(data["data"]) > 0
 
 
 def test_uk_sections_with_gb_backend_data(

--- a/apps/merino/tests/unit/curated_recommendations/test_localization.py
+++ b/apps/merino/tests/unit/curated_recommendations/test_localization.py
@@ -2,7 +2,10 @@
 
 import pytest
 
-from merino.curated_recommendations.localization import get_translation
+from merino.curated_recommendations.localization import (
+    LOCALIZED_SECTION_TITLES,
+    get_translation,
+)
 from merino.curated_recommendations.corpus_backends.protocol import SurfaceId
 
 
@@ -14,6 +17,7 @@ from merino.curated_recommendations.corpus_backends.protocol import SurfaceId
         (SurfaceId.NEW_TAB_DE_DE, "Meistgelesen"),
         (SurfaceId.NEW_TAB_EN_CA, "Popular Today"),
         (SurfaceId.NEW_TAB_EN_IE, "Popular Today"),
+        (SurfaceId.NEW_TAB_EN_INTL, "Popular Today"),
         (SurfaceId.NEW_TAB_EN_US, "Popular Today"),
         (SurfaceId.NEW_TAB_EN_XE, "Popular Today"),
         (SurfaceId.NEW_TAB_ES_ES, "Tendencias"),
@@ -29,6 +33,7 @@ from merino.curated_recommendations.corpus_backends.protocol import SurfaceId
         "de_de",
         "en_ca",
         "en_ie",
+        "en_intl",
         "en_us",
         "en_xe",
         "es_es",
@@ -44,9 +49,15 @@ def test_get_translation_top_stories(surface_id: SurfaceId, expected_title: str)
     assert expected_title == get_translation(surface_id, "top-stories", "Default")
 
 
-def test_get_translation_non_existing_locale(caplog):
-    """Test logs error and falls back to default when locale translations do not exist."""
-    result = get_translation(SurfaceId.NEW_TAB_EN_INTL, "business", "Default")
+def test_get_translation_unsupported_surface(caplog, monkeypatch):
+    """Test logs error and falls back to default when a surface has no translations.
+
+    Every surface is currently enabled for sections, so drop one to stand in for a
+    surface that has not been enabled yet.
+    """
+    monkeypatch.delitem(LOCALIZED_SECTION_TITLES, SurfaceId.NEW_TAB_PL_PL)
+
+    result = get_translation(SurfaceId.NEW_TAB_PL_PL, "business", "Default")
     assert result == "Default"
 
     errors = [r for r in caplog.records if r.levelname == "ERROR"]


### PR DESCRIPTION
## References

JIRA: [HNT-3085](https://mozilla-hub.atlassian.net/browse/HNT-3085)

## Description

Clients on the `NEW_TAB_EN_INTL` (India) surface that request `feeds: ["sections"]` now receive sections.

### Deliberately out of scope

We are still in internal QA, so this PR is intentionally narrower than the surface roll-outs above:

- **Legacy clients are unaffected.** `NEW_TAB_EN_INTL` is *not* added to `ROLLED_OUT_SECTION_SURFACES`, so requests without `feeds: ["sections"]` keep being served the grid from the scheduled surface backend. Clients are not forced into sections. Serving sections content to legacy clients is tracked separately in [HNT-2327](https://mozilla-hub.atlassian.net/browse/HNT-2327).
- **No backend experiment gating.** Sections are served because the client asked for them.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/apps/merino/metrics.yaml) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)

[HNT-3085]: https://mozilla-hub.atlassian.net/browse/HNT-3085?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HNT-2327]: https://mozilla-hub.atlassian.net/browse/HNT-2327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ