### PR TITLE
[HNT-3068] Add previous POTD in response json

### DIFF
--- a/apps/merino/merino/providers/rss/wikimedia_potd/backends/protocol.py
+++ b/apps/merino/merino/providers/rss/wikimedia_potd/backends/protocol.py
@@ -10,8 +10,8 @@ class WikimediaPotdError(BackendError):
     """Error raised by the Wikimedia POTD backend when the picture of the day cannot be produced."""
 
 
-class PictureOfTheDay(BaseModel):
-    """Model for the Wikimedia Picture of the Day."""
+class PictureOfTheDayBase(BaseModel):
+    """Model for a single day's Wikimedia Picture of the Day."""
 
     title: str = Field(description="Title of the picture of the day.")
     thumbnail_image_url: HttpUrl = Field(
@@ -36,6 +36,17 @@ class PictureOfTheDay(BaseModel):
     file_page: HttpUrl | None = Field(default=None, description="Commons file page URL.")
     license_label: str = Field(default="", description="License type, e.g. 'CC BY-SA 4.0'.")
     license_link: HttpUrl | None = Field(default=None, description="License URL.")
+
+
+class PictureOfTheDay(PictureOfTheDayBase):
+    """The picture of the day served to clients, with the previous day's picture attached."""
+
+    previous: PictureOfTheDayBase | None = Field(
+        default=None,
+        description=(
+            "The previous day's picture of the day, or null when that day has no manifest."
+        ),
+    )
 
 
 class WikimediaPictureOfTheDayBackend(Protocol):
@@ -105,8 +116,10 @@ class WikimediaPictureOfTheDayBackend(Protocol):
         """
         ...
 
-    def fetch_potd_from_gcs_bucket(self) -> PictureOfTheDay | None:  # pragma: no cover
-        """Fetch the PictureOfTheDay object from the gcs bucket.
+    def fetch_potd_from_gcs_bucket(
+        self, date_str: str | None = None
+    ) -> PictureOfTheDay | None:  # pragma: no cover
+        """Fetch the PictureOfTheDay object for `date_str` (defaults to today) from the gcs bucket.
 
         Returns:
             A PictureOfTheDay object if available, otherwise None.

--- a/apps/merino/merino/providers/rss/wikimedia_potd/backends/utils.py
+++ b/apps/merino/merino/providers/rss/wikimedia_potd/backends/utils.py
@@ -100,19 +100,18 @@ def previous_day(date_str: str) -> str:
 
 
 def as_previous_entry(potd: PictureOfTheDay | None) -> PictureOfTheDayBase | None:
-    """Convert yesterday's manifest into the entry attached under today's `previous`.
+    """Prepare the previous day's manifest for embedding under today's `previous`.
 
-    Yesterday's manifest carries its own `previous` from the day it was published. Dropping
-    that field here is what keeps every published manifest exactly one day deep, instead of
-    chaining back through each day the job has run.
+    The entry type has no `previous` field, so that day's own chain back through earlier
+    days drops away and each published manifest stays exactly one day deep.
 
     Returns:
-        The narrowed entry, or None when yesterday has no manifest.
+        The entry to embed, or None when that day published no manifest.
     """
     if potd is None:
         return None
 
-    return PictureOfTheDayBase.model_validate(potd.model_dump(exclude={"previous"}))
+    return PictureOfTheDayBase.model_validate(potd.model_dump())
 
 
 def is_valid_potd_image_url(url: HttpUrl) -> bool:

--- a/apps/merino/merino/providers/rss/wikimedia_potd/backends/utils.py
+++ b/apps/merino/merino/providers/rss/wikimedia_potd/backends/utils.py
@@ -1,11 +1,12 @@
 """Utility functions for parsing Wikimedia Featured API picture of the day data."""
 
 import re
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pydantic import HttpUrl
 
 from merino.providers.rss.wikimedia_potd.backends.protocol import (
     PictureOfTheDay,
+    PictureOfTheDayBase,
     WikimediaPotdError,
 )
 
@@ -83,11 +84,35 @@ def parse_discovered_languages(commons_data: dict) -> set[str]:
     return discovered_languages
 
 
-def build_potd_bucket_directory_path() -> str:
-    """Build the dated gcs bucket directory path where today's potd assets are stored."""
+def build_potd_bucket_directory_path(date_str: str | None = None) -> str:
+    """Build the dated gcs bucket directory path where a day's potd assets are stored.
+
+    `date_str` is a YYYY-MM-DD date and defaults to today (UTC).
+    """
     # YYYY-MM-DD format
-    date_time = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    date_time = date_str or datetime.now(timezone.utc).strftime("%Y-%m-%d")
     return f"wikimedia_potd/{date_time}/"
+
+
+def previous_day(date_str: str) -> str:
+    """Return the calendar day before `date_str`, both in YYYY-MM-DD format."""
+    return (datetime.strptime(date_str, "%Y-%m-%d") - timedelta(days=1)).strftime("%Y-%m-%d")
+
+
+def as_previous_entry(potd: PictureOfTheDay | None) -> PictureOfTheDayBase | None:
+    """Convert yesterday's manifest into the entry attached under today's `previous`.
+
+    Yesterday's manifest carries its own `previous` from the day it was published. Dropping
+    that field here is what keeps every published manifest exactly one day deep, instead of
+    chaining back through each day the job has run.
+
+    Returns:
+        The narrowed entry, or None when yesterday has no manifest.
+    """
+    if potd is None:
+        return None
+
+    return PictureOfTheDayBase.model_validate(potd.model_dump(exclude={"previous"}))
 
 
 def is_valid_potd_image_url(url: HttpUrl) -> bool:

--- a/apps/merino/merino/providers/rss/wikimedia_potd/backends/wikimedia_potd.py
+++ b/apps/merino/merino/providers/rss/wikimedia_potd/backends/wikimedia_potd.py
@@ -23,7 +23,9 @@ from merino.utils.gcs.models import Image
 from merino.utils.wikipedia import WIKIMEDIA_REQUEST_HEADERS
 from merino.providers.rss.wikimedia_potd.backends.image_processing import process_potd_image
 from merino.providers.rss.wikimedia_potd.backends.utils import (
+    as_previous_entry,
     parse_potd,
+    previous_day,
     extract_image_description_with_lang_code,
     parse_discovered_languages,
     build_potd_bucket_directory_path,
@@ -88,11 +90,17 @@ class WikimediaPictureOfTheDayBackend:
             # download thumbnail and high resolution images and get the respective cdn urls
             thumbnail_url, hi_res_url = await self.download_and_upload_potd_images(potd)
 
+            # attach yesterday's manifest so clients get the previous picture in the same
+            # response. A day whose job never published has no manifest, which the fetch
+            # reports as None, leaving `previous` null rather than failing today's upload.
+            previous_potd = self.fetch_potd_from_gcs_bucket(previous_day(today))
+
             potd_to_upload = potd.model_copy(
                 update={
                     "thumbnail_image_url": thumbnail_url,
                     "high_res_image_url": hi_res_url,
                     "localized_descriptions": localized_descriptions,
+                    "previous": as_previous_entry(previous_potd),
                 }
             )
 
@@ -321,15 +329,15 @@ class WikimediaPictureOfTheDayBackend:
         if self.gcs_uploader.get_file_by_name(destination_name) is None:
             raise WikimediaPotdError(f"Failed to upload POTD manifest: {destination_name}")
 
-    def fetch_potd_from_gcs_bucket(self) -> PictureOfTheDay | None:
-        """Fetch the PictureOfTheDay object from the gcs bucket.
+    def fetch_potd_from_gcs_bucket(self, date_str: str | None = None) -> PictureOfTheDay | None:
+        """Fetch the PictureOfTheDay object for `date_str` (defaults to today) from the gcs bucket.
 
         Returns:
             A PictureOfTheDay object if available, otherwise None.
         """
         try:
             blob = self.gcs_uploader.get_file_by_name(
-                f"{build_potd_bucket_directory_path()}potd.json"
+                f"{build_potd_bucket_directory_path(date_str)}potd.json"
             )
 
             if blob:

--- a/apps/merino/merino/providers/rss/wikimedia_potd/provider.py
+++ b/apps/merino/merino/providers/rss/wikimedia_potd/provider.py
@@ -10,6 +10,7 @@ from pydantic import HttpUrl
 from merino.providers.rss.base import BaseRssProvider
 from merino.providers.rss.wikimedia_potd.backends.protocol import (
     PictureOfTheDay,
+    PictureOfTheDayBase,
     WikimediaPictureOfTheDayBackend,
 )
 
@@ -69,7 +70,7 @@ class WikimediaPictureOfTheDayProvider(BaseRssProvider):
 
     @staticmethod
     def _select_description(
-        potd: PictureOfTheDay, accepted_languages: list[str] | None
+        potd: PictureOfTheDayBase, accepted_languages: list[str] | None
     ) -> str | None:
         """Return the best localized description for `accepted_languages`, or None.
 
@@ -100,6 +101,7 @@ class WikimediaPictureOfTheDayProvider(BaseRssProvider):
         potd isn't available yet we serve the previous day's cached potd rather than
         nothing. When `accepted_languages` matches a localized description, the returned
         potd's `description` is swapped for it; otherwise the default description is kept.
+        The picture attached under `previous` is localized the same way.
         """
         if not self._is_todays_potd(self.potd):
             await self._refresh_potd()
@@ -108,12 +110,19 @@ class WikimediaPictureOfTheDayProvider(BaseRssProvider):
             self.metrics_client.increment("potd.provider.cached.none")
             return None
 
-        localized = self._select_description(self.potd, accepted_languages)
+        potd = self.potd
 
+        localized = self._select_description(potd, accepted_languages)
         if localized is not None:
-            return self.potd.model_copy(update={"description": localized})
+            potd = potd.model_copy(update={"description": localized})
 
-        return self.potd
+        if potd.previous is not None:
+            localized_previous = self._select_description(potd.previous, accepted_languages)
+            if localized_previous is not None:
+                previous = potd.previous.model_copy(update={"description": localized_previous})
+                potd = potd.model_copy(update={"previous": previous})
+
+        return potd
 
     async def upload_picture_of_the_day(self) -> bool:
         """Execute the upload flow. This method is called by the job cli command only."""

--- a/apps/merino/merino/web/api_v1.py
+++ b/apps/merino/merino/web/api_v1.py
@@ -691,8 +691,15 @@ async def get_picture_of_the_day(
     # localized_descriptions is a server-side selection map used to swap `description` into
     # the client's language; it is not part of the client-facing contract, so exclude it here
     # (but keep it on the model and in the GCS manifest, which localization reads back from).
+    # The nested previous day's picture carries the same map and is excluded the same way.
     return JSONResponse(
-        content=jsonable_encoder(potd, exclude={"localized_descriptions"}),
+        content=jsonable_encoder(
+            potd,
+            exclude={
+                "localized_descriptions": True,
+                "previous": {"localized_descriptions": True},
+            },
+        ),
     )
 
 

--- a/apps/merino/tests/integration/api/v1/rss/__init__.py
+++ b/apps/merino/tests/integration/api/v1/rss/__init__.py
@@ -1,0 +1,5 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Integration tests for RSS API endpoints."""

--- a/apps/merino/tests/integration/api/v1/rss/conftest.py
+++ b/apps/merino/tests/integration/api/v1/rss/conftest.py
@@ -1,0 +1,81 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Test configurations for the rss API endpoint tests."""
+
+from typing import Any
+
+import pytest
+from pytest_mock import MockerFixture
+from pydantic import HttpUrl
+
+from merino.main import app
+from merino.providers.rss import get_wikimedia_potd_provider
+from merino.providers.rss.wikimedia_potd.backends.protocol import (
+    PictureOfTheDay,
+    PictureOfTheDayBase,
+    WikimediaPictureOfTheDayBackend,
+)
+from merino.providers.rss.wikimedia_potd.provider import WikimediaPictureOfTheDayProvider
+
+
+@pytest.fixture(name="backend_mock")
+def fixture_backend_mock(mocker: MockerFixture) -> Any:
+    """Create a WikimediaPictureOfTheDayBackend mock object for test."""
+    return mocker.AsyncMock(spec=WikimediaPictureOfTheDayBackend)
+
+
+@pytest.fixture(name="potd_provider")
+def fixture_potd_provider(backend_mock: Any, statsd_mock: Any) -> WikimediaPictureOfTheDayProvider:
+    """Create a picture of the day provider with a mocked backend."""
+    return WikimediaPictureOfTheDayProvider(
+        backend=backend_mock,
+        metrics_client=statsd_mock,
+        name="wikimedia_potd",
+        query_timeout_sec=1.0,
+        enabled_by_default=True,
+    )
+
+
+@pytest.fixture(name="potd")
+def fixture_potd() -> PictureOfTheDay:
+    """Return a picture of the day carrying the previous day, both localized into German."""
+    return PictureOfTheDay(
+        title="Wikimedia Commons Picture of the Day for June 7",
+        published_date="2026-06-07",
+        thumbnail_image_url=HttpUrl("https://test-cdn/wikimedia_potd/2026-06-07/thumbnail.png"),
+        high_res_image_url=HttpUrl("https://test-cdn/wikimedia_potd/2026-06-07/hi_res.webp"),
+        description="Today's description.",
+        localized_descriptions={"de": "Heutiger deutscher Text"},
+        author="Test Artist",
+        file_page=HttpUrl("https://commons.wikimedia.org/wiki/File:Today.jpg"),
+        license_label="CC BY-SA 4.0",
+        license_link=HttpUrl("https://creativecommons.org/licenses/by-sa/4.0"),
+        previous=PictureOfTheDayBase(
+            title="Wikimedia Commons Picture of the Day for June 6",
+            published_date="2026-06-06",
+            thumbnail_image_url=HttpUrl(
+                "https://test-cdn/wikimedia_potd/2026-06-06/thumbnail.png"
+            ),
+            high_res_image_url=HttpUrl("https://test-cdn/wikimedia_potd/2026-06-06/hi_res.webp"),
+            description="Yesterday's description.",
+            localized_descriptions={"de": "Gestriger deutscher Text"},
+            author="Previous Artist",
+            file_page=HttpUrl("https://commons.wikimedia.org/wiki/File:Yesterday.jpg"),
+            license_label="CC BY-SA 4.0",
+            license_link=HttpUrl("https://creativecommons.org/licenses/by-sa/4.0"),
+        ),
+    )
+
+
+@pytest.fixture(name="inject_potd_provider", autouse=True)
+def fixture_inject_potd_provider(potd_provider: WikimediaPictureOfTheDayProvider):
+    """Inject the picture of the day provider into the app for testing."""
+
+    def get_test_potd_provider() -> WikimediaPictureOfTheDayProvider:
+        return potd_provider
+
+    app.dependency_overrides[get_wikimedia_potd_provider] = get_test_potd_provider
+    yield
+    del app.dependency_overrides[get_wikimedia_potd_provider]

--- a/apps/merino/tests/integration/api/v1/rss/test_picture_of_the_day.py
+++ b/apps/merino/tests/integration/api/v1/rss/test_picture_of_the_day.py
@@ -1,0 +1,122 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Integration tests for the /api/v1/rss/picture-of-the-day endpoint."""
+
+import freezegun
+from fastapi.testclient import TestClient
+
+from merino.providers.rss.wikimedia_potd.backends.protocol import PictureOfTheDay
+from merino.providers.rss.wikimedia_potd.provider import WikimediaPictureOfTheDayProvider
+
+POTD_URL = "/api/v1/rss/picture-of-the-day"
+
+
+@freezegun.freeze_time("2026-06-07")
+def test_picture_of_the_day_returns_the_previous_day_alongside_today(
+    client: TestClient,
+    potd_provider: WikimediaPictureOfTheDayProvider,
+    potd: PictureOfTheDay,
+) -> None:
+    """Serves today's picture with the previous day's picture nested under `previous`."""
+    potd_provider.potd = potd
+
+    response = client.get(POTD_URL)
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "title": "Wikimedia Commons Picture of the Day for June 7",
+        "published_date": "2026-06-07",
+        "thumbnail_image_url": "https://test-cdn/wikimedia_potd/2026-06-07/thumbnail.png",
+        "high_res_image_url": "https://test-cdn/wikimedia_potd/2026-06-07/hi_res.webp",
+        "description": "Today's description.",
+        "author": "Test Artist",
+        "file_page": "https://commons.wikimedia.org/wiki/File:Today.jpg",
+        "license_label": "CC BY-SA 4.0",
+        "license_link": "https://creativecommons.org/licenses/by-sa/4.0",
+        "previous": {
+            "title": "Wikimedia Commons Picture of the Day for June 6",
+            "published_date": "2026-06-06",
+            "thumbnail_image_url": "https://test-cdn/wikimedia_potd/2026-06-06/thumbnail.png",
+            "high_res_image_url": "https://test-cdn/wikimedia_potd/2026-06-06/hi_res.webp",
+            "description": "Yesterday's description.",
+            "author": "Previous Artist",
+            "file_page": "https://commons.wikimedia.org/wiki/File:Yesterday.jpg",
+            "license_label": "CC BY-SA 4.0",
+            "license_link": "https://creativecommons.org/licenses/by-sa/4.0",
+        },
+    }
+
+
+@freezegun.freeze_time("2026-06-07")
+def test_picture_of_the_day_omits_the_localization_map_at_both_levels(
+    client: TestClient,
+    potd_provider: WikimediaPictureOfTheDayProvider,
+    potd: PictureOfTheDay,
+) -> None:
+    """Keeps the server-side localization map out of the response, nested one included."""
+    potd_provider.potd = potd
+
+    body = client.get(POTD_URL).json()
+
+    assert "localized_descriptions" not in body
+    assert "localized_descriptions" not in body["previous"]
+
+
+@freezegun.freeze_time("2026-06-07")
+def test_picture_of_the_day_localizes_both_descriptions_for_accept_language(
+    client: TestClient,
+    potd_provider: WikimediaPictureOfTheDayProvider,
+    potd: PictureOfTheDay,
+) -> None:
+    """Swaps in the client's language for today's description and the previous day's."""
+    potd_provider.potd = potd
+
+    body = client.get(POTD_URL, headers={"Accept-Language": "de-DE,de;q=0.9"}).json()
+
+    assert body["description"] == "Heutiger deutscher Text"
+    assert body["previous"]["description"] == "Gestriger deutscher Text"
+
+
+@freezegun.freeze_time("2026-06-07")
+def test_picture_of_the_day_keeps_default_descriptions_for_an_unmatched_language(
+    client: TestClient,
+    potd_provider: WikimediaPictureOfTheDayProvider,
+    potd: PictureOfTheDay,
+) -> None:
+    """Serves the default descriptions when the client's language has no localization."""
+    potd_provider.potd = potd
+
+    body = client.get(POTD_URL, headers={"Accept-Language": "fr-FR"}).json()
+
+    assert body["description"] == "Today's description."
+    assert body["previous"]["description"] == "Yesterday's description."
+
+
+@freezegun.freeze_time("2026-06-07")
+def test_picture_of_the_day_returns_previous_as_null_when_there_is_no_previous_day(
+    client: TestClient,
+    potd_provider: WikimediaPictureOfTheDayProvider,
+    potd: PictureOfTheDay,
+) -> None:
+    """Always sends the `previous` key, as null, so clients see one response shape."""
+    potd_provider.potd = potd.model_copy(update={"previous": None})
+
+    body = client.get(POTD_URL).json()
+
+    assert body["previous"] is None
+
+
+def test_picture_of_the_day_returns_null_when_nothing_is_cached(
+    client: TestClient,
+    potd_provider: WikimediaPictureOfTheDayProvider,
+    backend_mock,
+) -> None:
+    """Serves a null body when no picture has ever been cached, exclusions notwithstanding."""
+    backend_mock.fetch_potd_from_gcs_bucket.return_value = None
+
+    response = client.get(POTD_URL)
+
+    assert response.status_code == 200
+    assert response.json() is None

--- a/apps/merino/tests/integration/providers/rss/potd/test_wikimedia_potd.py
+++ b/apps/merino/tests/integration/providers/rss/potd/test_wikimedia_potd.py
@@ -47,6 +47,22 @@ def make_png_image(width: int = 40, height: int = 20) -> Image:
     return Image(content=buffer.getvalue(), content_type="image/png")
 
 
+async def upload_potd_for_day(
+    backend: WikimediaPictureOfTheDayBackend, mocker: MockerFixture, day: str
+) -> None:
+    """Run the upload job as if it were `day`, so the bucket gains that day's assets."""
+    client_mock: AsyncMock = cast(AsyncMock, backend.http_client)
+    client_mock.get.return_value = Response(
+        status_code=200,
+        content=TEST_FEATURED_JSON,
+        request=Request(method="GET", url=FEED_URL),
+    )
+    mocker.patch.object(backend, "download_potd_image").return_value = make_png_image()
+
+    with freezegun.freeze_time(day):
+        assert await backend.upload_picture_of_the_day() is True
+
+
 @pytest.fixture(name="backend")
 def fixture_backend(
     statsd_mock, mocker: MockerFixture, gcs_storage_client, gcs_storage_bucket
@@ -313,6 +329,77 @@ class TestUploadPictureOfTheDayMethod:
         sentry_capture.assert_called_once_with(unexpected_error)
 
 
+class TestPreviousDayManifest:
+    """Tests that a published manifest carries the previous day's picture."""
+
+    @pytest.mark.asyncio
+    async def test_manifest_embeds_the_previous_days_manifest(
+        self, backend: WikimediaPictureOfTheDayBackend, mocker: MockerFixture
+    ) -> None:
+        """The second day's manifest carries the first day's picture and its dated image urls."""
+        await upload_potd_for_day(backend, mocker, "2026-06-24")
+
+        with freezegun.freeze_time("2026-06-24"):
+            first_day = backend.fetch_potd_from_gcs_bucket()
+
+        # nothing precedes the first day, so it publishes without a previous picture
+        assert first_day is not None
+        assert first_day.previous is None
+
+        await upload_potd_for_day(backend, mocker, "2026-06-25")
+
+        with freezegun.freeze_time("2026-06-25"):
+            second_day = backend.fetch_potd_from_gcs_bucket()
+
+        assert second_day is not None
+        assert second_day.published_date == "2026-06-25"
+        assert second_day.previous is not None
+        assert second_day.previous.published_date == "2026-06-24"
+        assert second_day.previous.title == "Wikimedia Commons Picture of the Day for June 24"
+        # the embedded picture points at the first day's own immutable image paths
+        assert (
+            str(second_day.previous.thumbnail_image_url)
+            == "https://test-cdn-name/wikimedia_potd/2026-06-24/thumbnail.png"
+        )
+        assert (
+            str(second_day.previous.high_res_image_url)
+            == "https://test-cdn-name/wikimedia_potd/2026-06-24/hi_res.webp"
+        )
+
+    @pytest.mark.asyncio
+    async def test_manifest_never_chains_past_the_previous_day(
+        self, backend: WikimediaPictureOfTheDayBackend, mocker: MockerFixture
+    ) -> None:
+        """Each manifest stays one day deep however many days the job has run."""
+        for day in ("2026-06-24", "2026-06-25", "2026-06-26"):
+            await upload_potd_for_day(backend, mocker, day)
+
+        with freezegun.freeze_time("2026-06-26"):
+            third_day = backend.fetch_potd_from_gcs_bucket()
+
+        assert third_day is not None
+        assert third_day.previous is not None
+        assert third_day.previous.published_date == "2026-06-25"
+        # the second day's own previous is dropped rather than chained through
+        assert "previous" not in third_day.previous.model_dump()
+
+    @pytest.mark.asyncio
+    async def test_previous_is_unset_when_the_day_before_published_nothing(
+        self, backend: WikimediaPictureOfTheDayBackend, mocker: MockerFixture
+    ) -> None:
+        """Only the previous calendar day is looked up, so a skipped day leaves it unset."""
+        await upload_potd_for_day(backend, mocker, "2026-06-24")
+        # the job does not run on the 25th
+        await upload_potd_for_day(backend, mocker, "2026-06-26")
+
+        with freezegun.freeze_time("2026-06-26"):
+            third_day = backend.fetch_potd_from_gcs_bucket()
+
+        assert third_day is not None
+        assert third_day.published_date == "2026-06-26"
+        assert third_day.previous is None
+
+
 class TestFetchPictureOfTheDayMethod:
     """Tests for the fetch_picture_of_the_day method."""
 
@@ -525,6 +612,30 @@ class TestFetchPotdFromGcsBucketMethod:
         actual = backend.fetch_potd_from_gcs_bucket()
 
         assert actual is None
+
+    def test_fetch_potd_from_gcs_bucket_returns_the_given_days_manifest(
+        self, backend: WikimediaPictureOfTheDayBackend
+    ) -> None:
+        """Returns a past day's manifest when an explicit date is given."""
+        expected = PictureOfTheDay(
+            title="Test Potd",
+            description="Test potd description",
+            published_date="2026-06-06",
+            high_res_image_url=HttpUrl("https://www.test-image.com/image.jpeg"),
+            thumbnail_image_url=HttpUrl("https://www.test-image.com/image.jpeg"),
+        )
+
+        with freezegun.freeze_time("2026-06-06"):
+            backend.upload_potd_manifest(potd=expected)
+
+        with freezegun.freeze_time("2026-06-07"):
+            # today published nothing, but the day before is still addressable
+            assert backend.fetch_potd_from_gcs_bucket() is None
+            actual = backend.fetch_potd_from_gcs_bucket("2026-06-06")
+
+        assert actual is not None
+        assert actual.published_date == "2026-06-06"
+        assert actual.title == expected.title
 
     @freezegun.freeze_time("2026-06-07")
     def test_fetch_potd_from_gcs_bucket_returns_none_when_blob_retrieval_returns_an_error(

--- a/apps/merino/tests/unit/providers/rss/wikimedia_potd/backends/test_utils.py
+++ b/apps/merino/tests/unit/providers/rss/wikimedia_potd/backends/test_utils.py
@@ -208,6 +208,7 @@ def test_as_previous_entry_returns_none_when_there_is_no_manifest() -> None:
     """Returns None when yesterday has no manifest, so `previous` serializes as null."""
     assert as_previous_entry(None) is None
 
+
 def test_as_previous_entry_drops_the_days_own_previous() -> None:
     """Drops the fetched day's `previous` so a published manifest is only one day deep."""
     two_days_ago = PictureOfTheDayBase(

--- a/apps/merino/tests/unit/providers/rss/wikimedia_potd/backends/test_utils.py
+++ b/apps/merino/tests/unit/providers/rss/wikimedia_potd/backends/test_utils.py
@@ -10,14 +10,17 @@ from pydantic import HttpUrl
 
 from merino.providers.rss.wikimedia_potd.backends.protocol import (
     PictureOfTheDay,
+    PictureOfTheDayBase,
     WikimediaPotdError,
 )
 from merino.providers.rss.wikimedia_potd.backends.utils import (
+    as_previous_entry,
     is_valid_potd_image_url,
     parse_potd,
     extract_image_description_with_lang_code,
     parse_discovered_languages,
     build_potd_bucket_directory_path,
+    previous_day,
 )
 
 THUMBNAIL_URL = "https://upload.wikimedia.org/wikipedia/commons/thumb/a/ab/Test.jpg/320px-Test.jpg"
@@ -178,6 +181,79 @@ def test_is_valid_potd_image_url(url: HttpUrl, expected: bool) -> None:
 def test_build_potd_bucket_directory_path() -> None:
     """Test build_potd_bucket_directory_path returns the dated gcs bucket directory path."""
     assert build_potd_bucket_directory_path() == "wikimedia_potd/2026-06-07/"
+
+
+@freezegun.freeze_time("2026-06-07")
+def test_build_potd_bucket_directory_path_uses_the_given_date() -> None:
+    """Test that an explicit date is used instead of today, so past days can be addressed."""
+    assert build_potd_bucket_directory_path("2026-06-06") == "wikimedia_potd/2026-06-06/"
+
+
+@pytest.mark.parametrize(
+    ["date_str", "expected"],
+    [
+        ("2026-06-07", "2026-06-06"),
+        ("2026-06-01", "2026-05-31"),
+        ("2026-01-01", "2025-12-31"),
+        ("2028-03-01", "2028-02-29"),
+    ],
+    ids=["mid_month", "month_boundary", "year_boundary", "leap_day"],
+)
+def test_previous_day(date_str: str, expected: str) -> None:
+    """Test previous_day returns the calendar day before the given date."""
+    assert previous_day(date_str) == expected
+
+
+def test_as_previous_entry_returns_none_when_there_is_no_manifest() -> None:
+    """Returns None when yesterday has no manifest, so `previous` serializes as null."""
+    assert as_previous_entry(None) is None
+
+
+def test_as_previous_entry_carries_over_every_field() -> None:
+    """Returns an entry holding the day's fields, including the descriptions used to localize."""
+    yesterday = PictureOfTheDay(
+        title="Wikimedia Commons Picture of the Day for June 6",
+        published_date="2026-06-06",
+        thumbnail_image_url=HttpUrl(THUMBNAIL_URL),
+        high_res_image_url=HttpUrl(HIGH_RES_URL),
+        description="Yesterday's description.",
+        localized_descriptions={"de": "Deutscher Text"},
+        author="Test Artist",
+        file_page=HttpUrl(FILE_PAGE_URL),
+        license_label="CC BY-SA 4.0",
+        license_link=HttpUrl(LICENSE_URL),
+    )
+
+    entry = as_previous_entry(yesterday)
+
+    assert isinstance(entry, PictureOfTheDayBase)
+    assert entry.model_dump() == yesterday.model_dump(exclude={"previous"})
+
+
+def test_as_previous_entry_drops_the_days_own_previous() -> None:
+    """Drops the fetched day's `previous` so a published manifest is only one day deep."""
+    two_days_ago = PictureOfTheDayBase(
+        title="Wikimedia Commons Picture of the Day for June 5",
+        published_date="2026-06-05",
+        thumbnail_image_url=HttpUrl(THUMBNAIL_URL),
+        high_res_image_url=HttpUrl(HIGH_RES_URL),
+        description="Two days ago.",
+    )
+    yesterday = PictureOfTheDay(
+        title="Wikimedia Commons Picture of the Day for June 6",
+        published_date="2026-06-06",
+        thumbnail_image_url=HttpUrl(THUMBNAIL_URL),
+        high_res_image_url=HttpUrl(HIGH_RES_URL),
+        description="Yesterday's description.",
+        previous=two_days_ago,
+    )
+
+    entry = as_previous_entry(yesterday)
+
+    assert entry is not None
+    assert entry.published_date == "2026-06-06"
+    # the chain stops here: the entry has no `previous` field at all
+    assert "previous" not in entry.model_dump()
 
 
 def test_extract_image_description_with_lang_code_returns_lang_and_text(featured: dict) -> None:

--- a/apps/merino/tests/unit/providers/rss/wikimedia_potd/backends/test_utils.py
+++ b/apps/merino/tests/unit/providers/rss/wikimedia_potd/backends/test_utils.py
@@ -208,28 +208,6 @@ def test_as_previous_entry_returns_none_when_there_is_no_manifest() -> None:
     """Returns None when yesterday has no manifest, so `previous` serializes as null."""
     assert as_previous_entry(None) is None
 
-
-def test_as_previous_entry_carries_over_every_field() -> None:
-    """Returns an entry holding the day's fields, including the descriptions used to localize."""
-    yesterday = PictureOfTheDay(
-        title="Wikimedia Commons Picture of the Day for June 6",
-        published_date="2026-06-06",
-        thumbnail_image_url=HttpUrl(THUMBNAIL_URL),
-        high_res_image_url=HttpUrl(HIGH_RES_URL),
-        description="Yesterday's description.",
-        localized_descriptions={"de": "Deutscher Text"},
-        author="Test Artist",
-        file_page=HttpUrl(FILE_PAGE_URL),
-        license_label="CC BY-SA 4.0",
-        license_link=HttpUrl(LICENSE_URL),
-    )
-
-    entry = as_previous_entry(yesterday)
-
-    assert isinstance(entry, PictureOfTheDayBase)
-    assert entry.model_dump() == yesterday.model_dump(exclude={"previous"})
-
-
 def test_as_previous_entry_drops_the_days_own_previous() -> None:
     """Drops the fetched day's `previous` so a published manifest is only one day deep."""
     two_days_ago = PictureOfTheDayBase(

--- a/apps/merino/tests/unit/providers/rss/wikimedia_potd/backends/test_wikimedia_potd_backend.py
+++ b/apps/merino/tests/unit/providers/rss/wikimedia_potd/backends/test_wikimedia_potd_backend.py
@@ -330,11 +330,7 @@ class TestOrchestratePictureOfTheDayUpload:
 
 
 class TestUploadPictureOfTheDayAttachesPreviousDay:
-    """Tests that the uploaded manifest carries the previous day's picture.
-
-    The job embeds yesterday's manifest at write time so the serving path stays a single
-    read; these tests cover what ends up under `previous` on the manifest being published.
-    """
+    """Tests that the uploaded manifest carries the previous day's picture."""
 
     @staticmethod
     def _mock_upload_dependencies(backend, mocker: MockerFixture):
@@ -460,6 +456,7 @@ class TestFetchPotdFromGcsBucketMethod:
         """Reads the given day's manifest, which is how the job picks up the previous day."""
         self._mock_blob(backend, yesterdays_potd)
 
+        # fetch yesterday's potd
         result = backend.fetch_potd_from_gcs_bucket("2026-06-23")
 
         backend.gcs_uploader.get_file_by_name.assert_called_once_with(

--- a/apps/merino/tests/unit/providers/rss/wikimedia_potd/backends/test_wikimedia_potd_backend.py
+++ b/apps/merino/tests/unit/providers/rss/wikimedia_potd/backends/test_wikimedia_potd_backend.py
@@ -19,6 +19,7 @@ from pytest_mock import MockerFixture
 from merino.configs import settings
 from merino.providers.rss.wikimedia_potd.backends.protocol import (
     PictureOfTheDay,
+    PictureOfTheDayBase,
     WikimediaPotdError,
 )
 from merino.utils.gcs.gcs_uploader import GcsUploader
@@ -67,6 +68,19 @@ def fixture_backend(
         featured_api_base=FEED_URL,
         commons_api_url=COMMONS_API_URL,
         gcs_uploader=gcs_uploader_mock,
+    )
+
+
+@pytest.fixture(name="yesterdays_potd")
+def fixture_yesterdays_potd() -> PictureOfTheDay:
+    """Return the manifest published the day before the frozen 2026-06-24 upload date."""
+    return PictureOfTheDay(
+        title="Wikimedia Commons Picture of the Day for June 23",
+        description="Yesterday's description",
+        published_date="2026-06-23",
+        thumbnail_image_url=HttpUrl("https://cdn/wikimedia_potd/2026-06-23/thumbnail.jpeg"),
+        high_res_image_url=HttpUrl("https://cdn/wikimedia_potd/2026-06-23/hi_res.webp"),
+        localized_descriptions={"de": "Gestriger deutscher Text"},
     )
 
 
@@ -313,6 +327,154 @@ class TestOrchestratePictureOfTheDayUpload:
 
         result = await backend.upload_picture_of_the_day()
         assert result is False
+
+
+class TestUploadPictureOfTheDayAttachesPreviousDay:
+    """Tests that the uploaded manifest carries the previous day's picture.
+
+    The job embeds yesterday's manifest at write time so the serving path stays a single
+    read; these tests cover what ends up under `previous` on the manifest being published.
+    """
+
+    @staticmethod
+    def _mock_upload_dependencies(backend, mocker: MockerFixture):
+        """Stub out the Featured API fetch and image upload, returning the manifest upload mock."""
+        client_mock: AsyncMock = cast(AsyncMock, backend.http_client)
+        client_mock.get.return_value = Response(
+            status_code=200,
+            content=TEST_FEATURED_JSON,
+            request=Request(method="GET", url=FEED_URL),
+        )
+        mocker.patch.object(
+            backend,
+            "download_and_upload_potd_images",
+            return_value=(
+                HttpUrl("https://cdn/wikimedia_potd/2026-06-24/thumbnail.jpeg"),
+                HttpUrl("https://cdn/wikimedia_potd/2026-06-24/hi_res.webp"),
+            ),
+        )
+        return mocker.patch.object(backend, "upload_potd_manifest")
+
+    @freezegun.freeze_time("2026-06-24")
+    @pytest.mark.asyncio
+    async def test_upload_picture_of_the_day_embeds_the_previous_days_manifest(
+        self, backend, yesterdays_potd: PictureOfTheDay, mocker: MockerFixture
+    ) -> None:
+        """Fetches the previous calendar day's manifest and embeds it under `previous`."""
+        manifest_mock = self._mock_upload_dependencies(backend, mocker)
+        fetch_mock = mocker.patch.object(
+            backend, "fetch_potd_from_gcs_bucket", return_value=yesterdays_potd
+        )
+
+        result = await backend.upload_picture_of_the_day()
+        assert result is True
+
+        # only the previous calendar day is looked up, no walking further back
+        fetch_mock.assert_called_once_with("2026-06-23")
+
+        uploaded: PictureOfTheDay = manifest_mock.call_args.args[0]
+        assert uploaded.published_date == "2026-06-24"
+        assert uploaded.previous is not None
+        assert uploaded.previous.published_date == "2026-06-23"
+        assert str(uploaded.previous.high_res_image_url) == (
+            "https://cdn/wikimedia_potd/2026-06-23/hi_res.webp"
+        )
+        # the localization map rides along so `previous.description` can be localized on serve
+        assert uploaded.previous.localized_descriptions == {"de": "Gestriger deutscher Text"}
+
+    @freezegun.freeze_time("2026-06-24")
+    @pytest.mark.asyncio
+    async def test_upload_picture_of_the_day_leaves_previous_unset_when_yesterday_has_no_manifest(
+        self, backend, mocker: MockerFixture
+    ) -> None:
+        """Publishes with `previous` unset when yesterday's job never uploaded a manifest."""
+        manifest_mock = self._mock_upload_dependencies(backend, mocker)
+        mocker.patch.object(backend, "fetch_potd_from_gcs_bucket", return_value=None)
+
+        result = await backend.upload_picture_of_the_day()
+
+        # a missing previous day never fails today's upload
+        assert result is True
+        assert manifest_mock.call_args.args[0].previous is None
+
+    @freezegun.freeze_time("2026-06-24")
+    @pytest.mark.asyncio
+    async def test_upload_picture_of_the_day_does_not_chain_past_the_previous_day(
+        self, backend, yesterdays_potd: PictureOfTheDay, mocker: MockerFixture
+    ) -> None:
+        """Drops the previous day's own `previous`, keeping the manifest one day deep."""
+        manifest_mock = self._mock_upload_dependencies(backend, mocker)
+        mocker.patch.object(
+            backend,
+            "fetch_potd_from_gcs_bucket",
+            return_value=yesterdays_potd.model_copy(
+                update={
+                    "previous": PictureOfTheDayBase(
+                        title="Wikimedia Commons Picture of the Day for June 22",
+                        description="Two days ago",
+                        published_date="2026-06-22",
+                        thumbnail_image_url=HttpUrl("https://cdn/t.jpeg"),
+                        high_res_image_url=HttpUrl("https://cdn/h.webp"),
+                    )
+                }
+            ),
+        )
+
+        result = await backend.upload_picture_of_the_day()
+        assert result is True
+
+        uploaded: PictureOfTheDay = manifest_mock.call_args.args[0]
+        assert uploaded.previous is not None
+        assert uploaded.previous.published_date == "2026-06-23"
+        assert "previous" not in uploaded.previous.model_dump()
+
+
+class TestFetchPotdFromGcsBucketMethod:
+    """Tests for the date addressing of fetch_potd_from_gcs_bucket."""
+
+    @staticmethod
+    def _mock_blob(backend, potd: PictureOfTheDay) -> None:
+        """Make the bucket return `potd` as the manifest for whichever blob is requested."""
+        blob = MagicMock()
+        blob.download_as_text.return_value = potd.model_dump_json()
+        backend.gcs_uploader.get_file_by_name.return_value = blob
+
+    @freezegun.freeze_time("2026-06-24")
+    def test_fetch_potd_from_gcs_bucket_reads_todays_path_by_default(
+        self, backend, potd: PictureOfTheDay
+    ) -> None:
+        """Reads today's manifest when no date is given, as the serving path does."""
+        self._mock_blob(backend, potd)
+
+        result = backend.fetch_potd_from_gcs_bucket()
+
+        backend.gcs_uploader.get_file_by_name.assert_called_once_with(
+            "wikimedia_potd/2026-06-24/potd.json"
+        )
+        assert result == potd
+
+    @freezegun.freeze_time("2026-06-24")
+    def test_fetch_potd_from_gcs_bucket_reads_the_given_dates_path(
+        self, backend, yesterdays_potd: PictureOfTheDay
+    ) -> None:
+        """Reads the given day's manifest, which is how the job picks up the previous day."""
+        self._mock_blob(backend, yesterdays_potd)
+
+        result = backend.fetch_potd_from_gcs_bucket("2026-06-23")
+
+        backend.gcs_uploader.get_file_by_name.assert_called_once_with(
+            "wikimedia_potd/2026-06-23/potd.json"
+        )
+        assert result == yesterdays_potd
+
+    @freezegun.freeze_time("2026-06-24")
+    def test_fetch_potd_from_gcs_bucket_returns_none_when_the_day_has_no_manifest(
+        self, backend
+    ) -> None:
+        """Returns None when the day's blob is absent, which the job reports as no `previous`."""
+        backend.gcs_uploader.get_file_by_name.return_value = None
+
+        assert backend.fetch_potd_from_gcs_bucket("2026-06-23") is None
 
 
 class TestFetchPictureOfTheDayMethod:

--- a/apps/merino/tests/unit/providers/rss/wikimedia_potd/test_provider.py
+++ b/apps/merino/tests/unit/providers/rss/wikimedia_potd/test_provider.py
@@ -330,15 +330,14 @@ async def test_get_picture_of_the_day_serves_the_previous_day_alongside_today(
     assert potd.previous.published_date == "2026-06-06"
     assert potd.previous.description == "previous description"
 
+
 @freezegun.freeze_time("2026-06-07")
 @pytest.mark.asyncio
 async def test_get_picture_of_the_day_when_there_is_no_previous_day(
     provider: WikimediaPictureOfTheDayProvider, test_potd: PictureOfTheDay
 ) -> None:
     """Serves today's potd when no previous day is attached."""
-    provider.potd = test_potd.model_copy(
-        update={"previous": None}
-    )
+    provider.potd = test_potd.model_copy(update={"previous": None})
 
     potd = await provider.get_picture_of_the_day()
 
@@ -385,12 +384,11 @@ async def test_get_picture_of_the_day_keeps_the_previous_days_default_descriptio
     provider: WikimediaPictureOfTheDayProvider, test_potd_with_previous: PictureOfTheDay
 ) -> None:
     """Keeps today's localized description while the previous day falls back to its default."""
+    previous = test_potd_with_previous.previous
+    assert previous is not None
+
     provider.potd = test_potd_with_previous.model_copy(
-        update={
-            "previous": test_potd_with_previous.previous.model_copy(
-                update={"localized_descriptions": {}}
-            )
-        }
+        update={"previous": previous.model_copy(update={"localized_descriptions": {}})}
     )
 
     potd = await provider.get_picture_of_the_day(["de"])

--- a/apps/merino/tests/unit/providers/rss/wikimedia_potd/test_provider.py
+++ b/apps/merino/tests/unit/providers/rss/wikimedia_potd/test_provider.py
@@ -11,6 +11,7 @@ from pytest_mock import MockerFixture
 
 from merino.providers.rss.wikimedia_potd.backends.protocol import (
     PictureOfTheDay,
+    PictureOfTheDayBase,
     WikimediaPictureOfTheDayBackend,
 )
 from merino.providers.rss.wikimedia_potd.provider import WikimediaPictureOfTheDayProvider
@@ -45,6 +46,24 @@ def fixture_test_potd() -> PictureOfTheDay:
         high_res_image_url=HttpUrl("https://test-high-res.jpg"),
         description="test description",
         published_date="2026-06-07",
+    )
+
+
+@pytest.fixture(name="test_potd_with_previous")
+def fixture_test_potd_with_previous(test_potd: PictureOfTheDay) -> PictureOfTheDay:
+    """Return a test potd carrying the previous day's picture, both localized into German."""
+    return test_potd.model_copy(
+        update={
+            "localized_descriptions": {"de": "Deutscher Text"},
+            "previous": PictureOfTheDayBase(
+                title="Wikimedia Commons picture of the day",
+                thumbnail_image_url=HttpUrl("https://test-previous-thumbnail.jpg"),
+                high_res_image_url=HttpUrl("https://test-previous-high-res.jpg"),
+                description="previous description",
+                published_date="2026-06-06",
+                localized_descriptions={"de": "Vorheriger deutscher Text"},
+            ),
+        }
     )
 
 
@@ -294,3 +313,89 @@ async def test_get_picture_of_the_day_refetches_on_every_miss(
     # every request that serves nothing is counted
     assert statsd_mock.increment.call_count == 2
     statsd_mock.increment.assert_called_with("potd.provider.cached.none")
+
+
+@freezegun.freeze_time("2026-06-07")
+@pytest.mark.asyncio
+async def test_get_picture_of_the_day_serves_the_previous_day_alongside_today(
+    provider: WikimediaPictureOfTheDayProvider, test_potd_with_previous: PictureOfTheDay
+) -> None:
+    """Serves the previous day's picture embedded in the cached potd."""
+    provider.potd = test_potd_with_previous
+
+    potd = await provider.get_picture_of_the_day()
+
+    assert potd is not None
+    assert potd.previous is not None
+    assert potd.previous.published_date == "2026-06-06"
+    assert potd.previous.description == "previous description"
+
+@freezegun.freeze_time("2026-06-07")
+@pytest.mark.asyncio
+async def test_get_picture_of_the_day_when_there_is_no_previous_day(
+    provider: WikimediaPictureOfTheDayProvider, test_potd: PictureOfTheDay
+) -> None:
+    """Serves today's potd when no previous day is attached."""
+    provider.potd = test_potd.model_copy(
+        update={"previous": None}
+    )
+
+    potd = await provider.get_picture_of_the_day()
+
+    assert potd is not None
+    assert potd.previous is None
+
+
+@freezegun.freeze_time("2026-06-07")
+@pytest.mark.asyncio
+async def test_get_picture_of_the_day_localizes_both_descriptions(
+    provider: WikimediaPictureOfTheDayProvider, test_potd_with_previous: PictureOfTheDay
+) -> None:
+    """Swaps in the localized description for today and for the previous day."""
+    provider.potd = test_potd_with_previous
+
+    potd = await provider.get_picture_of_the_day(["de-DE", "en-US"])
+
+    assert potd is not None
+    assert potd.description == "Deutscher Text"
+    assert potd.previous is not None
+    assert potd.previous.description == "Vorheriger deutscher Text"
+
+
+@freezegun.freeze_time("2026-06-07")
+@pytest.mark.asyncio
+async def test_get_picture_of_the_day_localizes_the_previous_day_independently(
+    provider: WikimediaPictureOfTheDayProvider, test_potd_with_previous: PictureOfTheDay
+) -> None:
+    """Localizes the previous day even when today's picture has no matching description."""
+    provider.potd = test_potd_with_previous.model_copy(update={"localized_descriptions": {}})
+
+    potd = await provider.get_picture_of_the_day(["de"])
+
+    assert potd is not None
+    # same as the default (en) description of the test_potd fixture
+    assert potd.description == "test description"
+    assert potd.previous is not None
+    assert potd.previous.description == "Vorheriger deutscher Text"
+
+
+@freezegun.freeze_time("2026-06-07")
+@pytest.mark.asyncio
+async def test_get_picture_of_the_day_keeps_the_previous_days_default_description(
+    provider: WikimediaPictureOfTheDayProvider, test_potd_with_previous: PictureOfTheDay
+) -> None:
+    """Keeps today's localized description while the previous day falls back to its default."""
+    provider.potd = test_potd_with_previous.model_copy(
+        update={
+            "previous": test_potd_with_previous.previous.model_copy(
+                update={"localized_descriptions": {}}
+            )
+        }
+    )
+
+    potd = await provider.get_picture_of_the_day(["de"])
+
+    assert potd is not None
+    assert potd.description == "Deutscher Text"
+    assert potd.previous is not None
+    assert potd.previous.description == "previous description"


### PR DESCRIPTION
## References

JIRA: [HNT-3068](https://mozilla-hub.atlassian.net/browse/HNT-3068)

## Description
Update API response to add previous day's POTD object.

The new json response looks like this:
```
{ 
    "title": "...", 
    "published_date": "2026-08-25",
    "thumbnail_image_url": "...", 
    "high_res_image_url": "...",
    "description": "...",
    "author": "...",
    "file_page": "...",
    "license_label": "...",
    "license_link": "...",
    "previous": {
         "title": "...",
         "published_date": "2026-08-24",
         "thumbnail_image_url": "...",
         "high_res_image_url": "...",
         "description": "...",
         "author": "...",
         "file_page": "...",
         "license_label": "...",
         "license_link": "..."
    }
}
```



## PR Review Checklist
- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/merino-py/blob/main/CONTRIBUTING.md)
- [x] The PR title starts with the JIRA issue reference, format example `[DISCO-####]`, and has the same title (if applicable)
- [ ] `[load test: (abort|skip|warn)]` keywords are applied to the last commit message (if applicable)
- [ ] [Documentation](https://github.com/mozilla-services/merino-py/tree/main/docs) has been updated (if applicable)
- [ ] [Metric documentation](https://github.com/mozilla-services/merino-py/tree/main/apps/merino/metrics.yaml) has been updated (if applicable)
- [ ] [Functional and performance test](https://github.com/mozilla-services/merino-py/blob/main/docs/dev/testing.md) coverage has been expanded and maintained (if applicable)


┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/MC-2571)


[HNT-3068]: https://mozilla-hub.atlassian.net/browse/HNT-3068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ