### PR TITLE
HNT-3150 fix: add better cache control directives to particle GCS files

### DIFF
--- a/apps/merino/merino/configs/default.toml
+++ b/apps/merino/merino/configs/default.toml
@@ -1323,6 +1323,11 @@ enabled = false
 # The amount of time in seconds for the max-age Cache-control header.
 cache_ttl = 86400 # one day
 
+# MERINO_GAMES_PROVIDERS__PARTICLE__CACHE_CONTROL_HTML
+# HTML file needs a specific cache value set. All other particle files have
+# cache_control dictated by the remote provider's manifest.
+cache_control_html = "public, max-age=3600"
+
 # MERINO_GAMES_PROVIDERS__PARTICLE__GAME_URL
 # The URL pointing to the game hosted in GCP (GCS)
 game_url = "https://prod-games-particle.merino.prod.webservices.mozgcp.net/index.html"

--- a/apps/merino/merino/providers/games/particle/backends/filemanager.py
+++ b/apps/merino/merino/providers/games/particle/backends/filemanager.py
@@ -97,7 +97,9 @@ class ParticleRemoteFileManager:
         # return json, or None if the blob wasn't found in GCS (cold start)
         return manifest
 
-    async def upload_file(self, file_name: str, file_path: str, content_type: str) -> str:
+    async def upload_file(
+        self, file_name: str, file_path: str, content_type: str, cache_control: str
+    ) -> str:
         """Attempt to upload a file from the local filesystem to GCS. Overwrites an existing file."""
         blob_name = ""
 
@@ -109,6 +111,7 @@ class ParticleRemoteFileManager:
                 destination_name=f"{self.green_deployment_folder}/{file_name}",
                 content_type=content_type,
                 forced_upload=True,  # force an overwrite if necessary
+                cache_control=cache_control,
             )
 
             if blob:

--- a/apps/merino/merino/providers/games/particle/backends/particle.py
+++ b/apps/merino/merino/providers/games/particle/backends/particle.py
@@ -191,9 +191,10 @@ class ParticleBackend:
                 # assets/style-SOMEHASH.css, so directory information is
                 # retained in GCS.
                 file.gcs_staging_name = await self.remote_file_manager.upload_file(
+                    cache_control=file.cache_control,
+                    content_type=file.content_type,
                     file_name=file.remote_path,
                     file_path=file.local_path,
-                    content_type=file.content_type,
                 )
 
                 if file.gcs_staging_name:

--- a/apps/merino/merino/providers/games/particle/backends/utils.py
+++ b/apps/merino/merino/providers/games/particle/backends/utils.py
@@ -10,6 +10,7 @@ from enum import StrEnum
 from jsonschema import exceptions, validate
 from pydantic import Json
 
+from merino.configs import settings
 from merino.providers.games.particle.backends.errors import (
     ParticleManifestValidationError,
     ParticleRemoteFileProcessError,
@@ -17,6 +18,8 @@ from merino.providers.games.particle.backends.errors import (
 
 
 logger = logging.getLogger(__name__)
+
+cache_control_html = settings.games_providers.particle.cache_control_html
 
 
 class RemoteChannelEnum(StrEnum):
@@ -33,6 +36,8 @@ class GameFile:
 
     # the name of the file, e.g. style.css - pulled from remote_url
     name: str
+    # per-file cache settings specified by particle
+    cache_control: str
     # the content-type of the file
     content_type: str
     # the name of the file when staged in GCS
@@ -51,10 +56,14 @@ class GameFile:
     # set to True only after verifying SHA from downloaded file matches sha_target
     sha_verified: bool = False
 
-    def __init__(self, url: str, sha: str, content_type: str):
+    def __init__(self, cache_control: str, content_type: str, sha: str, url: str):
         """Initialize the instance by splitting up the remote file path into
         path and file name
         """
+        # until we implement manifest polling in the API pods (which will allow
+        # us to use the particle provided hashed HTML file name), we need to
+        # customize caching for the staticly named "index.html" file.
+        self.cache_control = cache_control_html if url.lower().endswith(".html") else cache_control
         self.content_type = content_type
         self.remote_path = url
         self.sha_target = sha
@@ -134,7 +143,12 @@ def get_files_from_manifest_for_channel(
 
     for file in files:
         game_files.append(
-            GameFile(url=file["url"], sha=file["sha256"], content_type=file["contentType"])
+            GameFile(
+                cache_control=file["cacheControl"],
+                url=file["url"],
+                sha=file["sha256"],
+                content_type=file["contentType"],
+            )
         )
 
     return game_files

--- a/apps/merino/tests/integration/providers/games/particle/test_filemanager.py
+++ b/apps/merino/tests/integration/providers/games/particle/test_filemanager.py
@@ -67,6 +67,7 @@ class TestRemoteFileManagerUploadFile:
             file_name="images/image.jpg",
             file_path="apps/merino/tests/data/games/particle/image.jpg",
             content_type="image/jpeg",
+            cache_control="public",
         )
 
         assert blob_name == f"{GREEN_DEPLOYMENT_FOLDER}/images/image.jpg"
@@ -83,6 +84,7 @@ class TestRemoteFileManagerUploadFile:
                 file_name="images/image.jpg",
                 file_path="/apps/merino/tests/data/games/image.jpg",
                 content_type="image/jpeg",
+                cache_control="public",
             )
 
             assert blob_name == ""

--- a/apps/merino/tests/unit/providers/games/particle/backends/test_filemanager.py
+++ b/apps/merino/tests/unit/providers/games/particle/backends/test_filemanager.py
@@ -210,11 +210,29 @@ class TestRemoteFileManagerEmptyStagingFolder:
         """Verify the call succeeds."""
         # simulate a partially staged fileset
         files: list[GameFile] = [
-            GameFile(url="https://test.com/test.html", sha="1234abcd", content_type="text/html"),
-            GameFile(url="https://test.com/test.jpg", sha="1234abcd", content_type="image/jpeg"),
-            GameFile(url="https://test.com/test.png", sha="1234abcd", content_type="image/png"),
             GameFile(
-                url="https://test.com/test.json", sha="1234abcd", content_type="application/json"
+                url="https://test.com/test.html",
+                sha="1234abcd",
+                content_type="text/html",
+                cache_control="public",
+            ),
+            GameFile(
+                url="https://test.com/test.jpg",
+                sha="1234abcd",
+                content_type="image/jpeg",
+                cache_control="public",
+            ),
+            GameFile(
+                url="https://test.com/test.png",
+                sha="1234abcd",
+                content_type="image/png",
+                cache_control="public",
+            ),
+            GameFile(
+                url="https://test.com/test.json",
+                sha="1234abcd",
+                content_type="application/json",
+                cache_control="public",
             ),
         ]
 
@@ -236,11 +254,29 @@ class TestRemoteFileManagerEmptyStagingFolder:
         """Verify the call succeeds and filters files correctly."""
         # simulate a partially staged fileset
         files: list[GameFile] = [
-            GameFile(url="https://test.com/test.html", sha="1234abcd", content_type="text/html"),
-            GameFile(url="https://test.com/test.jpg", sha="1234abcd", content_type="image/jpeg"),
-            GameFile(url="https://test.com/test.png", sha="1234abcd", content_type="image/png"),
             GameFile(
-                url="https://test.com/test.json", sha="1234abcd", content_type="application/json"
+                url="https://test.com/test.html",
+                sha="1234abcd",
+                content_type="text/html",
+                cache_control="public",
+            ),
+            GameFile(
+                url="https://test.com/test.jpg",
+                sha="1234abcd",
+                content_type="image/jpeg",
+                cache_control="public",
+            ),
+            GameFile(
+                url="https://test.com/test.png",
+                sha="1234abcd",
+                content_type="image/png",
+                cache_control="public",
+            ),
+            GameFile(
+                url="https://test.com/test.json",
+                sha="1234abcd",
+                content_type="application/json",
+                cache_control="public",
             ),
         ]
 
@@ -269,11 +305,29 @@ class TestRemoteFileManagerEmptyStagingFolder:
         """Verify sentry is called when the GCS client captures an exception."""
         # simulate a partially staged fileset
         files: list[GameFile] = [
-            GameFile(url="https://test.com/test.html", sha="1234abcd", content_type="text/html"),
-            GameFile(url="https://test.com/test.jpg", sha="1234abcd", content_type="image/jpeg"),
-            GameFile(url="https://test.com/test.png", sha="1234abcd", content_type="image/png"),
             GameFile(
-                url="https://test.com/test.json", sha="1234abcd", content_type="application/json"
+                url="https://test.com/test.html",
+                sha="1234abcd",
+                content_type="text/html",
+                cache_control="public",
+            ),
+            GameFile(
+                url="https://test.com/test.jpg",
+                sha="1234abcd",
+                content_type="image/jpeg",
+                cache_control="public",
+            ),
+            GameFile(
+                url="https://test.com/test.png",
+                sha="1234abcd",
+                content_type="image/png",
+                cache_control="public",
+            ),
+            GameFile(
+                url="https://test.com/test.json",
+                sha="1234abcd",
+                content_type="application/json",
+                cache_control="public",
             ),
         ]
 
@@ -313,10 +367,30 @@ class TestRemoteFileManagerDeployStagedFiles:
         """Test success scenario."""
         # simulate a staged fileset
         files: list[GameFile] = [
-            GameFile(url="runtime/test.html", sha="1234abcd", content_type="text/html"),
-            GameFile(url="assets/test.jpg", sha="1234abcd", content_type="image/jpeg"),
-            GameFile(url="assets/test.png", sha="1234abcd", content_type="image/png"),
-            GameFile(url="generated/test.json", sha="1234abcd", content_type="application/json"),
+            GameFile(
+                url="runtime/test.html",
+                sha="1234abcd",
+                content_type="text/html",
+                cache_control="public",
+            ),
+            GameFile(
+                url="assets/test.jpg",
+                sha="1234abcd",
+                content_type="image/jpeg",
+                cache_control="public",
+            ),
+            GameFile(
+                url="assets/test.png",
+                sha="1234abcd",
+                content_type="image/png",
+                cache_control="public",
+            ),
+            GameFile(
+                url="generated/test.json",
+                sha="1234abcd",
+                content_type="application/json",
+                cache_control="public",
+            ),
         ]
 
         # finish simulating a staged fileset
@@ -350,10 +424,30 @@ class TestRemoteFileManagerDeployStagedFiles:
         """Verify sentry is called when the GCS client captures an exception."""
         # simulate a staged fileset
         files: list[GameFile] = [
-            GameFile(url="runtime/test.html", sha="1234abcd", content_type="text/html"),
-            GameFile(url="assets/test.jpg", sha="1234abcd", content_type="image/jpeg"),
-            GameFile(url="assets/test.png", sha="1234abcd", content_type="image/png"),
-            GameFile(url="generated/test.json", sha="1234abcd", content_type="application/json"),
+            GameFile(
+                url="runtime/test.html",
+                sha="1234abcd",
+                content_type="text/html",
+                cache_control="public",
+            ),
+            GameFile(
+                url="assets/test.jpg",
+                sha="1234abcd",
+                content_type="image/jpeg",
+                cache_control="public",
+            ),
+            GameFile(
+                url="assets/test.png",
+                sha="1234abcd",
+                content_type="image/png",
+                cache_control="public",
+            ),
+            GameFile(
+                url="generated/test.json",
+                sha="1234abcd",
+                content_type="application/json",
+                cache_control="public",
+            ),
         ]
 
         # finish simulating a staged fileset

--- a/apps/merino/tests/unit/providers/games/particle/backends/test_particle_backend.py
+++ b/apps/merino/tests/unit/providers/games/particle/backends/test_particle_backend.py
@@ -135,8 +135,18 @@ def mock_cleanup_old_files_for_channel(backend):
 def mock_successfully_updated_game_files() -> list[GameFile]:
     """Mock files that have been successfully verified and uploaded."""
     files = [
-        GameFile(url="/path/to/file.jpg", sha="1234abcd", content_type="image/jpeg"),
-        GameFile(url="/path/to/style.css", sha="5678abcd", content_type="text/css; charset=utf-8"),
+        GameFile(
+            url="/path/to/file.jpg",
+            sha="1234abcd",
+            content_type="image/jpeg",
+            cache_control="public",
+        ),
+        GameFile(
+            url="/path/to/style.css",
+            sha="5678abcd",
+            content_type="text/css; charset=utf-8",
+            cache_control="public",
+        ),
     ]
 
     for f in files:
@@ -286,9 +296,17 @@ class TestUpdateChannelFiles:
     def setup_method(self):
         """Reset the list of GameFiles before each test."""
         self.mock_game_files = [
-            GameFile(url="path/to/file.jpg", sha="1234abcd", content_type="image/jpeg"),
             GameFile(
-                url="path/to/style.css", sha="5678abcd", content_type="text/css; charset=utf-8"
+                url="path/to/file.jpg",
+                sha="1234abcd",
+                content_type="image/jpeg",
+                cache_control="public",
+            ),
+            GameFile(
+                url="path/to/style.css",
+                sha="5678abcd",
+                content_type="text/css; charset=utf-8",
+                cache_control="public",
             ),
         ]
 
@@ -495,9 +513,17 @@ class TestStageChannelFiles:
     def setup_method(self):
         """Reset the list of GameFiles before each test."""
         self.mock_game_files = [
-            GameFile(url="path/to/file.jpg", sha="1234abcd", content_type="image/jpeg"),
             GameFile(
-                url="path/to/style.css", sha="5678abcd", content_type="text/css; charset=utf-8"
+                url="path/to/file.jpg",
+                sha="1234abcd",
+                content_type="image/jpeg",
+                cache_control="public",
+            ),
+            GameFile(
+                url="path/to/style.css",
+                sha="5678abcd",
+                content_type="text/css; charset=utf-8",
+                cache_control="public",
             ),
         ]
 
@@ -805,6 +831,7 @@ class TestStageChannelFiles:
                 url="path/to/file.jpg",
                 sha=self.MOCK_PARTICLE_GAME_FILE_SHA,
                 content_type="image/jpeg",
+                cache_control="public",
             ),
         ]
 
@@ -833,9 +860,17 @@ class TestDeployChannelFiles:
     def setup_method(self):
         """Reset the list of GameFiles before each test."""
         self.mock_game_files = [
-            GameFile(url="/path/to/file.jpg", sha="1234abcd", content_type="image/jpeg"),
             GameFile(
-                url="/path/to/style.css", sha="5678abcd", content_type="text/css; charset=utf-8"
+                url="/path/to/file.jpg",
+                sha="1234abcd",
+                content_type="image/jpeg",
+                cache_control="public",
+            ),
+            GameFile(
+                url="/path/to/style.css",
+                sha="5678abcd",
+                content_type="text/css; charset=utf-8",
+                cache_control="public",
             ),
         ]
 

--- a/apps/merino/tests/unit/providers/games/particle/backends/test_utils.py
+++ b/apps/merino/tests/unit/providers/games/particle/backends/test_utils.py
@@ -27,6 +27,7 @@ from merino.providers.games.particle.backends.utils import (
 )
 
 _manifest_schema_version = settings.games_providers.particle.manifest_schema_version
+_html_cache_control = settings.games_providers.particle.cache_control_html
 
 
 # BEGIN FIXTURES
@@ -253,13 +254,26 @@ class TestGameFile:
         url = "/path/to/a/remote/file.jpg"
         sha = "1234IDeclareASHAWar"
         content_type = "image/jpeg"
-        gf = GameFile(url=url, sha=sha, content_type=content_type)
+        cache_control = "public,max-age=31536000,immutable"
+        gf = GameFile(url=url, sha=sha, content_type=content_type, cache_control=cache_control)
 
         assert gf.sha_target == sha
         assert gf.remote_path == "/path/to/a/remote/file.jpg"
         assert gf.name == "file.jpg"
         assert gf.content_type == content_type
+        assert gf.cache_control == cache_control
         assert not gf.sha_verified
+
+    def test_initialzation_html_file_cache_control(self):
+        """Test that initializing a GameFile object customizes cache_control for the HTML file."""
+        url = "/path/to/a/remote/widget-123456.html"
+        sha = "1234IDeclareASHAWar"
+        content_type = "text/html"
+        cache_control = "public,max-age=31536000,immutable"
+        gf = GameFile(url=url, sha=sha, content_type=content_type, cache_control=cache_control)
+
+        assert gf.cache_control != cache_control
+        assert gf.cache_control == _html_cache_control
 
 
 class TestGetFilesForCleanupForChannel:
@@ -305,18 +319,42 @@ class TestGetFilesForCleanupForChannel:
         ) as mock_get_files:
             # the newly deployed files
             green_files = [
-                GameFile(url="assets/a.jpg", sha="123", content_type="image/jpeg"),
-                GameFile(url="assets/a.png", sha="123", content_type="image/png"),
-                GameFile(url="runtime/index-1234.html", sha="123", content_type="text/html"),
+                GameFile(
+                    url="assets/a.jpg",
+                    sha="123",
+                    content_type="image/jpeg",
+                    cache_control="public",
+                ),
+                GameFile(
+                    url="assets/a.png", sha="123", content_type="image/png", cache_control="public"
+                ),
+                GameFile(
+                    url="runtime/index-1234.html",
+                    sha="123",
+                    content_type="text/html",
+                    cache_control="public",
+                ),
             ]
 
             # the previously deployed files - two are different from green:
             # - assets/b.jpg
             # - runtime/index-5678.html
             blue_files = [
-                GameFile(url="assets/b.jpg", sha="123", content_type="image/jpeg"),
-                GameFile(url="assets/a.png", sha="123", content_type="image/png"),
-                GameFile(url="runtime/index-5678.html", sha="123", content_type="text/html"),
+                GameFile(
+                    url="assets/b.jpg",
+                    sha="123",
+                    content_type="image/jpeg",
+                    cache_control="public",
+                ),
+                GameFile(
+                    url="assets/a.png", sha="123", content_type="image/png", cache_control="public"
+                ),
+                GameFile(
+                    url="runtime/index-5678.html",
+                    sha="123",
+                    content_type="text/html",
+                    cache_control="public",
+                ),
             ]
 
             mock_get_files.side_effect = [green_files, blue_files]
@@ -341,9 +379,21 @@ class TestGetFilesForCleanupForChannel:
         ) as mock_get_files:
             # the newly deployed files
             green_files = [
-                GameFile(url="assets/a.jpg", sha="123", content_type="image/jpeg"),
-                GameFile(url="assets/a.png", sha="123", content_type="image/png"),
-                GameFile(url="runtime/index-1234.html", sha="123", content_type="text/html"),
+                GameFile(
+                    url="assets/a.jpg",
+                    sha="123",
+                    content_type="image/jpeg",
+                    cache_control="public",
+                ),
+                GameFile(
+                    url="assets/a.png", sha="123", content_type="image/png", cache_control="public"
+                ),
+                GameFile(
+                    url="runtime/index-1234.html",
+                    sha="123",
+                    content_type="text/html",
+                    cache_control="public",
+                ),
             ]
 
             mock_get_files.side_effect = [green_files]


### PR DESCRIPTION
## References

JIRA: [HNT-3150](https://mozilla-hub.atlassian.net/browse/DISCO-TODO)

## Description

use cache control settings provided by the particle manifest. this should reduce our cache miss significantly, reducing GCP costs and improving response times.

note that the `index.html` file needs to retain the default cache control of `public, max-age=3600`.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [ ] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/apps/merino/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2570)


[HNT-3150]: https://mozilla-hub.atlassian.net/browse/HNT-3150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ