### PR TITLE
[DISCO-4469] fix(fleece): control memory footprint for spacy nlp

### DIFF
--- a/apps/fleece/merino_fleece/configs/__init__.py
+++ b/apps/fleece/merino_fleece/configs/__init__.py
@@ -38,6 +38,13 @@ def _build_validators() -> list[Validator]:
             gt=0,
             must_exist=True,
         ),
+        # `gte=0` rather than `gt=0`: 0 is the documented way to disable recycling.
+        Validator(
+            "pii.recycle_after_texts",
+            is_type_of=int,
+            gte=0,
+            must_exist=True,
+        ),
         Validator("mars.enabled", is_type_of=bool, must_exist=True),
         Validator("mars.base_url", is_type_of=str, must_exist=True),
         Validator("mars.suggestion_url_path", is_type_of=str, must_exist=True),

--- a/apps/fleece/merino_fleece/configs/default.toml
+++ b/apps/fleece/merino_fleece/configs/default.toml
@@ -21,10 +21,10 @@ query_character_max = 500
 # Reload the SpaCy pipeline once it has processed this many texts. SpaCy interns every
 # novel token it sees, and the memory zone detection runs in reclaims those allocations
 # but not the index capacity behind them, so a long-lived process creeps upward at
-# roughly 78 bytes per novel token. Reloading resets it, and costs ~173ms during which
-# NER is paused -- the search term queue absorbs that. Lower bounds memory more tightly
-# at the cost of more frequent pauses; 0 disables recycling.
-recycle_after_texts = 500000
+# roughly 78 bytes per novel token. Reloading resets it, and costs a window (subsecond)
+# during which NER is paused -- the search term queue absorbs that. Lower bounds memory
+# more tightly at the cost of more frequent pauses; 0 disables recycling.
+recycle_after_texts = 100000
 
 # MERINO_FLEECE_PII__EXECUTOR_MAX_WORKERS
 # Size of the thread pool that runs CPU-bound SpaCy NER off the event loop.

--- a/apps/fleece/merino_fleece/configs/default.toml
+++ b/apps/fleece/merino_fleece/configs/default.toml
@@ -17,6 +17,15 @@ excluded_components = ["tok2vec", "tagger", "parser", "attribute_ruler", "lemmat
 # Maximum allowed length of the `q` query parameter.
 query_character_max = 500
 
+# MERINO_FLEECE_PII__RECYCLE_AFTER_TEXTS
+# Reload the SpaCy pipeline once it has processed this many texts. SpaCy interns every
+# novel token it sees, and the memory zone detection runs in reclaims those allocations
+# but not the index capacity behind them, so a long-lived process creeps upward at
+# roughly 78 bytes per novel token. Reloading resets it, and costs ~173ms during which
+# NER is paused -- the search term queue absorbs that. Lower bounds memory more tightly
+# at the cost of more frequent pauses; 0 disables recycling.
+recycle_after_texts = 500000
+
 # MERINO_FLEECE_PII__EXECUTOR_MAX_WORKERS
 # Size of the thread pool that runs CPU-bound SpaCy NER off the event loop.
 # Roughly match the number of CPU cores available to each worker process; a

--- a/apps/fleece/merino_fleece/pii/detector.py
+++ b/apps/fleece/merino_fleece/pii/detector.py
@@ -1,6 +1,25 @@
-"""SpaCy-backed PII detector. Flags text containing a PERSON named entity."""
+"""SpaCy-backed PII detector. Flags text containing a PERSON named entity.
+
+This process is long-lived and reads arbitrary search terms, whose token tail
+(typos, transliterations, product codes, non-English words) never saturates. SpaCy
+is built for batch work and interns every novel token it sees into the shared
+``Vocab``, so left alone it grows for the life of the pod. Two mechanisms bound
+that here, because neither is sufficient alone:
+
+1. Detection runs inside ``nlp.memory_zone()``. Without it, each novel token costs a
+   permanent entry in its internal cache. The zone routes those to a scratch pool that is
+   released when the block exits.
+
+2. The pipeline is reloaded every ``recycle_after_texts`` texts. The zone reclaims
+   allocations but not index capacity, reloading handles that.
+
+The zone makes any ``Doc`` created inside it invalid once the block exits, so the
+methods below reduce each document to a ``bool`` before returning; they must never
+hand a ``Doc``, ``Span``, or ``Token`` back to a caller.
+"""
 
 import logging
+import threading
 
 import spacy
 from spacy.cli.download import download as spacy_download
@@ -16,24 +35,69 @@ class PiiDetector:
 
     nlp: Language
 
-    def __init__(self, model_name: str, excluded_components: list[str]) -> None:
+    def __init__(
+        self,
+        model_name: str,
+        excluded_components: list[str],
+        recycle_after_texts: int = 0,
+    ) -> None:
         """Load the SpaCy model, auto-downloading it if not yet installed.
 
         Args:
             model_name: One of "en_core_web_sm", "en_core_web_md", "en_core_web_lg".
             excluded_components: SpaCy pipeline components to exclude at load time.
+            recycle_after_texts: Reload the pipeline once it has processed this many
+                texts, discarding the index capacity a memory zone cannot reclaim.
+                Zero disables recycling, which leaves the process growing slowly for
+                as long as it runs.
         """
+        self._model_name = model_name
+        self._excluded_components = excluded_components
+        self._recycle_after_texts = recycle_after_texts
+        self._texts_since_load = 0
+        # A memory zone swaps `nlp.vocab.mem` for the duration of the block, and a
+        # recycle swaps `nlp` wholesale, so two threads detecting at once could free
+        # one another's pool or model. The NER thread pool is size-1 today
+        # (`pii.executor_max_workers`), which makes this lock uncontended, but it is
+        # what keeps raising that setting from corrupting shared state rather than
+        # merely slowing detection down.
+        self._zone_lock = threading.Lock()
+        self.nlp = self._load()
+
+    def _load(self) -> Language:
+        """Load the SpaCy pipeline, downloading the model on first use if needed."""
         try:
-            self.nlp = spacy.load(model_name, exclude=excluded_components)
+            return spacy.load(self._model_name, exclude=self._excluded_components)
         except OSError:
-            logger.info("SpaCy model %s not found; downloading", model_name)
-            spacy_download(model_name)
-            self.nlp = spacy.load(model_name, exclude=excluded_components)
+            logger.info("SpaCy model %s not found; downloading", self._model_name)
+            spacy_download(self._model_name)
+            return spacy.load(self._model_name, exclude=self._excluded_components)
+
+    def _recycle_if_due(self, text_count: int) -> None:
+        """Reload the pipeline once it has processed ``recycle_after_texts`` texts.
+
+        Callers must hold ``_zone_lock`` and must not be inside a memory zone, since
+        the zone's exit path reaches into the vocab this replaces.
+        """
+        if self._recycle_after_texts <= 0:
+            return
+        self._texts_since_load += text_count
+        if self._texts_since_load < self._recycle_after_texts:
+            return
+        logger.info(
+            "Recycling SpaCy pipeline to release retained index capacity",
+            extra={"texts_since_load": self._texts_since_load},
+        )
+        self.nlp = self._load()
+        self._texts_since_load = 0
 
     def is_person(self, text: str) -> bool:
         """Return True iff `text` contains a PERSON named entity."""
-        doc = self.nlp(text)
-        return any(ent.label_ == PERSON_LABEL for ent in doc.ents)
+        with self._zone_lock:
+            with self.nlp.memory_zone():
+                verdict = any(ent.label_ == PERSON_LABEL for ent in self.nlp(text).ents)
+            self._recycle_if_due(1)
+            return verdict
 
     def is_person_batch(self, texts: list[str]) -> list[bool]:
         """Return, for each text, whether it contains a PERSON named entity.
@@ -48,10 +112,14 @@ class PiiDetector:
         """
         if not texts:
             return []
-        return [
-            any(ent.label_ == PERSON_LABEL for ent in doc.ents)
-            for doc in self.nlp.pipe(texts, batch_size=len(texts))
-        ]
+        with self._zone_lock:
+            with self.nlp.memory_zone():
+                verdicts = [
+                    any(ent.label_ == PERSON_LABEL for ent in doc.ents)
+                    for doc in self.nlp.pipe(texts, batch_size=len(texts))
+                ]
+            self._recycle_if_due(len(texts))
+            return verdicts
 
 
 def build_detector(settings) -> PiiDetector:
@@ -59,4 +127,5 @@ def build_detector(settings) -> PiiDetector:
     return PiiDetector(
         model_name=settings.pii.model,
         excluded_components=list(settings.pii.excluded_components),
+        recycle_after_texts=settings.pii.recycle_after_texts,
     )

--- a/apps/fleece/tests/unit/configs/test_validators.py
+++ b/apps/fleece/tests/unit/configs/test_validators.py
@@ -15,6 +15,7 @@ _DEFAULTS: dict[str, dict[str, Any]] = {
         "excluded_components": ["tok2vec"],
         "query_character_max": 100,
         "executor_max_workers": 4,
+        "recycle_after_texts": 500000,
     },
     "LOGGING": {"format": "mozlog", "level": "INFO", "can_propagate": False},
     "SENTRY": {"mode": "disabled", "dsn": "", "env": "dev", "traces_sample_rate": 0.0},
@@ -106,5 +107,22 @@ def test_missing_mars_section_rejected() -> None:
         environments=False,
         **{key: value for key, value in _DEFAULTS.items() if key != "MARS"},
     )
+    with pytest.raises(ValidationError):
+        instance.validators.validate()
+
+
+@pytest.mark.parametrize(
+    "value",
+    [pytest.param(0, id="zero_disables_recycling"), pytest.param(1000, id="positive")],
+)
+def test_valid_recycle_after_texts_accepted(value: int) -> None:
+    """Zero is a valid `recycle_after_texts`, being the documented way to disable it."""
+    instance = _build(PII={**_DEFAULTS["PII"], "recycle_after_texts": value})
+    instance.validators.validate()
+
+
+def test_negative_recycle_after_texts_rejected() -> None:
+    """A negative `recycle_after_texts` is meaningless and fails validation."""
+    instance = _build(PII={**_DEFAULTS["PII"], "recycle_after_texts": -1})
     with pytest.raises(ValidationError):
         instance.validators.validate()

--- a/apps/fleece/tests/unit/pii/test_detector.py
+++ b/apps/fleece/tests/unit/pii/test_detector.py
@@ -54,3 +54,59 @@ def test_is_person_batch_empty(detector: PiiDetector) -> None:
     reach `nlp.pipe`.
     """
     assert detector.is_person_batch([]) == []
+
+
+def test_detection_does_not_grow_the_vocab(detector: PiiDetector) -> None:
+    """Detecting over novel tokens leaves the shared StringStore unchanged.
+
+    SpaCy interns every unseen token into the `Vocab` permanently, so without the
+    memory zone this long-lived process leaks for every novel search term it reads.
+    The tokens below are nonsense precisely so none of them can already be interned.
+    """
+    before = len(detector.nlp.vocab.strings)
+
+    detector.is_person_batch([f"zqxjw{n:04d}kbrf mplvth{n:04d}" for n in range(200)])
+    detector.is_person("gwyndal thraxine plovemsk")
+
+    assert len(detector.nlp.vocab.strings) == before
+
+
+def test_recycle_replaces_the_pipeline_once_the_threshold_is_reached() -> None:
+    """The pipeline is reloaded only after `recycle_after_texts` texts have passed.
+
+    Recycling is what bounds the index capacity a memory zone cannot reclaim, so a
+    threshold that never fires -- or fires on every batch -- would either leak or pay
+    a model reload per request.
+    """
+    detector = PiiDetector(
+        model_name="en_core_web_sm", excluded_components=EXCLUDED, recycle_after_texts=10
+    )
+    first = detector.nlp
+
+    detector.is_person_batch(["a query", "another query"])
+    assert detector.nlp is first, "recycled before reaching the threshold"
+
+    # 2 + 7 = 9 texts, still one short.
+    detector.is_person_batch(["filler"] * 7)
+    assert detector.nlp is first, "recycled one text early"
+
+    detector.is_person("the tenth text")
+    assert detector.nlp is not first, "did not recycle on reaching the threshold"
+    assert detector._texts_since_load == 0
+
+
+def test_recycle_disabled_by_default(detector: PiiDetector) -> None:
+    """A zero threshold keeps the originally loaded pipeline forever."""
+    original = detector.nlp
+    detector.is_person_batch(["some query"] * 50)
+    assert detector.nlp is original
+
+
+def test_recycled_detector_still_detects() -> None:
+    """Detection works across a recycle, on both the old and the replacement pipeline."""
+    detector = PiiDetector(
+        model_name="en_core_web_sm", excluded_components=EXCLUDED, recycle_after_texts=1
+    )
+    for _ in range(3):
+        assert detector.is_person("Barack Obama visited Berlin.") is True
+        assert detector.is_person_batch(["The weather is nice today."]) == [False]


### PR DESCRIPTION
## References

JIRA: [DISCO-4469](https://mozilla-hub.atlassian.net/browse/DISCO-4469)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->

This controls the spaCy nlp footprint via:
- Wrap nlp tasks into `memory zones`.
- Reload the nlp pipeline to release the index capacity that cannot be released by momery zones.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/apps/merino/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2556)


[DISCO-4469]: https://mozilla-hub.atlassian.net/browse/DISCO-4469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ