### PR TITLE
[HNT-3134] Fix flaky stale-while-revalidate cache tests

### DIFF
--- a/apps/merino/tests/integration/api/v1/curated_recommendations/corpus_backends/test_scheduled_surface_backend.py
+++ b/apps/merino/tests/integration/api/v1/curated_recommendations/corpus_backends/test_scheduled_surface_backend.py
@@ -6,7 +6,7 @@ import logging
 import pytest
 
 from circuitbreaker import STATE_HALF_OPEN, CircuitBreakerMonitor
-from datetime import datetime
+from datetime import datetime, timedelta
 from httpx import AsyncClient, HTTPStatusError, Response
 from pydantic import HttpUrl
 from tests.types import FilterCaplogFixture
@@ -290,6 +290,7 @@ class TestScheduledSurfaceCircuitBreaker:
         make_scheduled_surface_backend,
         scheduled_surface_http_client: AsyncMock,
         fixture_request_data,
+        scheduled_surface_circuit_breaker,
         caplog,
         filter_caplog: FilterCaplogFixture,
     ):
@@ -305,8 +306,11 @@ class TestScheduledSurfaceCircuitBreaker:
 
             assert scheduled_surface_http_client.post.call_count == 1
 
-            # fast-forward time so the cache expires
-            time_gem.tick(delta=ScheduledSurfaceBackend.cache_time_to_live_max)
+            # Fast-forward past the max TTL with a margin: freezegun's tick() advances
+            # from the freeze start, so real time spent since freezing is not counted.
+            time_gem.tick(
+                delta=ScheduledSurfaceBackend.cache_time_to_live_max + timedelta(minutes=1)
+            )
 
             # open the circuit breaker
             await trip_breaker(make_scheduled_surface_backend, fixture_request_data)
@@ -343,8 +347,9 @@ class TestScheduledSurfaceCircuitBreaker:
 
             assert scheduled_surface_circuit_breaker.opened
 
-            # advance time so the circuit breaker recovers
-            time_gem.tick(RECOVERY_TIMEOUT + 5)
+            # Advance past the recovery timeout with a margin: freezegun's tick() advances
+            # from the freeze start, so the real time trip_breaker consumed is not counted.
+            time_gem.tick(RECOVERY_TIMEOUT + 60)
 
             assert scheduled_surface_circuit_breaker.state == STATE_HALF_OPEN
 

--- a/apps/merino/tests/integration/api/v1/curated_recommendations/corpus_backends/test_sections_backend.py
+++ b/apps/merino/tests/integration/api/v1/curated_recommendations/corpus_backends/test_sections_backend.py
@@ -6,6 +6,7 @@ import freezegun
 import logging
 import pytest
 
+from datetime import timedelta
 from httpx import AsyncClient, HTTPStatusError, Response
 from tests.types import FilterCaplogFixture
 from unittest.mock import AsyncMock
@@ -386,6 +387,7 @@ class TestSectionsCircuitBreaker:
         make_sections_backend,
         sections_http_client: AsyncMock,
         fixture_request_data,
+        sections_circuit_breaker,
         caplog,
         filter_caplog: FilterCaplogFixture,
     ):
@@ -401,8 +403,9 @@ class TestSectionsCircuitBreaker:
 
             assert sections_http_client.post.call_count == 1
 
-            # fast-forward time so the cache expires
-            time_gem.tick(delta=SectionsBackend.cache_time_to_live_max)
+            # Fast-forward past the max TTL with a margin: freezegun's tick() advances
+            # from the freeze start, so real time spent since freezing is not counted.
+            time_gem.tick(delta=SectionsBackend.cache_time_to_live_max + timedelta(minutes=1))
 
             # open the circuit breaker
             await trip_breaker(make_sections_backend, fixture_request_data)
@@ -439,8 +442,9 @@ class TestSectionsCircuitBreaker:
 
             assert sections_circuit_breaker.opened
 
-            # advance time so the circuit breaker recovers
-            time_gem.tick(RECOVERY_TIMEOUT + 5)
+            # Advance past the recovery timeout with a margin: freezegun's tick() advances
+            # from the freeze start, so the real time trip_breaker consumed is not counted.
+            time_gem.tick(RECOVERY_TIMEOUT + 60)
 
             assert sections_circuit_breaker.state == STATE_HALF_OPEN
 

--- a/apps/merino/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
+++ b/apps/merino/tests/integration/api/v1/curated_recommendations/test_curated_recommendations.py
@@ -1347,9 +1347,11 @@ class TestCorpusApiCaching:
                 request=fixture_request_data,
             )
 
-            # Progress time to after the cache expires.
-            frozen_datetime.tick(delta=ScheduledSurfaceBackend.cache_time_to_live_max)
-            frozen_datetime.tick(delta=timedelta(seconds=1))
+            # Progress time to after the cache expires, with a margin: freezegun's tick()
+            # advances from the freeze start, so real time spent since freezing is not counted.
+            frozen_datetime.tick(
+                delta=ScheduledSurfaceBackend.cache_time_to_live_max + timedelta(minutes=1)
+            )
 
             # When the cache is expired, the first fetch may return stale data.
             fetch_pl_pl(client)

--- a/apps/merino/tests/unit/curated_recommendations/corpus_backends/test_caching.py
+++ b/apps/merino/tests/unit/curated_recommendations/corpus_backends/test_caching.py
@@ -164,8 +164,9 @@ class TestStaleWhileRevalidate:
             assert result1 == 20
             assert self.call_count == 1
 
-            # Advance time beyond the expiration (advance >120s) to force staleness.
-            frozen_datetime.tick(121.0)
+            # Advance past the max TTL (120s) with a margin: freezegun's tick() advances
+            # from the freeze start, so real time spent since freezing is not counted.
+            frozen_datetime.tick(180.0)
 
             n = 1000
             tasks = [asyncio.create_task(self.compute_value(10)) for _ in range(n)]
@@ -199,7 +200,7 @@ class TestStaleWhileRevalidate:
             result1 = await self.failing_compute_after_first_call(5)
             assert result1 == 15
 
-            frozen_datetime.tick(121.0)  # Force staleness. Max ttl is 120 seconds.
+            frozen_datetime.tick(180.0)  # Force staleness: max TTL (120s) plus a margin.
             result2 = await self.failing_compute_after_first_call(5)
             assert result2 == 15
             # 2x margin for event loop overhead
@@ -237,8 +238,8 @@ class TestStaleWhileRevalidate:
             assert result == 15
             assert self.call_count == 1
 
-            # 2. Expire the cache. Max TTL is 120 seconds.
-            frozen_datetime.tick(121.0)
+            # 2. Expire the cache: max TTL (120s) plus a margin.
+            frozen_datetime.tick(180.0)
 
             # 3. Simulate multiple sequential requests, each separated by enough
             #    time for the background update task to complete and release the lock


### PR DESCRIPTION
## References

JIRA: [HNT-3134](https://mozilla-hub.atlassian.net/browse/HNT-3134)

## Description

`TestScheduledSurfaceCircuitBreaker::test_open_breaker_serves_stale_cache` fails intermittently in CI ([example run](https://github.com/mozilla-services/merino-py/actions/runs/33528342756/job/99924813210)). The test ticks the frozen clock forward by exactly `cache_time_to_live_max` to expire the stale-while-revalidate cache. However, freezegun's `tick()` advances from the moment the freeze started rather than from the current time, so real time spent on the first fetch is not counted. When the random TTL draws near its maximum on a slow runner, the cache is then still fresh after the tick, no revalidation task is spawned, and the expected "Returning stale data" log never appears.

The fix ticks one minute past the maximum TTL. The sections backend test, `test_cache_returned_on_subsequent_calls`, and the caching unit tests used the same pattern and get the same margin, and the breaker recovery tests get the same margin on their recovery ticks. The two stale-cache tests now also request the existing breaker reset fixture, since they previously left the shared circuit breaker open. The margins are frozen time, so test durations are unchanged.

I reproduced the failure locally by randomly pausing the test process with SIGSTOP to mimic CI scheduler stalls. Before the fix, the unmodified test failed 1 time in 45 runs. After the fix, 413 runs of this test and 60 runs of the sections clone under the same stress all passed. If the failure rate were unchanged, the chance of that outcome would be below 0.01 percent.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/apps/merino/metrics.yaml) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2564)


[HNT-3134]: https://mozilla-hub.atlassian.net/browse/HNT-3134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ