### PR TITLE
fix(merino): disable search term submission

### DIFF
--- a/apps/merino/merino/configs/flags/production.toml
+++ b/apps/merino/merino/configs/flags/production.toml
@@ -4,4 +4,4 @@ dynaconf_merge = true
 # Search term submission to merino-fleece; off by default,
 # rolled out by raising `enabled` toward 1.
 [production.flags.search-term-submission]
-enabled = 0.03
+enabled = 0


### PR DESCRIPTION
## References


## Description
Unbounded memory growth from spacy, disable so it doesn't crash out over the weekend

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2557)
