### PR TITLE
[HNT-3140] fix(fleece): tolerate in-flight heartbeat write in cancellation test

### DIFF
--- a/apps/fleece/tests/unit/sanitize/worker/test_worker.py
+++ b/apps/fleece/tests/unit/sanitize/worker/test_worker.py
@@ -143,7 +143,15 @@ async def test_heartbeat_refreshes_the_file(tmp_path: Path) -> None:
     await asyncio.gather(task, return_exceptions=True)
 
     assert path.read_text().isdigit()
-    assert not (tmp_path / "nested" / "heartbeat.tmp").exists()  # no leftover tmp file
+    # Cancelling the task does not stop an in-flight to_thread write: the executor thread may
+    # still be between writing heartbeat.tmp and its atomic rename. Wait for the rename to
+    # finish instead of asserting immediately.
+    tmp = tmp_path / "nested" / "heartbeat.tmp"
+    for _ in range(100):
+        if not tmp.exists():
+            break
+        await asyncio.sleep(0.01)
+    assert not tmp.exists()  # no leftover tmp file
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## References

JIRA: [HNT-3140](https://mozilla-hub.atlassian.net/browse/HNT-3140)

## Description


Fix a flaky test one surfaced in [a failed CI run](https://github.com/mozilla-services/merino-py/actions/runs/33556941919/job/100019966455).

`test_heartbeat_refreshes_the_file` cancels the heartbeat task and immediately asserts that no `heartbeat.tmp` is left behind. Cancellation interrupts the `await`, but an already-running `asyncio.to_thread` write keeps going on the executor thread — so the assert can observe the moment between writing `heartbeat.tmp` and its atomic rename. Poll for the rename to finish before asserting; the tmp file is always transient, so a leftover after the poll is still a real failure.

## QA

```bash
MERINO_ENV=testing uv run pytest apps/fleece/tests/unit/sanitize/worker/ -q
# → 13 passed
```

Race reproduced deterministically by patching a 50ms delay into the write-to-rename window: the old assertion fails ("immediately after cancel: tmp exists = True"), the polled assertion passes. 200 unmodified in-session repeats never hit the window on a warm machine, matching CI-only flakiness.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2566)


[HNT-3140]: https://mozilla-hub.atlassian.net/browse/HNT-3140