### PR TITLE
[HNT-2327] feat: serve India legacy grid from sections backend

### DIFF
--- a/apps/merino/merino/curated_recommendations/utils.py
+++ b/apps/merino/merino/curated_recommendations/utils.py
@@ -21,6 +21,7 @@ ROLLED_OUT_SECTION_SURFACES: frozenset[SurfaceId] = frozenset(
         SurfaceId.NEW_TAB_EN_CA,
         SurfaceId.NEW_TAB_EN_GB,
         SurfaceId.NEW_TAB_EN_IE,
+        SurfaceId.NEW_TAB_EN_INTL,
         SurfaceId.NEW_TAB_EN_US,
         SurfaceId.NEW_TAB_ES_ES,
         SurfaceId.NEW_TAB_FR_BE,

--- a/apps/merino/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/apps/merino/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -517,7 +517,9 @@ class TestLegacyEndpoints:
     """Test the legacy curated recommendations endpoints (fx114 and fx115-129).
 
     These endpoints have two code paths:
-    - Rolled-out section surfaces (en-US, en-CA, en-GB, de-DE, fr-FR, es-ES, it-IT, de-AT, de-CH, fr-BE): use sections backend via get_legacy_recommendations_from_sections
+    - Rolled-out section surfaces (en-US, en-CA, en-GB, de-DE, fr-FR, es-ES, it-IT, de-AT,
+      de-CH, fr-BE, and region IN): use sections backend via
+      get_legacy_recommendations_from_sections
     - Other locales (pl-PL, etc.): use scheduler backend via CuratedRecommendationsProvider
     """
 
@@ -621,6 +623,39 @@ class TestLegacyEndpoints:
         assert len(items) == requested_count
 
     @pytest.mark.parametrize(
+        "endpoint,locale_param,items_key,default_count",
+        [
+            ("legacy-115-129", "locale", "data", 30),
+            ("legacy-114", "locale_lang", "recommendations", 20),
+        ],
+    )
+    def test_india_returns_valid_response(
+        self,
+        endpoint: str,
+        locale_param: str,
+        items_key: str,
+        default_count: int,
+        client: TestClient,
+    ):
+        """Test both legacy endpoints for India (region IN maps to NEW_TAB_EN_INTL).
+
+        India is selected by region rather than locale, and is served from the sections
+        backend like the other rolled-out section surfaces.
+        """
+        response = client.get(
+            f"/api/v1/curated-recommendations/{endpoint}",
+            params={locale_param: "en-US", "region": "IN"},
+        )
+
+        assert response.status_code == 200
+        items = response.json()[items_key]
+
+        assert len(items) == default_count
+        assert all(item["title"] for item in items)
+        assert all(item["url"] for item in items)
+        assert all(item["excerpt"] for item in items)
+
+    @pytest.mark.parametrize(
         "endpoint,locale_param",
         [
             ("legacy-115-129", "locale"),
@@ -671,14 +706,18 @@ class TestLegacyEndpoints:
     @freezegun.freeze_time("2012-01-14 03:21:34", tz_offset=0)
     @pytest.mark.parametrize(
         "region,expected_surface",
-        [("GB", SurfaceId.NEW_TAB_EN_GB), ("IE", SurfaceId.NEW_TAB_EN_IE)],
+        [
+            ("GB", SurfaceId.NEW_TAB_EN_GB),
+            ("IE", SurfaceId.NEW_TAB_EN_IE),
+            ("IN", SurfaceId.NEW_TAB_EN_INTL),
+        ],
     )
     def test_en_gb_non_sections_request(
         self, region: str, expected_surface: SurfaceId, client: TestClient
     ):
         """Test en-GB non-sections request via main endpoint (backward-compatible path).
 
-        GB/IE clients without feeds=["sections"] use get_legacy_recommendations_from_sections.
+        GB/IE/IN clients without feeds=["sections"] use get_legacy_recommendations_from_sections.
         """
         response = client.post(
             "/api/v1/curated-recommendations",
@@ -2764,8 +2803,9 @@ class TestSections:
     def test_india_without_sections_feed_is_not_forced_into_sections(self, client: TestClient):
         """Test that clients in India that do not request sections keep the legacy grid.
 
-        NEW_TAB_EN_INTL is not in ROLLED_OUT_SECTION_SURFACES, so non-sections requests are
-        still served from the scheduled surface backend.
+        NEW_TAB_EN_INTL is in ROLLED_OUT_SECTION_SURFACES, so non-sections requests are served
+        a flat list sourced from the sections backend (via the legacy adapter), not a sections
+        feed.
         """
         response = client.post(
             "/api/v1/curated-recommendations",
@@ -2777,6 +2817,8 @@ class TestSections:
         assert data["surfaceId"] == SurfaceId.NEW_TAB_EN_INTL.value
         assert data["feeds"] is None
         assert len(data["data"]) > 0
+        # scheduledCorpusItemId equals corpusItemId (sections backend behavior)
+        assert all(item["scheduledCorpusItemId"] == item["corpusItemId"] for item in data["data"])
 
 
 def test_uk_sections_with_gb_backend_data(

--- a/apps/merino/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/apps/merino/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -523,31 +523,36 @@ class TestLegacyEndpoints:
     - Other locales (pl-PL, etc.): use scheduler backend via CuratedRecommendationsProvider
     """
 
-    # Locales that use the sections backend (rolled-out section surfaces)
-    SECTIONS_BACKEND_LOCALES = [
-        "de-AT",
-        "de-CH",
-        "de-DE",
-        "en-CA",
-        "en-GB",
-        "en-US",
-        "es-ES",
-        "fr-BE",
-        "fr-FR",
-        "it-IT",
+    # (locale, region) pairs that use the sections backend (rolled-out section surfaces).
+    # India (NEW_TAB_EN_INTL) is selected by region because no dedicated locale exists for it.
+    SECTIONS_BACKEND_MARKETS: list[tuple[str, str | None]] = [
+        ("de-AT", None),
+        ("de-CH", None),
+        ("de-DE", None),
+        ("en-CA", None),
+        ("en-GB", None),
+        ("en-US", None),
+        ("en-US", "IN"),
+        ("es-ES", None),
+        ("fr-BE", None),
+        ("fr-FR", None),
+        ("it-IT", None),
     ]
-    # Locales that use the scheduler backend (non-rolled-out)
-    SCHEDULER_BACKEND_LOCALES = ["pl-PL"]
+    # (locale, region) pairs that use the scheduler backend (non-rolled-out)
+    SCHEDULER_BACKEND_MARKETS: list[tuple[str, str | None]] = [("pl-PL", None)]
 
     @pytest.mark.parametrize(
-        "locale",
-        SECTIONS_BACKEND_LOCALES + SCHEDULER_BACKEND_LOCALES,
+        "locale,region",
+        SECTIONS_BACKEND_MARKETS + SCHEDULER_BACKEND_MARKETS,
     )
-    def test_fx115_129_returns_valid_response(self, locale: str, client: TestClient):
-        """Test the legacy fx115-129 endpoint returns expected response for all supported locales."""
-        response = client.get(
-            "/api/v1/curated-recommendations/legacy-115-129", params={"locale": locale}
-        )
+    def test_fx115_129_returns_valid_response(
+        self, locale: str, region: str | None, client: TestClient
+    ):
+        """Test the legacy fx115-129 endpoint returns expected response for all supported markets."""
+        params = {"locale": locale}
+        if region:
+            params["region"] = region
+        response = client.get("/api/v1/curated-recommendations/legacy-115-129", params=params)
 
         assert response.status_code == 200
         data = response.json()
@@ -566,15 +571,17 @@ class TestLegacyEndpoints:
         assert all(item["imageUrl"] for item in corpus_items)
 
     @pytest.mark.parametrize(
-        "locale_lang",
-        SECTIONS_BACKEND_LOCALES + SCHEDULER_BACKEND_LOCALES,
+        "locale_lang,region",
+        SECTIONS_BACKEND_MARKETS + SCHEDULER_BACKEND_MARKETS,
     )
-    def test_fx114_returns_valid_response(self, locale_lang: str, client: TestClient):
-        """Test the legacy fx114 endpoint returns expected response for all supported locales."""
-        response = client.get(
-            "/api/v1/curated-recommendations/legacy-114",
-            params={"locale_lang": locale_lang},
-        )
+    def test_fx114_returns_valid_response(
+        self, locale_lang: str, region: str | None, client: TestClient
+    ):
+        """Test the legacy fx114 endpoint returns expected response for all supported markets."""
+        params = {"locale_lang": locale_lang}
+        if region:
+            params["region"] = region
+        response = client.get("/api/v1/curated-recommendations/legacy-114", params=params)
 
         assert response.status_code == 200
         data = response.json()
@@ -598,7 +605,7 @@ class TestLegacyEndpoints:
             ("legacy-114", "locale_lang", "count", 20),
         ],
     )
-    @pytest.mark.parametrize("locale", SECTIONS_BACKEND_LOCALES + SCHEDULER_BACKEND_LOCALES)
+    @pytest.mark.parametrize("locale,region", SECTIONS_BACKEND_MARKETS + SCHEDULER_BACKEND_MARKETS)
     def test_count_parameter(
         self,
         endpoint: str,
@@ -606,14 +613,15 @@ class TestLegacyEndpoints:
         count_param: str,
         default_count: int,
         locale: str,
+        region: str | None,
         client: TestClient,
     ):
-        """Test that the count parameter limits results for both endpoints and all locales."""
+        """Test that the count parameter limits results for both endpoints and all markets."""
         requested_count = 5
-        response = client.get(
-            f"/api/v1/curated-recommendations/{endpoint}",
-            params={locale_param: locale, count_param: requested_count},
-        )
+        params = {locale_param: locale, count_param: requested_count}
+        if region:
+            params["region"] = region
+        response = client.get(f"/api/v1/curated-recommendations/{endpoint}", params=params)
 
         assert response.status_code == 200
         data = response.json()
@@ -621,39 +629,6 @@ class TestLegacyEndpoints:
         # Get items from correct response field
         items = data["data"] if endpoint == "legacy-115-129" else data["recommendations"]
         assert len(items) == requested_count
-
-    @pytest.mark.parametrize(
-        "endpoint,locale_param,items_key,default_count",
-        [
-            ("legacy-115-129", "locale", "data", 30),
-            ("legacy-114", "locale_lang", "recommendations", 20),
-        ],
-    )
-    def test_india_returns_valid_response(
-        self,
-        endpoint: str,
-        locale_param: str,
-        items_key: str,
-        default_count: int,
-        client: TestClient,
-    ):
-        """Test both legacy endpoints for India (region IN maps to NEW_TAB_EN_INTL).
-
-        India is selected by region rather than locale, and is served from the sections
-        backend like the other rolled-out section surfaces.
-        """
-        response = client.get(
-            f"/api/v1/curated-recommendations/{endpoint}",
-            params={locale_param: "en-US", "region": "IN"},
-        )
-
-        assert response.status_code == 200
-        items = response.json()[items_key]
-
-        assert len(items) == default_count
-        assert all(item["title"] for item in items)
-        assert all(item["url"] for item in items)
-        assert all(item["excerpt"] for item in items)
 
     @pytest.mark.parametrize(
         "endpoint,locale_param",


### PR DESCRIPTION
## References

JIRA: [HNT-2327](https://mozilla-hub.atlassian.net/browse/HNT-2327)

## Description

Add `NEW_TAB_EN_INTL` to `ROLLED_OUT_SECTION_SURFACES` so requests that do not ask for sections are served ML section content through the legacy adapter (`get_legacy_recommendations_from_sections`) instead of the scheduled surface backend. This covers:

- `POST /api/v1/curated-recommendations` without `feeds=["sections"]` (Fx 130+ clients on the legacy grid layout)
- `GET /api/v1/curated-recommendations/legacy-115-129`
- `GET /api/v1/curated-recommendations/legacy-114`

Follow-up to HNT-3085 (#1750), which served India sections on request and deliberately left legacy clients on the scheduler during internal QA. Mirrors the IE rollout in HNT-2596 (#1525). Response shape is unchanged for these clients (flat list, `feeds: null`); only the data source changes.

# QA

With Merino running locally (`make dev`):

```bash
# Main endpoint, non-sections request from India
curl -s -X POST localhost:8000/api/v1/curated-recommendations \
  -H 'Content-Type: application/json' -d '{"locale":"en-US","region":"IN"}' \
  | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['surfaceId'], d['feeds'], len(d['data']), all(i['scheduledCorpusItemId']==i['corpusItemId'] for i in d['data']), [i['publisher'] for i in d['data'][:3]])"

# Legacy endpoints
curl -s 'localhost:8000/api/v1/curated-recommendations/legacy-115-129?locale=en-US&region=IN' \
  | python3 -c "import json,sys; d=json.load(sys.stdin); print(len(d['data']), [i['publisher'] for i in d['data'][:3]])"
curl -s 'localhost:8000/api/v1/curated-recommendations/legacy-114?locale_lang=en-US&region=IN' \
  | python3 -c "import json,sys; d=json.load(sys.stdin); print(len(d['recommendations']), [i['domain'] for i in d['recommendations'][:3]])"
```

Expected: `surfaceId=NEW_TAB_EN_INTL`, `feeds=None`, India-relevant publishers, and `scheduledCorpusItemId == corpusItemId` on every item (the sections-adapter signature; the scheduler path sets a distinct scheduled ID).

Result observed locally:

```
NEW_TAB_EN_INTL None 100 True ['The Indian Express', 'The Hindu', 'Travel + Leisure']
30 ['The Indian Express', 'Al Jazeera English', 'News18']
20 ['The Indian Express', 'Martha Stewart', 'News18']
```

Also passing locally: 245 integration tests in `test_curated_recommendations.py`, 615 unit tests in `tests/unit/curated_recommendations/`, and `make lint`.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2562)


[HNT-2327]: https://mozilla-hub.atlassian.net/browse/HNT-2327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ