### PR TITLE
feat(suggest) DISCO-4471 Add query params for stock widget

### DIFF
--- a/apps/merino/.claude/rules/architecture.md
+++ b/apps/merino/.claude/rules/architecture.md
@@ -27,7 +27,7 @@ If provider data seems stale, check if the corresponding job has run:
 
 ## Other Components
 
-- **Circuit breakers** (`apps/merino/merino/governance/`): Weather and FlightAware providers use circuit breakers. 10 failures -> open -> 30s recovery -> fallback returns `[]`.
+- **Circuit breakers** (`apps/merino/merino/governance/`): Weather, FlightAware, and Finance (polygon) providers use circuit breakers. 10 failures -> open -> 30s recovery -> fallback returns `[]`.
 - **SyncedGcsBlob** (`apps/merino/merino/utils/synced_gcs_blob.py`): Periodically pulls GCS blob, calls callback on change. Used by curated_recommendations backends.
 - **Cron jobs** (`packages/merino-common/merino_common/utils/cron.py`): Background refresh for providers (ADM, Weather, Top Picks, Finance, etc.).
 - **Blocklists** (`apps/merino/merino/utils/blocklists.py`): `TOP_PICKS_BLOCKLIST`, `WIKIPEDIA_TITLE_BLOCKLIST`.

--- a/apps/merino/merino/configs/default.toml
+++ b/apps/merino/merino/configs/default.toml
@@ -1004,6 +1004,27 @@ score = 0.29
 # for finance data. This will override the default global query timeout.
 query_timeout_sec = 1.0
 
+# MERINO_PROVIDERS__POLYGON__SEARCH_MIN_QUERY_LENGTH
+# Ticker searches shorter than this skip the upstream substring search, which
+# would only return an alphabetical slice of the market, and run the exact
+# symbol lookup alone.
+search_min_query_length = 2
+
+# MERINO_PROVIDERS__POLYGON__SEARCH_RESULT_LIMIT
+# Upper bound on matches returned to the stocks widget's search pick-list.
+search_result_limit = 10
+
+# MERINO_PROVIDERS__POLYGON__SEARCH_UPSTREAM_LIMIT
+# How many matches to request upstream per search. The API orders matches by
+# ticker rather than relevance, so a wider window gives ranking something to
+# work with.
+search_upstream_limit = 50
+
+# MERINO_PROVIDERS__POLYGON__SEARCH_SECURITY_TYPES
+# Upstream security type codes served to the widget's ticker search: common
+# stock, ADRs, and ETFs. Warrants, units, rights, and preferred shares are out.
+search_security_types = ["CS", "ADRC", "ETF"]
+
 # MERINO_PROVIDERS__POLYGON__CONNECT_TIMEOUT_SEC
 # A floating point (in seconds) indicating the maximum waiting period for the
 # polygon backend http client to establish a connection to the host.
@@ -1051,6 +1072,10 @@ url_single_ticker_snapshot = "v3/snapshot"
 
 # MERINO_POLYGON__URL_TICKER_OVERVIEW
 url_single_ticker_overview = "/v3/reference/tickers/{ticker}"
+
+# MERINO_POLYGON__URL_REFERENCE_TICKERS
+# Reference tickers endpoint; supports searching by symbol or company name.
+url_reference_tickers = "v3/reference/tickers"
 
 # MERINO_ACCUWEATHER__URL_PARAM_API_KEY
 # The name of the query param whose value is the API key, not the key itself.

--- a/apps/merino/merino/configs/default.toml
+++ b/apps/merino/merino/configs/default.toml
@@ -91,6 +91,12 @@ log_suggest_request = true
 # Excluded providers for query logging
 excluded_providers = ["accuweather", "geolocation"]
 
+# MERINO_LOGGING__EXCLUDED_SOURCES
+# Request sources excluded from query logging and search term submission. New
+# Tab widgets send ticker symbols and free text for upstream search, not urlbar
+# search terms.
+excluded_sources = ["newtab"]
+
 [default.governance]
 # MERINO_GOVERNANCE__CRON_INTERVAL_SEC
 # The interval of the background cron job for Merino governance.

--- a/apps/merino/merino/configs/default.toml
+++ b/apps/merino/merino/configs/default.toml
@@ -1004,6 +1004,13 @@ score = 0.29
 # for finance data. This will override the default global query timeout.
 query_timeout_sec = 1.0
 
+# MERINO_PROVIDERS__POLYGON__SEARCH_QUERY_TIMEOUT_SEC
+# Timeout for stocks widget ticker searches (request_type=ticker_search).
+# The upstream reference search scans company names and is materially slower
+# than snapshot lookups, and the widget waits far longer than the urlbar, so
+# searches get their own budget instead of the keystroke-tuned one above.
+search_query_timeout_sec = 4.0
+
 # MERINO_PROVIDERS__POLYGON__SEARCH_MIN_QUERY_LENGTH
 # Ticker searches shorter than this skip the upstream substring search, which
 # would only return an alphabetical slice of the market, and run the exact

--- a/apps/merino/merino/governance/circuitbreakers.py
+++ b/apps/merino/merino/governance/circuitbreakers.py
@@ -73,6 +73,19 @@ class FlightawareCircuitBreaker(CircuitBreaker):
     FALLBACK_FUNCTION = _suggest_provider_fallback_fn
 
 
+class PolygonCircuitBreaker(CircuitBreaker):
+    """Circuit breaker for the polygon (finance) provider."""
+
+    FAILURE_THRESHOLD = settings.providers.polygon.circuit_breaker_failure_threshold
+    RECOVERY_TIMEOUT = settings.providers.polygon.circuit_breaker_recover_timeout_sec
+    # Raised by the backend for Polygon API failures. Redis failures degrade to
+    # cache misses inside the backend and deliberately do not trip it.
+    EXPECTED_EXCEPTION = BackendError
+    # When the breaker is open, stand in for the upstream response with an
+    # empty result; the backend then serves whatever the cache still holds.
+    FALLBACK_FUNCTION = _suggest_provider_fallback_fn
+
+
 class WikipediaCircuitBreaker(CircuitBreaker):
     """Circuit breaker for the wikipedia provider."""
 

--- a/apps/merino/merino/jobs/polygon/polygon_ingestion.py
+++ b/apps/merino/merino/jobs/polygon/polygon_ingestion.py
@@ -35,6 +35,7 @@ class PolygonIngestion:
                 url_param_api_key=settings.polygon.url_param_api_key,
                 url_single_ticker_snapshot=settings.polygon.url_single_ticker_snapshot,
                 url_single_ticker_overview=settings.polygon.url_single_ticker_overview,
+                url_reference_tickers=settings.polygon.url_reference_tickers,
                 ticker_ttl_sec=settings.providers.polygon.cache_ttls.ticker_ttl_sec,
                 gcs_uploader=GcsUploader(
                     settings.image_gcs.gcs_project,

--- a/apps/merino/merino/jobs/polygon/polygon_ingestion.py
+++ b/apps/merino/merino/jobs/polygon/polygon_ingestion.py
@@ -48,6 +48,7 @@ class PolygonIngestion:
             score=setting.score,
             name="polygon",
             query_timeout_sec=setting.query_timeout_sec,
+            search_query_timeout_sec=setting.search_query_timeout_sec,
             enabled_by_default=setting.enabled_by_default,
             resync_interval_sec=setting.resync_interval_sec,
             cron_interval_sec=setting.cron_interval_sec,

--- a/apps/merino/merino/middleware/logging.py
+++ b/apps/merino/merino/middleware/logging.py
@@ -39,8 +39,9 @@ LOG_SUGGEST_REQUEST: bool = settings.logging.log_suggest_request
 # Whether to submit search terms to merino-fleece for sanitization.
 SUBMIT_SEARCH_TERMS: bool = settings.message_handler.enabled
 
-# Excluded providers for logging
+# Providers and request sources whose queries are neither logged nor submitted.
 EXCLUDED_PROVIDERS: frozenset[str] = frozenset(settings.logging.excluded_providers)
+EXCLUDED_SOURCES: frozenset[str] = frozenset(settings.logging.excluded_sources)
 
 # Queries longer than this are rejected by the suggest endpoint with HTTP 400, so they
 # are never worth submitting.
@@ -55,6 +56,16 @@ _enqueue_counter = _meter.create_counter(
         "`success`, `error` (the queue rejected it) or `skipped` (prefiltered out)."
     ),
 )
+
+
+def _is_loggable_suggest_request(request: Request) -> bool:
+    """Whether this suggest request's query is eligible for logging and submission."""
+    params = request.query_params
+    return (
+        PATTERN.match(request.url.path) is not None
+        and params.get("providers", "").strip().lower() not in EXCLUDED_PROVIDERS
+        and params.get("source", "").strip().lower() not in EXCLUDED_SOURCES
+    )
 
 
 def _skip_reason(query: str | None) -> str | None:
@@ -106,11 +117,8 @@ class LoggingMiddleware:
                 request = Request(scope=scope)
                 dt: datetime = datetime.fromtimestamp(time.time())
                 # https://mozilla-hub.atlassian.net/browse/DISCO-2489
-                if (
-                    (LOG_SUGGEST_REQUEST or SUBMIT_SEARCH_TERMS)
-                    and PATTERN.match(request.url.path)
-                    and request.query_params.get("providers", "").strip().lower()
-                    not in EXCLUDED_PROVIDERS
+                if (LOG_SUGGEST_REQUEST or SUBMIT_SEARCH_TERMS) and _is_loggable_suggest_request(
+                    request
                 ):
                     suggest_log_data: SuggestLogDataModel = create_suggest_log_data(
                         request, message, dt

--- a/apps/merino/merino/providers/suggest/base.py
+++ b/apps/merino/merino/providers/suggest/base.py
@@ -201,3 +201,11 @@ class BaseProvider(ABC):
     def query_timeout_sec(self) -> float:
         """Return the query timeout for this provider."""
         return self._query_timeout_sec
+
+    def query_timeout_sec_for(self, srequest: SuggestionRequest) -> float:
+        """Return the query timeout for one request.
+
+        Defaults to the provider-wide timeout. Providers whose request types
+        have different latency profiles override this.
+        """
+        return self.query_timeout_sec

--- a/apps/merino/merino/providers/suggest/custom_details.py
+++ b/apps/merino/merino/providers/suggest/custom_details.py
@@ -1,9 +1,9 @@
 """Custom Details specific Models"""
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from merino.middleware.geolocation import Coordinates
-from merino.providers.suggest.finance.backends.protocol import TickerSummary
+from merino.providers.suggest.finance.backends.protocol import TickerMatch, TickerSummary
 from merino.providers.suggest.flightaware.backends.protocol import FlightSummary
 from merino.providers.suggest.yelp.backends.protocol import YelpBusinessDetails
 
@@ -48,6 +48,11 @@ class PolygonDetails(BaseModel):
     """Polygon specific fields."""
 
     values: list[TickerSummary]
+    matches: list[TickerMatch] | None = Field(
+        default=None,
+        description="Candidates for the stocks widget's search pick-list. "
+        "Only present on `request_type=ticker_search` responses.",
+    )
 
 
 class FlightAwareDetails(BaseModel):

--- a/apps/merino/merino/providers/suggest/finance/backends/polygon/backend.py
+++ b/apps/merino/merino/providers/suggest/finance/backends/polygon/backend.py
@@ -1,5 +1,6 @@
 """A wrapper for Polygon API interactions."""
 
+import asyncio
 import itertools
 import hashlib
 import logging
@@ -16,6 +17,7 @@ from merino.providers.suggest.finance.backends.polygon.filemanager import (
 from merino.providers.suggest.finance.backends.protocol import (
     FinanceManifest,
     GetManifestResultCode,
+    TickerMatch,
     TickerSnapshot,
     TickerSummary,
 )
@@ -29,9 +31,12 @@ from merino.providers.suggest.finance.backends.polygon.stock_ticker_company_mapp
     ALL_STOCK_TICKER_COMPANY_MAPPING,
 )
 from merino.providers.suggest.finance.backends.polygon.utils import (
+    TICKER_SYMBOL_PATTERN,
     extract_snapshot_if_valid,
+    extract_ticker_matches_from_search_response,
     build_ticker_summary,
     generate_cache_key_for_ticker,
+    rank_ticker_matches,
 )
 from merino.utils.gcs.gcs_uploader import GcsUploader
 from merino.utils.gcs.models import Image
@@ -44,6 +49,17 @@ __all__ = [
 logger = logging.getLogger(__name__)
 
 GCS_BLOB_NAME = "polygon_latest.json"
+
+# Upper bound on matches returned to the stocks widget's search pick-list.
+TICKER_SEARCH_LIMIT: int = settings.providers.polygon.search_result_limit
+
+# The search API orders matches by ticker, not relevance, so the real hit can
+# sit far down the alphabet. Fetch a wider window for ranking to work with.
+TICKER_SEARCH_UPSTREAM_LIMIT: int = settings.providers.polygon.search_upstream_limit
+
+# Below this many characters the substring search returns an alphabetical slice
+# of the whole market, so only the exact symbol lookup runs.
+TICKER_SEARCH_MIN_QUERY_LENGTH: int = settings.providers.polygon.search_min_query_length
 
 # The Lua script to write ticker snapshots and their TTLs for a list of keys.
 #
@@ -97,6 +113,7 @@ class PolygonBackend:
     url_param_api_key: str
     url_single_ticker_snapshot: str
     url_single_ticker_overview: str
+    url_reference_tickers: str
     filemanager: PolygonFilemanager
 
     def __init__(
@@ -107,6 +124,7 @@ class PolygonBackend:
         url_param_api_key: str,
         url_single_ticker_snapshot: str,
         url_single_ticker_overview: str,
+        url_reference_tickers: str,
         metrics_client: aiodogstatsd.Client,
         http_client: AsyncClient,
         gcs_uploader: GcsUploader,
@@ -123,6 +141,7 @@ class PolygonBackend:
         self.gcs_uploader = gcs_uploader
         self.url_single_ticker_snapshot = url_single_ticker_snapshot
         self.url_single_ticker_overview = url_single_ticker_overview
+        self.url_reference_tickers = url_reference_tickers
         self.filemanager = PolygonFilemanager(
             gcs_bucket_path=settings.image_gcs.gcs_bucket,
             blob_name=GCS_BLOB_NAME,
@@ -216,6 +235,70 @@ class PolygonBackend:
 
             # TODO @Herraj -- Propagate the error for circuit breaking as PolygonError.
         return []
+
+    async def search_tickers(self, query: str) -> list[TickerMatch]:
+        """Search the reference tickers endpoint by symbol or company name.
+
+        The search API matches substrings anywhere in the name and orders
+        results by ticker, so the intended security can fall outside the
+        response window entirely (searching "EA" returns names containing
+        "ea"). For symbol-shaped queries an exact ticker lookup therefore runs
+        concurrently and its hit is ranked first; the remaining matches are
+        fetched with a wider window and re-ranked by relevance. Queries below
+        the minimum length skip the substring search, which would only return
+        an alphabetical slice of the market.
+
+        Results are intentionally not cached: the query is free text typed by
+        the user, mirroring how weather location completion talks to its API.
+
+        Raises:
+            PolygonError: When an upstream request fails.
+        """
+        query = query.strip()
+        symbol = query.upper()
+
+        try:
+            async with asyncio.TaskGroup() as tg:
+                search_task = (
+                    tg.create_task(
+                        self._fetch_reference_tickers(
+                            {"search": query, "limit": str(TICKER_SEARCH_UPSTREAM_LIMIT)}
+                        )
+                    )
+                    if len(query) >= TICKER_SEARCH_MIN_QUERY_LENGTH
+                    else None
+                )
+                exact_task = (
+                    tg.create_task(self._fetch_reference_tickers({"ticker": symbol}))
+                    if TICKER_SYMBOL_PATTERN.match(symbol)
+                    else None
+                )
+        except ExceptionGroup as e:
+            # The task group wraps failures; surface one backend error so the
+            # provider's circuit breaker can count it.
+            raise PolygonError(PolygonErrorMessages.FAILED_TICKER_SEARCH, exceptions=e.exceptions)
+
+        exact = exact_task.result() if exact_task is not None else []
+        searched = search_task.result() if search_task is not None else []
+        exact_tickers = {match.ticker for match in exact}
+        ranked = [
+            match
+            for match in rank_ticker_matches(searched, query)
+            if match.ticker not in exact_tickers
+        ]
+
+        return (exact + ranked)[:TICKER_SEARCH_LIMIT]
+
+    async def _fetch_reference_tickers(self, params: dict[str, str]) -> list[TickerMatch]:
+        """Make one reference tickers request and extract the matches."""
+        request_params = {
+            "market": "stocks",
+            "active": "true",
+            self.url_param_api_key: self.api_key,
+            **params,
+        }
+        response = await self._get_json("search", self.url_reference_tickers, request_params)
+        return extract_ticker_matches_from_search_response(response)
 
     async def fetch_ticker_snapshot(self, ticker: str) -> Any:
         """Fetch the snapshot for one ticker.

--- a/apps/merino/merino/providers/suggest/finance/backends/polygon/backend.py
+++ b/apps/merino/merino/providers/suggest/finance/backends/polygon/backend.py
@@ -23,6 +23,7 @@ from merino.providers.suggest.finance.backends.protocol import (
 )
 from merino.cache.protocol import CacheAdapter
 from merino.exceptions import CacheAdapterError
+from merino.governance.circuitbreakers import PolygonCircuitBreaker
 from merino.providers.suggest.finance.backends.polygon.errors import (
     PolygonError,
     PolygonErrorMessages,
@@ -60,6 +61,24 @@ TICKER_SEARCH_UPSTREAM_LIMIT: int = settings.providers.polygon.search_upstream_l
 # Below this many characters the substring search returns an alphabetical slice
 # of the whole market, so only the exact symbol lookup runs.
 TICKER_SEARCH_MIN_QUERY_LENGTH: int = settings.providers.polygon.search_min_query_length
+
+# Upstream requests must time out before the API handler's task runner cancels
+# the provider task: an httpx timeout becomes a PolygonError that the circuit
+# breaker counts, while a cancellation is invisible to it and resets its
+# failure count. Keep each request type under its query budget with a margin.
+UPSTREAM_TIMEOUT_FACTOR = 0.9
+SNAPSHOT_REQUEST_TIMEOUT_SEC: float = (
+    settings.providers.polygon.query_timeout_sec * UPSTREAM_TIMEOUT_FACTOR
+)
+SEARCH_REQUEST_TIMEOUT_SEC: float = (
+    settings.providers.polygon.search_query_timeout_sec * UPSTREAM_TIMEOUT_FACTOR
+)
+
+# One breaker guards both upstream request paths, applied below the cache read
+# so that cache-served requests neither reset its failure count nor get refused
+# while it is open. When open, the fallback stands in for the upstream response
+# and cached data can still be served.
+_upstream_breaker = PolygonCircuitBreaker(name="polygon")
 
 # The Lua script to write ticker snapshots and their TTLs for a list of keys.
 #
@@ -236,6 +255,7 @@ class PolygonBackend:
             # TODO @Herraj -- Propagate the error for circuit breaking as PolygonError.
         return []
 
+    @_upstream_breaker
     async def search_tickers(self, query: str) -> list[TickerMatch]:
         """Search the reference tickers endpoint by symbol or company name.
 
@@ -274,8 +294,12 @@ class PolygonBackend:
                     else None
                 )
         except ExceptionGroup as e:
-            # The task group wraps failures; surface one backend error so the
-            # provider's circuit breaker can count it.
+            # Upstream failures surface as one backend error for the circuit
+            # breaker to count. Anything else in the group is a bug in our own
+            # code and must surface as itself, not as an upstream failure.
+            _, bugs = e.split(PolygonError)
+            if bugs is not None:
+                raise bugs from e
             raise PolygonError(PolygonErrorMessages.FAILED_TICKER_SEARCH, exceptions=e.exceptions)
 
         exact = exact_task.result() if exact_task is not None else []
@@ -297,31 +321,46 @@ class PolygonBackend:
             self.url_param_api_key: self.api_key,
             **params,
         }
-        response = await self._get_json("search", self.url_reference_tickers, request_params)
+        response = await self._get_json(
+            "search", self.url_reference_tickers, request_params, SEARCH_REQUEST_TIMEOUT_SEC
+        )
         return extract_ticker_matches_from_search_response(response)
 
+    @_upstream_breaker
     async def fetch_ticker_snapshot(self, ticker: str) -> Any:
         """Fetch the snapshot for one ticker.
+
+        When the breaker is open, the fallback returns an empty result: callers
+        treat it as an upstream response with no snapshot, so cached quotes are
+        still served while no request leaves for the upstream.
 
         Raises:
             PolygonError: When the upstream request fails.
         """
         params = {"ticker": ticker, self.url_param_api_key: self.api_key}
-        return await self._get_json("snapshot", self.url_single_ticker_snapshot, params)
+        return await self._get_json(
+            "snapshot", self.url_single_ticker_snapshot, params, SNAPSHOT_REQUEST_TIMEOUT_SEC
+        )
 
-    async def _get_json(self, operation: str, url: str, params: dict[str, str]) -> Any:
+    async def _get_json(
+        self, operation: str, url: str, params: dict[str, str], timeout: float
+    ) -> Any:
         """Issue one upstream GET on the request path and return the decoded body.
 
         Emits `polygon.request.<operation>.get` counters and latency. Any HTTP
-        failure, including timeouts, is logged once and re-raised as a
-        `PolygonError` for the provider to handle.
+        failure, including timeouts and undecodable response bodies, is logged
+        once and re-raised as a `PolygonError` so the provider's circuit
+        breaker can count it.
         """
         self.metrics_client.increment(f"polygon.request.{operation}.get")
         try:
             with self.metrics_client.timeit(f"polygon.request.{operation}.get.latency"):
-                response: Response = await self.http_client.get(url, params=params)
+                response: Response = await self.http_client.get(
+                    url, params=params, timeout=timeout
+                )
             response.raise_for_status()
-        except HTTPError as ex:
+            return response.json()
+        except (HTTPError, ValueError) as ex:
             self.metrics_client.increment(f"polygon.request.{operation}.get.failed")
             detail = (
                 f"{ex.response.status_code} {ex.response.reason_phrase}"
@@ -332,8 +371,6 @@ class PolygonBackend:
             raise PolygonError(
                 PolygonErrorMessages.HTTP_REQUEST_ERROR, operation=operation, detail=detail
             ) from ex
-
-        return response.json()
 
     async def get_ticker_image_url(self, ticker: str) -> str | None:
         """Get the logo URL for the ticker (requires API key when fetching)"""

--- a/apps/merino/merino/providers/suggest/finance/backends/polygon/backend.py
+++ b/apps/merino/merino/providers/suggest/finance/backends/polygon/backend.py
@@ -4,7 +4,7 @@ import itertools
 import hashlib
 import logging
 import aiodogstatsd
-from httpx import AsyncClient, Response, HTTPStatusError
+from httpx import AsyncClient, HTTPError, HTTPStatusError, Response
 import orjson
 from pydantic import HttpUrl, ValidationError
 from merino.configs import settings
@@ -21,6 +21,10 @@ from merino.providers.suggest.finance.backends.protocol import (
 )
 from merino.cache.protocol import CacheAdapter
 from merino.exceptions import CacheAdapterError
+from merino.providers.suggest.finance.backends.polygon.errors import (
+    PolygonError,
+    PolygonErrorMessages,
+)
 from merino.providers.suggest.finance.backends.polygon.stock_ticker_company_mapping import (
     ALL_STOCK_TICKER_COMPANY_MAPPING,
 )
@@ -135,7 +139,11 @@ class PolygonBackend:
         self.cache_control = settings.providers.polygon.image_cache_control
 
     async def get_snapshots(self, tickers: list[str]) -> list[TickerSnapshot]:
-        """Get snapshots for the list of tickers."""
+        """Get snapshots for the list of tickers.
+
+        Raises:
+            PolygonError: When an upstream snapshot request fails.
+        """
         # check the cache first.
         cached = await self.get_snapshots_from_cache(tickers)
         # each tuple has the shape of `(snapshot, ttl)` and ignore the none tuples for now.
@@ -153,7 +161,9 @@ class PolygonBackend:
         else:
             self.metrics_client.increment("polygon.snapshot.cache.miss")
 
-        # Fetch any missing tickers from the API.
+        # Fetch any missing tickers from the API, one request per ticker. The
+        # approved use of the upstream API requires that a user's symbols are
+        # requested independently and never combined into one request.
         fetched_snapshots: list[TickerSnapshot] = []
         for ticker in missed_tickers:
             if (
@@ -207,25 +217,38 @@ class PolygonBackend:
             # TODO @Herraj -- Propagate the error for circuit breaking as PolygonError.
         return []
 
-    async def fetch_ticker_snapshot(self, ticker: str) -> Any | None:
-        """Make a request and fetch the snapshot for this single ticker."""
+    async def fetch_ticker_snapshot(self, ticker: str) -> Any:
+        """Fetch the snapshot for one ticker.
+
+        Raises:
+            PolygonError: When the upstream request fails.
+        """
         params = {"ticker": ticker, self.url_param_api_key: self.api_key}
+        return await self._get_json("snapshot", self.url_single_ticker_snapshot, params)
 
+    async def _get_json(self, operation: str, url: str, params: dict[str, str]) -> Any:
+        """Issue one upstream GET on the request path and return the decoded body.
+
+        Emits `polygon.request.<operation>.get` counters and latency. Any HTTP
+        failure, including timeouts, is logged once and re-raised as a
+        `PolygonError` for the provider to handle.
+        """
+        self.metrics_client.increment(f"polygon.request.{operation}.get")
         try:
-            self.metrics_client.increment("polygon.request.snapshot.get")
-
-            with self.metrics_client.timeit("polygon.request.snapshot.get.latency"):
-                response: Response = await self.http_client.get(
-                    self.url_single_ticker_snapshot, params=params
-                )
-
+            with self.metrics_client.timeit(f"polygon.request.{operation}.get.latency"):
+                response: Response = await self.http_client.get(url, params=params)
             response.raise_for_status()
-        except HTTPStatusError as ex:
-            logger.warning(
-                f"Polygon request error for ticker snapshot: {ex.response.status_code} {ex.response.reason_phrase}"
+        except HTTPError as ex:
+            self.metrics_client.increment(f"polygon.request.{operation}.get.failed")
+            detail = (
+                f"{ex.response.status_code} {ex.response.reason_phrase}"
+                if isinstance(ex, HTTPStatusError)
+                else type(ex).__name__
             )
-            self.metrics_client.increment("polygon.request.snapshot.get.failed")
-            return None
+            logger.warning(f"Polygon {operation} request failed: {detail}")
+            raise PolygonError(
+                PolygonErrorMessages.HTTP_REQUEST_ERROR, operation=operation, detail=detail
+            ) from ex
 
         return response.json()
 

--- a/apps/merino/merino/providers/suggest/finance/backends/polygon/errors.py
+++ b/apps/merino/merino/providers/suggest/finance/backends/polygon/errors.py
@@ -12,6 +12,7 @@ class PolygonErrorMessages(Enum):
     CACHE_WRITE_ERROR = "Something went wrong with storing to cache. Did not update cache."
     CACHE_READ_ERROR = "Failed to read from cache: {exception}"
     FAILED_FINANCE_REPORT = "Failed to fetch finance report: {exceptions}"
+    FAILED_TICKER_SEARCH = "Failed to search tickers: {exceptions}"
     HTTP_REQUEST_ERROR = "Polygon {operation} request failed: {detail}"
     HTTP_UNEXPECTED_RESPONSE = "Unexpected response for request: {req}"
 

--- a/apps/merino/merino/providers/suggest/finance/backends/polygon/errors.py
+++ b/apps/merino/merino/providers/suggest/finance/backends/polygon/errors.py
@@ -12,6 +12,7 @@ class PolygonErrorMessages(Enum):
     CACHE_WRITE_ERROR = "Something went wrong with storing to cache. Did not update cache."
     CACHE_READ_ERROR = "Failed to read from cache: {exception}"
     FAILED_FINANCE_REPORT = "Failed to fetch finance report: {exceptions}"
+    HTTP_REQUEST_ERROR = "Polygon {operation} request failed: {detail}"
     HTTP_UNEXPECTED_RESPONSE = "Unexpected response for request: {req}"
 
     def format_message(self, **kwargs) -> str:

--- a/apps/merino/merino/providers/suggest/finance/backends/polygon/utils.py
+++ b/apps/merino/merino/providers/suggest/finance/backends/polygon/utils.py
@@ -6,7 +6,12 @@ from typing import Any
 import hashlib
 
 from pydantic import HttpUrl
-from merino.providers.suggest.finance.backends.protocol import TickerSnapshot, TickerSummary
+from merino.configs import settings
+from merino.providers.suggest.finance.backends.protocol import (
+    TickerMatch,
+    TickerSnapshot,
+    TickerSummary,
+)
 from merino.providers.suggest.finance.backends.polygon.stock_ticker_company_mapping import (
     ALL_STOCK_TICKER_COMPANY_MAPPING,
     STOCK_TICKER_EAGER_MATCH_BLOCKLIST,
@@ -35,6 +40,20 @@ STOCK_QUERY_PATTERN = re.compile(
 # A single ticker symbol: uppercase alphanumerics with an optional share-class
 # suffix ("BRK.B"). Accepts widget quote lookups.
 TICKER_SYMBOL_PATTERN = re.compile(r"^[A-Z0-9]{1,6}(?:[.\-][A-Z0-9]{1,3})?$")
+
+# The equities universe served to the widget's ticker search, as upstream
+# security type codes.
+SEARCH_SECURITY_TYPES: frozenset[str] = frozenset(settings.providers.polygon.search_security_types)
+
+# Exchange labels shown in suggestions, keyed by the MIC reported by the API.
+# Unknown MICs fall back to the MIC itself.
+MIC_DISPLAY_NAMES = {
+    "XNAS": "NASDAQ",
+    "XNYS": "NYSE",
+    "ARCX": "NYSE",
+    "BATS": "BATS",
+    "XASE": "AMEX",
+}
 
 
 def get_tickers_for_query(query: str) -> list[str] | None:
@@ -138,6 +157,67 @@ def extract_snapshot_if_valid(data: dict[str, Any] | None) -> TickerSnapshot | N
     except KeyError, IndexError, TypeError:
         logger.warning(f"Polygon snapshot response json has incorrect shape: {data}")
         return None
+
+
+def extract_ticker_matches_from_search_response(
+    data: dict[str, Any] | None,
+) -> list[TickerMatch]:
+    """Extract widget search matches from a reference tickers search response.
+
+    Keeps only active U.S. listings of the supported security types; anything
+    else (warrants, units, foreign locales, delisted entries) is dropped.
+    """
+    results = data.get("results") if isinstance(data, dict) else None
+    if not isinstance(results, list):
+        return []
+
+    matches: list[TickerMatch] = []
+    for result in results:
+        if not isinstance(result, dict):
+            continue
+        ticker = result.get("ticker")
+        name = result.get("name")
+        security_type = result.get("type")
+        if (
+            not isinstance(ticker, str)
+            or not isinstance(name, str)
+            or security_type not in SEARCH_SECURITY_TYPES
+            or result.get("locale") != "us"
+            or result.get("active") is not True
+        ):
+            continue
+        mic = result.get("primary_exchange")
+        matches.append(
+            TickerMatch(
+                ticker=ticker,
+                name=name,
+                exchange=MIC_DISPLAY_NAMES.get(mic, mic) if isinstance(mic, str) else "",
+                is_etf=security_type == "ETF",
+            )
+        )
+    return matches
+
+
+def rank_ticker_matches(matches: list[TickerMatch], query: str) -> list[TickerMatch]:
+    """Order search matches by relevance; the API returns them ordered by ticker.
+
+    Exact symbol first, then symbols starting with the query, then names
+    starting with the query (a leading "The " ignored), then common stock and
+    ADRs ahead of ETFs. Ties keep the API order.
+    """
+    query_lower = query.strip().lower()
+    query_upper = query_lower.upper()
+
+    def tier(match: TickerMatch) -> tuple[bool, bool, bool, bool]:
+        name = match.name.lower().removeprefix("the ")
+        return (
+            match.ticker != query_upper,
+            not match.ticker.startswith(query_upper),
+            not name.startswith(query_lower),
+            match.is_etf,
+        )
+
+    return sorted(matches, key=tier)
 
 
 def format_number(number: int | float) -> str:

--- a/apps/merino/merino/providers/suggest/finance/backends/polygon/utils.py
+++ b/apps/merino/merino/providers/suggest/finance/backends/polygon/utils.py
@@ -81,12 +81,19 @@ def get_tickers_for_query(query: str) -> list[str] | None:
 
 
 def extract_snapshot_if_valid(data: dict[str, Any] | None) -> TickerSnapshot | None:
-    """Extract the TickerSnapshot from the nested JSON response, if it has the valid json structure."""
+    """Extract the TickerSnapshot from the nested JSON response, if it has the valid json structure.
+
+    Unknown and delisted tickers come back as a result entry carrying an
+    `error` key instead of session data. That is an expected outcome rather
+    than a malformed response, so it yields None without a warning.
+    """
     if data is None:
         return None
 
     try:
         result = data["results"][0]
+        if "error" in result:
+            return None
         ticker = result["ticker"]
         market_status = result["market_status"]
 

--- a/apps/merino/merino/providers/suggest/finance/backends/polygon/utils.py
+++ b/apps/merino/merino/providers/suggest/finance/backends/polygon/utils.py
@@ -110,9 +110,11 @@ def extract_snapshot_if_valid(data: dict[str, Any] | None) -> TickerSnapshot | N
 
     Unknown and delisted tickers come back as a result entry carrying an
     `error` key instead of session data. That is an expected outcome rather
-    than a malformed response, so it yields None without a warning.
+    than a malformed response, so it yields None without a warning. So does
+    an empty result, which is what the backend's circuit breaker substitutes
+    for the upstream response while it is open.
     """
-    if data is None:
+    if not data:
         return None
 
     try:

--- a/apps/merino/merino/providers/suggest/finance/backends/polygon/utils.py
+++ b/apps/merino/merino/providers/suggest/finance/backends/polygon/utils.py
@@ -32,15 +32,9 @@ STOCK_QUERY_PATTERN = re.compile(
     r"^(?:(?P<keyword1>\w+)\s+stocks?)$|^(?:stocks?\s+(?P<keyword2>\w+))$", re.IGNORECASE
 )
 
-
-def lookup_ticker_company(ticker: str) -> str:
-    """Get the ticker company for a stock or ETF ticker symbol."""
-    return str(ALL_TICKER_COMPANY_MAPPING[ticker]["company"])
-
-
-def lookup_ticker_exchange(ticker: str) -> str:
-    """Get the ticker exchange for ticker symbol. Stock or ETF."""
-    return str(ALL_TICKER_COMPANY_MAPPING[ticker]["exchange"])
+# A single ticker symbol: uppercase alphanumerics with an optional share-class
+# suffix ("BRK.B"). Accepts widget quote lookups.
+TICKER_SYMBOL_PATTERN = re.compile(r"^[A-Z0-9]{1,6}(?:[.\-][A-Z0-9]{1,3})?$")
 
 
 def get_tickers_for_query(query: str) -> list[str] | None:
@@ -78,6 +72,18 @@ def get_tickers_for_query(query: str) -> list[str] | None:
             return [keyword]
 
     return None
+
+
+def get_tickers_for_newtab_query(query: str) -> list[str] | None:
+    """Return the single ticker symbol in a stocks widget query, or None.
+
+    Widget lookups are not gated on the curated mappings: any well-formed
+    symbol is passed through for a direct snapshot lookup. One symbol per
+    request is deliberate. The approved use of the upstream API requires that
+    a user's symbols are requested independently, so a list is not a symbol.
+    """
+    symbol = query.strip().upper()
+    return [symbol] if TICKER_SYMBOL_PATTERN.match(symbol) else None
 
 
 def extract_snapshot_if_valid(data: dict[str, Any] | None) -> TickerSnapshot | None:
@@ -121,11 +127,13 @@ def extract_snapshot_if_valid(data: dict[str, Any] | None) -> TickerSnapshot | N
         )
 
         last_trade_price = format_number(price)
+        name = result.get("name")
 
         return TickerSnapshot(
             ticker=ticker,
             todays_change_percent=todays_change_percent,
             last_trade_price=last_trade_price,
+            name=name if isinstance(name, str) else None,
         )
     except KeyError, IndexError, TypeError:
         logger.warning(f"Polygon snapshot response json has incorrect shape: {data}")
@@ -140,10 +148,16 @@ def format_number(number: int | float) -> str:
 
 
 def build_ticker_summary(snapshot: TickerSnapshot, image_url: HttpUrl | None) -> TickerSummary:
-    """Build a ticker summary for a finance suggestion response."""
+    """Build a ticker summary for a finance suggestion response.
+
+    Tickers outside the curated mappings (widget lookups) fall back to the
+    company name reported by the snapshot; snapshots carry no exchange, so it
+    is left empty for those.
+    """
     ticker = snapshot.ticker
-    company = lookup_ticker_company(ticker)
-    exchange = lookup_ticker_exchange(ticker)
+    entry = ALL_TICKER_COMPANY_MAPPING.get(ticker)
+    company = str(entry["company"]) if entry else (snapshot.name or ticker)
+    exchange = str(entry["exchange"]) if entry else ""
     serp_query = f"{ticker} stock"
     last_price = f"${snapshot.last_trade_price} USD"
     todays_change_perc = snapshot.todays_change_percent

--- a/apps/merino/merino/providers/suggest/finance/backends/protocol.py
+++ b/apps/merino/merino/providers/suggest/finance/backends/protocol.py
@@ -1,7 +1,7 @@
 """Protocol for finance provider backends."""
 
 from enum import Enum
-from typing import Any, Dict, Protocol
+from typing import Dict, Protocol
 from pydantic import BaseModel, HttpUrl
 
 from merino.exceptions import BackendError
@@ -75,10 +75,6 @@ class FinanceBackend(Protocol):
 
     async def shutdown(self) -> None:  # pragma: no cover
         """Close down any open connections."""
-        ...
-
-    async def fetch_ticker_snapshot(self, ticker: str) -> Any | None:
-        """Make a request and fetch the snapshot for this single ticker."""
         ...
 
     async def get_ticker_image_url(self, ticker) -> str | None:

--- a/apps/merino/merino/providers/suggest/finance/backends/protocol.py
+++ b/apps/merino/merino/providers/suggest/finance/backends/protocol.py
@@ -27,6 +27,19 @@ class TickerSnapshot(BaseModel):
     name: str | None = None
 
 
+class TickerMatch(BaseModel):
+    """One candidate from a ticker search, shown in the widget's search pick-list.
+
+    The user selects a match client-side; the widget stores the ticker symbol
+    and uses it for subsequent quote lookups. Merino keeps no selection state.
+    """
+
+    ticker: str
+    name: str
+    exchange: str
+    is_etf: bool
+
+
 class TickerSummary(BaseModel):
     """Ticker summary."""
 
@@ -76,6 +89,10 @@ class FinanceBackend(Protocol):
         Raises:
             BackendError: Category of error specific to provider backends.
         """
+        ...
+
+    async def search_tickers(self, query: str) -> list[TickerMatch]:  # pragma: no cover
+        """Search the upstream reference data by ticker symbol or company name."""
         ...
 
     async def shutdown(self) -> None:  # pragma: no cover

--- a/apps/merino/merino/providers/suggest/finance/backends/protocol.py
+++ b/apps/merino/merino/providers/suggest/finance/backends/protocol.py
@@ -15,11 +15,16 @@ class FinanceBackendError(BackendError):
 
 
 class TickerSnapshot(BaseModel):
-    """Ticker Snapshot."""
+    """Ticker Snapshot.
+
+    `name` is the company name as reported by the snapshot API. It is optional
+    so that cache entries written before the field existed still validate.
+    """
 
     ticker: str
     todays_change_percent: str
     last_trade_price: str
+    name: str | None = None
 
 
 class TickerSummary(BaseModel):

--- a/apps/merino/merino/providers/suggest/finance/provider.py
+++ b/apps/merino/merino/providers/suggest/finance/provider.py
@@ -33,6 +33,9 @@ from merino.configs import settings
 
 logger = logging.getLogger(__name__)
 
+# The `request_type` the stocks widget sends for its search pick-list.
+TICKER_SEARCH_REQUEST_TYPE = "ticker_search"
+
 
 class Provider(BaseProvider):
     """Suggestion provider for finance."""
@@ -159,11 +162,16 @@ class Provider(BaseProvider):
     async def _query_widget(self, srequest: SuggestionRequest) -> list[BaseSuggestion]:
         """Serve the New Tab stocks widget.
 
-        The widget sends an empty query for the default ETF set or a single
-        ticker symbol for a quote. Quote lookups bypass the curated mappings
-        entirely; the widget stores symbols client-side and asks for them one
-        request at a time, which keeps every upstream lookup independent.
+        The widget sends three request shapes: an empty query for the default
+        ETF set, a single ticker symbol for a quote, and free text with
+        `request_type=ticker_search` for its search pick-list. Quote lookups
+        bypass the curated mappings entirely; the widget obtains symbols from
+        ticker search, stores them client-side, and asks for quotes one symbol
+        per request, which keeps every upstream lookup independent.
         """
+        if srequest.request_type == TICKER_SEARCH_REQUEST_TYPE:
+            return await self._search_tickers(srequest)
+
         tickers = (
             get_tickers_for_newtab_query(srequest.query)
             if srequest.query
@@ -188,6 +196,26 @@ class Provider(BaseProvider):
             ]
 
         return [self.build_suggestion(PolygonDetails(values=summaries))]
+
+    async def _search_tickers(self, srequest: SuggestionRequest) -> list[BaseSuggestion]:
+        """Serve a widget ticker search: candidate matches for free text.
+
+        Unlike weather location completion, digit-bearing queries are not
+        filtered as soft PII: names like "3M" are legitimate finance searches,
+        and forwarding widget search input upstream is the approved design.
+        """
+        if not srequest.query:
+            return []
+
+        with self.metrics_client.timeit(
+            "polygon.provider.search.latency", tags={"source": "newtab"}
+        ):
+            matches = await self.backend.search_tickers(srequest.query)
+
+        if not matches:
+            return []
+
+        return [self.build_suggestion(PolygonDetails(values=[], matches=matches))]
 
     def build_suggestion(self, details: PolygonDetails) -> BaseSuggestion:
         """Wrap polygon details in the generic suggestion envelope."""

--- a/apps/merino/merino/providers/suggest/finance/provider.py
+++ b/apps/merino/merino/providers/suggest/finance/provider.py
@@ -25,6 +25,7 @@ from merino.providers.suggest.finance.backends.polygon.etf_ticker_company_mappin
     STOCKS_WIDGET_DEFAULT_ETFS,
 )
 from merino.providers.suggest.finance.backends.polygon.utils import (
+    get_tickers_for_newtab_query,
     get_tickers_for_query,
 )
 from merino_common.utils import cron
@@ -145,48 +146,58 @@ class Provider(BaseProvider):
 
     async def query(self, srequest: SuggestionRequest) -> list[BaseSuggestion]:
         """Provide finance suggestions."""
-        tickers: list[str] | None
-        if srequest.source == "newtab" and not srequest.query:
-            tickers = STOCKS_WIDGET_DEFAULT_ETFS
-        else:
-            # Get the list of tickers (0 to 3) for the query string.
-            tickers = get_tickers_for_query(srequest.query)
-
         try:
-            if not tickers:
-                return []
-            else:
-                # Tag requests from the New Tab stocks widget with "newtab".
-                tags = {"source": "newtab"} if srequest.source == "newtab" else {}
-                with self.metrics_client.timeit("polygon.provider.query.latency", tags=tags):
-                    ticker_summaries: list[TickerSummary] = []
-                    # Get snapshots for the extracted tickers. Can return 0 to 3 snapshots.
-                    ticker_snapshots = await self.backend.get_snapshots(tickers)
+            if srequest.source == "newtab":
+                return await self._query_widget(srequest)
 
-                    # Build ticker summary for each snapshot and its ticker's image
-                    for snapshot in ticker_snapshots:
-                        image_url = self.get_image_url_for_ticker(snapshot.ticker)
-                        ticker_summaries.append(
-                            self.backend.get_ticker_summary(snapshot, image_url)
-                        )
-
-                    return [self.build_suggestion(ticker_summaries)]
-
+            # Get the list of tickers (0 to 3) for the query string.
+            return await self._quote(get_tickers_for_query(srequest.query), tags={})
         except Exception as e:
             logger.warning(f"Exception occurred for Polygon provider: {e}")
             return []
 
-    def build_suggestion(self, data: list[TickerSummary]) -> BaseSuggestion:
-        """Build the suggestion with custom polygon details since this is a finance suggestion."""
-        custom_details = CustomDetails(polygon=PolygonDetails(values=data))
+    async def _query_widget(self, srequest: SuggestionRequest) -> list[BaseSuggestion]:
+        """Serve the New Tab stocks widget.
 
+        The widget sends an empty query for the default ETF set or a single
+        ticker symbol for a quote. Quote lookups bypass the curated mappings
+        entirely; the widget stores symbols client-side and asks for them one
+        request at a time, which keeps every upstream lookup independent.
+        """
+        tickers = (
+            get_tickers_for_newtab_query(srequest.query)
+            if srequest.query
+            else STOCKS_WIDGET_DEFAULT_ETFS
+        )
+        return await self._quote(tickers, tags={"source": "newtab"})
+
+    async def _quote(
+        self, tickers: list[str] | None, tags: dict[str, str]
+    ) -> list[BaseSuggestion]:
+        """Build one suggestion carrying a summary per ticker the backend could resolve."""
+        if not tickers:
+            return []
+
+        with self.metrics_client.timeit("polygon.provider.query.latency", tags=tags):
+            snapshots = await self.backend.get_snapshots(tickers)
+            summaries: list[TickerSummary] = [
+                self.backend.get_ticker_summary(
+                    snapshot, self.get_image_url_for_ticker(snapshot.ticker)
+                )
+                for snapshot in snapshots
+            ]
+
+        return [self.build_suggestion(PolygonDetails(values=summaries))]
+
+    def build_suggestion(self, details: PolygonDetails) -> BaseSuggestion:
+        """Wrap polygon details in the generic suggestion envelope."""
         return BaseSuggestion(
             title="Finance Suggestion",
             url=HttpUrl(self.url),
             provider=self.name,
             is_sponsored=False,
             score=self.score,
-            custom_details=custom_details,
+            custom_details=CustomDetails(polygon=details),
         )
 
     def get_image_url_for_ticker(self, ticker: str) -> HttpUrl | None:

--- a/apps/merino/merino/providers/suggest/finance/provider.py
+++ b/apps/merino/merino/providers/suggest/finance/provider.py
@@ -48,6 +48,7 @@ class Provider(BaseProvider):
     cron_task_fetch: asyncio.Task
     resync_interval_sec: int
     cron_interval_sec: int
+    search_query_timeout_sec: float
     last_fetch_at: float
     last_fetch_failure_at: float | None = None
 
@@ -58,6 +59,7 @@ class Provider(BaseProvider):
         score: float,
         name: str,
         query_timeout_sec: float,
+        search_query_timeout_sec: float,
         resync_interval_sec: int,
         cron_interval_sec: int,
         enabled_by_default: bool = False,
@@ -67,6 +69,7 @@ class Provider(BaseProvider):
         self.score = score
         self._name = name
         self._query_timeout_sec = query_timeout_sec
+        self.search_query_timeout_sec = search_query_timeout_sec
         self._enabled_by_default = enabled_by_default
         self.url = HttpUrl("https://merino.services.mozilla.com/")
         self.manifest_data = FinanceManifest(tickers={})
@@ -146,6 +149,19 @@ class Provider(BaseProvider):
     def normalize_query(self, query: str) -> str:
         """Remove trailing spaces from the query string and support both $(stock) and $ (stock)"""
         return query.strip().replace("$", "STOCK ").replace("  ", " ")
+
+    def query_timeout_sec_for(self, srequest: SuggestionRequest) -> float:
+        """Return the query timeout for one request.
+
+        Widget ticker searches hit the upstream reference search, which is
+        materially slower than quote lookups, and the widget waits far longer
+        than the urlbar, so they get their own budget instead of the
+        keystroke-tuned provider timeout. Gated on the same conditions as the
+        search dispatch, so no other request shape can claim the wider budget.
+        """
+        if srequest.source == "newtab" and srequest.request_type == TICKER_SEARCH_REQUEST_TYPE:
+            return self.search_query_timeout_sec
+        return self.query_timeout_sec
 
     async def query(self, srequest: SuggestionRequest) -> list[BaseSuggestion]:
         """Provide finance suggestions."""

--- a/apps/merino/merino/providers/suggest/finance/provider.py
+++ b/apps/merino/merino/providers/suggest/finance/provider.py
@@ -164,11 +164,16 @@ class Provider(BaseProvider):
         return self.query_timeout_sec
 
     async def query(self, srequest: SuggestionRequest) -> list[BaseSuggestion]:
-        """Provide finance suggestions."""
-        try:
-            if srequest.source == "newtab":
-                return await self._query_widget(srequest)
+        """Provide finance suggestions.
 
+        Widget requests (`source=newtab`) rely on the backend's circuit breaker
+        around its upstream fetches. Urlbar requests keep their original
+        contract: any failure is logged and yields no suggestion.
+        """
+        if srequest.source == "newtab":
+            return await self._query_widget(srequest)
+
+        try:
             # Get the list of tickers (0 to 3) for the query string.
             return await self._quote(get_tickers_for_query(srequest.query), tags={})
         except Exception as e:
@@ -184,6 +189,10 @@ class Provider(BaseProvider):
         bypass the curated mappings entirely; the widget obtains symbols from
         ticker search, stores them client-side, and asks for quotes one symbol
         per request, which keeps every upstream lookup independent.
+
+        `BackendError`s raised by the backend are intentionally unhandled here:
+        the backend's circuit breaker has already counted them, and the API
+        handler drops failed provider tasks from the response.
         """
         if srequest.request_type == TICKER_SEARCH_REQUEST_TYPE:
             return await self._search_tickers(srequest)

--- a/apps/merino/merino/providers/suggest/manager.py
+++ b/apps/merino/merino/providers/suggest/manager.py
@@ -282,6 +282,7 @@ def _create_provider(provider_id: str, setting: Settings) -> BaseProvider:
                 score=setting.score,
                 name=provider_id,
                 query_timeout_sec=setting.query_timeout_sec,
+                search_query_timeout_sec=setting.search_query_timeout_sec,
                 enabled_by_default=setting.enabled_by_default,
                 resync_interval_sec=setting.resync_interval_sec,
                 cron_interval_sec=setting.cron_interval_sec,

--- a/apps/merino/merino/providers/suggest/manager.py
+++ b/apps/merino/merino/providers/suggest/manager.py
@@ -269,6 +269,7 @@ def _create_provider(provider_id: str, setting: Settings) -> BaseProvider:
                     url_param_api_key=settings.polygon.url_param_api_key,
                     url_single_ticker_snapshot=settings.polygon.url_single_ticker_snapshot,
                     url_single_ticker_overview=settings.polygon.url_single_ticker_overview,
+                    url_reference_tickers=settings.polygon.url_reference_tickers,
                     gcs_uploader=GcsUploader(
                         settings.image_gcs.gcs_project,
                         settings.image_gcs.gcs_bucket,

--- a/apps/merino/merino/web/api_v1.py
+++ b/apps/merino/merino/web/api_v1.py
@@ -297,6 +297,7 @@ async def suggest(
             pass
 
     lookups: list[Task] = []
+    query_timeouts: list[float] = []
     languages = get_accepted_languages(accept_language)
 
     validate_suggest_custom_location_params(city, region, country, source)
@@ -329,6 +330,7 @@ async def suggest(
             client_variants=client_variants_list,
         )
         p.validate(srequest)
+        query_timeouts.append(p.query_timeout_sec_for(srequest))
         task = metrics_client.timeit_task(p.query(srequest), f"providers.{p.name}.query")
         # `timeit_task()` doesn't support task naming, need to set the task name manually
         task.set_name(p.name)
@@ -336,10 +338,7 @@ async def suggest(
 
     completed_tasks, _ = await task_runner.gather(
         lookups,
-        timeout=max(
-            (provider.query_timeout_sec for provider in search_from),
-            default=QUERY_TIMEOUT_SEC,
-        ),
+        timeout=max(query_timeouts, default=QUERY_TIMEOUT_SEC),
         timeout_cb=partial(task_runner.metrics_timeout_handler, metrics_client),
     )
     suggestions = list(

--- a/apps/merino/merino/web/api_v1.py
+++ b/apps/merino/merino/web/api_v1.py
@@ -100,12 +100,15 @@ router = APIRouter()
 NORMALIZATION_PROVIDERS: frozenset[str] = frozenset(settings.query_normalization.providers)
 
 
-def _should_normalize_query(provider_name: str, client_variants: list[str]) -> bool:
+def _should_normalize_query(provider_name: str, client_variants: list[str], source: str) -> bool:
     """Whether a provider receives the normalized query for this request.
 
-    sports/polygon are always-on (graduated); AMP is gated on the experiment variant.
+    Normalization targets phrases typed into the urlbar. New Tab widgets send
+    ticker symbols and free text meant for upstream search, which must reach
+    the provider untouched. sports/polygon are always-on (graduated); AMP is
+    gated on the experiment variant.
     """
-    if provider_name not in NORMALIZATION_PROVIDERS:
+    if source == "newtab" or provider_name not in NORMALIZATION_PROVIDERS:
         return False
     if provider_name == ProviderType.ADM:
         return AMP_FUZZY_VARIANT in client_variants
@@ -316,7 +319,7 @@ async def suggest(
     for p in search_from:
         q_for_provider = (
             q_normalized
-            if use_normalization and _should_normalize_query(p.name, client_variants_list)
+            if use_normalization and _should_normalize_query(p.name, client_variants_list, source)
             else q
         )
         srequest = SuggestionRequest(

--- a/apps/merino/merino/web/api_v1.py
+++ b/apps/merino/merino/web/api_v1.py
@@ -156,7 +156,9 @@ async def suggest(
     providers: str | None = None,
     client_variants: str | None = Query(default=None, max_length=CLIENT_VARIANT_CHARACTER_MAX),
     sources: tuple[dict[str, BaseProvider], list[BaseProvider]] = Depends(get_suggest_providers),
-    request_type: Annotated[str | None, Query(pattern="^(location|weather)$")] = None,
+    request_type: Annotated[
+        str | None, Query(pattern="^(location|weather|ticker_search)$")
+    ] = None,
 ) -> Response:
     """Query Merino for suggestions.
 
@@ -197,7 +199,9 @@ async def suggest(
     - `request_type`: [Optional] For AccuWeather provider, the request type should be either a
         "location" or "weather" string. For "location" it will get location completion
         suggestion. For "weather" it will return weather suggestions. If omitted, it defaults
-        to weather suggestions.
+        to weather suggestions. For the Polygon provider with `source=newtab`, the
+        "ticker_search" request type searches tickers by symbol or company name and returns
+        candidate matches instead of prices.
 
     **Headers:**
 

--- a/apps/merino/tests/integration/api/v1/suggest/test_suggest_finance.py
+++ b/apps/merino/tests/integration/api/v1/suggest/test_suggest_finance.py
@@ -194,3 +194,53 @@ def test_suggest_for_finance_suggestion_returns_no_suggestion_for_eager_match_bl
     body = response.json()
 
     assert len(body["suggestions"]) == 0
+
+
+def test_suggest_finance_newtab_returns_quote_for_unmapped_ticker(
+    client: TestClient,
+    backend_mock,
+) -> None:
+    """Test that a newtab quote lookup resolves a symbol outside the curated mappings."""
+    backend_mock.fetch_manifest_data.return_value = (1, None)
+    backend_mock.get_snapshots.return_value = [
+        TickerSnapshot(
+            ticker="KLAR",
+            last_trade_price="14.55",
+            todays_change_percent="+2.14",
+            name="Klarna Group plc",
+        )
+    ]
+    backend_mock.get_ticker_summary.return_value = TickerSummary(
+        ticker="KLAR",
+        name="Klarna Group plc",
+        last_price="$14.55 USD",
+        todays_change_perc="+2.14",
+        query="KLAR stock",
+        image_url=None,
+        exchange="",
+    )
+
+    response = client.get("/api/v1/suggest?q=klar&providers=polygon&source=newtab")
+
+    assert response.status_code == 200
+    backend_mock.get_snapshots.assert_awaited_once_with(["KLAR"])
+    values = response.json()["suggestions"][0]["custom_details"]["polygon"]["values"]
+    assert [(v["ticker"], v["name"], v["exchange"]) for v in values] == [
+        ("KLAR", "Klarna Group plc", "")
+    ]
+
+
+def test_suggest_finance_newtab_rejects_symbol_list(
+    client: TestClient,
+    backend_mock,
+) -> None:
+    """Test that a newtab quote lookup takes one symbol per request: a comma-separated
+    list yields no suggestion and no backend call.
+    """
+    backend_mock.fetch_manifest_data.return_value = (1, None)
+
+    response = client.get("/api/v1/suggest?q=HLN,AAPL&providers=polygon&source=newtab")
+
+    assert response.status_code == 200
+    assert response.json()["suggestions"] == []
+    backend_mock.get_snapshots.assert_not_awaited()

--- a/apps/merino/tests/integration/api/v1/suggest/test_suggest_finance.py
+++ b/apps/merino/tests/integration/api/v1/suggest/test_suggest_finance.py
@@ -254,6 +254,25 @@ def test_suggest_finance_newtab_rejects_symbol_list(
     backend_mock.get_snapshots.assert_not_awaited()
 
 
+def test_suggest_finance_newtab_query_bypasses_normalization(
+    client: TestClient,
+    backend_mock,
+    mocker: MockerFixture,
+) -> None:
+    """Test that widget symbols reach the provider untouched even when the urlbar
+    normalization pipeline is active: a share class suffix would not survive it.
+    """
+    backend_mock.fetch_manifest_data.return_value = (1, None)
+    backend_mock.get_snapshots.return_value = []
+    pipeline = mocker.patch("merino.web.api_v1.get_pipeline").return_value
+    pipeline.normalize.return_value = "brk b"
+
+    response = client.get("/api/v1/suggest?q=BRK.B&providers=polygon&source=newtab")
+
+    assert response.status_code == 200
+    backend_mock.get_snapshots.assert_awaited_once_with(["BRK.B"])
+
+
 def test_suggest_finance_ticker_search_returns_matches(
     client: TestClient,
     backend_mock,

--- a/apps/merino/tests/integration/api/v1/suggest/test_suggest_finance.py
+++ b/apps/merino/tests/integration/api/v1/suggest/test_suggest_finance.py
@@ -12,6 +12,10 @@ from fastapi.testclient import TestClient
 from pytest_mock import MockerFixture
 
 from merino.configs import settings
+from merino.providers.suggest.finance.backends.polygon.errors import (
+    PolygonError,
+    PolygonErrorMessages,
+)
 from merino.providers.suggest.finance.backends.protocol import (
     TickerMatch,
     TickerSnapshot,
@@ -306,6 +310,25 @@ def test_suggest_finance_ticker_search_outlives_the_provider_query_timeout(
     assert response.status_code == 200
     matches = response.json()["suggestions"][0]["custom_details"]["polygon"]["matches"]
     assert [m["ticker"] for m in matches] == ["AAPL"]
+
+
+def test_suggest_finance_backend_error_yields_no_suggestions(
+    client: TestClient,
+    backend_mock,
+) -> None:
+    """Test that a failed upstream request degrades to an empty response: the
+    provider lets the error through for its circuit breaker and the handler
+    drops the failed task.
+    """
+    backend_mock.fetch_manifest_data.return_value = (1, None)
+    backend_mock.get_snapshots.side_effect = PolygonError(
+        PolygonErrorMessages.HTTP_REQUEST_ERROR, operation="snapshot", detail="503"
+    )
+
+    response = client.get("/api/v1/suggest?q=AAPL&providers=polygon&source=newtab")
+
+    assert response.status_code == 200
+    assert response.json()["suggestions"] == []
 
 
 def test_suggest_finance_returns_400_for_unknown_request_type(

--- a/apps/merino/tests/integration/api/v1/suggest/test_suggest_finance.py
+++ b/apps/merino/tests/integration/api/v1/suggest/test_suggest_finance.py
@@ -11,6 +11,7 @@ from fastapi.testclient import TestClient
 from pytest_mock import MockerFixture
 
 from merino.providers.suggest.finance.backends.protocol import (
+    TickerMatch,
     TickerSnapshot,
     TickerSummary,
 )
@@ -244,3 +245,49 @@ def test_suggest_finance_newtab_rejects_symbol_list(
     assert response.status_code == 200
     assert response.json()["suggestions"] == []
     backend_mock.get_snapshots.assert_not_awaited()
+
+
+def test_suggest_finance_ticker_search_returns_matches(
+    client: TestClient,
+    backend_mock,
+) -> None:
+    """Test that a newtab ticker search returns candidate matches under polygon custom details."""
+    backend_mock.fetch_manifest_data.return_value = (1, None)
+    backend_mock.search_tickers.return_value = [
+        TickerMatch(ticker="AAPL", name="Apple Inc.", exchange="NASDAQ", is_etf=False),
+        TickerMatch(
+            ticker="APLE", name="Apple Hospitality REIT, Inc.", exchange="NYSE", is_etf=False
+        ),
+    ]
+
+    response = client.get(
+        "/api/v1/suggest?q=apple&providers=polygon&source=newtab&request_type=ticker_search"
+    )
+
+    assert response.status_code == 200
+    backend_mock.search_tickers.assert_awaited_once_with("apple")
+    polygon = response.json()["suggestions"][0]["custom_details"]["polygon"]
+    assert polygon["values"] == []
+    assert polygon["matches"] == [
+        {"ticker": "AAPL", "name": "Apple Inc.", "exchange": "NASDAQ", "is_etf": False},
+        {
+            "ticker": "APLE",
+            "name": "Apple Hospitality REIT, Inc.",
+            "exchange": "NYSE",
+            "is_etf": False,
+        },
+    ]
+
+
+def test_suggest_finance_returns_400_for_unknown_request_type(
+    client: TestClient,
+    backend_mock,
+) -> None:
+    """Test that the suggest endpoint rejects request_type values outside the allowed set."""
+    backend_mock.fetch_manifest_data.return_value = (1, None)
+
+    response = client.get(
+        "/api/v1/suggest?q=apple&providers=polygon&source=newtab&request_type=bogus"
+    )
+
+    assert response.status_code == 400

--- a/apps/merino/tests/integration/api/v1/suggest/test_suggest_finance.py
+++ b/apps/merino/tests/integration/api/v1/suggest/test_suggest_finance.py
@@ -4,12 +4,14 @@
 
 """Integration tests for the Merino v1 suggest API endpoint configured with the polygon (finance) provider."""
 
+import asyncio
 from typing import Any
 
 import pytest
 from fastapi.testclient import TestClient
 from pytest_mock import MockerFixture
 
+from merino.configs import settings
 from merino.providers.suggest.finance.backends.protocol import (
     TickerMatch,
     TickerSnapshot,
@@ -48,6 +50,7 @@ def fixture_providers(backend_mock: Any, statsd_mock: Any) -> dict[str, FinanceP
         score=0.8,
         name="polygon",
         query_timeout_sec=0.2,
+        search_query_timeout_sec=settings.providers.polygon.search_query_timeout_sec,
         enabled_by_default=False,
         resync_interval_sec=60,
         cron_interval_sec=60,
@@ -277,6 +280,32 @@ def test_suggest_finance_ticker_search_returns_matches(
             "is_etf": False,
         },
     ]
+
+
+def test_suggest_finance_ticker_search_outlives_the_provider_query_timeout(
+    client: TestClient,
+    backend_mock,
+) -> None:
+    """Test that ticker searches run under their own timeout budget: the upstream
+    name search is slower than quote lookups and must not be cancelled by the
+    keystroke-tuned provider timeout.
+    """
+    backend_mock.fetch_manifest_data.return_value = (1, None)
+
+    async def slow_search(query: str) -> list[TickerMatch]:
+        # Longer than the 0.2s provider query timeout used by the fixture.
+        await asyncio.sleep(0.3)
+        return [TickerMatch(ticker="AAPL", name="Apple Inc.", exchange="NASDAQ", is_etf=False)]
+
+    backend_mock.search_tickers.side_effect = slow_search
+
+    response = client.get(
+        "/api/v1/suggest?q=apple&providers=polygon&source=newtab&request_type=ticker_search"
+    )
+
+    assert response.status_code == 200
+    matches = response.json()["suggestions"][0]["custom_details"]["polygon"]["matches"]
+    assert [m["ticker"] for m in matches] == ["AAPL"]
 
 
 def test_suggest_finance_returns_400_for_unknown_request_type(

--- a/apps/merino/tests/integration/providers/suggest/finance/backends/test_polygon.py
+++ b/apps/merino/tests/integration/providers/suggest/finance/backends/test_polygon.py
@@ -75,6 +75,7 @@ def fixture_polygon_parameters(
         "url_param_api_key": "apiKey",
         "url_single_ticker_snapshot": URL_SINGLE_TICKER_SNAPSHOT,
         "url_single_ticker_overview": URL_SINGLE_TICKER_OVERVIEW,
+        "url_reference_tickers": settings.polygon.url_reference_tickers,
         "gcs_uploader": mocker.MagicMock(),
         "cache": RedisAdapter(redis_client),
         "ticker_ttl_sec": TICKER_TTL_SEC,

--- a/apps/merino/tests/unit/middleware/test_logging.py
+++ b/apps/merino/tests/unit/middleware/test_logging.py
@@ -111,6 +111,25 @@ async def test_no_logging_for_excluded_provider(
     assert len(caplog.messages) == 0
 
 
+@pytest.mark.parametrize("source", settings.logging.excluded_sources)
+@pytest.mark.asyncio
+async def test_no_logging_for_excluded_source(
+    caplog: LogCaptureFixture,
+    receive_mock: Receive,
+    send_mock: Send,
+    source: str,
+) -> None:
+    """Test that no logging action takes place for a suggest request from an excluded source."""
+    caplog.set_level(logging.INFO)
+    scope = _suggest_scope()
+    scope["query_string"] = f"q=AAPL&providers=polygon&source={source}".encode()
+    logging_middleware: LoggingMiddleware = LoggingMiddleware(app)
+
+    await logging_middleware(scope, receive_mock, send_mock)
+
+    assert len(caplog.messages) == 0
+
+
 @pytest.mark.asyncio
 async def test_logging_for_included_provider(
     mocker: MockerFixture,

--- a/apps/merino/tests/unit/providers/suggest/finance/backends/conftest.py
+++ b/apps/merino/tests/unit/providers/suggest/finance/backends/conftest.py
@@ -1,0 +1,30 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Shared fixtures for the Polygon backend unit tests."""
+
+from typing import Any, Callable
+
+import pytest
+
+
+@pytest.fixture(name="search_result")
+def fixture_search_result() -> Callable[..., dict[str, Any]]:
+    """Return a factory for reference tickers search result entries."""
+
+    def make(
+        ticker: str, name: str, security_type: str = "CS", **overrides: Any
+    ) -> dict[str, Any]:
+        return {
+            "ticker": ticker,
+            "name": name,
+            "market": "stocks",
+            "locale": "us",
+            "primary_exchange": "XNAS",
+            "type": security_type,
+            "active": True,
+            **overrides,
+        }
+
+    return make

--- a/apps/merino/tests/unit/providers/suggest/finance/backends/test_polygon.py
+++ b/apps/merino/tests/unit/providers/suggest/finance/backends/test_polygon.py
@@ -10,7 +10,7 @@ import logging
 from pydantic import HttpUrl
 import pytest
 from unittest.mock import AsyncMock, MagicMock, call
-from httpx import AsyncClient, HTTPStatusError, Request, Response
+from httpx import AsyncClient, HTTPStatusError, ReadTimeout, Request, Response
 from pytest_mock import MockerFixture
 from typing import Any, Awaitable, Callable, cast
 from merino.cache.redis import RedisAdapter
@@ -22,6 +22,10 @@ from merino.configs import settings
 from redis.asyncio import Redis
 
 from merino.providers.suggest.finance.backends.polygon.backend import PolygonBackend
+from merino.providers.suggest.finance.backends.polygon.errors import (
+    PolygonError,
+    PolygonErrorMessages,
+)
 from merino.providers.suggest.finance.backends.protocol import (
     FinanceManifest,
     GetManifestResultCode,
@@ -235,12 +239,12 @@ async def test_fetch_ticker_snapshot_success(
 
 
 @pytest.mark.asyncio
-async def test_fetch_ticker_snapshot_failure_for_http_500(
+async def test_fetch_ticker_snapshot_raises_for_http_500(
     polygon: PolygonBackend,
     caplog: LogCaptureFixture,
     filter_caplog: FilterCaplogFixture,
 ) -> None:
-    """Test fetch_ticker_snapshot method. Should raise for status on HTTPStatusError 500."""
+    """Test fetch_ticker_snapshot method. Should raise PolygonError on HTTPStatusError 500."""
     caplog.set_level(logging.WARNING)
 
     client_mock: AsyncMock = cast(AsyncMock, polygon.http_client)
@@ -259,20 +263,46 @@ async def test_fetch_ticker_snapshot_failure_for_http_500(
         request=Request(method="GET", url=(f"{base_url}{snapshot_endpoint}")),
     )
 
-    _ = await polygon.fetch_ticker_snapshot(ticker)
+    with pytest.raises(PolygonError):
+        await polygon.fetch_ticker_snapshot(ticker)
 
     records = filter_caplog(
         caplog.records, "merino.providers.suggest.finance.backends.polygon.backend"
     )
 
     assert len(caplog.records) == 1
-
-    assert records[0].message.startswith("Polygon request error")
-    assert "500 Internal Server Error" in records[0].message
+    assert records[0].message == "Polygon snapshot request failed: 500 Internal Server Error"
     increment_metric_mock.assert_has_calls(
         [call("polygon.request.snapshot.get"), call("polygon.request.snapshot.get.failed")],
         any_order=False,
     )
+
+
+@pytest.mark.asyncio
+async def test_fetch_ticker_snapshot_raises_for_timeout(
+    polygon: PolygonBackend,
+    caplog: LogCaptureFixture,
+    filter_caplog: FilterCaplogFixture,
+) -> None:
+    """Test fetch_ticker_snapshot method. A timed out request should raise PolygonError too."""
+    caplog.set_level(logging.WARNING)
+
+    client_mock: AsyncMock = cast(AsyncMock, polygon.http_client)
+    client_mock.get.side_effect = ReadTimeout("timed out")
+
+    # Mock metrics client.
+    polygon.metrics_client = MagicMock()
+
+    with pytest.raises(PolygonError):
+        await polygon.fetch_ticker_snapshot("AAPL")
+
+    records = filter_caplog(
+        caplog.records, "merino.providers.suggest.finance.backends.polygon.backend"
+    )
+    assert [record.message for record in records] == [
+        "Polygon snapshot request failed: ReadTimeout"
+    ]
+    polygon.metrics_client.increment.assert_any_call("polygon.request.snapshot.get.failed")
 
 
 @pytest.mark.asyncio
@@ -368,14 +398,14 @@ async def test_get_snapshots_success_and_fail(
         ticker="TSLA", last_trade_price="200.00", todays_change_percent="1.50"
     )
 
-    # Mocking the fetch_ticker_snapshot method to return single_ticker_snapshot_response fixture for two of the calls.
-    # Returns None for one of the calls.
+    # Mocking the fetch_ticker_snapshot method to return single_ticker_snapshot_response fixture
+    # for all three calls; extract_snapshot_if_valid below decides which ones are valid.
     fetch_mock = mocker.patch.object(
         polygon,
         "fetch_ticker_snapshot",
         side_effect=[
             single_ticker_snapshot_response,  # -> valid
-            None,  # -> invalid
+            single_ticker_snapshot_response,  # -> invalid
             single_ticker_snapshot_response,  # -> valid
         ],
     )
@@ -507,12 +537,12 @@ async def test_get_snapshots_partial_cache_hit(
 
 
 @pytest.mark.asyncio
-async def test_get_snapshots_partial_cache_hit_with_api_failure(
+async def test_get_snapshots_partial_cache_hit_with_unknown_ticker(
     mocker,
     polygon: PolygonBackend,
     single_ticker_snapshot_response: dict[str, Any],
 ) -> None:
-    """Test partial cache hit where one missed ticker returns an invalid API response."""
+    """Test partial cache hit where one missed ticker is unknown upstream."""
     tickers = ["SPY", "ONEQ", "DIA", "IWM"]
     spy_snap = TickerSnapshot(
         ticker="SPY", last_trade_price="450.00", todays_change_percent="0.50"
@@ -531,11 +561,12 @@ async def test_get_snapshots_partial_cache_hit_with_api_failure(
         return_value=[(spy_snap, 300), (dia_snap, 300)],
     )
 
-    # Mocking the fetch_ticker_snapshot method. Returns valid response for ONEQ, None for IWM.
+    # Mocking the fetch_ticker_snapshot method. Returns a response for ONEQ and IWM;
+    # extract_snapshot_if_valid below yields no snapshot for IWM.
     fetch_mock = mocker.patch.object(
         polygon,
         "fetch_ticker_snapshot",
-        side_effect=[single_ticker_snapshot_response, None],
+        side_effect=[single_ticker_snapshot_response, single_ticker_snapshot_response],
     )
 
     # Patch extract_snapshot_if_valid to map payloads -> snapshots/None.
@@ -560,6 +591,32 @@ async def test_get_snapshots_partial_cache_hit_with_api_failure(
     # Only ONEQ and IWM should have been fetched.
     assert fetch_mock.await_count == 2
     assert fetch_mock.await_args_list == [call("ONEQ"), call("IWM")]
+
+
+@pytest.mark.asyncio
+async def test_get_snapshots_raises_on_upstream_failure(
+    mocker,
+    polygon: PolygonBackend,
+) -> None:
+    """Test get_snapshots when a snapshot request fails: the PolygonError propagates and
+    nothing is written to the cache.
+    """
+    mocker.patch.object(
+        polygon,
+        "fetch_ticker_snapshot",
+        side_effect=PolygonError(
+            PolygonErrorMessages.HTTP_REQUEST_ERROR, operation="snapshot", detail="503"
+        ),
+    )
+    store_mock = mocker.patch.object(polygon, "store_snapshots_in_cache")
+
+    # Mock metrics client.
+    polygon.metrics_client = MagicMock()
+
+    with pytest.raises(PolygonError):
+        await polygon.get_snapshots(["AAPL"])
+
+    store_mock.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/apps/merino/tests/unit/providers/suggest/finance/backends/test_polygon.py
+++ b/apps/merino/tests/unit/providers/suggest/finance/backends/test_polygon.py
@@ -22,6 +22,7 @@ from merino.configs import settings
 from redis.asyncio import Redis
 
 from merino.providers.suggest.finance.backends.polygon.backend import (
+    SNAPSHOT_REQUEST_TIMEOUT_SEC,
     TICKER_SEARCH_UPSTREAM_LIMIT,
     PolygonBackend,
 )
@@ -226,7 +227,6 @@ async def test_fetch_ticker_snapshot_success(
 
     # Mock metrics client.
     polygon.metrics_client = MagicMock()
-    timeit_metric_mock = polygon.metrics_client.timeit
 
     client_mock.get.return_value = Response(
         status_code=200,
@@ -234,13 +234,15 @@ async def test_fetch_ticker_snapshot_success(
         request=Request(method="GET", url=(f"{base_url}{snapshot_endpoint}")),
     )
 
-    expected = single_ticker_snapshot_response
     actual = await polygon.fetch_ticker_snapshot(ticker)
 
-    assert actual is not None
-    assert actual == expected
-    assert actual["ticker"]["ticker"] == "AAPL"
-    timeit_metric_mock.assert_called_once_with("polygon.request.snapshot.get.latency")
+    assert actual == single_ticker_snapshot_response
+    client_mock.get.assert_awaited_once_with(
+        URL_SINGLE_TICKER_SNAPSHOT,
+        params={"ticker": "AAPL", "apiKey": "api_key"},
+        timeout=SNAPSHOT_REQUEST_TIMEOUT_SEC,
+    )
+    polygon.metrics_client.timeit.assert_called_once_with("polygon.request.snapshot.get.latency")
 
 
 @pytest.mark.parametrize(
@@ -261,7 +263,7 @@ async def test_upstream_http_error_raises_polygon_error(
     operation: str,
 ) -> None:
     """Test that an upstream HTTP failure is logged once, counted, and raised as a
-    PolygonError for the provider to handle.
+    PolygonError so the provider's circuit breaker can observe it.
     """
     caplog.set_level(logging.WARNING)
     client_mock: AsyncMock = cast(AsyncMock, polygon.http_client)
@@ -317,6 +319,55 @@ async def test_fetch_ticker_snapshot_raises_for_timeout(
     polygon.metrics_client.increment.assert_any_call("polygon.request.snapshot.get.failed")
 
 
+@pytest.mark.asyncio
+async def test_upstream_undecodable_body_raises_polygon_error(
+    polygon: PolygonBackend,
+    caplog: LogCaptureFixture,
+    filter_caplog: FilterCaplogFixture,
+) -> None:
+    """Test that a 200 with a non-JSON body is logged, counted, and raised as a
+    PolygonError, the same as any other upstream failure.
+    """
+    caplog.set_level(logging.WARNING)
+    client_mock: AsyncMock = cast(AsyncMock, polygon.http_client)
+    polygon.metrics_client = MagicMock()
+    client_mock.get.return_value = Response(
+        status_code=200,
+        content=b"<html>service unavailable</html>",
+        request=Request(method="GET", url="https://api.polygon.io"),
+    )
+
+    with pytest.raises(PolygonError):
+        await polygon.fetch_ticker_snapshot("AAPL")
+
+    records = filter_caplog(
+        caplog.records, "merino.providers.suggest.finance.backends.polygon.backend"
+    )
+    assert [record.message for record in records] == [
+        "Polygon snapshot request failed: JSONDecodeError"
+    ]
+    polygon.metrics_client.increment.assert_has_calls(
+        [call("polygon.request.snapshot.get"), call("polygon.request.snapshot.get.failed")]
+    )
+
+
+@pytest.mark.asyncio
+async def test_search_tickers_does_not_convert_bugs_to_backend_errors(
+    polygon: PolygonBackend, mocker: MockerFixture
+) -> None:
+    """Test that only upstream failures become PolygonError: a programming error
+    inside the search tasks surfaces as itself instead of feeding the breaker.
+    """
+    mocker.patch.object(
+        polygon, "_fetch_reference_tickers", side_effect=TypeError("extractor bug")
+    )
+
+    with pytest.raises(ExceptionGroup) as exc_info:
+        await polygon.search_tickers("apple")
+
+    assert any(isinstance(error, TypeError) for error in exc_info.value.exceptions)
+
+
 def _reference_tickers_responder(
     search_results: list[dict[str, Any]], exact_results: list[dict[str, Any]]
 ) -> Callable[..., Response]:
@@ -324,7 +375,7 @@ def _reference_tickers_responder(
     exact `ticker` params get exact_results.
     """
 
-    def responder(url: str, params: dict[str, str]) -> Response:
+    def responder(url: str, params: dict[str, str], timeout: float) -> Response:
         results = search_results if "search" in params else exact_results
         return Response(
             status_code=200,

--- a/apps/merino/tests/unit/providers/suggest/finance/backends/test_polygon.py
+++ b/apps/merino/tests/unit/providers/suggest/finance/backends/test_polygon.py
@@ -21,7 +21,10 @@ from pytest import LogCaptureFixture
 from merino.configs import settings
 from redis.asyncio import Redis
 
-from merino.providers.suggest.finance.backends.polygon.backend import PolygonBackend
+from merino.providers.suggest.finance.backends.polygon.backend import (
+    TICKER_SEARCH_UPSTREAM_LIMIT,
+    PolygonBackend,
+)
 from merino.providers.suggest.finance.backends.polygon.errors import (
     PolygonError,
     PolygonErrorMessages,
@@ -36,6 +39,7 @@ from merino.providers.suggest.finance.backends.protocol import (
 
 URL_SINGLE_TICKER_SNAPSHOT = settings.polygon.url_single_ticker_snapshot
 URL_SINGLE_TICKER_OVERVIEW = settings.polygon.url_single_ticker_overview
+URL_REFERENCE_TICKERS = settings.polygon.url_reference_tickers
 TICKER_TTL_SEC = settings.providers.polygon.cache_ttls.ticker_ttl_sec
 
 
@@ -99,6 +103,7 @@ def fixture_polygon_parameters(
         "url_param_api_key": "apiKey",
         "url_single_ticker_snapshot": URL_SINGLE_TICKER_SNAPSHOT,
         "url_single_ticker_overview": URL_SINGLE_TICKER_OVERVIEW,
+        "url_reference_tickers": URL_REFERENCE_TICKERS,
         "gcs_uploader": mock_gcs_uploader,
         "cache": RedisAdapter(redis_mock_cache_miss),
         "ticker_ttl_sec": TICKER_TTL_SEC,
@@ -238,42 +243,49 @@ async def test_fetch_ticker_snapshot_success(
     timeit_metric_mock.assert_called_once_with("polygon.request.snapshot.get.latency")
 
 
+@pytest.mark.parametrize(
+    "request_upstream, operation",
+    [
+        (lambda polygon: polygon.fetch_ticker_snapshot("AAPL"), "snapshot"),
+        # A multi-word query issues only the search request.
+        (lambda polygon: polygon.search_tickers("apple inc"), "search"),
+    ],
+    ids=["snapshot", "ticker_search"],
+)
 @pytest.mark.asyncio
-async def test_fetch_ticker_snapshot_raises_for_http_500(
+async def test_upstream_http_error_raises_polygon_error(
     polygon: PolygonBackend,
     caplog: LogCaptureFixture,
     filter_caplog: FilterCaplogFixture,
+    request_upstream: Callable[[PolygonBackend], Awaitable[Any]],
+    operation: str,
 ) -> None:
-    """Test fetch_ticker_snapshot method. Should raise PolygonError on HTTPStatusError 500."""
+    """Test that an upstream HTTP failure is logged once, counted, and raised as a
+    PolygonError for the provider to handle.
+    """
     caplog.set_level(logging.WARNING)
-
     client_mock: AsyncMock = cast(AsyncMock, polygon.http_client)
-
-    ticker = "AAPL"
-    base_url = "https://api.polygon.io/apiKey=api_key"
-    snapshot_endpoint = URL_SINGLE_TICKER_SNAPSHOT.format(ticker=ticker)
-
-    # Mock metrics client.
     polygon.metrics_client = MagicMock()
-    increment_metric_mock = polygon.metrics_client.increment
-
     client_mock.get.return_value = Response(
         status_code=500,
         content=b"",
-        request=Request(method="GET", url=(f"{base_url}{snapshot_endpoint}")),
+        request=Request(method="GET", url="https://api.polygon.io"),
     )
 
     with pytest.raises(PolygonError):
-        await polygon.fetch_ticker_snapshot(ticker)
+        await request_upstream(polygon)
 
     records = filter_caplog(
         caplog.records, "merino.providers.suggest.finance.backends.polygon.backend"
     )
-
-    assert len(caplog.records) == 1
-    assert records[0].message == "Polygon snapshot request failed: 500 Internal Server Error"
-    increment_metric_mock.assert_has_calls(
-        [call("polygon.request.snapshot.get"), call("polygon.request.snapshot.get.failed")],
+    assert [record.message for record in records] == [
+        f"Polygon {operation} request failed: 500 Internal Server Error"
+    ]
+    polygon.metrics_client.increment.assert_has_calls(
+        [
+            call(f"polygon.request.{operation}.get"),
+            call(f"polygon.request.{operation}.get.failed"),
+        ],
         any_order=False,
     )
 
@@ -303,6 +315,101 @@ async def test_fetch_ticker_snapshot_raises_for_timeout(
         "Polygon snapshot request failed: ReadTimeout"
     ]
     polygon.metrics_client.increment.assert_any_call("polygon.request.snapshot.get.failed")
+
+
+def _reference_tickers_responder(
+    search_results: list[dict[str, Any]], exact_results: list[dict[str, Any]]
+) -> Callable[..., Response]:
+    """Answer reference tickers requests: `search` params get search_results,
+    exact `ticker` params get exact_results.
+    """
+
+    def responder(url: str, params: dict[str, str]) -> Response:
+        results = search_results if "search" in params else exact_results
+        return Response(
+            status_code=200,
+            content=orjson.dumps({"results": results, "status": "OK"}),
+            request=Request(method="GET", url="https://api.polygon.io/v3/reference/tickers"),
+        )
+
+    return responder
+
+
+@pytest.mark.parametrize(
+    "query, search_results, exact_results, expected_tickers, expected_lookups",
+    [
+        # A symbol-shaped name runs both lookups; the exact hit is deduplicated and first.
+        (
+            "apple",
+            [("AAPL", "Apple Inc."), ("PAPL", "Pineapple Financial Inc.")],
+            [("AAPL", "Apple Inc.")],
+            ["AAPL", "PAPL"],
+            {"search", "ticker"},
+        ),
+        # Searching "EA" matches "ea" anywhere in a name and the API truncates
+        # alphabetically, so the EA ticker itself may be absent from search results.
+        (
+            "EA",
+            [("AACG", "ATA Creativity Global"), ("ABFL", "Abacus FCF Leaders ETF")],
+            [("EA", "Electronic Arts Inc.")],
+            ["EA", "AACG", "ABFL"],
+            {"search", "ticker"},
+        ),
+        # Free text that cannot be a symbol issues only the search request.
+        (
+            "berkshire hathaway",
+            [("BRK.B", "Berkshire Hathaway Inc.")],
+            [],
+            ["BRK.B"],
+            {"search"},
+        ),
+        # Below the minimum query length only the exact lookup runs.
+        (
+            "F",
+            [("FORD", "Forward Industries, Inc.")],
+            [("F", "Ford Motor Company")],
+            ["F"],
+            {"ticker"},
+        ),
+    ],
+    ids=["symbol_shaped_name", "exact_hit_outside_search_window", "free_text", "short_query"],
+)
+@pytest.mark.asyncio
+async def test_search_tickers(
+    polygon: PolygonBackend,
+    search_result: Callable[..., dict[str, Any]],
+    query: str,
+    search_results: list[tuple[str, str]],
+    exact_results: list[tuple[str, str]],
+    expected_tickers: list[str],
+    expected_lookups: set[str],
+) -> None:
+    """Test search_tickers: which upstream lookups a query triggers and how their
+    results are merged and ranked.
+    """
+    client_mock: AsyncMock = cast(AsyncMock, polygon.http_client)
+    client_mock.get.side_effect = _reference_tickers_responder(
+        search_results=[search_result(*args) for args in search_results],
+        exact_results=[search_result(*args) for args in exact_results],
+    )
+
+    matches = await polygon.search_tickers(query)
+
+    assert [match.ticker for match in matches] == expected_tickers
+
+    requests = [c.kwargs["params"] for c in client_mock.get.await_args_list]
+    assert {
+        "search" if "search" in params else "ticker" for params in requests
+    } == expected_lookups
+    for params in requests:
+        assert params["market"] == "stocks"
+        assert params["active"] == "true"
+        assert params["apiKey"] == "api_key"
+        if "search" in params:
+            assert params["search"] == query
+            assert params["limit"] == str(TICKER_SEARCH_UPSTREAM_LIMIT)
+        else:
+            assert params["ticker"] == query.upper()
 
 
 @pytest.mark.asyncio

--- a/apps/merino/tests/unit/providers/suggest/finance/backends/test_utils.py
+++ b/apps/merino/tests/unit/providers/suggest/finance/backends/test_utils.py
@@ -7,19 +7,25 @@
 import pytest
 import copy
 import logging
-from typing import Any
+from typing import Any, Callable
 
 from pytest import LogCaptureFixture
 
 from merino.providers.suggest.finance.backends.polygon.utils import (
     build_ticker_summary,
     extract_snapshot_if_valid,
+    extract_ticker_matches_from_search_response,
     get_tickers_for_newtab_query,
     get_tickers_for_query,
     format_number,
+    rank_ticker_matches,
 )
 
-from merino.providers.suggest.finance.backends.protocol import TickerSnapshot, TickerSummary
+from merino.providers.suggest.finance.backends.protocol import (
+    TickerMatch,
+    TickerSnapshot,
+    TickerSummary,
+)
 
 
 @pytest.fixture(name="single_ticker_snapshot_response")
@@ -245,6 +251,97 @@ def test_extract_snapshot_if_valid_returns_none_for_missing_property(
     del invalid_json_response["results"][0]["session"]["change_percent"]
 
     assert extract_snapshot_if_valid(invalid_json_response) is None
+
+
+@pytest.mark.parametrize(
+    "response",
+    [None, {}, {"results": "nope"}, {"results": [None, 42]}],
+    ids=["none", "no_results", "results_not_a_list", "results_not_objects"],
+)
+def test_extract_ticker_matches_ignores_malformed_responses(response) -> None:
+    """Test that malformed search responses yield nothing rather than raising."""
+    assert extract_ticker_matches_from_search_response(response) == []
+
+
+def test_extract_ticker_matches_from_search_response(
+    search_result: Callable[..., dict[str, Any]],
+) -> None:
+    """Test that a reference search response yields only active U.S. matches of
+    the supported security types, with exchange MICs mapped to display names.
+    """
+    response = {
+        "results": [
+            search_result("AAPL", "Apple Inc."),
+            search_result(
+                "VTI", "Vanguard Total Stock Market ETF", "ETF", primary_exchange="ARCX"
+            ),
+            # Unknown MIC falls back to the MIC itself.
+            search_result("XYZ", "Block, Inc.", primary_exchange="XPHL"),
+            search_result("AAPLW", "Apple Warrant", "WARRANT"),
+            search_result("APC", "Apple Inc.", locale="de", primary_exchange="XFRA"),
+            search_result("WBA", "Walgreens Boots Alliance, Inc.", active=False),
+            {"ticker": None, "type": "CS", "locale": "us", "active": True},
+        ],
+        "status": "OK",
+    }
+
+    matches = extract_ticker_matches_from_search_response(response)
+
+    assert matches == [
+        TickerMatch(ticker="AAPL", name="Apple Inc.", exchange="NASDAQ", is_etf=False),
+        TickerMatch(
+            ticker="VTI", name="Vanguard Total Stock Market ETF", exchange="NYSE", is_etf=True
+        ),
+        TickerMatch(ticker="XYZ", name="Block, Inc.", exchange="XPHL", is_etf=False),
+    ]
+
+
+def _match(ticker: str, name: str, is_etf: bool = False) -> TickerMatch:
+    return TickerMatch(ticker=ticker, name=name, exchange="NYSE", is_etf=is_etf)
+
+
+@pytest.mark.parametrize(
+    "query, matches, expected_tickers",
+    [
+        # GS: a stock whose name starts with the query once "The " is ignored. The
+        # ETFs also carry the name prefix but rank below stocks. SACH is a
+        # substring-only hit and ranks last.
+        (
+            "goldman sachs",
+            [
+                _match("AAAU", "Goldman Sachs Physical Gold ETF", is_etf=True),
+                _match("GBIL", "Goldman Sachs Access Treasury 0-1 Year ETF", is_etf=True),
+                _match("GS", "The Goldman Sachs Group, Inc."),
+                _match("SACH", "Sachem Capital Corp."),
+            ],
+            ["GS", "AAAU", "GBIL", "SACH"],
+        ),
+        # An exact symbol outranks a name-prefix hit.
+        (
+            "ford",
+            [_match("FORD", "Forward Industries, Inc."), _match("F", "Ford Motor Company")],
+            ["FORD", "F"],
+        ),
+        # A symbol-prefix hit outranks a name-prefix hit.
+        (
+            "goog",
+            [
+                _match("ABCD", "Goog Corp"),
+                _match("GOOGL", "Alphabet Inc. Class A"),
+                _match("GOOG", "Alphabet Inc. Class C"),
+            ],
+            ["GOOG", "GOOGL", "ABCD"],
+        ),
+    ],
+    ids=["name_prefix_and_type", "exact_symbol_first", "symbol_prefix_before_name_prefix"],
+)
+def test_rank_ticker_matches(
+    query: str, matches: list[TickerMatch], expected_tickers: list[str]
+) -> None:
+    """Test the ranking tiers: exact symbol, symbol prefix, name prefix (a leading
+    "The " ignored), stocks before ETFs, then API order.
+    """
+    assert [m.ticker for m in rank_ticker_matches(matches, query)] == expected_tickers
 
 
 @pytest.mark.parametrize(

--- a/apps/merino/tests/unit/providers/suggest/finance/backends/test_utils.py
+++ b/apps/merino/tests/unit/providers/suggest/finance/backends/test_utils.py
@@ -6,7 +6,10 @@
 
 import pytest
 import copy
+import logging
 from typing import Any
+
+from pytest import LogCaptureFixture
 
 from merino.providers.suggest.finance.backends.polygon.utils import (
     build_ticker_summary,
@@ -204,6 +207,22 @@ def test_extract_snapshot_if_valid_success(
 def test_extract_snapshot_if_valid_returns_none() -> None:
     """Test extract_ticker_snapshot_returns_none method. Should return None when snapshot param is None."""
     assert extract_snapshot_if_valid(None) is None
+
+
+def test_extract_snapshot_if_valid_returns_none_for_unknown_ticker(
+    caplog: LogCaptureFixture,
+) -> None:
+    """Test extract_snapshot_if_valid with an unknown ticker. The API answers with an error
+    entry instead of session data; that is expected and must not be logged as malformed.
+    """
+    caplog.set_level(logging.WARNING)
+    response = {
+        "results": [{"ticker": "ZZZZZZ", "error": "NOT_FOUND", "message": "Ticker not found."}],
+        "status": "OK",
+    }
+
+    assert extract_snapshot_if_valid(response) is None
+    assert not caplog.records
 
 
 def test_extract_snapshot_if_valid_returns_none_for_invalid_value_type(

--- a/apps/merino/tests/unit/providers/suggest/finance/backends/test_utils.py
+++ b/apps/merino/tests/unit/providers/suggest/finance/backends/test_utils.py
@@ -13,9 +13,8 @@ from pytest import LogCaptureFixture
 
 from merino.providers.suggest.finance.backends.polygon.utils import (
     build_ticker_summary,
-    lookup_ticker_company,
-    lookup_ticker_exchange,
     extract_snapshot_if_valid,
+    get_tickers_for_newtab_query,
     get_tickers_for_query,
     format_number,
 )
@@ -89,40 +88,6 @@ def fixture_single_ticker_snapshot_response() -> dict[str, Any]:
     }
 
 
-def test_lookup_stock_ticker_company_success() -> None:
-    """Test lookup_ticker_company method. Should return valid company name."""
-    assert lookup_ticker_company("TSLA") == "Tesla Inc"
-
-
-def test_lookup_etf_ticker_company_success() -> None:
-    """Test lookup_ticker_company method. Should return valid company name."""
-    assert lookup_ticker_company("VOO") == "Vanguard S&P 500 ETF"
-
-
-def test_lookup_ticker_company_fail() -> None:
-    """Test lookup_ticker_company method. Although this use case wouldn't happen at run time but we are still testing for it."""
-    with pytest.raises(KeyError) as error:
-        _ = lookup_ticker_company("BOB")
-    assert error.typename == "KeyError"
-
-
-def test_lookup_stock_ticker_exchange_success() -> None:
-    """Test lookup_ticker_exchange method. Should return valid exchange name."""
-    assert lookup_ticker_exchange("TSLA") == "NASDAQ"
-
-
-def test_lookup_etf_ticker_exchange_success() -> None:
-    """Test lookup_ticker_exchange method. Should return valid exchange name."""
-    assert lookup_ticker_exchange("VOO") == "NYSE"
-
-
-def test_lookup_ticker_exchange_fail() -> None:
-    """Test lookup_ticker_exchange method. Although this use case wouldn't happen at run time but we are still testing for it."""
-    with pytest.raises(KeyError) as error:
-        _ = lookup_ticker_exchange("BOB")
-    assert error.typename == "KeyError"
-
-
 @pytest.mark.parametrize(
     "test_keyword, expected_tickers",
     [
@@ -151,18 +116,46 @@ def test_get_tickers_for_query(test_keyword, expected_tickers) -> None:
     assert get_tickers_for_query(test_keyword) == expected_tickers
 
 
+@pytest.mark.parametrize(
+    "query, expected_tickers",
+    [
+        ("AAPL", ["AAPL"]),
+        ("  aapl ", ["AAPL"]),  # Case and surrounding whitespace normalized.
+        ("BRK.B", ["BRK.B"]),
+        ("KLAR", ["KLAR"]),  # Not in the curated mappings; passed through as is.
+        ("AAPL,KLAR", None),  # One symbol per request; lists are not symbols.
+        ("apple stock", None),  # Keyword queries are not symbols.
+        ("TOOLONGSYMBOL", None),
+        ("", None),
+    ],
+    ids=[
+        "plain",
+        "lowercase_and_whitespace",
+        "class_suffix",
+        "unmapped_ticker",
+        "symbol_list",
+        "keyword_query",
+        "too_long",
+        "empty",
+    ],
+)
+def test_get_tickers_for_newtab_query(query, expected_tickers) -> None:
+    """Test get_tickers_for_newtab_query for various widget queries."""
+    assert get_tickers_for_newtab_query(query) == expected_tickers
+
+
 def test_extract_snapshot_if_valid_success(
     single_ticker_snapshot_response: dict[str, Any],
 ) -> None:
     """Test extract_ticker_snapshot_returns_none method. Should return TickerSnapshot object."""
     expected_market_open = TickerSnapshot(
-        ticker="AAPL", last_trade_price="229.47", todays_change_percent="+0.82"
+        ticker="AAPL", last_trade_price="229.47", todays_change_percent="+0.82", name="Apple Inc."
     )
     actual_market_open = extract_snapshot_if_valid(single_ticker_snapshot_response)
 
     # should also validate for int values
     expected_market_open_with_int_values = TickerSnapshot(
-        ticker="AAPL", last_trade_price="229", todays_change_percent="+0.82"
+        ticker="AAPL", last_trade_price="229", todays_change_percent="+0.82", name="Apple Inc."
     )
     # deep copying the fixture to over write a value.
     single_ticker_snapshot_response_with_int_values = copy.deepcopy(
@@ -177,14 +170,14 @@ def test_extract_snapshot_if_valid_success(
     single_ticker_snapshot_response["results"][0]["market_status"] = "closed"
     # the change percent value is 0.946 from the fixture but the function rounds it to 2 decimal places.
     expected_market_closed = TickerSnapshot(
-        ticker="AAPL", last_trade_price="229.31", todays_change_percent="+0.95"
+        ticker="AAPL", last_trade_price="229.31", todays_change_percent="+0.95", name="Apple Inc."
     )
     actual_market_closed = extract_snapshot_if_valid(single_ticker_snapshot_response)
 
     # setting the market status to early_trading.
     single_ticker_snapshot_response["results"][0]["market_status"] = "early_trading"
     expected_market_early_trading = TickerSnapshot(
-        ticker="AAPL", last_trade_price="227.16", todays_change_percent="-0.13"
+        ticker="AAPL", last_trade_price="227.16", todays_change_percent="-0.13", name="Apple Inc."
     )
     actual_market_early_trading = extract_snapshot_if_valid(single_ticker_snapshot_response)
 
@@ -192,7 +185,7 @@ def test_extract_snapshot_if_valid_success(
     single_ticker_snapshot_response["results"][0]["market_status"] = "late_trading"
     # the change percent value is 0.946 from the fixture but the function rounds it to 2 decimal places.
     expected_market_late_trading = TickerSnapshot(
-        ticker="AAPL", last_trade_price="229.31", todays_change_percent="+0.95"
+        ticker="AAPL", last_trade_price="229.31", todays_change_percent="+0.95", name="Apple Inc."
     )
     actual_market_late_trading = extract_snapshot_if_valid(single_ticker_snapshot_response)
 
@@ -252,6 +245,32 @@ def test_extract_snapshot_if_valid_returns_none_for_missing_property(
     del invalid_json_response["results"][0]["session"]["change_percent"]
 
     assert extract_snapshot_if_valid(invalid_json_response) is None
+
+
+@pytest.mark.parametrize(
+    "snapshot_name, expected_name",
+    [("Klarna Group plc", "Klarna Group plc"), (None, "KLAR")],
+    ids=["snapshot_name", "falls_back_to_symbol"],
+)
+def test_build_ticker_summary_for_unmapped_ticker(
+    snapshot_name: str | None, expected_name: str
+) -> None:
+    """Test that tickers outside the curated mappings take the company name from
+    the snapshot, or the symbol when the snapshot carries none, and no exchange.
+    """
+    actual = build_ticker_summary(
+        snapshot=TickerSnapshot(
+            ticker="KLAR",
+            last_trade_price="40.50",
+            todays_change_percent="+1.20",
+            name=snapshot_name,
+        ),
+        image_url=None,
+    )
+
+    assert actual.name == expected_name
+    assert actual.exchange == ""
+    assert actual.query == "KLAR stock"
 
 
 def test_build_ticker_summary_success() -> None:

--- a/apps/merino/tests/unit/providers/suggest/finance/backends/test_utils.py
+++ b/apps/merino/tests/unit/providers/suggest/finance/backends/test_utils.py
@@ -203,9 +203,12 @@ def test_extract_snapshot_if_valid_success(
     assert actual_market_closed == expected_market_closed
 
 
-def test_extract_snapshot_if_valid_returns_none() -> None:
-    """Test extract_ticker_snapshot_returns_none method. Should return None when snapshot param is None."""
-    assert extract_snapshot_if_valid(None) is None
+@pytest.mark.parametrize("data", [None, {}], ids=["none", "empty"])
+def test_extract_snapshot_if_valid_returns_none(data: dict[str, Any] | None) -> None:
+    """Test extract_snapshot_if_valid with no response body. An empty result is what
+    the circuit breaker substitutes for the upstream response while it is open.
+    """
+    assert extract_snapshot_if_valid(data) is None
 
 
 def test_extract_snapshot_if_valid_returns_none_for_unknown_ticker(

--- a/apps/merino/tests/unit/providers/suggest/finance/test_provider.py
+++ b/apps/merino/tests/unit/providers/suggest/finance/test_provider.py
@@ -5,12 +5,14 @@
 """Unit tests for the finance provider module."""
 
 import asyncio
+import logging
 import time
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from pydantic import HttpUrl
+from pytest import LogCaptureFixture
 from pytest_mock import MockerFixture
 from starlette.exceptions import HTTPException
 
@@ -23,6 +25,10 @@ from merino.providers.suggest.finance.backends.protocol import (
     TickerMatch,
     TickerSnapshot,
     TickerSummary,
+)
+from merino.providers.suggest.finance.backends.polygon.errors import (
+    PolygonError,
+    PolygonErrorMessages,
 )
 from merino.providers.suggest.finance.backends.polygon.etf_ticker_company_mapping import (
     STOCKS_WIDGET_DEFAULT_ETFS,
@@ -490,6 +496,57 @@ async def test_query_ticker_search_allows_digit_queries(
 
     backend_mock.search_tickers.assert_awaited_once_with("3m")
     assert len(suggestions) == 1
+
+
+@pytest.mark.parametrize(
+    "backend_method, srequest_kwargs",
+    [
+        ("get_snapshots", {"query": "KLAR", "source": "newtab"}),
+        (
+            "search_tickers",
+            {"query": "apple", "source": "newtab", "request_type": "ticker_search"},
+        ),
+    ],
+    ids=["quote", "ticker_search"],
+)
+@pytest.mark.asyncio
+async def test_query_propagates_backend_errors_for_circuit_breaker(
+    backend_mock: Any,
+    provider: Provider,
+    geolocation: Location,
+    backend_method: str,
+    srequest_kwargs: dict[str, Any],
+) -> None:
+    """Widget queries should propagate backend errors so the circuit breaker can observe them."""
+    getattr(backend_mock, backend_method).side_effect = PolygonError(
+        PolygonErrorMessages.HTTP_REQUEST_ERROR, operation="snapshot", detail="500"
+    )
+
+    with pytest.raises(PolygonError):
+        await provider.query(SuggestionRequest(geolocation=geolocation, **srequest_kwargs))
+
+
+@pytest.mark.asyncio
+async def test_query_urlbar_swallows_backend_errors(
+    backend_mock: Any,
+    provider: Provider,
+    geolocation: Location,
+    caplog: LogCaptureFixture,
+) -> None:
+    """Urlbar queries keep their original contract: a backend failure is logged
+    and yields no suggestion instead of reaching the circuit breaker.
+    """
+    caplog.set_level(logging.WARNING)
+    backend_mock.get_snapshots.side_effect = PolygonError(
+        PolygonErrorMessages.HTTP_REQUEST_ERROR, operation="snapshot", detail="500"
+    )
+
+    suggestions = await provider.query(SuggestionRequest(query="ddog", geolocation=geolocation))
+
+    assert suggestions == []
+    assert [record.message for record in caplog.records] == [
+        "Exception occurred for Polygon provider: Polygon snapshot request failed: 500"
+    ]
 
 
 @pytest.mark.parametrize(

--- a/apps/merino/tests/unit/providers/suggest/finance/test_provider.py
+++ b/apps/merino/tests/unit/providers/suggest/finance/test_provider.py
@@ -20,6 +20,7 @@ from merino.providers.suggest.finance.backends.protocol import (
     FinanceBackend,
     FinanceManifest,
     GetManifestResultCode,
+    TickerMatch,
     TickerSnapshot,
     TickerSummary,
 )
@@ -395,6 +396,99 @@ async def test_query_urlbar_unmapped_ticker_returns_no_suggestion(
 
     assert suggestions == []
     backend_mock.get_snapshots.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_query_ticker_search_returns_matches(
+    backend_mock: Any,
+    provider: Provider,
+    statsd_mock: Any,
+    geolocation: Location,
+) -> None:
+    """Test that a newtab ticker search returns one suggestion carrying the
+    candidate matches under the polygon custom details.
+    """
+    matches = [
+        TickerMatch(ticker="AAPL", name="Apple Inc.", exchange="NASDAQ", is_etf=False),
+        TickerMatch(
+            ticker="APLE", name="Apple Hospitality REIT, Inc.", exchange="NYSE", is_etf=False
+        ),
+    ]
+    backend_mock.search_tickers.return_value = matches
+
+    suggestions: list[BaseSuggestion] = await provider.query(
+        SuggestionRequest(
+            query="apple", geolocation=geolocation, source="newtab", request_type="ticker_search"
+        )
+    )
+
+    backend_mock.search_tickers.assert_awaited_once_with("apple")
+    backend_mock.get_snapshots.assert_not_awaited()
+    assert [suggestion.custom_details for suggestion in suggestions] == [
+        CustomDetails(polygon=PolygonDetails(values=[], matches=matches))
+    ]
+    statsd_mock.timeit.assert_called_once_with(
+        "polygon.provider.search.latency", tags={"source": "newtab"}
+    )
+
+
+@pytest.mark.parametrize(
+    "srequest_kwargs, backend_matches",
+    [
+        ({"query": "aaple", "source": "newtab"}, []),
+        ({"query": "", "source": "newtab"}, None),
+        ({"query": "klarna"}, None),  # Search is only served to the widget.
+    ],
+    ids=["no_matches", "empty_query", "not_newtab"],
+)
+@pytest.mark.asyncio
+async def test_query_ticker_search_returns_no_suggestion(
+    backend_mock: Any,
+    provider: Provider,
+    geolocation: Location,
+    srequest_kwargs: dict[str, Any],
+    backend_matches: list[TickerMatch] | None,
+) -> None:
+    """Test the ticker search requests that yield nothing. A None `backend_matches`
+    means the backend must not be consulted at all.
+    """
+    backend_mock.search_tickers.return_value = backend_matches or []
+
+    suggestions: list[BaseSuggestion] = await provider.query(
+        SuggestionRequest(geolocation=geolocation, request_type="ticker_search", **srequest_kwargs)
+    )
+
+    assert suggestions == []
+    backend_mock.get_snapshots.assert_not_awaited()
+    if backend_matches is None:
+        backend_mock.search_tickers.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_query_ticker_search_allows_digit_queries(
+    backend_mock: Any,
+    provider: Provider,
+    geolocation: Location,
+) -> None:
+    """Test that digit-bearing queries reach the backend: names like "3M" are
+    legitimate finance searches, so ticker search applies no soft-PII gate.
+    """
+    backend_mock.search_tickers.return_value = [
+        TickerMatch(ticker="MMM", name="3M Company", exchange="NYSE", is_etf=False)
+    ]
+
+    suggestions: list[BaseSuggestion] = await provider.query(
+        SuggestionRequest(
+            query="3m",
+            geolocation=geolocation,
+            source="newtab",
+            request_type="ticker_search",
+            is_soft_pii=True,
+        )
+    )
+
+    backend_mock.search_tickers.assert_awaited_once_with("3m")
+    assert len(suggestions) == 1
 
 
 # TODO add test for when backend.get_snapshots returns []

--- a/apps/merino/tests/unit/providers/suggest/finance/test_provider.py
+++ b/apps/merino/tests/unit/providers/suggest/finance/test_provider.py
@@ -119,6 +119,7 @@ def fixture_provider(backend_mock: Any, statsd_mock: Any) -> Provider:
         name="finance",
         score=0.3,
         query_timeout_sec=0.2,
+        search_query_timeout_sec=1.0,
         cron_interval_sec=60,
         resync_interval_sec=86400,
     )
@@ -489,6 +490,33 @@ async def test_query_ticker_search_allows_digit_queries(
 
     backend_mock.search_tickers.assert_awaited_once_with("3m")
     assert len(suggestions) == 1
+
+
+@pytest.mark.parametrize(
+    "source, request_type, expected_timeout",
+    [
+        ("newtab", "ticker_search", 1.0),
+        ("urlbar", "ticker_search", 0.2),
+        ("newtab", None, 0.2),
+        ("urlbar", None, 0.2),
+    ],
+    ids=["widget_ticker_search", "ticker_search_without_newtab", "widget_quote", "urlbar"],
+)
+def test_query_timeout_sec_for(
+    provider: Provider,
+    geolocation: Location,
+    source: str,
+    request_type: str | None,
+    expected_timeout: float,
+) -> None:
+    """Test that only widget ticker searches get the search timeout: the wider
+    budget must not be claimable by request_type alone.
+    """
+    srequest = SuggestionRequest(
+        query="apple", geolocation=geolocation, source=source, request_type=request_type
+    )
+
+    assert provider.query_timeout_sec_for(srequest) == expected_timeout
 
 
 # TODO add test for when backend.get_snapshots returns []

--- a/apps/merino/tests/unit/providers/suggest/finance/test_provider.py
+++ b/apps/merino/tests/unit/providers/suggest/finance/test_provider.py
@@ -326,30 +326,75 @@ async def test_query_returns_default_etfs_for_newtab_source_with_empty_query(
     )
 
 
+@pytest.mark.parametrize(
+    "query, expected_tickers",
+    [
+        ("ddog", ["DDOG"]),
+        ("KLAR", ["KLAR"]),  # Outside the curated mappings; passed through as is.
+        ("brk.b", ["BRK.B"]),
+    ],
+    ids=["mapped_symbol", "unmapped_symbol", "class_suffix"],
+)
 @pytest.mark.asyncio
-async def test_query_uses_ticker_lookup_for_newtab_source_with_non_empty_query(
+async def test_query_newtab_resolves_symbols_directly(
     backend_mock: Any,
     provider: Provider,
     statsd_mock: Any,
     ticker_summary: TickerSummary,
     ticker_snapshot: TickerSnapshot,
     geolocation: Location,
+    query: str,
+    expected_tickers: list[str],
 ) -> None:
-    """Test that query uses get_tickers_for_query when source is newtab but query is non-empty."""
+    """Test that a non-empty newtab query is resolved as one ticker symbol with one
+    backend lookup, bypassing the curated mappings.
+    """
     backend_mock.get_snapshots.return_value = [ticker_snapshot]
     backend_mock.get_ticker_summary.return_value = ticker_summary
 
     suggestions: list[BaseSuggestion] = await provider.query(
-        SuggestionRequest(query="ddog", geolocation=geolocation, source="newtab")
+        SuggestionRequest(query=query, geolocation=geolocation, source="newtab")
     )
 
-    backend_mock.get_snapshots.assert_awaited_once_with(["DDOG"])
+    backend_mock.get_snapshots.assert_awaited_once_with(expected_tickers)
     assert len(suggestions) == 1
-
-    # Verify source=newtab is tracked on individual ticker lookups from newtab.
     statsd_mock.timeit.assert_called_once_with(
         "polygon.provider.query.latency", tags={"source": "newtab"}
     )
+
+
+@pytest.mark.parametrize("query", ["apple stock", "definitely not a ticker", "AAPL,KLAR"])
+@pytest.mark.asyncio
+async def test_query_newtab_non_symbol_query_returns_no_suggestion(
+    backend_mock: Any,
+    provider: Provider,
+    geolocation: Location,
+    query: str,
+) -> None:
+    """Test that newtab quote lookups accept one symbol only: keyword phrases, free
+    text and symbol lists resolve to nothing without a backend call.
+    """
+    suggestions: list[BaseSuggestion] = await provider.query(
+        SuggestionRequest(query=query, geolocation=geolocation, source="newtab")
+    )
+
+    assert suggestions == []
+    backend_mock.get_snapshots.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_query_urlbar_unmapped_ticker_returns_no_suggestion(
+    backend_mock: Any,
+    provider: Provider,
+    geolocation: Location,
+) -> None:
+    """Test that urlbar queries stay gated on the curated mappings."""
+    suggestions: list[BaseSuggestion] = await provider.query(
+        SuggestionRequest(query="KLAR", geolocation=geolocation, source="urlbar")
+    )
+
+    assert suggestions == []
+    backend_mock.get_snapshots.assert_not_awaited()
 
 
 # TODO add test for when backend.get_snapshots returns []


### PR DESCRIPTION
## References

JIRA: [DISCO-4471](https://mozilla-hub.atlassian.net/browse/DISCO-4471)

## Description
* For the stock widget, we want to bypass the hand coded mappings files for stock data, and query the Massive API directly. 
* We also want to use the existing Redis cache. 
* We have to request and fetch each stock individually, and are legally not allowed to bulk fetch either from Merino or from Massive.

### For easier review

I split up the PR into 6 commits, trying to logically group changes so it's easier to review:
https://github.com/mozilla-services/merino-py/pull/1766/commits

### New queries:

Fetch the price for a ticker symbol (forwarded to the Massive API with `source=newtab`)
```bash
/api/v1/suggest?q=AAPL&providers=polygon&source=newtab 
```

Query possible stock tickers (for search)
```bash
/api/v1/suggest?q=apple&providers=polygon&source=newtab&request_type=ticker_search
```

### Test locally

You can test this locally by running `make dev` in the root folder (make sure to add the Massive API key in the config). 

In a new tab in the terminal, send these queries:

#### Search for Apple stock

```bash
curl -s "http://localhost:8000/api/v1/suggest?q=apple&providers=polygon&source=newtab&request_type=ticker_search" | jq .
```

#### Get the AAPL stock price
```bash
curl -s "http://localhost:8000/api/v1/suggest?q=AAPL&providers=polygon&source=newtab" | jq .
```



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [x] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [x] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/apps/merino/metrics.yaml) has been updated (if applicable)
- [x] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2567)


[DISCO-4471]: https://mozilla-hub.atlassian.net/browse/DISCO-4471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ