### PR TITLE
chore(merino): re-enable fleece search term submission at 3%

### DIFF
--- a/apps/merino/merino/configs/flags/production.toml
+++ b/apps/merino/merino/configs/flags/production.toml
@@ -4,4 +4,4 @@ dynaconf_merge = true
 # Search term submission to merino-fleece; off by default,
 # rolled out by raising `enabled` toward 1.
 [production.flags.search-term-submission]
-enabled = 0
+enabled = 0.03


### PR DESCRIPTION
## References

JIRA: 

## Description
https://github.com/mozilla-services/merino-py/pull/1757 should have fixed the unbounded memory growth, we can re-enable at test level (3%)



┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2561)
