### PR TITLE
[HNT-3124] Resize potd hi-res image to bounded WebP before upload

### DIFF
--- a/apps/merino/merino/configs/default.toml
+++ b/apps/merino/merino/configs/default.toml
@@ -1250,6 +1250,18 @@ commons_api_url = "https://commons.wikimedia.org/w/api.php"
 # Cache control headers for stored images in the bucket (1hr)
 cache_control = "public, max-age=3600"
 
+# MERINO_RSS_PROVIDERS__WIKIMEDIA_POTD__IMAGE_MAX_DIMENSION
+# Upper bound (in pixels) on the longest edge of the hi-res image uploaded to the bucket.
+# Larger sources are downscaled to fit, preserving aspect ratio; smaller sources are kept
+# at their original size. 3840 matches the width of a 4K UHD display, the largest common
+# resolution the New Tab wallpaper renders at.
+image_max_dimension = 3840
+
+# MERINO_RSS_PROVIDERS__WIKIMEDIA_POTD__IMAGE_WEBP_QUALITY
+# WebP quality (0-100) used when re-encoding the hi-res image, matching the quality the
+# New Tab image cache (img-getpocket.cdn.mozilla.net) uses for content thumbnails.
+image_webp_quality = 75
+
 [default.games_providers.particle]
 # MERINO_GAMES_PROVIDERS__PARTICLE__TYPE
 # The type of this provider, should be `particle`.

--- a/apps/merino/merino/configs/default.toml
+++ b/apps/merino/merino/configs/default.toml
@@ -1247,8 +1247,10 @@ featured_api_base = "https://api.wikimedia.org/feed/v1/wikipedia"
 commons_api_url = "https://commons.wikimedia.org/w/api.php"
 
 # MERINO_RSS_PROVIDERS__WIKIMEDIA_POTD__CACHE_CONTROL
-# Cache control headers for stored images in the bucket (1hr)
-cache_control = "public, max-age=3600"
+# Each day's images are uploaded to a fresh dated path and never modified, so clients and
+# the CDN may cache them forever; hourly re-fetching was a major CDN cost driver (SREIN-1732).
+# Remediating a bad image requires publishing it at a new path via the manifest.
+cache_control = "public, max-age=31536000, immutable"
 
 # MERINO_RSS_PROVIDERS__WIKIMEDIA_POTD__IMAGE_MAX_DIMENSION
 # Upper bound (in pixels) on the longest edge of the hi-res image uploaded to the bucket.

--- a/apps/merino/merino/providers/rss/wikimedia_potd/backends/image_processing.py
+++ b/apps/merino/merino/providers/rss/wikimedia_potd/backends/image_processing.py
@@ -11,9 +11,8 @@ from merino.utils.gcs.models import Image
 
 logger = logging.getLogger(__name__)
 
-# Refuse sources above this pixel count to bound decode memory (non-JPEG formats decode at
-# full resolution). Exceeding it fails the day's update, so the previous picture keeps
-# serving. 500 megapixels covers all but the rarest Picture of the Day sources.
+# A decoded image holds ~3 bytes per pixel in memory, so an unbounded source could OOM the
+# job pod. Failing this check skips the day's update and keeps the previous picture serving.
 MAX_SOURCE_PIXELS = 500_000_000
 
 

--- a/apps/merino/merino/providers/rss/wikimedia_potd/backends/image_processing.py
+++ b/apps/merino/merino/providers/rss/wikimedia_potd/backends/image_processing.py
@@ -11,10 +11,11 @@ from merino.utils.gcs.models import Image
 
 logger = logging.getLogger(__name__)
 
-# Upper bound on the source image size in pixels. A source above this bound fails the day's
-# update (the provider keeps serving the previous picture) rather than risking an
-# out-of-memory decode. 500 megapixels covers Picture of the Day sources with ample margin;
-# the 2026-08-31 picture that motivated this bound was 18018x8275 (~149 megapixels).
+# Upper bound on the source image size in pixels, bounding the worst-case decode. A source
+# above this bound fails the day's update (the provider keeps serving the previous picture)
+# instead of being processed or shipped raw. 500 megapixels covers all but the rarest
+# Picture of the Day sources; the 2026-08-31 picture that motivated this bound was
+# 18018x8275 (~149 megapixels).
 MAX_SOURCE_PIXELS = 500_000_000
 
 
@@ -31,10 +32,10 @@ def process_potd_image(image: Image, max_dimension: int, webp_quality: int) -> I
     """
     try:
         # PIL's decompression bomb guard warns at ~89 megapixels, below routine POTD sizes,
-        # so it is swapped for the explicit MAX_SOURCE_PIXELS check below. The guard only
-        # runs while the header is parsed in open(), and this function only runs in the
-        # single-threaded potd update job, so the brief global override cannot race other
-        # PIL users such as the navigational suggestions job.
+        # so it is swapped for the explicit MAX_SOURCE_PIXELS check below while open() parses
+        # the header. The override is scoped to this call because the web service imports
+        # this module and its guard must stay intact there; nothing else in the potd update
+        # job uses PIL concurrently.
         original_max_pixels = PILImage.MAX_IMAGE_PIXELS
         PILImage.MAX_IMAGE_PIXELS = None
         try:
@@ -51,29 +52,22 @@ def process_potd_image(image: Image, max_dimension: int, webp_quality: int) -> I
                 )
 
             # decode JPEG sources at a reduced DCT scale (a no-op for other formats) so a
-            # very large picture is never held at full resolution in memory. Passing the
-            # current mode keeps the pixel format unchanged; only the scale is reduced.
+            # very large picture is never held at full resolution in memory
             img.draft(img.mode, (max_dimension, max_dimension))
 
             # bake the EXIF orientation into the pixels since the tag is stripped on save
             processed = ImageOps.exif_transpose(img)
 
-        # WebP encodes RGB or RGBA: flatten palette images and keep alpha only when present
-        has_alpha = processed.mode in ("RGBA", "LA") or (
-            processed.mode == "P" and "transparency" in processed.info
-        )
-        processed = processed.convert("RGBA" if has_alpha else "RGB")
-
         # in-place downscale that preserves the aspect ratio and never upscales
         processed.thumbnail((max_dimension, max_dimension), PILImage.Resampling.LANCZOS)
 
         buffer = BytesIO()
-        # EXIF and other metadata are dropped; the ICC profile is kept so colors survive
+        # the WebP encoder converts to RGB itself, keeping alpha when present. EXIF and
+        # other metadata are dropped; the ICC profile is kept so colors survive.
         processed.save(
             buffer,
             format="WEBP",
             quality=webp_quality,
-            method=6,
             icc_profile=processed.info.get("icc_profile"),
         )
     except OSError as ex:

--- a/apps/merino/merino/providers/rss/wikimedia_potd/backends/image_processing.py
+++ b/apps/merino/merino/providers/rss/wikimedia_potd/backends/image_processing.py
@@ -1,0 +1,94 @@
+"""Image processing for Wikimedia Picture of the Day assets."""
+
+import logging
+from io import BytesIO
+
+from PIL import Image as PILImage
+from PIL import ImageOps
+
+from merino.providers.rss.wikimedia_potd.backends.protocol import WikimediaPotdError
+from merino.utils.gcs.models import Image
+
+logger = logging.getLogger(__name__)
+
+# Upper bound on the source image size in pixels. A source above this bound fails the day's
+# update (the provider keeps serving the previous picture) rather than risking an
+# out-of-memory decode. 500 megapixels covers Picture of the Day sources with ample margin;
+# the 2026-08-31 picture that motivated this bound was 18018x8275 (~149 megapixels).
+MAX_SOURCE_PIXELS = 500_000_000
+
+
+def process_potd_image(image: Image, max_dimension: int, webp_quality: int) -> Image:
+    """Downscale a POTD image to fit within `max_dimension` and re-encode it as WebP.
+
+    The aspect ratio is preserved and images already within bounds are never upscaled.
+    The EXIF orientation is applied to the pixels, and all metadata except the ICC color
+    profile is stripped from the output.
+
+    Returns:
+        An Image holding the WebP content. Raises WikimediaPotdError when the source
+        cannot be decoded or is larger than MAX_SOURCE_PIXELS.
+    """
+    try:
+        # PIL's decompression bomb guard warns at ~89 megapixels, below routine POTD sizes,
+        # so it is swapped for the explicit MAX_SOURCE_PIXELS check below. The guard only
+        # runs while the header is parsed in open(), and this function only runs in the
+        # single-threaded potd update job, so the brief global override cannot race other
+        # PIL users such as the navigational suggestions job.
+        original_max_pixels = PILImage.MAX_IMAGE_PIXELS
+        PILImage.MAX_IMAGE_PIXELS = None
+        try:
+            img = PILImage.open(BytesIO(image.content))
+        finally:
+            PILImage.MAX_IMAGE_PIXELS = original_max_pixels
+
+        with img:
+            source_width, source_height = img.size
+            if source_width * source_height > MAX_SOURCE_PIXELS:
+                raise WikimediaPotdError(
+                    f"POTD image of {source_width}x{source_height} pixels exceeds the "
+                    f"{MAX_SOURCE_PIXELS} pixel processing bound"
+                )
+
+            # decode JPEG sources at a reduced DCT scale (a no-op for other formats) so a
+            # very large picture is never held at full resolution in memory. Passing the
+            # current mode keeps the pixel format unchanged; only the scale is reduced.
+            img.draft(img.mode, (max_dimension, max_dimension))
+
+            # bake the EXIF orientation into the pixels since the tag is stripped on save
+            processed = ImageOps.exif_transpose(img)
+
+        # WebP encodes RGB or RGBA: flatten palette images and keep alpha only when present
+        has_alpha = processed.mode in ("RGBA", "LA") or (
+            processed.mode == "P" and "transparency" in processed.info
+        )
+        processed = processed.convert("RGBA" if has_alpha else "RGB")
+
+        # in-place downscale that preserves the aspect ratio and never upscales
+        processed.thumbnail((max_dimension, max_dimension), PILImage.Resampling.LANCZOS)
+
+        buffer = BytesIO()
+        # EXIF and other metadata are dropped; the ICC profile is kept so colors survive
+        processed.save(
+            buffer,
+            format="WEBP",
+            quality=webp_quality,
+            method=6,
+            icc_profile=processed.info.get("icc_profile"),
+        )
+    except OSError as ex:
+        raise WikimediaPotdError(f"Failed to process POTD image: {ex}") from ex
+
+    processed_image = Image(content=buffer.getvalue(), content_type="image/webp")
+
+    logger.info(
+        "Processed POTD image",
+        extra={
+            "source_dimensions": f"{source_width}x{source_height}",
+            "processed_dimensions": f"{processed.width}x{processed.height}",
+            "source_bytes": len(image.content),
+            "processed_bytes": len(processed_image.content),
+        },
+    )
+
+    return processed_image

--- a/apps/merino/merino/providers/rss/wikimedia_potd/backends/image_processing.py
+++ b/apps/merino/merino/providers/rss/wikimedia_potd/backends/image_processing.py
@@ -59,8 +59,8 @@ def process_potd_image(image: Image, max_dimension: int, webp_quality: int) -> I
         processed.thumbnail((max_dimension, max_dimension), PILImage.Resampling.LANCZOS)
 
         buffer = BytesIO()
-        # the WebP encoder converts to RGB itself, keeping alpha when present. EXIF and
-        # other metadata are dropped; the ICC profile is kept so colors survive.
+        # the WebP encoder converts to RGB itself. EXIF and other metadata are dropped;
+        # the ICC profile is kept so colors survive.
         processed.save(
             buffer,
             format="WEBP",

--- a/apps/merino/merino/providers/rss/wikimedia_potd/backends/image_processing.py
+++ b/apps/merino/merino/providers/rss/wikimedia_potd/backends/image_processing.py
@@ -11,11 +11,9 @@ from merino.utils.gcs.models import Image
 
 logger = logging.getLogger(__name__)
 
-# Upper bound on the source image size in pixels, bounding the worst-case decode. A source
-# above this bound fails the day's update (the provider keeps serving the previous picture)
-# instead of being processed or shipped raw. 500 megapixels covers all but the rarest
-# Picture of the Day sources; the 2026-08-31 picture that motivated this bound was
-# 18018x8275 (~149 megapixels).
+# Refuse sources above this pixel count to bound decode memory (non-JPEG formats decode at
+# full resolution). Exceeding it fails the day's update, so the previous picture keeps
+# serving. 500 megapixels covers all but the rarest Picture of the Day sources.
 MAX_SOURCE_PIXELS = 500_000_000
 
 

--- a/apps/merino/merino/providers/rss/wikimedia_potd/backends/protocol.py
+++ b/apps/merino/merino/providers/rss/wikimedia_potd/backends/protocol.py
@@ -55,6 +55,9 @@ class WikimediaPictureOfTheDayBackend(Protocol):
     ) -> tuple[HttpUrl, HttpUrl]:  # pragma: no cover
         """Download and upload potd thumbnail and high resolution images.
 
+        The high resolution image is downscaled to fit `image_max_dimension` and re-encoded
+        as WebP before upload; the thumbnail is uploaded unmodified.
+
         Returns:
             tuple[HttpUrl, HttpUrl]. Raises WikimediaPotdError on failure.
         """

--- a/apps/merino/merino/providers/rss/wikimedia_potd/backends/wikimedia_potd.py
+++ b/apps/merino/merino/providers/rss/wikimedia_potd/backends/wikimedia_potd.py
@@ -1,5 +1,6 @@
 """Wikimedia Picture of the Day backend."""
 
+import asyncio
 import logging
 import aiodogstatsd
 from datetime import datetime, timezone
@@ -21,6 +22,7 @@ from merino.providers.rss.wikimedia_potd.backends.protocol import (
 from merino.utils.gcs.gcs_uploader import GcsUploader
 from merino.utils.gcs.models import Image
 from merino.utils.wikipedia import WIKIMEDIA_REQUEST_HEADERS
+from merino.providers.rss.wikimedia_potd.backends.image_processing import process_potd_image
 from merino.providers.rss.wikimedia_potd.backends.utils import (
     parse_potd,
     extract_image_description_with_lang_code,
@@ -55,6 +57,8 @@ class WikimediaPictureOfTheDayBackend:
         self.http_client = http_client
         self.gcs_uploader = gcs_uploader
         self.cache_control = settings.rss_providers.wikimedia_potd.cache_control
+        self.image_max_dimension = settings.rss_providers.wikimedia_potd.image_max_dimension
+        self.image_webp_quality = settings.rss_providers.wikimedia_potd.image_webp_quality
 
     async def upload_picture_of_the_day(self) -> bool:
         """Orchestrates fetching the Featured API, extracting the Picture of the Day (POTD),
@@ -185,6 +189,16 @@ class WikimediaPictureOfTheDayBackend:
         # download thumbnail and high resolution images for the above potd instance
         thumbnail_image = await self.download_potd_image(potd.thumbnail_image_url)
         hi_res_image = await self.download_potd_image(potd.high_res_image_url)
+
+        # bound the hi-res image's resolution and re-encode it as WebP before uploading;
+        # the Wikimedia original can be arbitrarily large (110MB on 2026-08-31). Runs in a
+        # worker thread because decoding and encoding are CPU-bound.
+        hi_res_image = await asyncio.to_thread(
+            process_potd_image,
+            hi_res_image,
+            self.image_max_dimension,
+            self.image_webp_quality,
+        )
 
         # upload thumbnail and high resolution images to the gcs bucket / cdn
         thumbnail_cdn_url = self.upload_potd_image(image=thumbnail_image, is_thumbnail=True)

--- a/apps/merino/merino/providers/rss/wikimedia_potd/backends/wikimedia_potd.py
+++ b/apps/merino/merino/providers/rss/wikimedia_potd/backends/wikimedia_potd.py
@@ -1,6 +1,5 @@
 """Wikimedia Picture of the Day backend."""
 
-import asyncio
 import logging
 import aiodogstatsd
 from datetime import datetime, timezone
@@ -183,6 +182,9 @@ class WikimediaPictureOfTheDayBackend:
     ) -> tuple[HttpUrl, HttpUrl]:
         """Download and upload potd thumbnail and high resolution images.
 
+        The high resolution image is downscaled to fit `image_max_dimension` and re-encoded
+        as WebP before upload; the thumbnail is uploaded unmodified.
+
         Returns:
             tuple[HttpUrl, HttpUrl]. Raises WikimediaPotdError on failure.
         """
@@ -191,13 +193,9 @@ class WikimediaPictureOfTheDayBackend:
         hi_res_image = await self.download_potd_image(potd.high_res_image_url)
 
         # bound the hi-res image's resolution and re-encode it as WebP before uploading;
-        # the Wikimedia original can be arbitrarily large (110MB on 2026-08-31). Runs in a
-        # worker thread because decoding and encoding are CPU-bound.
-        hi_res_image = await asyncio.to_thread(
-            process_potd_image,
-            hi_res_image,
-            self.image_max_dimension,
-            self.image_webp_quality,
+        # the Wikimedia original can be arbitrarily large (110MB on 2026-08-31)
+        hi_res_image = process_potd_image(
+            hi_res_image, self.image_max_dimension, self.image_webp_quality
         )
 
         # upload thumbnail and high resolution images to the gcs bucket / cdn

--- a/apps/merino/tests/integration/providers/rss/potd/test_wikimedia_potd.py
+++ b/apps/merino/tests/integration/providers/rss/potd/test_wikimedia_potd.py
@@ -4,6 +4,7 @@
 
 """Integration tests for the Picture of the Day Provider."""
 
+from io import BytesIO
 from pathlib import Path
 
 import pytest
@@ -11,8 +12,9 @@ import freezegun
 import orjson
 
 from typing import cast
-from pydantic import HttpUrl
 from unittest.mock import call, AsyncMock, Mock
+from PIL import Image as PILImage
+from pydantic import HttpUrl
 from httpx import AsyncClient, HTTPError, Request, Response
 from pytest_mock import MockerFixture
 from merino.providers.rss.wikimedia_potd.backends.protocol import (
@@ -34,6 +36,15 @@ TEST_FEATURED_JSON = Path(
 
 # A well-formed JSON response that is missing the "image" object, so parse_potd raises.
 TEST_FEATURED_JSON_NO_IMAGE = "{}"
+
+
+def make_png_image(width: int = 40, height: int = 20) -> Image:
+    """Return an Image holding valid PNG content, so it survives hi-res processing."""
+    buffer = BytesIO()
+    with PILImage.new("RGB", (width, height)) as img:
+        img.save(buffer, format="PNG")
+
+    return Image(content=buffer.getvalue(), content_type="image/png")
 
 
 @pytest.fixture(name="backend")
@@ -76,9 +87,7 @@ class TestUploadPictureOfTheDayMethod:
         )
 
         # mock download_and_upload_potd_images(potd) returns
-        mocker.patch.object(backend, "download_potd_image").return_value = Image(
-            content=b"255", content_type="Image/png"
-        )
+        mocker.patch.object(backend, "download_potd_image").return_value = make_png_image()
 
         # call the orchestrate method
         result = await backend.upload_picture_of_the_day()
@@ -95,9 +104,10 @@ class TestUploadPictureOfTheDayMethod:
             str(potd_manifest.thumbnail_image_url)
             == "https://test-cdn-name/wikimedia_potd/2026-06-24/thumbnail.png"
         )
+        # the hi-res image is re-encoded as WebP before upload, so its extension changes
         assert (
             str(potd_manifest.high_res_image_url)
-            == "https://test-cdn-name/wikimedia_potd/2026-06-24/hi_res.png"
+            == "https://test-cdn-name/wikimedia_potd/2026-06-24/hi_res.webp"
         )
         assert "Sagittarius" in potd_manifest.description
         assert potd_manifest.author == "Test Artist"
@@ -109,7 +119,7 @@ class TestUploadPictureOfTheDayMethod:
         potd_blobs = list(gcs_storage_client.get_bucket(gcs_storage_bucket.name).list_blobs())
 
         assert len(potd_blobs) == 3
-        assert potd_blobs[0].name == "wikimedia_potd/2026-06-24/hi_res.png"
+        assert potd_blobs[0].name == "wikimedia_potd/2026-06-24/hi_res.webp"
         assert potd_blobs[1].name == "wikimedia_potd/2026-06-24/potd.json"
         assert potd_blobs[2].name == "wikimedia_potd/2026-06-24/thumbnail.png"
 
@@ -164,7 +174,7 @@ class TestUploadPictureOfTheDayMethod:
         ]
 
         backend_download_method_mock = mocker.patch.object(backend, "download_potd_image")
-        backend_download_method_mock.return_value = Image(content=b"255", content_type="Image/png")
+        backend_download_method_mock.return_value = make_png_image()
 
         result = await backend.upload_picture_of_the_day()
         assert result is True
@@ -238,9 +248,7 @@ class TestUploadPictureOfTheDayMethod:
             content=TEST_FEATURED_JSON,
             request=Request(method="GET", url=FEED_URL),
         )
-        mocker.patch.object(backend, "download_potd_image").return_value = Image(
-            content=b"255", content_type="Image/png"
-        )
+        mocker.patch.object(backend, "download_potd_image").return_value = make_png_image()
         mocker.patch.object(backend, "upload_potd_manifest").side_effect = WikimediaPotdError(
             "manifest upload failed"
         )
@@ -265,9 +273,7 @@ class TestUploadPictureOfTheDayMethod:
             request=Request(method="GET", url=FEED_URL),
         )
         # Images "download" fine; only the GCS upload should fail.
-        mocker.patch.object(backend, "download_potd_image").return_value = Image(
-            content=b"255", content_type="Image/png"
-        )
+        mocker.patch.object(backend, "download_potd_image").return_value = make_png_image()
 
         # Simulate a real GCS write failure at the storage layer, so the real
         # GcsUploader.upload_content path runs.

--- a/apps/merino/tests/unit/providers/rss/wikimedia_potd/backends/test_image_processing.py
+++ b/apps/merino/tests/unit/providers/rss/wikimedia_potd/backends/test_image_processing.py
@@ -75,17 +75,8 @@ class TestProcessPotdImage:
         with open_processed(result) as img:
             assert img.mode == "RGBA"
 
-    def test_flattens_palette_image(self) -> None:
-        """Converts a palette-mode source without transparency to plain RGB."""
-        result = process_potd_image(
-            make_image(50, 50, image_format="PNG", mode="P"), max_dimension=200, webp_quality=75
-        )
-
-        with open_processed(result) as img:
-            assert img.mode == "RGB"
-
-    def test_applies_exif_orientation(self) -> None:
-        """Bakes the EXIF orientation into the pixels, swapping the stored dimensions."""
+    def test_applies_exif_orientation_and_strips_metadata(self) -> None:
+        """Bakes the EXIF orientation into the pixels and drops the EXIF metadata itself."""
         exif = PILImage.Exif()
         exif[EXIF_ORIENTATION_TAG] = 6
 
@@ -95,17 +86,6 @@ class TestProcessPotdImage:
 
         with open_processed(result) as img:
             assert img.size == (100, 200)
-
-    def test_strips_exif_metadata(self) -> None:
-        """Drops EXIF metadata from the output."""
-        exif = PILImage.Exif()
-        exif[EXIF_ORIENTATION_TAG] = 6
-
-        result = process_potd_image(
-            make_image(200, 100, exif=exif), max_dimension=300, webp_quality=75
-        )
-
-        with open_processed(result) as img:
             assert not img.getexif()
 
     def test_raises_for_undecodable_content(self) -> None:

--- a/apps/merino/tests/unit/providers/rss/wikimedia_potd/backends/test_image_processing.py
+++ b/apps/merino/tests/unit/providers/rss/wikimedia_potd/backends/test_image_processing.py
@@ -66,15 +66,6 @@ class TestProcessPotdImage:
         with open_processed(result) as img:
             assert img.format == "WEBP"
 
-    def test_keeps_alpha_channel(self) -> None:
-        """Preserves the alpha channel of a transparent source image."""
-        result = process_potd_image(
-            make_image(50, 50, image_format="PNG", mode="RGBA"), max_dimension=200, webp_quality=75
-        )
-
-        with open_processed(result) as img:
-            assert img.mode == "RGBA"
-
     def test_applies_exif_orientation_and_strips_metadata(self) -> None:
         """Bakes the EXIF orientation into the pixels and drops the EXIF metadata itself."""
         exif = PILImage.Exif()

--- a/apps/merino/tests/unit/providers/rss/wikimedia_potd/backends/test_image_processing.py
+++ b/apps/merino/tests/unit/providers/rss/wikimedia_potd/backends/test_image_processing.py
@@ -1,0 +1,126 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Unit tests for Wikimedia POTD image processing."""
+
+from io import BytesIO
+
+import pytest
+from PIL import Image as PILImage
+from pytest_mock import MockerFixture
+
+from merino.providers.rss.wikimedia_potd.backends.image_processing import process_potd_image
+from merino.providers.rss.wikimedia_potd.backends.protocol import WikimediaPotdError
+from merino.utils.gcs.models import Image
+
+# EXIF tag id for orientation; value 6 means the pixels are rotated 90 degrees.
+EXIF_ORIENTATION_TAG = 0x0112
+
+
+def make_image(
+    width: int, height: int, image_format: str = "JPEG", mode: str = "RGB", **save_kwargs
+) -> Image:
+    """Return an Image with generated content of the given dimensions and format."""
+    buffer = BytesIO()
+    with PILImage.new(mode, (width, height)) as img:
+        img.save(buffer, format=image_format, **save_kwargs)
+
+    return Image(content=buffer.getvalue(), content_type=f"image/{image_format.lower()}")
+
+
+def open_processed(image: Image) -> PILImage.Image:
+    """Open the content of a processed Image with PIL."""
+    return PILImage.open(BytesIO(image.content))
+
+
+class TestProcessPotdImage:
+    """Tests for the process_potd_image function."""
+
+    @pytest.mark.parametrize(
+        ("source_size", "expected_size"),
+        [
+            ((800, 400), (200, 100)),
+            ((400, 800), (100, 200)),
+            ((200, 200), (200, 200)),
+            ((120, 80), (120, 80)),
+        ],
+        ids=["downscales_landscape", "downscales_portrait", "keeps_exact_fit", "never_upscales"],
+    )
+    def test_bounds_the_longest_edge_preserving_aspect_ratio(
+        self, source_size: tuple[int, int], expected_size: tuple[int, int]
+    ) -> None:
+        """Downscales images to fit max_dimension without upscaling smaller ones."""
+        result = process_potd_image(make_image(*source_size), max_dimension=200, webp_quality=75)
+
+        with open_processed(result) as img:
+            assert img.size == expected_size
+
+    def test_re_encodes_as_webp(self) -> None:
+        """Returns WebP content with the matching content type regardless of source format."""
+        result = process_potd_image(
+            make_image(50, 50, image_format="PNG"), max_dimension=200, webp_quality=75
+        )
+
+        assert result.content_type == "image/webp"
+        with open_processed(result) as img:
+            assert img.format == "WEBP"
+
+    def test_keeps_alpha_channel(self) -> None:
+        """Preserves the alpha channel of a transparent source image."""
+        result = process_potd_image(
+            make_image(50, 50, image_format="PNG", mode="RGBA"), max_dimension=200, webp_quality=75
+        )
+
+        with open_processed(result) as img:
+            assert img.mode == "RGBA"
+
+    def test_flattens_palette_image(self) -> None:
+        """Converts a palette-mode source without transparency to plain RGB."""
+        result = process_potd_image(
+            make_image(50, 50, image_format="PNG", mode="P"), max_dimension=200, webp_quality=75
+        )
+
+        with open_processed(result) as img:
+            assert img.mode == "RGB"
+
+    def test_applies_exif_orientation(self) -> None:
+        """Bakes the EXIF orientation into the pixels, swapping the stored dimensions."""
+        exif = PILImage.Exif()
+        exif[EXIF_ORIENTATION_TAG] = 6
+
+        result = process_potd_image(
+            make_image(200, 100, exif=exif), max_dimension=300, webp_quality=75
+        )
+
+        with open_processed(result) as img:
+            assert img.size == (100, 200)
+
+    def test_strips_exif_metadata(self) -> None:
+        """Drops EXIF metadata from the output."""
+        exif = PILImage.Exif()
+        exif[EXIF_ORIENTATION_TAG] = 6
+
+        result = process_potd_image(
+            make_image(200, 100, exif=exif), max_dimension=300, webp_quality=75
+        )
+
+        with open_processed(result) as img:
+            assert not img.getexif()
+
+    def test_raises_for_undecodable_content(self) -> None:
+        """Raises WikimediaPotdError when the content is not a decodable image."""
+        image = Image(content=b"not an image", content_type="image/jpeg")
+
+        with pytest.raises(WikimediaPotdError):
+            process_potd_image(image, max_dimension=200, webp_quality=75)
+
+    def test_raises_when_source_exceeds_pixel_bound(self, mocker: MockerFixture) -> None:
+        """Raises WikimediaPotdError when the source has more pixels than MAX_SOURCE_PIXELS."""
+        mocker.patch(
+            "merino.providers.rss.wikimedia_potd.backends.image_processing.MAX_SOURCE_PIXELS",
+            100,
+        )
+
+        with pytest.raises(WikimediaPotdError):
+            process_potd_image(make_image(20, 20), max_dimension=200, webp_quality=75)

--- a/apps/merino/tests/unit/providers/rss/wikimedia_potd/backends/test_image_processing.py
+++ b/apps/merino/tests/unit/providers/rss/wikimedia_potd/backends/test_image_processing.py
@@ -14,7 +14,7 @@ from merino.providers.rss.wikimedia_potd.backends.image_processing import proces
 from merino.providers.rss.wikimedia_potd.backends.protocol import WikimediaPotdError
 from merino.utils.gcs.models import Image
 
-# EXIF tag id for orientation; value 6 means the pixels are rotated 90 degrees.
+# EXIF tag id for the image orientation.
 EXIF_ORIENTATION_TAG = 0x0112
 
 
@@ -69,6 +69,8 @@ class TestProcessPotdImage:
     def test_applies_exif_orientation_and_strips_metadata(self) -> None:
         """Bakes the EXIF orientation into the pixels and drops the EXIF metadata itself."""
         exif = PILImage.Exif()
+        # orientation 6 means "rotate 90 degrees clockwise to display", so the 200x100 source
+        # below must come out as 100x200
         exif[EXIF_ORIENTATION_TAG] = 6
 
         result = process_potd_image(

--- a/apps/merino/tests/unit/providers/rss/wikimedia_potd/backends/test_wikimedia_potd_backend.py
+++ b/apps/merino/tests/unit/providers/rss/wikimedia_potd/backends/test_wikimedia_potd_backend.py
@@ -4,12 +4,14 @@
 
 """Unit tests for the Wikimedia Picture of the Day backend."""
 
+from io import BytesIO
 from pathlib import Path
 
 import pytest
 import freezegun
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock
+from PIL import Image as PILImage
 from pydantic import HttpUrl
 from httpx import AsyncClient, HTTPError, ReadTimeout, Request, Response
 from pytest_mock import MockerFixture
@@ -28,6 +30,16 @@ from merino.utils.gcs.models import Image
 
 FEED_URL = "https://example.com/feed"
 COMMONS_API_URL = "https://commons.example.com/w/api.php"
+
+
+def make_jpeg_image(width: int = 40, height: int = 20) -> Image:
+    """Return an Image holding valid JPEG content, so it survives hi-res processing."""
+    buffer = BytesIO()
+    with PILImage.new("RGB", (width, height)) as img:
+        img.save(buffer, format="JPEG")
+
+    return Image(content=buffer.getvalue(), content_type="image/jpeg")
+
 
 # The sample response is stored verbatim as JSON so the fixture matches the Featured API payload.
 TEST_FEATURED_JSON = Path(
@@ -79,7 +91,7 @@ class TestDownloadAndUploadPotdImagesMethod:
         self, backend, potd, mocker: MockerFixture
     ) -> None:
         """Test that download_and_upload_potd_images method returns two urls when successful."""
-        test_image = Image(content=b"255", content_type="Image/jpeg")
+        test_image = make_jpeg_image()
 
         client_mock: AsyncMock = cast(AsyncMock, backend.http_client)
 
@@ -111,6 +123,61 @@ class TestDownloadAndUploadPotdImagesMethod:
 
         assert thumbnail_url == expected_uploaded_url
         assert hires_url == expected_uploaded_url
+
+    @pytest.mark.asyncio
+    @freezegun.freeze_time("2026-06-24")
+    async def test_download_and_upload_potd_images_processes_hi_res_but_not_thumbnail(
+        self, backend, potd, mocker: MockerFixture
+    ) -> None:
+        """Uploads the hi-res image re-encoded as WebP and the thumbnail unmodified."""
+        test_image = make_jpeg_image()
+
+        client_mock: AsyncMock = cast(AsyncMock, backend.http_client)
+        client_mock.get.side_effect = [
+            Response(
+                status_code=200,
+                content=test_image.content,
+                request=Request(method="GET", url=str(potd.thumbnail_image_url)),
+                headers={"content-type": test_image.content_type},
+            ),
+            Response(
+                status_code=200,
+                content=test_image.content,
+                request=Request(method="GET", url=str(potd.high_res_image_url)),
+                headers={"content-type": test_image.content_type},
+            ),
+        ]
+
+        upload_mock = mocker.patch.object(backend, "upload_potd_image")
+        upload_mock.return_value = HttpUrl("https://www.uploaded-test-image.com/image.webp")
+
+        await backend.download_and_upload_potd_images(potd)
+
+        thumbnail_call, hi_res_call = upload_mock.call_args_list
+        assert thumbnail_call.kwargs["image"].content_type == "image/jpeg"
+        assert thumbnail_call.kwargs["image"].content == test_image.content
+        assert hi_res_call.kwargs["image"].content_type == "image/webp"
+
+    @pytest.mark.asyncio
+    @freezegun.freeze_time("2026-06-24")
+    async def test_download_and_upload_potd_images_raises_when_hi_res_is_not_decodable(
+        self, backend, potd, mocker: MockerFixture
+    ) -> None:
+        """Propagates WikimediaPotdError when the hi-res image cannot be processed."""
+        client_mock: AsyncMock = cast(AsyncMock, backend.http_client)
+        client_mock.get.return_value = Response(
+            status_code=200,
+            content=b"not an image",
+            request=Request(method="GET", url=str(potd.high_res_image_url)),
+            headers={"content-type": "image/jpeg"},
+        )
+
+        upload_mock = mocker.patch.object(backend, "upload_potd_image")
+
+        with pytest.raises(WikimediaPotdError):
+            await backend.download_and_upload_potd_images(potd)
+
+        upload_mock.assert_not_called()
 
     @pytest.mark.asyncio
     @freezegun.freeze_time("2026-06-24")
@@ -158,9 +225,7 @@ class TestDownloadAndUploadPotdImagesMethod:
         self, backend, potd, mocker: MockerFixture
     ) -> None:
         """Propagates the error raised by upload_potd_image."""
-        mocker.patch.object(backend, "download_potd_image").return_value = Image(
-            content=b"255", content_type="Image/jpeg"
-        )
+        mocker.patch.object(backend, "download_potd_image").return_value = make_jpeg_image()
         mocker.patch.object(backend, "upload_potd_image").side_effect = WikimediaPotdError(
             "upload failed"
         )
@@ -241,9 +306,7 @@ class TestOrchestratePictureOfTheDayUpload:
         )
 
         # mocking download method to return a valid value but raise on the upload method
-        mocker.patch.object(backend, "download_potd_image").return_value = Image(
-            content=b"255", content_type="Image/jpeg"
-        )
+        mocker.patch.object(backend, "download_potd_image").return_value = make_jpeg_image()
         mocker.patch.object(backend, "upload_potd_image").side_effect = WikimediaPotdError(
             "upload failed"
         )


### PR DESCRIPTION
## References

JIRA: [HNT-3124](https://mozilla-hub.atlassian.net/browse/HNT-3124)

## Description

The potd job re-hosted the untouched Wikimedia original on the wallpaper path. On 2026-08-31 that was a **110MB, 18018×8275 (~149 megapixel) JPEG**, which New Tab clients downloaded in full and re-decoded on every new-tab activation (several seconds per paint, per dholbert's Slack report). It also feeds directly into the CDN cost concerns tracked in [HNT-3056](https://mozilla-hub.atlassian.net/browse/HNT-3056).

The `update-wikimedia-potd` job now processes the hi-res image before uploading to GCS:

- **Downscale to fit within 3840px on the longest edge** (4K UHD width), preserving aspect ratio and never upscaling. The POTD widget blueprint requires ≥1920px width and prefers ≥2560px, so 3840 keeps ample headroom; today's image becomes 3840×1764 — the same rendition Wikimedia itself offers as a download.
- **Re-encode as WebP quality 75**, matching the quality the New Tab image cache (img-getpocket.cdn.mozilla.net) uses for content thumbnails. The manifest's `high_res_image_url` now points at `hi_res.webp`.
- **Strip metadata** (EXIF etc.), after applying the EXIF orientation to the pixels; the ICC profile is kept so colors survive.
- **Fail safe**: a source that cannot be decoded or exceeds a 500 megapixel bound fails the day's update, so the provider keeps serving the previous day's picture rather than shipping an unprocessed original. JPEG sources are decoded at a reduced DCT scale (`draft()`), so even very large pictures never materialize at full resolution in memory.

The thumbnail (already a small Wikimedia rendition) is uploaded unmodified, as before.

Also folded in per SREIN-1732: **image Cache-Control goes from `max-age=3600` to `public, max-age=31536000, immutable`**. Each day's images live at a fresh dated path and are never modified, so hourly re-fetching only burned CDN transfer. Note this closes the "swap a bad image in place" remediation used on 2026-08-31 — remediation now means publishing the fixed image at a new path via the manifest, which stays short-cached as the mutable pointer.

Verified against the actual 2026-08-31 image:

| | before | after |
|---|---|---|
| bytes | 109,951,518 | 1,461,482 (**75× smaller**) |
| dimensions | 18018×8275 | 3840×1764 |
| format | JPEG | WebP q75 |

Processing took 2.2s with ~580MB peak RSS in the job process (dominated by two in-memory copies of the 110MB source; the decode buffer itself stays ~28MB thanks to DCT draft). Worth confirming the job pod's memory limit accommodates this.

### Why these choices (data from a full-year scan of the Featured API, 2025)

- **PNG support is kept deliberately**: 98.3% of days are JPEG, but ~4-5 days/year are PNG and the Featured API does *not* normalize the source format. SVG (~2 days/yr) and GIF (~1 every few years) sources are already rejected by the pre-existing URL extension check and fail safe.
- **The pixel-bound override is exercised, not theoretical**: ~2.2% of 2025 days exceeded Pillow's default ~89MP decompression-bomb guard (which would otherwise warn/error), including a 1.02-gigapixel day (23181×44120) that exceeds even the 500MP bound and fails safe.

### Notes for reviewers

- The proposed ["How the POTD widget should crop pictures" ADR](https://mozilla-hub.atlassian.net/wiki/spaces/FPS/pages/2981003324) documents keeping the untouched original on the wallpaper path; this PR deliberately revises that decision in response to the incident.
- Alternative considered: wrapping the source in the image cache (thumbor). Rejected for this fix because its `MAX_SOURCE_SIZE` is ~19.5MB and it runs in a 30s/2GB Lambda, so it would refuse exactly the oversized sources that motivate this change, and would add a cross-repo deploy dependency.
- Possible follow-up: request an appropriately sized rendition from Wikimedia's thumb service instead of downloading the original, which would avoid the 110MB fetch entirely and also cover the rare SVG/gigapixel days.
- New config: `image_max_dimension` (3840) and `image_webp_quality` (75) under `rss_providers.wikimedia_potd`.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/apps/merino/metrics.yaml) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)

[HNT-3124]: https://mozilla-hub.atlassian.net/browse/HNT-3124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


[HNT-3056]: https://mozilla-hub.atlassian.net/browse/HNT-3056?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
