### PR TITLE
[DISCO-4466] fix(common): downgrade to warning on successful AsyncBatchQueue fallback

### DIFF
--- a/apps/merino/merino/message_handlers/search_terms/fleece.py
+++ b/apps/merino/merino/message_handlers/search_terms/fleece.py
@@ -45,20 +45,21 @@ class FleeceClient:
         """
         submission = SearchTermsSubmission(search_terms=search_terms)
         start = time.perf_counter()
-        outcome = "success"
+        outcome = "error"
         try:
             response = await self.http_client.post(
                 self.search_terms_path, json=submission.model_dump()
             )
             response.raise_for_status()
         except HTTPError as ex:
-            outcome = "error"
             if isinstance(ex, HTTPStatusError):
                 raise FleeceError(
                     "Fleece returned an unexpected status "
                     f"{ex.response.status_code} {ex.response.reason_phrase}"
                 ) from ex
             raise FleeceError(f"Failed to submit search terms to Fleece: {ex}") from ex
+        else:
+            outcome = "success"
         finally:
             _submit_duration_histogram.record(time.perf_counter() - start, {"outcome": outcome})
 

--- a/apps/merino/tests/unit/message_handlers/search_terms/test_fleece.py
+++ b/apps/merino/tests/unit/message_handlers/search_terms/test_fleece.py
@@ -4,6 +4,7 @@
 
 """Unit tests for the merino-fleece search terms client."""
 
+import asyncio
 import json
 from collections.abc import Callable
 
@@ -12,6 +13,7 @@ import pytest
 from pytest_mock import MockerFixture
 
 from merino.configs import settings
+from merino.message_handlers.search_terms import fleece
 from merino.message_handlers.search_terms.errors import FleeceError
 from merino.message_handlers.search_terms.fleece import FleeceClient
 from merino_common.models.suggest_logging import SuggestRequestParams
@@ -82,6 +84,88 @@ async def test_submit_raises_fleece_error_on_transport_error(
     client = FleeceClient(http_client=http_client)
     with pytest.raises(FleeceError, match="Failed to submit search terms"):
         await client.submit([params("apple")])
+
+
+@pytest.mark.asyncio
+async def test_submit_records_success_outcome(mocker: MockerFixture, params: Params) -> None:
+    """Test that a successful submission is recorded as a success in the duration histogram."""
+    histogram = mocker.patch.object(fleece, "_submit_duration_histogram")
+    request = httpx.Request("POST", "http://fleece/api/v1/search-terms")
+    http_client = mocker.AsyncMock(spec=httpx.AsyncClient)
+    http_client.post.return_value = httpx.Response(201, request=request)
+
+    client = FleeceClient(http_client=http_client)
+    await client.submit([params("apple")])
+
+    assert histogram.record.call_args.args[1] == {"outcome": "success"}
+
+
+@pytest.mark.asyncio
+async def test_submit_records_error_outcome_on_bad_status(
+    mocker: MockerFixture, params: Params
+) -> None:
+    """Test that a failed submission is recorded as an error in the duration histogram."""
+    histogram = mocker.patch.object(fleece, "_submit_duration_histogram")
+    transport = httpx.MockTransport(lambda request: httpx.Response(503))
+
+    async with httpx.AsyncClient(base_url="http://fleece", transport=transport) as http_client:
+        client = FleeceClient(http_client=http_client)
+        with pytest.raises(FleeceError):
+            await client.submit([params("apple")])
+
+    assert histogram.record.call_args.args[1] == {"outcome": "error"}
+
+
+@pytest.mark.asyncio
+async def test_submit_records_error_outcome_on_closed_client(
+    mocker: MockerFixture, params: Params
+) -> None:
+    """Test that a submission on a closed HTTP client is recorded as an error.
+
+    httpx raises a bare RuntimeError, not an HTTPError, when the client is closed, so the
+    failure escapes `except HTTPError`.
+    """
+    histogram = mocker.patch.object(fleece, "_submit_duration_histogram")
+    transport = httpx.MockTransport(lambda request: httpx.Response(201))
+    http_client = httpx.AsyncClient(base_url="http://fleece", transport=transport)
+    await http_client.aclose()
+
+    client = FleeceClient(http_client=http_client)
+    with pytest.raises(RuntimeError, match="the client has been closed"):
+        await client.submit([params("apple")])
+
+    assert histogram.record.call_args.args[1] == {"outcome": "error"}
+
+
+@pytest.mark.asyncio
+async def test_submit_records_error_outcome_on_cancellation(
+    mocker: MockerFixture, params: Params
+) -> None:
+    """Test that a cancelled submission is recorded as an error in the duration histogram.
+
+    A cancelled request raises `asyncio.CancelledError`, a BaseException that escapes
+    `except HTTPError` too.
+    """
+    histogram = mocker.patch.object(fleece, "_submit_duration_histogram")
+    in_flight = asyncio.Event()
+
+    async def hang(request: httpx.Request) -> httpx.Response:
+        """Block the request until the submitting task is cancelled."""
+        in_flight.set()
+        await asyncio.Event().wait()
+        raise AssertionError("unreachable: the request is cancelled while waiting")
+
+    transport = httpx.MockTransport(hang)
+
+    async with httpx.AsyncClient(base_url="http://fleece", transport=transport) as http_client:
+        client = FleeceClient(http_client=http_client)
+        task = asyncio.create_task(client.submit([params("apple")]))
+        await in_flight.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    assert histogram.record.call_args.args[1] == {"outcome": "error"}
 
 
 @pytest.mark.asyncio

--- a/packages/merino-common/merino_common/utils/async_batch_queue.py
+++ b/packages/merino-common/merino_common/utils/async_batch_queue.py
@@ -120,6 +120,13 @@ class AsyncBatchQueue(Generic[T]):
            already pulled into the run loop. This metric is not recorded on drops due
            to ``shutdown(force=True)``.
 
+    Logging:
+        The log level of a batch failure reflects the final outcome, not the first
+        failure. If ``on_error`` fallback is successful, log at ``warning``. ``error``
+        is reserved for the cases that lose data: no ``on_error`` is configured, or
+        ``on_error`` itself raised. The Sentry logging integration turns Error records
+        into events, so this ties alert to data loss only.
+
     Examples:
         ```
         batcher: AsyncBatchQueue[int] = AsyncBatchQueue(
@@ -336,9 +343,15 @@ class AsyncBatchQueue(Generic[T]):
         try:
             await self._batch_callback(batch)
         except Exception as e:
-            self.logger.error("Error processing batch", exc_info=True)
             self._record_outcome(self._processed_counter, len(batch), error=e)
-            if self._error_callback is not None:
+            if self._error_callback is None:
+                self.logger.error("Error processing batch", exc_info=True)
+            else:
+                # Graceful fallback is expected; only log a warning
+                # until the fallback itself fails.
+                self.logger.warning(
+                    "Error processing batch, routing to error callback", exc_info=True
+                )
                 try:
                     await self._error_callback(batch, e)
                     self._record_outcome(self._error_callback_counter, len(batch), error=None)

--- a/packages/merino-common/tests/unit/utils/test_async_batch_queue.py
+++ b/packages/merino-common/tests/unit/utils/test_async_batch_queue.py
@@ -5,8 +5,10 @@
 """Unit tests for the AsyncBatchQueue graceful-shutdown behavior."""
 
 import asyncio
+import logging
 import os
 import signal
+from collections.abc import Awaitable, Callable
 
 import pytest
 from opentelemetry.sdk.metrics import MeterProvider
@@ -763,3 +765,79 @@ async def test_remaining_capacity_recovers_as_batches_are_collected() -> None:
 
     assert processed == [1, 2]
     assert batcher.remaining_capacity() == 2
+
+
+LOGGER_NAME = "merino_common.utils.async_batch_queue"
+
+
+async def _run_one_failing_batch(
+    on_error: Callable[[list[int], Exception], Awaitable[None]] | None,
+    caplog: pytest.LogCaptureFixture,
+) -> list[logging.LogRecord]:
+    """Process a single batch whose on_batch raises, returning the queue's log records."""
+    caplog.set_level(logging.WARNING, logger=LOGGER_NAME)
+
+    async def on_batch(batch: list[int]) -> None:
+        raise ValueError("boom")
+
+    batcher: AsyncBatchQueue[int] = AsyncBatchQueue(
+        on_batch=on_batch,
+        on_error=on_error,
+        max_batch_size=1,
+        collection_delay_s=0.02,
+        meter_provider=None,
+    )
+    await batcher.start()
+    batcher.put(1)
+    # A graceful stop drains the queue, so the batch is processed by the time it returns.
+    await batcher.stop()
+
+    return [record for record in caplog.records if record.name == LOGGER_NAME]
+
+
+@pytest.mark.asyncio
+async def test_absorbed_batch_failure_logs_warning_not_error(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A batch failure that the error callback absorbs is logged at warning, not error.
+
+    Sentry's logging integration turns every error record into an event, so logging
+    this at error reports an issue per failed batch for a condition the queue is
+    designed to recover from. The traceback is kept, as a breadcrumb for the error
+    that does get reported when the fallback fails too.
+    """
+
+    async def on_error(batch: list[int], exc: Exception) -> None:
+        pass  # the fallback absorbs the batch cleanly
+
+    records = await _run_one_failing_batch(on_error, caplog)
+
+    assert [record.levelno for record in records] == [logging.WARNING]
+    assert records[0].exc_info is not None, "the warning keeps the traceback for debugging"
+
+
+@pytest.mark.asyncio
+async def test_batch_failure_logs_error_without_an_error_callback(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Without an error callback there is no fallback, so a failed batch is data loss
+    and keeps the error level.
+    """
+    records = await _run_one_failing_batch(None, caplog)
+
+    assert [record.levelno for record in records] == [logging.ERROR]
+
+
+@pytest.mark.asyncio
+async def test_failed_error_callback_logs_error(caplog: pytest.LogCaptureFixture) -> None:
+    """When the error callback raises, both paths have failed and the batch is lost, so
+    an error is logged after the warning that recorded the primary failure.
+    """
+
+    async def on_error(batch: list[int], exc: Exception) -> None:
+        raise RuntimeError("fallback down")
+
+    records = await _run_one_failing_batch(on_error, caplog)
+
+    assert [record.levelno for record in records] == [logging.WARNING, logging.ERROR]
+    assert "Error callback raised on batch" in records[1].message


### PR DESCRIPTION


## References

JIRA: [DISCO-4466](https://mozilla-hub.atlassian.net/browse/DISCO-4466)

## Description

fix(common): downgrade to warning on successful AsyncBatchQueue fallback
Sentry is turning error-level logs into events and causing false alarms. The graceful fallback is intended behavior, so we should warn only unless it also fails and data is lost.

fix(merino): ensure error outcome is reported for non-HTTP errors

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/apps/merino/metrics.yaml) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2554)


[DISCO-4466]: https://mozilla-hub.atlassian.net/browse/DISCO-4466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ